### PR TITLE
Share portal and desktop utility shell

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,17 +4,19 @@
 
 mdbase connect is a desktop utility used in ordinary daylight at a personal
 computer while the user is making a consequential access decision. The theme is
-minimal, precise, and almost entirely white. A narrow white sidebar provides
-stable desktop navigation without becoming a contrasting visual rail. The
-content remains an uninterrupted white canvas. Hierarchy comes from typography,
-spacing, and alignment rather than tinted surfaces, boxes, or decoration.
+minimal, precise, and almost entirely white. Portal and desktop share a compact
+product header, visual tokens, and core controls. Desktop views sit in a quiet
+horizontal tab row below that header; the compact portal overview needs no
+section navigation. Content remains an uninterrupted white canvas. Hierarchy
+comes from typography, spacing, and alignment rather than tinted surfaces,
+boxes, or decoration.
 
 ## Color
 
 - Ink: `oklch(21% 0.018 255)`
 - Accent: `oklch(45% 0.105 238)`
 - Accent dark: `oklch(35% 0.09 238)`
-- White: `oklch(1 0 0)`
+- Paper: `oklch(99.5% 0.002 255)`
 - Hover: `oklch(98% 0.003 255)`
 - Line: `oklch(92% 0.006 255)`
 - Strong line: `oklch(82% 0.008 255)`
@@ -23,8 +25,8 @@ spacing, and alignment rather than tinted surfaces, boxes, or decoration.
 - Danger red: `oklch(50% 0.11 28)`
 - Muted text: `oklch(54% 0.014 255)`
 
-Use a light monochrome strategy. White is the only major surface. Controls stay
-white and use fine grey outlines rather than dark fills. Green indicates verified
+Use a light monochrome strategy. Paper is the only major surface. Controls stay
+on paper and use fine grey outlines rather than dark fills. Green indicates verified
 connection or completion. Amber indicates pending attention. Red indicates
 revocation, disconnection, or destructive local administration. Semantic color
 should occupy as little space as possible.
@@ -44,10 +46,12 @@ label.
 
 ## Layout
 
-- Desktop shell uses a narrow persistent sidebar beside a flexible content
-  workspace. Both stay white, separated by one near-white rule.
-- Primary navigation is conventional and text-led, with counts only when action
-  is required.
+- Portal and desktop share a full-width product header with identity or
+  connection state aligned opposite the wordmark.
+- Desktop primary navigation uses a single horizontal tab row. Counts appear
+  only when they clarify local collection state or pending action.
+- The portal keeps requests, computers, and service details in one centered
+  overview. It does not add navigation when the complete page is already visible.
 - Configuration rows are preferred over card grids. Pending access decisions
   use ruled rows. Empty states are plain text with a single next action.
 - Whitespace establishes section rhythm. Fine dividers are limited to dense

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit"
   },
   "dependencies": {
+    "@mdbase/connect-ui": "workspace:*",
     "@fontsource/atkinson-hyperlegible": "^5.2.0",
     "@fontsource/azeret-mono": "^5.2.0",
     "react": "^19.2.0",

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -3,6 +3,7 @@ import "@fontsource/atkinson-hyperlegible/latin-700.css";
 import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
+import "@mdbase/connect-ui/styles.css";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import "./styles.css";
@@ -139,33 +140,29 @@ function App() {
 
   return (
     <div className="shell">
-      <aside className="sidebar">
-        <div className="brand-lockup">
-          <span className="brand-dot" aria-hidden="true" />
-          <div className="brand-copy"><strong>mdbase</strong><span>connect</span></div>
+      <header className="product-header desktop-header">
+        <div className="product-header-inner">
+          <div className="product-brand"><span className="product-brand-dot" aria-hidden="true" /><strong>mdbase</strong><span className="product-brand-label">connect</span></div>
+          <div className="product-header-meta">
+            <StatusDot state={status?.paused ? "paused" : status?.state === "connected" ? "connected" : "idle"} />
+            <div className="product-header-meta-copy"><strong>{connectionLabel}</strong><small>{access.account?.connector_name ?? "This computer"} · {status?.registered_collections ?? 0} registered</small></div>
+          </div>
         </div>
+      </header>
 
-        <nav className="primary-nav" aria-label="mdbase connect">
+      <nav className="view-tabs" aria-label="mdbase connect views">
+        <div className="view-tabs-inner">
           <NavButton route="overview" current={route} label="Overview" onSelect={setRoute} />
           <NavButton route="collections" current={route} label="Collections" count={collections.length} onSelect={setRoute} />
           <NavButton route="access" current={route} label="App access" attention={access.pending_authorizations.length} onSelect={setRoute} />
           <NavButton route="activity" current={route} label="Activity" onSelect={setRoute} />
           <NavButton route="settings" current={route} label="Settings" onSelect={setRoute} />
-        </nav>
-
-        <div className="connector-summary">
-          <StatusDot state={status?.paused ? "paused" : status?.state === "connected" ? "connected" : "idle"} />
-          <div><strong>{connectionLabel}</strong><small>{access.account?.connector_name ?? "This computer"}</small></div>
         </div>
-      </aside>
+      </nav>
 
       <main className="content">
         <header className="topbar">
           <div><p className="eyebrow">{copy.eyebrow}</p><h1>{copy.title}</h1><p className="lede">{copy.lede}</p></div>
-          <div className="agent-pill">
-            <StatusDot state={status?.paused ? "paused" : status?.state === "connected" ? "connected" : "idle"} />
-            <span><strong>{connectionLabel}</strong><small>{status?.registered_collections ?? 0} registered collections</small></span>
-          </div>
         </header>
 
         <div aria-live="polite">
@@ -566,7 +563,7 @@ function OperationChoices({ allowed, selected, onChange, compact = false }: { al
 }
 
 function NavButton({ route, current, label, count, attention, onSelect }: { route: Route; current: Route; label: string; count?: number; attention?: number; onSelect(route: Route): void }) {
-  return <button className={current === route ? "active" : ""} aria-current={current === route ? "page" : undefined} onClick={() => onSelect(route)}><span>{label}</span>{attention ? <b className="attention-count">{attention}</b> : count !== undefined ? <b>{count}</b> : null}</button>;
+  return <button className={`view-tab ${current === route ? "active" : ""}`} aria-current={current === route ? "page" : undefined} onClick={() => onSelect(route)}><span>{label}</span>{attention ? <b className="view-tab-count attention">{attention}</b> : count !== undefined ? <b className="view-tab-count">{count}</b> : null}</button>;
 }
 
 function SectionHeading({ title, note, count, children }: { title: string; note: string; count?: number; children?: React.ReactNode }) {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1,67 +1,15 @@
-:root {
-  color-scheme: light;
-  color: oklch(21% 0.018 255);
-  background: oklch(1 0 0);
-  font-family: "Atkinson Hyperlegible", "Segoe UI", sans-serif;
-  font-synthesis: none;
-  --ink: oklch(21% 0.018 255);
-  --action: oklch(35% 0.09 238);
-  --muted: oklch(54% 0.014 255);
-  --faint: oklch(70% 0.009 255);
-  --line: oklch(92% 0.006 255);
-  --line-strong: oklch(82% 0.008 255);
-  --paper: oklch(1 0 0);
-  --hover: oklch(98% 0.003 255);
-  --signal: oklch(45% 0.105 238);
-  --control-on: oklch(82% 0.008 255);
-  --connected: oklch(43% 0.09 153);
-  --warning: oklch(60% 0.09 75);
-  --danger: oklch(50% 0.11 28);
-  --mono: "Azeret Mono", "SFMono-Regular", "Cascadia Code", monospace;
-  --ease: cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-*, *::before, *::after { box-sizing: border-box; }
 html, body, #root { width: 100%; min-width: 100%; height: 100%; min-height: 100%; margin: 0; }
-body { overflow: hidden; color: var(--ink); background: var(--paper); -webkit-font-smoothing: antialiased; }
-button, input, select { font: inherit; }
+body { overflow: hidden; }
 button { color: inherit; }
-button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px solid var(--signal); outline-offset: 3px; }
-code, .mono { font-family: var(--mono); }
-
-.shell { display: grid; grid-template-columns: 168px minmax(0, 1fr); height: 100vh; background: var(--paper); }
-.sidebar { display: flex; flex-direction: column; padding: 30px 14px 20px; border-right: 1px solid var(--line); color: var(--ink); background: var(--paper); }
-.brand-lockup { display: flex; align-items: center; gap: 9px; padding: 0 8px; }
-.brand-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--signal); }
-.brand-copy { display: flex; align-items: baseline; gap: 6px; font-family: var(--mono); letter-spacing: -0.015em; }
-.brand-copy strong { font-size: 13px; font-weight: 600; }
-.brand-copy span { color: var(--muted); font-size: 10px; }
-.primary-nav { display: grid; gap: 1px; margin-top: 54px; }
-.primary-nav button { display: flex; align-items: center; justify-content: space-between; width: 100%; min-height: 36px; padding: 0 8px; border: 0; border-radius: 3px; color: var(--muted); background: transparent; font-size: 12px; text-align: left; cursor: pointer; transition: color 160ms var(--ease), background 160ms var(--ease); }
-.primary-nav button:hover { color: var(--ink); background: var(--hover); }
-.primary-nav button.active { color: var(--ink); background: transparent; font-weight: 700; }
-.primary-nav b { color: var(--faint); font-family: var(--mono); font-size: 8px; font-weight: 400; }
-.primary-nav .attention-count { min-width: 18px; color: var(--muted); background: transparent; text-align: right; }
-.connector-summary { display: grid; grid-template-columns: 7px 1fr; align-items: start; gap: 9px; margin-top: auto; padding: 16px 8px 0; border-top: 1px solid var(--line); }
-.connector-summary div { display: grid; gap: 2px; }
-.connector-summary strong { font-size: 11px; font-weight: 700; }
-.connector-summary small { color: var(--muted); font-size: 10px; }
-
-.content { min-width: 0; padding: 52px clamp(38px, 6vw, 80px) 64px; overflow: auto; background: var(--paper); }
+.shell { display: flex; flex-direction: column; height: 100vh; background: var(--paper); }
+.desktop-header .product-header-inner, .view-tabs-inner { width: min(70rem, 100%); }
+.content { min-width: 0; flex: 1 1 auto; padding: 42px clamp(38px, 6vw, 80px) 64px; overflow: auto; background: var(--paper); }
 .content > * { width: min(960px, 100%); margin-inline: auto; }
-.topbar { display: block; min-height: 84px; }
+.topbar { display: block; min-height: 76px; }
 .topbar .eyebrow { display: none; }
 .eyebrow { margin: 0 0 8px; color: var(--muted); font-family: var(--mono); font-size: 9px; font-weight: 500; }
 h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spacing: -0.03em; }
 .lede { max-width: 600px; margin: 8px 0 0; color: var(--muted); font-size: 13px; line-height: 1.5; }
-.agent-pill { display: none; }
-.agent-pill > span:last-child { display: grid; gap: 2px; }
-.agent-pill strong { font-size: 10px; font-weight: 600; }
-.agent-pill small { color: var(--muted); font-size: 8px; }
-.status-dot { display: inline-block; width: 6px; height: 6px; flex: 0 0 auto; border-radius: 50%; background: var(--faint); }
-.status-dot.connected { background: var(--connected); }
-.status-dot.paused { background: var(--warning); }
-.status-dot.danger { background: var(--danger); }
 .message { margin: 18px 0 0; padding: 10px 0; border-bottom: 1px solid; font-size: 11px; }
 .error-message { color: var(--danger); border-color: color-mix(in oklch, var(--danger) 34%, var(--line)); }
 .notice-message { color: oklch(0.43 0.1 158); border-color: color-mix(in oklch, var(--connected) 34%, var(--line)); }
@@ -206,8 +154,6 @@ fieldset legend { margin-bottom: 6px; }
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 22px; padding-top: 15px; border-top: 1px solid var(--line); }
 
 @media (max-width: 1000px) {
-  .shell { grid-template-columns: 164px minmax(0, 1fr); }
-  .sidebar { padding-inline: 13px; }
   .request-panel { grid-template-columns: minmax(130px, 0.7fr) minmax(280px, 1.3fr); }
   .decision-actions { grid-column: 1 / -1; display: flex; justify-content: flex-end; }
   .grant-row { grid-template-columns: minmax(120px, 0.7fr) minmax(220px, 1.3fr); }
@@ -215,10 +161,6 @@ fieldset legend { margin-bottom: 6px; }
   .manual-grant { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 780px) {
-  .shell { grid-template-columns: 116px minmax(0, 1fr); }
-  .brand-copy span, .connector-summary small { display: none; }
-  .sidebar { padding-inline: 10px; }
-  .primary-nav button { padding-inline: 7px; font-size: 10px; }
   .content { padding-inline: 24px; }
   .readiness-panel, .pairing-panel { grid-template-columns: 1fr; gap: 24px; }
   .overview-row { grid-template-columns: 95px minmax(0, 1fr) auto; }

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@mdbase/connect-ui": "workspace:*",
     "@fontsource/atkinson-hyperlegible": "^5.2.0",
     "@fontsource/azeret-mono": "^5.2.0",
     "react": "^19.2.0",

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -3,6 +3,7 @@ import "@fontsource/atkinson-hyperlegible/latin-700.css";
 import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
+import "@mdbase/connect-ui/styles.css";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
@@ -128,17 +129,21 @@ function Dashboard() {
 
   return (
     <div className="account-shell">
-      <aside className="account-nav">
-        <div className="nav-brand"><Brand /><span>connect</span></div>
-        <nav><a className={data.pending_authorizations.length ? "active" : ""} href="#requests">Requests{data.pending_authorizations.length ? <b>{data.pending_authorizations.length}</b> : null}</a><a className={!data.pending_authorizations.length ? "active" : ""} href="#computers">Computers</a><a href="#account">Account</a></nav>
-        <div className="signed-in"><span>{initials(data.user.name)}</span><div><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></div></div>
-      </aside>
+      <header className="product-header account-header">
+        <div className="product-header-inner">
+          <Brand productLabel />
+          <div className="product-header-meta">
+            <div className="product-header-meta-copy"><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></div>
+            <span className="product-avatar" aria-hidden="true">{initials(data.user.name)}</span>
+          </div>
+        </div>
+      </header>
       <main className="account-main">
         <header><p className="eyebrow">Your account</p><h1>Your connections.</h1><p>Approve application requests and manage the computers connected to your account.</p></header>
         {error && <div className="message error">{error}</div>}
-        <section id="requests" className={data.pending_authorizations.length ? "attention-section" : ""}>
+        <section id="requests" aria-label="Access requests" className={data.pending_authorizations.length ? "attention-section" : "requests-clear"}>
+          {data.pending_authorizations.length === 0 ? <div className="quiet-status" role="status"><span className="status-dot connected" aria-hidden="true" /><span>No access requests waiting</span></div> : <>
           <SectionHeading title="Access requests" note="A request expires automatically if you do nothing." count={data.pending_authorizations.length} />
-          {data.pending_authorizations.length === 0 ? <div className="quiet-empty"><span className="status-check" aria-hidden="true">✓</span><div><strong>No requests waiting</strong><p>New application requests will appear here.</p></div></div> : (
             <div className="request-list">{data.pending_authorizations.map((request) => (
               <article className="request-row" key={request.id}>
                 <RequestIdentity request={request} />
@@ -151,8 +156,7 @@ function Dashboard() {
                   onDecision={refresh}
                 />
               </article>
-            ))}</div>
-          )}
+            ))}</div></>}
         </section>
         <section id="computers">
           <SectionHeading title="Connected computers" note="Revoking a computer immediately invalidates all of its application access." count={data.connectors.length} />
@@ -164,8 +168,8 @@ function Dashboard() {
           )}
         </section>
         <section id="account">
-          <SectionHeading title="Account" note="Identity, recovery, and service administration." />
-          <div className="account-rows"><AccountRow label="Name" value={data.user.name} /><AccountRow label={data.user.login ? "GitHub" : "Email"} value={identityLabel(data.user)} mono /><AccountRow label="Authentication" value={authenticationLabel(data.authentication.provider)} detail={data.authentication.provider === "tailscale" ? "Controlled by your tailnet" : undefined} /><AccountRow label="Plan" value="Private preview" detail="Registration is not available" /></div>
+          <SectionHeading title="Account" note="Authentication and service details." />
+          <div className="account-rows"><AccountRow label="Authentication" value={authenticationLabel(data.authentication.provider)} detail={data.authentication.provider === "tailscale" ? "Controlled by your tailnet" : undefined} /><AccountRow label="Plan" value="Private preview" detail="Registration is not available" /></div>
           {data.authentication.provider !== "tailscale" && <button className="button secondary" onClick={() => void api("/v1/logout", { method: "POST" }).then(() => { location.href = "/login"; })}>Sign out</button>}
         </section>
       </main>
@@ -360,7 +364,7 @@ function ApprovalForm({
 }
 
 function AccountRow({ label, value, detail, mono = false }: { label: string; value: string; detail?: string; mono?: boolean }) { return <div className="account-row"><span>{label}</span><div><strong className={mono ? "mono" : ""}>{value}</strong>{detail && <small>{detail}</small>}</div></div>; }
-function Brand() { return <div className="brand"><span className="brand-dot" aria-hidden="true" /><strong>mdbase</strong></div>; }
+function Brand({ productLabel = false }: { productLabel?: boolean }) { return <div className="product-brand"><span className="product-brand-dot" aria-hidden="true" /><strong>mdbase</strong>{productLabel && <span className="product-brand-label">connect</span>}</div>; }
 function SectionHeading({ title, note, count }: { title: string; note: string; count?: number }) { return <div className="section-heading"><div><h2>{title}</h2><p>{note}</p></div>{count !== undefined && <span>{count}</span>}</div>; }
 function Empty({ title, text }: { title: string; text: string }) { return <div className="empty"><span className="empty-folder" /><strong>{title}</strong><p>{text}</p></div>; }
 function Loading({ error = "" }: { error?: string }) { return <main className="loading"><Brand /><p>{error || "Opening mdbase connect…"}</p></main>; }

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -1,28 +1,7 @@
 :root {
-  color-scheme: light;
-  color: oklch(21% 0.018 255);
-  background: oklch(100% 0 0);
-  font-family: "Atkinson Hyperlegible", "Segoe UI", sans-serif;
-  font-synthesis: none;
-  --paper: oklch(100% 0 0);
-  --paper-hover: oklch(98% 0.003 255);
-  --ink: oklch(21% 0.018 255);
-  --ink-soft: oklch(39% 0.016 255);
-  --ink-muted: oklch(54% 0.014 255);
-  --line: oklch(92% 0.006 255);
-  --line-strong: oklch(82% 0.008 255);
-  --accent: oklch(45% 0.105 238);
-  --accent-dark: oklch(35% 0.09 238);
-  --connected: oklch(43% 0.09 153);
-  --danger: oklch(50% 0.11 28);
-  --mono: "Azeret Mono", "SFMono-Regular", "Cascadia Code", monospace;
-  --ease: cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
+  --paper-hover: var(--hover);
+  --ink-muted: var(--muted);
+  --accent-dark: var(--action);
 }
 
 html,
@@ -30,160 +9,34 @@ body,
 #root {
   min-width: 320px;
   min-height: 100%;
-  margin: 0;
 }
 
-body {
-  color: var(--ink);
-  background: var(--paper);
-  -webkit-font-smoothing: antialiased;
-}
-
-button,
-input,
-select {
-  color: inherit;
-  font: inherit;
-}
-
-button:focus-visible,
-input:focus-visible,
-select:focus-visible,
-a:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-}
-
-code,
-.mono {
-  font-family: var(--mono);
-}
-
-.brand,
-.page-brand,
-.nav-brand {
+.page-brand {
   display: flex;
   align-items: center;
-}
-
-.brand {
-  gap: 0.6rem;
-  font-family: var(--mono);
-}
-
-.brand-dot {
-  width: 0.42rem;
-  height: 0.42rem;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: var(--accent);
-}
-
-.brand strong {
-  font-size: 0.82rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.page-brand,
-.nav-brand {
   gap: 0.65rem;
 }
 
-.page-brand > span,
-.nav-brand > span {
+.page-brand > span {
   color: var(--ink-muted);
   font-family: var(--mono);
   font-size: 0.7rem;
 }
 
 .account-shell {
-  display: grid;
-  grid-template-columns: 12rem minmax(0, 1fr);
   min-height: 100vh;
 }
 
-.account-nav {
+.account-header {
   position: sticky;
   top: 0;
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  padding: 2rem 1.25rem 1.5rem;
-  border-right: 1px solid var(--line);
-  background: var(--paper);
-}
-
-.account-nav nav {
-  display: grid;
-  gap: 0.1rem;
-  margin-top: 3.6rem;
-}
-
-.account-nav nav a {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: 2.25rem;
-  padding: 0 0.5rem;
-  border-radius: 3px;
-  color: var(--ink-muted);
-  font-size: 0.78rem;
-  text-decoration: none;
-  transition: color 160ms var(--ease), background-color 160ms var(--ease);
-}
-
-.account-nav nav a:hover {
-  color: var(--ink);
-  background: var(--paper-hover);
-}
-
-.account-nav nav a.active {
-  color: var(--ink);
-  font-weight: 700;
-}
-
-.account-nav nav b {
-  color: var(--accent-dark);
-  font-family: var(--mono);
-  font-size: 0.62rem;
-  font-weight: 500;
-}
-
-.signed-in {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: center;
-  gap: 0.55rem;
-  margin-top: auto;
-  padding: 1rem 0.5rem 0;
-  border-top: 1px solid var(--line);
-}
-
-.signed-in > span {
-  display: none;
-}
-
-.signed-in div {
-  display: grid;
-  gap: 0.12rem;
-  min-width: 0;
-}
-
-.signed-in strong {
-  font-size: 0.72rem;
-}
-
-.signed-in small {
-  overflow: hidden;
-  color: var(--ink-muted);
-  font-size: 0.66rem;
-  text-overflow: ellipsis;
+  z-index: 10;
 }
 
 .account-main {
-  width: min(62rem, 100%);
-  padding: 4.25rem clamp(2.5rem, 7vw, 6rem) 6rem;
+  width: min(70rem, 100%);
+  margin-inline: auto;
+  padding: 3.5rem clamp(1.5rem, 5vw, 4rem) 5rem;
 }
 
 .account-main header {
@@ -223,8 +76,22 @@ h1 {
 }
 
 .account-main section {
-  margin-top: 3.5rem;
+  margin-top: 3rem;
   scroll-margin-top: 1.5rem;
+}
+
+.account-main .requests-clear {
+  margin-top: 1.8rem;
+}
+
+.quiet-status {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 2.6rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-muted);
+  font-size: 0.74rem;
 }
 
 .section-heading {
@@ -282,7 +149,6 @@ h1 {
 .computer-row strong,
 .account-row strong,
 .request-identity strong,
-.quiet-empty strong,
 .empty strong {
   font-size: 0.82rem;
 }
@@ -290,7 +156,6 @@ h1 {
 .computer-row small,
 .account-row small,
 .request-identity small,
-.quiet-empty p,
 .empty p {
   color: var(--ink-muted);
   font-size: 0.72rem;
@@ -500,27 +365,15 @@ select {
   color: var(--danger);
 }
 
-.quiet-empty,
 .empty {
   padding: 1.8rem 0;
   border-bottom: 1px solid var(--line);
 }
 
-.quiet-empty {
-  display: block;
-}
-
-.quiet-empty div {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.quiet-empty p,
 .empty p {
   margin: 0.3rem 0 0;
 }
 
-.status-check,
 .empty-folder {
   display: none;
 }
@@ -679,35 +532,8 @@ select {
 }
 
 @media (max-width: 760px) {
-  .account-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .account-nav {
-    position: static;
-    height: auto;
-    padding: 1.25rem 1.25rem 0.8rem;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .account-nav nav {
-    display: flex;
-    gap: 0.25rem;
-    margin-top: 1.5rem;
-    overflow-x: auto;
-  }
-
-  .account-nav nav a {
-    flex: 0 0 auto;
-  }
-
-  .signed-in {
-    display: none;
-  }
-
   .account-main {
-    padding: 2.8rem 1.5rem 4rem;
+    padding: 2.5rem 1.5rem 4rem;
   }
 
   h1,

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/portal/package.json apps/portal/package.json
 COPY packages/protocol/package.json packages/protocol/package.json
 COPY packages/sync/package.json packages/sync/package.json
+COPY packages/ui/package.json packages/ui/package.json
 COPY services/server/package.json services/server/package.json
 
 RUN pnpm install --frozen-lockfile \
@@ -16,6 +17,7 @@ RUN pnpm install --frozen-lockfile \
 COPY apps/portal apps/portal
 COPY packages/protocol packages/protocol
 COPY packages/sync packages/sync
+COPY packages/ui packages/ui
 COPY services/server services/server
 
 RUN pnpm --filter @mdbase/connect-protocol build \

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mdbase/connect-ui",
+  "version": "0.1.0-alpha.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./styles.css": "./styles.css"
+  }
+}

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1,0 +1,257 @@
+:root {
+  color-scheme: light;
+  color: oklch(21% 0.018 255);
+  background: oklch(99.5% 0.002 255);
+  font-family: "Atkinson Hyperlegible", "Segoe UI", sans-serif;
+  font-synthesis: none;
+  --paper: oklch(99.5% 0.002 255);
+  --hover: oklch(97.5% 0.004 255);
+  --ink: oklch(21% 0.018 255);
+  --ink-soft: oklch(39% 0.016 255);
+  --muted: oklch(54% 0.014 255);
+  --faint: oklch(70% 0.009 255);
+  --line: oklch(92% 0.006 255);
+  --line-strong: oklch(82% 0.008 255);
+  --accent: oklch(45% 0.105 238);
+  --action: oklch(35% 0.09 238);
+  --control-on: oklch(82% 0.008 255);
+  --connected: oklch(43% 0.09 153);
+  --warning: oklch(60% 0.09 75);
+  --danger: oklch(50% 0.11 28);
+  --mono: "Azeret Mono", "SFMono-Regular", "Cascadia Code", monospace;
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+}
+
+body {
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+button,
+input,
+select {
+  color: inherit;
+  font: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+code,
+.mono {
+  font-family: var(--mono);
+}
+
+.product-header {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+  z-index: 10;
+}
+
+.product-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  width: min(70rem, 100%);
+  min-height: 4.25rem;
+  margin-inline: auto;
+  padding-inline: clamp(1.5rem, 5vw, 4rem);
+}
+
+.product-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex: 0 0 auto;
+  color: var(--ink);
+  font-family: var(--mono);
+}
+
+.product-brand-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.product-brand strong {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.product-brand-label {
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.product-header-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.product-header-meta-copy {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+  text-align: right;
+}
+
+.product-header-meta-copy strong {
+  overflow: hidden;
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.product-header-meta-copy small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.product-avatar {
+  display: grid;
+  place-items: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  flex: 0 0 auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  font-weight: 600;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 0.4rem;
+  height: 0.4rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--faint);
+}
+
+.status-dot.connected { background: var(--connected); }
+.status-dot.paused { background: var(--warning); }
+.status-dot.danger { background: var(--danger); }
+
+.view-tabs {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.view-tabs-inner {
+  display: flex;
+  align-items: stretch;
+  gap: 1.8rem;
+  width: min(70rem, 100%);
+  min-height: 2.85rem;
+  margin-inline: auto;
+  padding-inline: clamp(1.5rem, 5vw, 4rem);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.view-tabs-inner::-webkit-scrollbar { display: none; }
+
+.view-tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  font-size: 0.76rem;
+  cursor: pointer;
+  transition: color 160ms var(--ease);
+}
+
+.view-tab::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: transparent;
+  transform: scaleX(0.65);
+  transition: background-color 160ms var(--ease), transform 160ms var(--ease);
+}
+
+.view-tab:hover { color: var(--ink); }
+
+.view-tab.active {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.view-tab.active::after {
+  background: var(--accent);
+  transform: scaleX(1);
+}
+
+.view-tab-count {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  font-weight: 500;
+}
+
+.view-tab-count.attention { color: var(--action); }
+
+@media (max-width: 600px) {
+  .product-header-inner {
+    gap: 1rem;
+    min-height: 3.75rem;
+  }
+
+  .product-header-meta-copy small { display: none; }
+
+  .view-tabs-inner {
+    gap: 1.35rem;
+    min-height: 2.7rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fontsource/azeret-mono':
         specifier: ^5.2.0
         version: 5.3.0
+      '@mdbase/connect-ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -78,6 +81,9 @@ importers:
       '@fontsource/azeret-mono':
         specifier: ^5.2.0
         version: 5.3.0
+      '@mdbase/connect-ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -216,6 +222,8 @@ importers:
       vitest:
         specifier: ^4.0.0
         version: 4.1.10(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/ui: {}
 
   services/server:
     dependencies:


### PR DESCRIPTION
## What changed

- replace the portal's vestigial sidebar with a compact account header and stacked overview
- replace the Electron sidebar with a shared header and horizontal view tabs
- move common tokens, brand, status, header, and tab styles into a workspace UI package
- compress the portal's empty access-request state and remove duplicated account identity rows
- update the documented interface direction to match the shared shell

## Why

The portal's sidebar linked to sections already visible in a single viewport, while the desktop rail consumed substantial space beside compact views. The new shell keeps the portal simple and gives Electron navigation proportional to its five real views.

## Validation

- portal and desktop TypeScript checks
- portal and desktop production builds
- portal and desktop package tests
- Electron navigation smoke test
- desktop and mobile portal render checks, including horizontal overflow
