### PR TITLE
Harden SDK package outputs

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -30,6 +30,7 @@ jobs:
       - run: pnpm build
       - run: pnpm typecheck
       - run: pnpm test
+      - run: pnpm package:audit
 
   server-container:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "e2e": "pnpm build && cargo build --workspace && node scripts/e2e.mjs",
     "e2e:sync": "pnpm build && node scripts/sync-e2e.mjs",
     "e2e:oracle": "pnpm build && cargo build --workspace && node scripts/oracle-e2e.mjs",
+    "package:audit": "pnpm build && node scripts/package-audit.mjs",
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,6 +3,14 @@
   "version": "0.1.0-alpha.1",
   "private": false,
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
+    "directory": "packages/client"
+  },
+  "homepage": "https://mdbase.dev",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -14,7 +22,7 @@
     "@mdbase/connect-protocol": "workspace:*"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,12 +2,14 @@ import type {
   CollectionChange,
   CollectionChangesPage,
   CollectionDescription,
+  CollectionFileMetadata,
   CollectionOperation,
   EncryptedRelayOperationResponse,
   GrantEncryption,
   GrantScope,
   JsonObject,
   MdbaseOperationEnvelope,
+  RecordSummary,
   RecordResult
 } from "@mdbase/connect-protocol";
 import {
@@ -31,6 +33,7 @@ export type {
   CollectionChangesPage,
   CollectionContractDescriptor,
   CollectionDescription,
+  CollectionFileMetadata,
   CollectionOperation as MdbaseOperation,
   CollectionTypeDescriptor,
   ContractRequirement,
@@ -38,7 +41,8 @@ export type {
   JsonObject,
   MdbaseDiagnostic,
   MdbaseOperationEnvelope,
-  RecordResult
+  RecordResult,
+  RecordSummary
 } from "@mdbase/connect-protocol";
 
 export interface MdbaseConnectOptions {
@@ -66,7 +70,7 @@ export interface QueryInput {
 }
 
 export interface QueryResult<Record extends JsonObject = JsonObject> {
-  results: Array<RecordResult<Record> & JsonObject>;
+  results: Array<RecordSummary<Record> & JsonObject>;
   meta?: {
     total_count: number;
     has_more: boolean;

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0-alpha.1",
   "private": false,
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
+    "directory": "packages/devkit"
+  },
+  "homepage": "https://mdbase.dev",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -19,7 +26,7 @@
     "ajv": "^8.17.1"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -3,12 +3,24 @@
   "version": "0.1.0-alpha.1",
   "private": false,
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
+    "directory": "packages/protocol"
+  },
+  "homepage": "https://mdbase.dev",
+  "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./schemas/*": "./schemas/*"
   },
+  "files": ["dist", "schemas"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "node --test test/*.test.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -224,12 +224,27 @@ export interface MdbaseOperationEnvelope<Result = JsonObject> {
   diagnostics: MdbaseDiagnostic[];
 }
 
-export interface RecordResult<Frontmatter extends JsonObject = JsonObject> {
+export interface CollectionFileMetadata extends JsonObject {
+  name: string;
+  folder: string;
+  size: number;
+  mtime: string;
+  tags?: string[];
+  links?: unknown[];
+  embeds?: unknown[];
+}
+
+export interface RecordSummary<Frontmatter extends JsonObject = JsonObject> {
   path: string;
   frontmatter: Frontmatter;
   raw_frontmatter?: Frontmatter;
   body?: string;
   types: string[];
+  file?: CollectionFileMetadata;
+}
+
+export interface RecordResult<Frontmatter extends JsonObject = JsonObject>
+  extends RecordSummary<Frontmatter> {
   revision: string;
 }
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -3,23 +3,31 @@
   "version": "0.1.0-alpha.1",
   "private": false,
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
+    "directory": "packages/sync"
+  },
+  "homepage": "https://mdbase.dev",
+  "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./node": {
-      "types": "./src/node.ts",
+      "types": "./dist/node.d.ts",
       "import": "./dist/node.js"
     }
   },
-  "files": ["src", "dist", "README.md"],
+  "files": ["dist", "README.md"],
   "dependencies": {
     "@mdbase/connect-protocol": "workspace:*",
     "yaml": "^2.8.1"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/tasknotes/package.json
+++ b/packages/tasknotes/package.json
@@ -3,15 +3,23 @@
   "version": "0.1.0-alpha.1",
   "private": false,
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
+    "directory": "packages/tasknotes"
+  },
+  "homepage": "https://mdbase.dev",
+  "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "files": ["dist", "README.md"],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/scripts/package-audit.mjs
+++ b/scripts/package-audit.mjs
@@ -1,0 +1,42 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const root = resolve(import.meta.dirname, "..");
+const packages = ["protocol", "client", "devkit", "sync", "tasknotes"];
+const scratch = await mkdtemp(join(tmpdir(), "mdbase-connect-packages-"));
+
+try {
+  for (const packageName of packages) {
+    const packageRoot = join(root, "packages", packageName);
+    const archive = join(scratch, `${packageName}.tgz`);
+    await run("pnpm", ["pack", "--out", archive], { cwd: packageRoot });
+    const entries = (await run("tar", ["-tzf", archive])).stdout.trim().split("\n");
+    const manifest = JSON.parse((await run("tar", ["-xOf", archive, "package/package.json"])).stdout);
+    assert(manifest.license === "MIT", `${manifest.name} is missing its MIT license metadata`);
+    assert(manifest.repository?.url, `${manifest.name} is missing repository metadata`);
+    assert(!entries.some((entry) => /(?:^|\/)src\//.test(entry)), `${manifest.name} publishes source files`);
+    assert(!entries.some((entry) => /(?:^|\/)(?:test|tests)\//.test(entry) || /\.test\.[^.]+$/.test(entry)), `${manifest.name} publishes test files`);
+    for (const target of exportTargets(manifest.exports)) {
+      if (target.includes("*")) continue;
+      const entry = `package/${target.replace(/^\.\//, "")}`;
+      assert(entries.includes(entry), `${manifest.name} exports missing file ${target}`);
+    }
+    process.stdout.write(`${manifest.name} package is consumable (${entries.length} files)\n`);
+  }
+} finally {
+  await rm(scratch, { recursive: true, force: true });
+}
+
+function exportTargets(value) {
+  if (typeof value === "string") return [value];
+  if (!value || typeof value !== "object") return [];
+  return Object.values(value).flatMap(exportTargets);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}


### PR DESCRIPTION
## Summary

- publish compiled entry points and complete package metadata for the public SDK packages
- distinguish query summaries from revision-bearing record reads in the shared types
- add a package-consumption audit to CI

## Verification

- pnpm package:audit
- pnpm typecheck
- pnpm test
- consumed the packed client and protocol tarballs from mdbase-editor