### PR TITLE
Add collection and access management

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,8 +50,12 @@ label.
   connection state aligned opposite the wordmark.
 - Desktop primary navigation uses a single horizontal tab row. Counts appear
   only when they clarify local collection state or pending action.
-- The portal keeps requests, computers, and service details in one centered
-  overview. It does not add navigation when the complete page is already visible.
+- The portal keeps requests, active application grants, computers, and service
+  details in one centered overview. It does not add navigation when the complete
+  page is already visible.
+- Collection metadata editing expands inline beneath the collection row. Name
+  and description remain visibly tied to `mdbase.yaml`; availability is a
+  separate immediate control.
 - Configuration rows are preferred over card grids. Pending access decisions
   use ruled rows. Empty states are plain text with a single next action.
 - Whitespace establishes section rhythm. Fine dividers are limited to dense

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ encryption; the relay sees routing metadata and ciphertext.
   filesystem watching, and outbound WebSocket relay.
 - `crates/connect-cli`: local administration and operation CLI.
 - `apps/desktop`: Electron controller for collection registration, application
-  access, browser pairing, local activity, tray operation, and launch-at-login.
+  metadata and availability, application access, browser pairing, local
+  activity, tray operation, and launch-at-login.
 - `services/server`: Fastify control plane and transient relay backed by
   PostgreSQL.
-- `apps/portal`: deliberately small account, computer-recovery, secure pairing,
-  and remote approval surface. Routine collection configuration stays in the
-  local controller, and there is no developer portal.
+- `apps/portal`: deliberately small account, computer management, secure
+  pairing, remote approval, and grant-review surface. Routine collection
+  configuration stays in the local controller, and there is no developer
+  portal.
 - `packages/client`: browser SDK using authorization code + PKCE.
 - `packages/protocol`: shared versioned web/relay contracts.
 - `packages/devkit`: canonical artifact validation and an explicit frontend

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -174,6 +174,36 @@ function registerIpc(): void {
     if (typeof name !== "string" || name.trim().length === 0) throw new Error("Enter a collection name.");
     return requestReadyAgent("collections.create", { path, name: name.trim() });
   });
+  ipcMain.handle("connect:collections:update-metadata", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid collection metadata.");
+    const collectionId = value.collectionId;
+    const name = value.name;
+    const description = value.description;
+    if (typeof collectionId !== "string") throw new Error("Invalid collection ID.");
+    if (typeof name !== "string" || name.trim().length === 0 || [...name.trim()].length > 100) {
+      throw new Error("Collection name must be between 1 and 100 characters.");
+    }
+    if (description !== undefined && (typeof description !== "string" || [...description.trim()].length > 500)) {
+      throw new Error("Collection description must be 500 characters or fewer.");
+    }
+    return requestReadyAgent("collections.update-metadata", {
+      collection_id: collectionId,
+      name: name.trim(),
+      description: typeof description === "string" && description.trim() ? description.trim() : undefined
+    });
+  });
+  ipcMain.handle("connect:collections:set-enabled", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid collection setting.");
+    if (typeof value.collectionId !== "string" || typeof value.enabled !== "boolean") {
+      throw new Error("Invalid collection setting.");
+    }
+    return requestReadyAgent("collections.set-enabled", {
+      collection_id: value.collectionId,
+      enabled: value.enabled
+    });
+  });
   ipcMain.handle("connect:collections:validate", async (event, collectionId: unknown) => {
     trustedIpc(event);
     if (typeof collectionId !== "string") throw new Error("Invalid collection ID.");
@@ -196,6 +226,15 @@ function registerIpc(): void {
     )).find((candidate) => candidate.path === path);
     if (!collection) throw new Error("That path is not a registered collection.");
     return shell.openPath(collection.path);
+  });
+  ipcMain.handle("connect:collections:open-config", async (event, collectionId: unknown) => {
+    trustedIpc(event);
+    if (typeof collectionId !== "string") throw new Error("Invalid collection ID.");
+    const collection = (await requestReadyAgent<Array<{ id: string; path: string }>>(
+      "collections.list"
+    )).find((candidate) => candidate.id === collectionId);
+    if (!collection) throw new Error("That collection is not registered.");
+    return shell.openPath(join(collection.path, "mdbase.yaml"));
   });
   ipcMain.handle("connect:startup:get", async (event) => {
     trustedIpc(event);
@@ -297,6 +336,13 @@ function registerIpc(): void {
     trustedIpc(event);
     if (typeof paused !== "boolean") throw new Error("Invalid pause setting.");
     return requestReadyAgent("access.pause", { paused }, 10_000);
+  });
+  ipcMain.handle("connect:account:rename-computer", async (event, name: unknown) => {
+    trustedIpc(event);
+    if (typeof name !== "string" || name.trim().length === 0 || [...name.trim()].length > 100) {
+      throw new Error("Computer name must be between 1 and 100 characters.");
+    }
+    return requestReadyAgent("account.rename-computer", { name: name.trim() }, 10_000);
   });
   ipcMain.handle("connect:apps:discover", async (event, manifestUrl: unknown) => {
     trustedIpc(event);

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -7,11 +7,17 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
   chooseCreateFolder: () => ipcRenderer.invoke("connect:collections:choose-create"),
   createCollection: (input: { path: string; name: string }) =>
     ipcRenderer.invoke("connect:collections:create", input),
+  updateCollectionMetadata: (input: { collectionId: string; name: string; description?: string }) =>
+    ipcRenderer.invoke("connect:collections:update-metadata", input),
+  setCollectionEnabled: (collectionId: string, enabled: boolean) =>
+    ipcRenderer.invoke("connect:collections:set-enabled", { collectionId, enabled }),
   validateCollection: (collectionId: string) =>
     ipcRenderer.invoke("connect:collections:validate", collectionId),
   removeCollection: (collectionId: string) =>
     ipcRenderer.invoke("connect:collections:remove", collectionId),
   openPath: (path: string) => ipcRenderer.invoke("connect:path:open", path),
+  openCollectionConfig: (collectionId: string) =>
+    ipcRenderer.invoke("connect:collections:open-config", collectionId),
   getLaunchAtLogin: () => ipcRenderer.invoke("connect:startup:get"),
   setLaunchAtLogin: (enabled: boolean) => ipcRenderer.invoke("connect:startup:set", enabled),
   getCloudConfig: () => ipcRenderer.invoke("connect:cloud:get"),
@@ -23,6 +29,7 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
   pairingStatus: (pairingId: string) => ipcRenderer.invoke("connect:pairing:status", pairingId),
   accessSnapshot: () => ipcRenderer.invoke("connect:access:snapshot"),
   setAccessPaused: (paused: boolean) => ipcRenderer.invoke("connect:access:pause", paused),
+  renameComputer: (name: string) => ipcRenderer.invoke("connect:account:rename-computer", name),
   discoverApplication: (manifestUrl: string) => ipcRenderer.invoke("connect:apps:discover", manifestUrl),
   createGrant: (input: { applicationId: string; collectionId: string; operations: string[] }) =>
     ipcRenderer.invoke("connect:grants:create", input),

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -8,6 +8,7 @@ interface AgentStatus {
 interface CollectionSummary {
   id: string;
   display_name: string;
+  description?: string;
   path: string;
   spec_version: string;
   enabled: boolean;
@@ -104,9 +105,12 @@ interface Window {
     addCollection(): Promise<CollectionSummary | null>;
     chooseCreateFolder(): Promise<string | null>;
     createCollection(input: { path: string; name: string }): Promise<CollectionSummary>;
+    updateCollectionMetadata(input: { collectionId: string; name: string; description?: string }): Promise<CollectionSummary>;
+    setCollectionEnabled(collectionId: string, enabled: boolean): Promise<CollectionSummary>;
     validateCollection(collectionId: string): Promise<unknown>;
     removeCollection(collectionId: string): Promise<CollectionSummary>;
     openPath(path: string): Promise<string>;
+    openCollectionConfig(collectionId: string): Promise<string>;
     getLaunchAtLogin(): Promise<StartupSetting>;
     setLaunchAtLogin(enabled: boolean): Promise<StartupSetting>;
     getCloudConfig(): Promise<CloudSetting>;
@@ -120,6 +124,7 @@ interface Window {
     pairingStatus(pairingId: string): Promise<{ status: "pending" | "paired"; connector?: { id: string; name: string } }>;
     accessSnapshot(): Promise<AccessSnapshot>;
     setAccessPaused(paused: boolean): Promise<{ paused: boolean }>;
+    renameComputer(name: string): Promise<{ connector: { id: string; name: string } }>;
     discoverApplication(manifestUrl: string): Promise<{ application: ApplicationSummary }>;
     createGrant(input: { applicationId: string; collectionId: string; operations: string[] }): Promise<unknown>;
     updateGrant(input: { grantId: string; operations: string[] }): Promise<unknown>;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -304,20 +304,57 @@ function Collections({ collections, busy, onAdd, onCreate, onAct, onNotice }: {
         <Empty title="No collections registered" text="Add a folder with an existing mdbase.yaml, or create a new collection." action="Create the first collection" onAction={onCreate} />
       ) : (
         <div className="collection-list">
-          {collections.map((collection) => (
-            <article className="collection-card" key={collection.id}>
-              <div className="collection-glyph" aria-hidden="true"><span /></div>
-              <div className="collection-copy"><div className="collection-title-row"><h3>{collection.display_name}</h3><span className="version">v{collection.spec_version}</span></div><button className="path" title={collection.path} onClick={() => void window.mdbaseConnect.openPath(collection.path)}>{collection.path}</button></div>
-              <div className="collection-status"><StatusDot state={collection.enabled ? "connected" : "idle"} />{collection.enabled ? "Available" : "Disabled"}</div>
-              <div className="row-actions">
-                <button className="quiet-action" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.validateCollection(collection.id); onNotice(`${collection.display_name} passed collection validation.`); })}>Validate</button>
-                <button className="quiet-action danger" disabled={busy} onClick={() => { if (window.confirm(`Remove ${collection.display_name} from mdbase connect? Its files will not be deleted.`)) void onAct(async () => { await window.mdbaseConnect.removeCollection(collection.id); onNotice(`${collection.display_name} was removed.`); }); }}>Remove</button>
-              </div>
-            </article>
-          ))}
+          {collections.map((collection) => <CollectionRow key={collection.id} collection={collection} busy={busy} onAct={onAct} onNotice={onNotice} />)}
         </div>
       )}
     </section>
+  );
+}
+
+function CollectionRow({ collection, busy, onAct, onNotice }: {
+  collection: CollectionSummary;
+  busy: boolean;
+  onAct(action: () => Promise<void>): Promise<void>;
+  onNotice(value: string): void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(collection.display_name);
+  const [description, setDescription] = useState(collection.description ?? "");
+  useEffect(() => {
+    if (!editing) {
+      setName(collection.display_name);
+      setDescription(collection.description ?? "");
+    }
+  }, [collection.description, collection.display_name, editing]);
+
+  const changed = name.trim() !== collection.display_name
+    || description.trim() !== (collection.description ?? "");
+  return (
+    <article className={`collection-card ${editing ? "editing" : ""}`}>
+      <div className="collection-summary">
+        <div className="collection-copy">
+          <div className="collection-title-row"><h3>{collection.display_name}</h3><span className="version">v{collection.spec_version}</span></div>
+          {collection.description && <p>{collection.description}</p>}
+          <button className="path" title={collection.path} onClick={() => void window.mdbaseConnect.openPath(collection.path)}>{collection.path}</button>
+        </div>
+        <div className="collection-status"><StatusDot state={collection.enabled ? "connected" : "idle"} />{collection.enabled ? "Available" : "Disabled"}</div>
+        <div className="row-actions">
+          <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : "Details"}</button>
+          <button className="quiet-action" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.setCollectionEnabled(collection.id, !collection.enabled); onNotice(collection.enabled ? `${collection.display_name} is no longer available to remote applications.` : `${collection.display_name} is available again.`); })}>{collection.enabled ? "Disable" : "Enable"}</button>
+        </div>
+      </div>
+      {editing && <div className="collection-editor">
+        <form onSubmit={(event) => { event.preventDefault(); void onAct(async () => { const updated = await window.mdbaseConnect.updateCollectionMetadata({ collectionId: collection.id, name, description }); setEditing(false); onNotice(`${updated.display_name} details were saved to mdbase.yaml.`); }); }}>
+          <label><span>Name</span><input value={name} maxLength={100} required onChange={(event) => setName(event.target.value)} /></label>
+          <label><span>Description</span><textarea value={description} maxLength={500} rows={2} placeholder="Optional" onChange={(event) => setDescription(event.target.value)} /></label>
+          <div className="editor-actions"><button type="button" className="button secondary" disabled={busy} onClick={() => void window.mdbaseConnect.openCollectionConfig(collection.id)}>Open mdbase.yaml</button><button className="button primary" disabled={busy || !changed || !name.trim()}>Save details</button></div>
+        </form>
+        <div className="collection-maintenance">
+          <button className="quiet-action" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.validateCollection(collection.id); onNotice(`${collection.display_name} passed collection validation.`); })}>Validate collection</button>
+          <button className="quiet-action danger" disabled={busy} onClick={() => { if (window.confirm(`Remove ${collection.display_name} from mdbase connect? Its files will not be deleted.`)) void onAct(async () => { await window.mdbaseConnect.removeCollection(collection.id); onNotice(`${collection.display_name} was removed.`); }); }}>Remove from mdbase connect</button>
+        </div>
+      </div>}
+    </article>
   );
 }
 
@@ -480,7 +517,7 @@ function Settings({ startup, cloud, access, status, busy, onAct, onNotice, onPai
         <section>
           <SectionHeading title="Portal connection" note="Account and routing metadata for this computer." />
           <div className="settings-rows">
-            <SettingRow label="Computer" value={access.account?.connector_name ?? "This computer"} detail={access.account?.user_email ?? "Account details unavailable while offline"} />
+            <ComputerNameSetting account={access.account} online={access.online} busy={busy} onAct={onAct} onNotice={onNotice} />
             <SettingRow label="Server" value={cloud.serverUrl ?? "Configured"} detail={access.online ? "Control service reachable" : "Using cached local policy"} mono />
             <SettingRow label="Connection" value={status?.state === "connected" ? "Connected" : "Offline"} detail="The relay connection is always outbound from this computer" />
           </div>
@@ -497,6 +534,26 @@ function Settings({ startup, cloud, access, status, busy, onAct, onNotice, onPai
       <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Local paths are never synchronized.</strong><p>The portal receives collection names, versions, stable identifiers, and grant metadata. Record payloads pass through the relay only while an operation is active.</p></div></section>
     </div>
   );
+}
+
+function ComputerNameSetting({ account, online, busy, onAct, onNotice }: {
+  account?: ConnectorAccount;
+  online: boolean;
+  busy: boolean;
+  onAct(action: () => Promise<void>): Promise<void>;
+  onNotice(value: string): void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(account?.connector_name ?? "This computer");
+  useEffect(() => {
+    if (!editing) setName(account?.connector_name ?? "This computer");
+  }, [account?.connector_name, editing]);
+  if (!editing) return <div className="setting-row"><span>Computer</span><div><strong>{account?.connector_name ?? "This computer"}</strong><small>{account?.user_email ?? "Account details unavailable while offline"}</small></div><button className="quiet-action" disabled={busy || !online} onClick={() => setEditing(true)}>Rename</button></div>;
+  return <form className="setting-row setting-editor" onSubmit={(event) => { event.preventDefault(); void onAct(async () => { const result = await window.mdbaseConnect.renameComputer(name); setEditing(false); onNotice(`This computer is now named ${result.connector.name}.`); }); }}>
+    <span>Computer</span>
+    <label><span>Computer name</span><input autoFocus value={name} maxLength={100} required onChange={(event) => setName(event.target.value)} /></label>
+    <div className="row-actions"><button type="button" className="quiet-action" disabled={busy} onClick={() => setEditing(false)}>Cancel</button><button className="button primary" disabled={busy || !name.trim() || name.trim() === account?.connector_name}>Save</button></div>
+  </form>;
 }
 
 function SettingRow({ label, value, detail, mono = false }: { label: string; value: string; detail: string; mono?: boolean }) {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -59,16 +59,24 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 
 .collection-section, .activity-section { margin-top: 30px; }
 .collection-list, .grant-list, .activity-list { display: grid; margin-top: 10px; }
-.collection-card { display: grid; grid-template-columns: minmax(170px, 1fr) auto auto; align-items: center; gap: 18px; min-height: 68px; padding: 10px 0; border-bottom: 1px solid var(--line); }
+.collection-card { border-bottom: 1px solid var(--line); }
 .collection-card:first-child { border-top: 1px solid var(--line); }
+.collection-summary { display: grid; grid-template-columns: minmax(170px, 1fr) auto auto; align-items: center; gap: 18px; min-height: 68px; padding: 10px 0; }
 .collection-glyph { display: none; }
 .collection-copy, .grant-identity { min-width: 0; }
 .collection-title-row { display: flex; align-items: center; gap: 8px; }
 .collection-title-row h3 { margin: 0; overflow: hidden; font-size: 13px; font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
+.collection-copy > p { max-width: 62ch; margin: 4px 0 0; color: var(--muted); font-size: 10px; line-height: 1.4; }
 .version { color: var(--faint); font-family: var(--mono); font-size: 8px; }
 .path { display: block; max-width: 100%; margin: 5px 0 0; padding: 0; overflow: hidden; border: 0; color: var(--muted); background: transparent; font-family: var(--mono); font-size: 9px; text-align: left; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
 .path:hover { color: var(--ink); }
 .collection-status { display: flex; align-items: center; gap: 8px; color: var(--muted); font-size: 10px; }
+.collection-editor { display: grid; gap: 14px; padding: 16px 0 18px; border-top: 1px solid var(--line); }
+.collection-editor form { display: grid; grid-template-columns: minmax(160px, 0.7fr) minmax(260px, 1.3fr) auto; align-items: end; gap: 14px; }
+.collection-editor label { display: grid; gap: 5px; }
+.collection-editor textarea { min-height: 58px; padding: 8px 10px; resize: vertical; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font: inherit; font-size: 12px; line-height: 1.4; }
+.editor-actions { display: flex; gap: 7px; }
+.collection-maintenance { display: flex; justify-content: space-between; gap: 12px; padding-top: 2px; }
 .row-actions { display: flex; align-items: center; justify-content: flex-end; gap: 3px; }
 .empty-state { display: grid; justify-items: start; padding: 32px 0 28px; border-bottom: 1px solid var(--line); text-align: left; }
 .empty-folder { display: none; }
@@ -122,12 +130,14 @@ fieldset legend { margin-bottom: 6px; }
 
 .settings-rows { border-top: 1px solid var(--line); }
 .setting-row, .setting-toggle { min-height: 64px; padding: 10px 0; border-bottom: 1px solid var(--line); }
-.setting-row { display: grid; grid-template-columns: 140px 1fr; align-items: center; gap: 20px; }
+.setting-row { display: grid; grid-template-columns: 140px minmax(0, 1fr) auto; align-items: center; gap: 20px; }
 .setting-row > span { color: var(--muted); font-size: 11px; }
 .setting-row div { display: grid; gap: 3px; }
 .setting-row strong { font-size: 13px; font-weight: 700; }
 .setting-row strong.mono { font-size: 10px; }
 .setting-row small { color: var(--muted); font-size: 10px; }
+.setting-editor label { display: grid; gap: 5px; }
+.setting-editor label > span { font-size: 9px; }
 .setting-toggle.disabled { opacity: 0.48; }
 .disconnect-button { margin-top: 14px; }
 .privacy-block { display: block; padding: 18px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
@@ -159,6 +169,8 @@ fieldset legend { margin-bottom: 6px; }
   .grant-row { grid-template-columns: minmax(120px, 0.7fr) minmax(220px, 1.3fr); }
   .grant-row .row-actions { grid-column: 1 / -1; }
   .manual-grant { grid-template-columns: 1fr 1fr; }
+  .collection-editor form { grid-template-columns: 1fr 1fr; }
+  .editor-actions { grid-column: 1 / -1; justify-content: flex-end; }
 }
 @media (max-width: 780px) {
   .content { padding-inline: 24px; }

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -16,6 +16,8 @@ import {
 } from "./api";
 import "./styles.css";
 
+const allOperations = ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename"];
+
 function Portal() {
   const pairingId = location.pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
   const authorizationId = location.pathname.match(/^\/authorize\/([0-9a-f-]+)$/i)?.[1];
@@ -158,12 +160,23 @@ function Dashboard() {
               </article>
             ))}</div></>}
         </section>
+        <section id="permissions">
+          <SectionHeading title="Application access" note="Review exact permissions, narrow them, or revoke access immediately." count={data.grants.filter((grant) => !grant.revoked_at).length} />
+          {data.grants.every((grant) => grant.revoked_at) ? (
+            <Empty title="No applications connected" text="Approved website connections will appear here." />
+          ) : (
+            <div className="portal-grant-list">{data.grants.filter((grant) => !grant.revoked_at).map((grant) => {
+              const collection = data.collections.find((candidate) => candidate.id === grant.collection_id);
+              return <PortalGrant key={grant.id} grant={grant} connectorName={collection?.connector_name ?? "Unknown computer"} onChanged={refresh} onError={setError} />;
+            })}</div>
+          )}
+        </section>
         <section id="computers">
           <SectionHeading title="Connected computers" note="Revoking a computer immediately invalidates all of its application access." count={data.connectors.length} />
           {data.connectors.length === 0 ? <Empty title="No computers connected" text="Open mdbase connect on a computer and choose Connect this computer." /> : (
             <div className="computer-list">{data.connectors.map((connector) => {
-              const count = data.collections.filter((collection) => collection.connector_id === connector.id).length;
-              return <div className="computer-row" key={connector.id}><span className="computer-icon" aria-hidden="true" /><div><strong>{connector.name}</strong><small>{count} {count === 1 ? "collection" : "collections"} · {connector.last_seen_at ? `Seen ${relativeTime(connector.last_seen_at)}` : "Not connected yet"}</small></div><span className={`availability ${connector.last_seen_at ? "online" : "idle"}`}><i />{connector.last_seen_at ? "Registered" : "Pending"}</span><button className="quiet-danger" onClick={() => { if (window.confirm(`Revoke ${connector.name}? Applications connected through it will stop working.`)) void api(`/v1/connectors/${connector.id}`, { method: "DELETE" }).then(refresh).catch((reason) => setError(message(reason))); }}>Revoke</button></div>;
+              const collections = data.collections.filter((collection) => collection.connector_id === connector.id);
+              return <ComputerRow key={connector.id} connector={connector} collectionCount={collections.length} availableCount={collections.filter((collection) => collection.enabled).length} onChanged={refresh} onError={setError} />;
             })}</div>
           )}
         </section>
@@ -175,6 +188,124 @@ function Dashboard() {
       </main>
     </div>
   );
+}
+
+function ComputerRow({ connector, collectionCount, availableCount, onChanged, onError }: {
+  connector: DashboardData["connectors"][number];
+  collectionCount: number;
+  availableCount: number;
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(connector.name);
+  const [busy, setBusy] = useState(false);
+  useEffect(() => { if (!editing) setName(connector.name); }, [connector.name, editing]);
+  const online = connector.last_seen_at !== null
+    && Date.now() - new Date(connector.last_seen_at).getTime() < 45_000;
+
+  async function rename(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim() || name.trim() === connector.name) return;
+    setBusy(true);
+    try {
+      await api(`/v1/connectors/${connector.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ name: name.trim() })
+      });
+      setEditing(false);
+      await onChanged();
+    } catch (reason) {
+      onError(message(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revoke() {
+    if (!window.confirm(`Revoke ${connector.name}? Applications connected through it will stop working.`)) return;
+    setBusy(true);
+    try {
+      await api(`/v1/connectors/${connector.id}`, { method: "DELETE" });
+      await onChanged();
+    } catch (reason) {
+      onError(message(reason));
+      setBusy(false);
+    }
+  }
+
+  return <div className={`computer-row ${editing ? "editing" : ""}`}>
+    {editing ? <form className="computer-name-form" onSubmit={(event) => void rename(event)}>
+      <label><span>Computer name</span><input autoFocus value={name} maxLength={100} onChange={(event) => setName(event.target.value)} /></label>
+      <div><button type="button" className="quiet-action" disabled={busy} onClick={() => setEditing(false)}>Cancel</button><button className="button primary" disabled={busy || !name.trim() || name.trim() === connector.name}>Save</button></div>
+    </form> : <div><strong>{connector.name}</strong><small>{collectionCount} {collectionCount === 1 ? "collection" : "collections"}, {availableCount} available · {connector.last_seen_at ? `Seen ${relativeTime(connector.last_seen_at)}` : "Not connected yet"}</small></div>}
+    {!editing && <><span className={`availability ${online ? "online" : "idle"}`}><i />{online ? "Online" : connector.last_seen_at ? "Offline" : "Pending"}</span><div className="computer-actions"><button className="quiet-action" disabled={busy} onClick={() => setEditing(true)}>Rename</button><button className="quiet-danger" disabled={busy} onClick={() => void revoke()}>Revoke</button></div></>}
+  </div>;
+}
+
+function PortalGrant({ grant, connectorName, onChanged, onError }: {
+  grant: DashboardData["grants"][number];
+  connectorName: string;
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  const [operations, setOperations] = useState(new Set(grant.operations));
+  const [busy, setBusy] = useState(false);
+  useEffect(() => setOperations(new Set(grant.operations)), [grant.operations]);
+  const orderedOperations = [
+    ...allOperations.filter((operation) => grant.operations.includes(operation)),
+    ...grant.operations.filter((operation) => !allOperations.includes(operation))
+  ];
+  const changed = orderedOperations.some((operation) => operations.has(operation) !== grant.operations.includes(operation));
+
+  function toggle(operation: string) {
+    setOperations((current) => {
+      const next = new Set(current);
+      if (next.has(operation)) next.delete(operation); else next.add(operation);
+      return next;
+    });
+  }
+
+  async function save() {
+    setBusy(true);
+    try {
+      await api(`/v1/grants/${grant.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ operations: orderedOperations.filter((operation) => operations.has(operation)) })
+      });
+      await onChanged();
+    } catch (reason) {
+      onError(message(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revoke() {
+    if (!window.confirm(`Revoke ${grant.application_name} access to ${grant.collection_name}?`)) return;
+    setBusy(true);
+    try {
+      await api(`/v1/grants/${grant.id}`, { method: "DELETE" });
+      await onChanged();
+    } catch (reason) {
+      onError(message(reason));
+      setBusy(false);
+    }
+  }
+
+  return <details className="portal-grant">
+    <summary>
+      <div><strong>{grant.application_name}</strong><small>{host(grant.homepage)}</small></div>
+      <div><strong>{grant.collection_name}</strong><small>{connectorName}</small></div>
+      <span>{grant.operations.length} {grant.operations.length === 1 ? "permission" : "permissions"}</span>
+      <b>Review</b>
+    </summary>
+    <div className="portal-grant-detail">
+      <div><p className="detail-label">Allowed actions</p><div className="permission-options grant-permissions">{orderedOperations.map((operation) => <label key={operation}><input type="checkbox" checked={operations.has(operation)} disabled={busy} onChange={() => toggle(operation)} /><span>{operationLabel(operation)}</span></label>)}</div></div>
+      <div className="grant-context"><p><span>Scope</span><strong>{grant.scope.contracts.length ? scopeDescription(grant.scope.contracts) : "All record types in this collection."}</strong></p><p><span>Connected</span><strong>{relativeTime(grant.created_at)}</strong></p></div>
+      <div className="grant-actions"><button className="button secondary" disabled={busy || !changed || operations.size === 0} onClick={() => void save()}>Save narrower access</button><button className="quiet-danger" disabled={busy} onClick={() => void revoke()}>Revoke access</button></div>
+    </div>
+  </details>;
 }
 
 function Pairing({ pairingId }: { pairingId: string }) {

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -124,7 +124,8 @@ h1 {
 
 .computer-list,
 .account-rows,
-.request-list {
+.request-list,
+.portal-grant-list {
   border-top: 1px solid var(--line);
 }
 
@@ -144,6 +145,40 @@ h1 {
 .computer-row > div {
   display: grid;
   gap: 0.2rem;
+}
+
+.computer-actions {
+  display: flex !important;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: 0.15rem !important;
+}
+
+.computer-name-form {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(14rem, 1fr) auto;
+  align-items: end;
+  gap: 1rem;
+  width: 100%;
+  padding: 0.75rem 0;
+}
+
+.computer-name-form label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.computer-name-form label span {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.computer-name-form > div {
+  display: flex;
+  grid-auto-flow: initial;
+  gap: 0.4rem;
 }
 
 .computer-row strong,
@@ -191,8 +226,136 @@ h1 {
   cursor: pointer;
 }
 
+.quiet-action {
+  padding: 0.35rem 0.45rem;
+  border: 0;
+  border-radius: 3px;
+  color: var(--ink-soft);
+  background: transparent;
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.quiet-action:hover,
 .quiet-danger:hover {
   background: var(--paper-hover);
+}
+
+.quiet-action:disabled,
+.quiet-danger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.portal-grant {
+  border-bottom: 1px solid var(--line);
+}
+
+.portal-grant summary {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) minmax(10rem, 1fr) auto auto;
+  align-items: center;
+  gap: 1.25rem;
+  min-height: 4.5rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.portal-grant summary::-webkit-details-marker {
+  display: none;
+}
+
+.portal-grant summary > div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.portal-grant summary strong {
+  overflow: hidden;
+  font-size: 0.82rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.portal-grant summary small,
+.portal-grant summary > span {
+  overflow: hidden;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.portal-grant summary small {
+  font-family: var(--mono);
+}
+
+.portal-grant summary b {
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+}
+
+.portal-grant summary b::after {
+  content: " +";
+  color: var(--ink-muted);
+}
+
+.portal-grant[open] summary b::after {
+  content: " −";
+}
+
+.portal-grant-detail {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1.2fr) minmax(13rem, 0.8fr);
+  gap: 1.4rem 2.5rem;
+  padding: 0.2rem 0 1.4rem;
+}
+
+.detail-label {
+  margin: 0 0 0.55rem;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.grant-permissions {
+  justify-content: flex-start;
+}
+
+.grant-context {
+  display: grid;
+  align-content: start;
+  gap: 0.65rem;
+}
+
+.grant-context p {
+  display: grid;
+  gap: 0.2rem;
+  margin: 0;
+}
+
+.grant-context span {
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+}
+
+.grant-context strong {
+  font-size: 0.72rem;
+  font-weight: 400;
+  line-height: 1.45;
+}
+
+.grant-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--line);
 }
 
 .account-row {
@@ -544,6 +707,27 @@ select {
 
   .computer-row {
     grid-template-columns: 1fr auto;
+  }
+
+  .computer-name-form,
+  .portal-grant-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-grant summary {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.55rem 1rem;
+    padding: 0.8rem 0;
+  }
+
+  .portal-grant summary > div:nth-child(2),
+  .portal-grant summary > span {
+    grid-column: 1;
+  }
+
+  .portal-grant summary > b {
+    grid-column: 2;
+    grid-row: 1;
   }
 
   .availability {

--- a/crates/connect-agent/src/cloud.rs
+++ b/crates/connect-agent/src/cloud.rs
@@ -1,7 +1,7 @@
 use mdbase_connect_core::ConnectError;
 use mdbase_connect_protocol::{
     AccessSnapshot, ApplicationDiscoverParams, AuthorizationApproveParams, AuthorizationIdParams,
-    GrantCreateParams, GrantIdParams, GrantUpdateParams,
+    ComputerNameParams, GrantCreateParams, GrantIdParams, GrantUpdateParams,
 };
 use reqwest::{Client, Method, Response};
 use serde::de::DeserializeOwned;
@@ -25,6 +25,18 @@ impl CloudControlClient {
 
     pub async fn snapshot(&self) -> Result<AccessSnapshot, ConnectError> {
         self.json(Method::GET, "/v1/connectors/control", None).await
+    }
+
+    pub async fn rename_computer(
+        &self,
+        params: &ComputerNameParams,
+    ) -> Result<Value, ConnectError> {
+        self.json(
+            Method::PATCH,
+            "/v1/connectors/self",
+            Some(serde_json::to_value(params)?),
+        )
+        .await
     }
 
     pub async fn discover(

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -381,6 +381,26 @@ impl AgentState {
                 }
                 result.and_then(|value| serde_json::to_value(value).map_err(ConnectError::from))
             }
+            ControlCommand::CollectionUpdateMetadata(params) => {
+                let result = self.registry.update_metadata(
+                    params.collection_id,
+                    &params.name,
+                    params.description.as_deref(),
+                );
+                if result.is_ok() {
+                    self.watcher.rescan(params.collection_id);
+                }
+                result.and_then(|value| serde_json::to_value(value).map_err(ConnectError::from))
+            }
+            ControlCommand::CollectionSetEnabled(params) => {
+                let result = self
+                    .registry
+                    .set_enabled(params.collection_id, params.enabled);
+                if result.is_ok() {
+                    self.refresh_watchers();
+                }
+                result.and_then(|value| serde_json::to_value(value).map_err(ConnectError::from))
+            }
             ControlCommand::CollectionRemove(params) => {
                 let result = self.registry.remove(params.collection_id);
                 if result.is_ok() {
@@ -405,6 +425,10 @@ impl AgentState {
                 .registry
                 .set_paused(params.paused)
                 .map(|_| serde_json::json!({ "paused": params.paused })),
+            ControlCommand::AccountRenameComputer(params) => match self.cloud() {
+                Ok(cloud) => cloud.rename_computer(&params).await,
+                Err(error) => Err(error),
+            },
             ControlCommand::ApplicationDiscover(params) => match self.cloud() {
                 Ok(cloud) => cloud.discover(&params).await,
                 Err(error) => Err(error),
@@ -510,6 +534,7 @@ impl AgentState {
         for pending in &mut snapshot.pending_authorizations {
             pending.compatible_collection_ids = collections
                 .iter()
+                .filter(|collection| collection.enabled)
                 .filter_map(|collection| {
                     self.registry
                         .is_compatible(collection.id, &pending.requirements)

--- a/crates/connect-core/Cargo.toml
+++ b/crates/connect-core/Cargo.toml
@@ -15,8 +15,8 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -14,8 +14,10 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::env;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use tempfile::NamedTempFile;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -137,6 +139,7 @@ impl CollectionRegistry {
                 id TEXT PRIMARY KEY,
                 path TEXT NOT NULL UNIQUE,
                 display_name TEXT NOT NULL,
+                description TEXT,
                 spec_version TEXT NOT NULL,
                 enabled INTEGER NOT NULL DEFAULT 1,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -206,6 +209,7 @@ impl CollectionRegistry {
             "ALTER TABLE grants ADD COLUMN created_at TEXT NOT NULL DEFAULT ''",
             "ALTER TABLE grants ADD COLUMN scope TEXT NOT NULL DEFAULT '{\"contracts\":[]}'",
             "ALTER TABLE grants ADD COLUMN encryption TEXT",
+            "ALTER TABLE collections ADD COLUMN description TEXT",
         ] {
             if let Err(error) = connection.execute(migration, []) {
                 if !error.to_string().contains("duplicate column name") {
@@ -219,7 +223,7 @@ impl CollectionRegistry {
     pub fn list(&self) -> Result<Vec<CollectionSummary>, ConnectError> {
         let connection = self.connection()?;
         let mut statement = connection.prepare(
-            "SELECT id, display_name, path, spec_version, enabled
+            "SELECT id, display_name, description, path, spec_version, enabled
              FROM collections ORDER BY display_name COLLATE NOCASE, path",
         )?;
         let rows = statement.query_map([], |row| {
@@ -227,15 +231,16 @@ impl CollectionRegistry {
             Ok((
                 id,
                 row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(2)?,
                 row.get::<_, String>(3)?,
-                row.get::<_, bool>(4)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, bool>(5)?,
             ))
         })?;
 
         let mut collections = rows
             .map(|row| {
-                let (id, display_name, path, spec_version, enabled) = row?;
+                let (id, display_name, description, path, spec_version, enabled) = row?;
                 let id = Uuid::parse_str(&id).map_err(|error| {
                     ConnectError::CollectionOpen(format!(
                         "invalid collection id in registry: {error}"
@@ -244,6 +249,7 @@ impl CollectionRegistry {
                 Ok(CollectionSummary {
                     id,
                     display_name,
+                    description,
                     path,
                     spec_version,
                     enabled,
@@ -254,6 +260,7 @@ impl CollectionRegistry {
         drop(statement);
         drop(connection);
         for collection in &mut collections {
+            let _ = self.refresh_summary_metadata(collection);
             if let Ok(description) = self.describe(collection.id) {
                 collection.contracts = description
                     .contracts
@@ -265,6 +272,12 @@ impl CollectionRegistry {
                     .collect();
             }
         }
+        collections.sort_by(|left, right| {
+            left.display_name
+                .to_lowercase()
+                .cmp(&right.display_name.to_lowercase())
+                .then_with(|| left.path.cmp(&right.path))
+        });
         Ok(collections)
     }
 
@@ -292,25 +305,22 @@ impl CollectionRegistry {
         let metadata = read_collection_metadata(&path)?;
         let path_string = path.to_string_lossy().to_string();
         let id = Uuid::new_v5(&COLLECTION_NAMESPACE, path_string.as_bytes());
-        let display_name = metadata
-            .name
-            .or_else(|| {
-                path.file_name()
-                    .map(|name| name.to_string_lossy().to_string())
-            })
-            .unwrap_or_else(|| "Collection".to_string());
+        let display_name = collection_display_name(&metadata, &path);
+        let description = normalized_optional(metadata.description);
 
         self.connection()?.execute(
-            "INSERT INTO collections (id, path, display_name, spec_version, enabled)
-             VALUES (?1, ?2, ?3, ?4, 1)
+            "INSERT INTO collections (id, path, display_name, description, spec_version, enabled)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1)
              ON CONFLICT(path) DO UPDATE SET
                display_name = excluded.display_name,
+               description = excluded.description,
                spec_version = excluded.spec_version,
                updated_at = CURRENT_TIMESTAMP",
             params![
                 id.to_string(),
                 path_string,
                 display_name,
+                description,
                 metadata.spec_version
             ],
         )?;
@@ -346,20 +356,94 @@ impl CollectionRegistry {
         self.add(path)
     }
 
+    pub fn update_metadata(
+        &self,
+        id: Uuid,
+        name: &str,
+        description: Option<&str>,
+    ) -> Result<CollectionSummary, ConnectError> {
+        let name = name.trim();
+        if name.is_empty() || name.chars().count() > 100 {
+            return Err(ConnectError::CollectionOpen(
+                "Collection name must be between 1 and 100 characters.".to_string(),
+            ));
+        }
+        let description = description.map(str::trim).filter(|value| !value.is_empty());
+        if description.is_some_and(|value| value.chars().count() > 500) {
+            return Err(ConnectError::CollectionOpen(
+                "Collection description must be 500 characters or fewer.".to_string(),
+            ));
+        }
+
+        let registered = self.get(id)?;
+        let config_path = Path::new(&registered.path).join("mdbase.yaml");
+        let source = fs::read_to_string(&config_path)?;
+        let mut config: serde_yaml::Value = serde_yaml::from_str(&source)?;
+        let mapping = config.as_mapping_mut().ok_or_else(|| {
+            ConnectError::CollectionOpen("mdbase.yaml must contain a YAML mapping.".to_string())
+        })?;
+        mapping.insert(
+            serde_yaml::Value::String("name".to_string()),
+            serde_yaml::Value::String(name.to_string()),
+        );
+        let description_key = serde_yaml::Value::String("description".to_string());
+        if let Some(description) = description {
+            mapping.insert(
+                description_key,
+                serde_yaml::Value::String(description.to_string()),
+            );
+        } else {
+            mapping.remove(&description_key);
+        }
+
+        let serialized = serde_yaml::to_string(&config)?;
+        let root = config_path.parent().ok_or_else(|| {
+            ConnectError::CollectionOpen("Collection config has no parent folder.".to_string())
+        })?;
+        let permissions = fs::metadata(&config_path)?.permissions();
+        let mut temporary = NamedTempFile::new_in(root)?;
+        temporary.as_file().set_permissions(permissions)?;
+        temporary.write_all(serialized.as_bytes())?;
+        temporary.as_file().sync_all()?;
+        temporary
+            .persist(&config_path)
+            .map_err(|error| ConnectError::Io(error.error))?;
+
+        let mut updated = registered;
+        self.refresh_summary_metadata(&mut updated)?;
+        self.providers
+            .lock()
+            .map_err(|_| ConnectError::CollectionOpen("provider registry lock poisoned".into()))?
+            .remove(&id);
+        Ok(updated)
+    }
+
+    pub fn set_enabled(&self, id: Uuid, enabled: bool) -> Result<CollectionSummary, ConnectError> {
+        let changed = self.connection()?.execute(
+            "UPDATE collections SET enabled = ?2, updated_at = CURRENT_TIMESTAMP WHERE id = ?1",
+            params![id.to_string(), enabled],
+        )?;
+        if changed == 0 {
+            return Err(ConnectError::CollectionNotFound(id));
+        }
+        self.get(id)
+    }
+
     pub fn get(&self, id: Uuid) -> Result<CollectionSummary, ConnectError> {
         let connection = self.connection()?;
         let row = connection
             .query_row(
-                "SELECT display_name, path, spec_version, enabled
+                "SELECT display_name, description, path, spec_version, enabled
                  FROM collections WHERE id = ?1",
                 [id.to_string()],
                 |row| {
                     Ok(CollectionSummary {
                         id,
                         display_name: row.get(0)?,
-                        path: row.get(1)?,
-                        spec_version: row.get(2)?,
-                        enabled: row.get(3)?,
+                        description: row.get(1)?,
+                        path: row.get(2)?,
+                        spec_version: row.get(3)?,
+                        enabled: row.get(4)?,
                         contracts: Vec::new(),
                     })
                 },
@@ -427,6 +511,11 @@ impl CollectionRegistry {
         scope: &GrantScope,
     ) -> Result<Value, ConnectError> {
         let registered = self.get(id)?;
+        if !registered.enabled {
+            return Err(ConnectError::AccessDenied(
+                "This collection is disabled on its computer.".to_string(),
+            ));
+        }
         let provider = self.provider_for(&registered)?;
         provider.with_collection(|collection| {
             self.scoped_operation_loaded(&registered, collection, operation, input, scope)
@@ -746,6 +835,37 @@ impl CollectionRegistry {
         )?;
         transaction.commit()?;
         Ok(cursor as u64)
+    }
+
+    fn refresh_summary_metadata(
+        &self,
+        collection: &mut CollectionSummary,
+    ) -> Result<(), ConnectError> {
+        let path = Path::new(&collection.path);
+        let metadata = read_collection_metadata(path)?;
+        let display_name = collection_display_name(&metadata, path);
+        let description = normalized_optional(metadata.description);
+        if collection.display_name != display_name
+            || collection.description != description
+            || collection.spec_version != metadata.spec_version
+        {
+            self.connection()?.execute(
+                "UPDATE collections
+                 SET display_name = ?2, description = ?3, spec_version = ?4,
+                     updated_at = CURRENT_TIMESTAMP
+                 WHERE id = ?1",
+                params![
+                    collection.id.to_string(),
+                    display_name,
+                    description,
+                    metadata.spec_version
+                ],
+            )?;
+            collection.display_name = display_name;
+            collection.description = description;
+            collection.spec_version = metadata.spec_version;
+        }
+        Ok(())
     }
 
     pub fn changes(
@@ -1374,11 +1494,33 @@ struct CollectionMetadata {
     spec_version: String,
     #[serde(default)]
     name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
 }
 
 fn read_collection_metadata(root: &Path) -> Result<CollectionMetadata, ConnectError> {
     let source = fs::read_to_string(root.join("mdbase.yaml"))?;
     Ok(serde_yaml::from_str(&source)?)
+}
+
+fn collection_display_name(metadata: &CollectionMetadata, path: &Path) -> String {
+    metadata
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .unwrap_or_else(|| "Collection".to_string())
+}
+
+fn normalized_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn error_message(value: &Value, fallback: &str) -> String {
@@ -1460,6 +1602,62 @@ mod tests {
             "unregistering must not delete collection files"
         );
         assert!(registry.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn collection_metadata_refreshes_edits_and_disabled_collections_fail_closed() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("notes");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let created = registry.create(&root, Some("Notes")).unwrap();
+        assert_eq!(created.description, None);
+
+        let config_path = root.join("mdbase.yaml");
+        let mut config: serde_yaml::Value =
+            serde_yaml::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        let mapping = config.as_mapping_mut().unwrap();
+        mapping.insert(
+            serde_yaml::Value::String("name".to_string()),
+            serde_yaml::Value::String("External name".to_string()),
+        );
+        mapping.insert(
+            serde_yaml::Value::String("description".to_string()),
+            serde_yaml::Value::String("Changed outside the app".to_string()),
+        );
+        mapping.insert(
+            serde_yaml::Value::String("x-preview".to_string()),
+            serde_yaml::from_str("{ keep: true }").unwrap(),
+        );
+        fs::write(&config_path, serde_yaml::to_string(&config).unwrap()).unwrap();
+
+        let refreshed = registry.list().unwrap().remove(0);
+        assert_eq!(refreshed.display_name, "External name");
+        assert_eq!(
+            refreshed.description.as_deref(),
+            Some("Changed outside the app")
+        );
+
+        let updated = registry
+            .update_metadata(created.id, "Edited safely", Some("A useful collection"))
+            .unwrap();
+        assert_eq!(updated.display_name, "Edited safely");
+        assert_eq!(updated.description.as_deref(), Some("A useful collection"));
+        let persisted: serde_yaml::Value =
+            serde_yaml::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(persisted["x-preview"]["keep"], true);
+
+        let disabled = registry.set_enabled(created.id, false).unwrap();
+        assert!(!disabled.enabled);
+        assert!(matches!(
+            registry.scoped_operation(
+                created.id,
+                "describe",
+                &json!({}),
+                &GrantScope { contracts: vec![] }
+            ),
+            Err(ConnectError::AccessDenied(message)) if message.contains("disabled")
+        ));
     }
 
     #[test]

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -37,6 +37,10 @@ pub enum ControlCommand {
     CollectionAdd(CollectionPathParams),
     #[serde(rename = "collections.create")]
     CollectionCreate(CollectionCreateParams),
+    #[serde(rename = "collections.update-metadata")]
+    CollectionUpdateMetadata(CollectionMetadataParams),
+    #[serde(rename = "collections.set-enabled")]
+    CollectionSetEnabled(CollectionEnabledParams),
     #[serde(rename = "collections.remove")]
     CollectionRemove(CollectionIdParams),
     #[serde(rename = "collections.validate")]
@@ -47,6 +51,8 @@ pub enum ControlCommand {
     AccessSnapshot,
     #[serde(rename = "access.pause")]
     AccessPause(AccessPauseParams),
+    #[serde(rename = "account.rename-computer")]
+    AccountRenameComputer(ComputerNameParams),
     #[serde(rename = "apps.discover")]
     ApplicationDiscover(ApplicationDiscoverParams),
     #[serde(rename = "grants.create")]
@@ -76,6 +82,20 @@ pub struct CollectionCreateParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollectionMetadataParams {
+    pub collection_id: Uuid,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollectionEnabledParams {
+    pub collection_id: Uuid,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollectionIdParams {
     pub collection_id: Uuid,
 }
@@ -91,6 +111,11 @@ pub struct CollectionOperationParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccessPauseParams {
     pub paused: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComputerNameParams {
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -207,6 +232,8 @@ pub enum AgentConnectionState {
 pub struct CollectionSummary {
     pub id: Uuid,
     pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub path: String,
     pub spec_version: String,
     pub enabled: bool,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -44,7 +44,8 @@ in the portal or copied through the clipboard.
 Once paired, use the local app to create or register collections, inspect app
 manifests, approve pending requests, edit or revoke grants, pause all remote
 access, and review local activity. The portal remains available for account
-state and emergency computer revocation.
+state, computer naming and revocation, remote grant review, narrowing, and
+revocation.
 
 For headless development, the agent still accepts an explicitly provisioned
 connector token:

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -50,6 +50,7 @@ select {
 button:focus-visible,
 input:focus-visible,
 select:focus-visible,
+textarea:focus-visible,
 a:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -327,6 +327,60 @@ describe("mdbase connect server", () => {
       expect.objectContaining({ display_name: "Workouts" })
     );
     expect(dashboard.json().grants[0].application_name).toBe("Workout Tracker");
+
+    const renamedComputer = await app.inject({
+      method: "PATCH",
+      url: `/v1/connectors/${connector.connector.id}`,
+      headers: { cookie },
+      payload: { name: "Desk computer" }
+    });
+    expect(renamedComputer.statusCode).toBe(200);
+    expect(renamedComputer.json().connector.name).toBe("Desk computer");
+    const locallyRenamedComputer = await app.inject({
+      method: "PATCH",
+      url: "/v1/connectors/self",
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: { name: "Studio computer" }
+    });
+    expect(locallyRenamedComputer.statusCode).toBe(200);
+    expect(locallyRenamedComputer.json().connector.name).toBe("Studio computer");
+
+    const broadenedForTest = await app.inject({
+      method: "POST",
+      url: "/v1/grants",
+      headers: { cookie },
+      payload: {
+        application_id: applicationId,
+        collection_id: collectionId,
+        operations: ["read", "query"]
+      }
+    });
+    expect(broadenedForTest.statusCode).toBe(201);
+    const managedGrantId = broadenedForTest.json().grant.id as string;
+    const narrowed = await app.inject({
+      method: "PATCH",
+      url: `/v1/grants/${managedGrantId}`,
+      headers: { cookie },
+      payload: { operations: ["read"] }
+    });
+    expect(narrowed.statusCode).toBe(200);
+    expect(narrowed.json().grant.operations).toEqual(["read"]);
+    const permissionExpansion = await app.inject({
+      method: "PATCH",
+      url: `/v1/grants/${managedGrantId}`,
+      headers: { cookie },
+      payload: { operations: ["read", "query"] }
+    });
+    expect(permissionExpansion.statusCode).toBe(409);
+    expect(permissionExpansion.json().error.code).toBe("permission_expansion_requires_approval");
+    const narrowedPolicy = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/control",
+      headers: { authorization: `Bearer ${connector.token}` }
+    });
+    expect(narrowedPolicy.json().grants).toContainEqual(
+      expect.objectContaining({ id: managedGrantId, operations: ["read"] })
+    );
   });
 
   it("uses a trusted Tailscale identity instead of a development session", async () => {

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -489,6 +489,35 @@ export async function buildApp(options: BuildOptions) {
     return reply.code(201).send({ connector: connector.rows[0], token });
   });
 
+  app.patch("/v1/connectors/self", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const input = z.object({ name: z.string().trim().min(1).max(100) }).strict().parse(request.body);
+    const renamed = await options.db.query<{ id: string; name: string }>(
+      "UPDATE connectors SET name = $2 WHERE id = $1 RETURNING id, name",
+      [connector.id, input.name]
+    );
+    await audit(options.db, connector.user_id, "connector.renamed", connector.id, {
+      name: input.name,
+      source: "local_controller"
+    });
+    return { connector: renamed.rows[0] };
+  });
+
+  app.patch("/v1/connectors/:connectorId", async (request, reply) => {
+    const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
+    if (!user) return;
+    const { connectorId } = z.object({ connectorId: z.uuid() }).parse(request.params);
+    const input = z.object({ name: z.string().trim().min(1).max(100) }).strict().parse(request.body);
+    const renamed = await options.db.query<{ id: string; name: string }>(
+      "UPDATE connectors SET name = $3 WHERE id = $1 AND user_id = $2 RETURNING id, name",
+      [connectorId, user.id, input.name]
+    );
+    if (!renamed.rows[0]) return reply.code(404).send(apiError("connector_not_found", "Computer not found."));
+    await audit(options.db, user.id, "connector.renamed", connectorId, { name: input.name });
+    return { connector: renamed.rows[0] };
+  });
+
   app.delete("/v1/connectors/:connectorId", async (request, reply) => {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
@@ -938,6 +967,46 @@ export async function buildApp(options: BuildOptions) {
     await relay.pushPolicy(ownership.rows[0].connector_id);
     await audit(options.db, user.id, "grant.created", grant.id, input);
     return reply.code(201).send({ grant });
+  });
+
+  app.patch("/v1/grants/:grantId", async (request, reply) => {
+    const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
+    if (!user) return;
+    const { grantId } = z.object({ grantId: z.uuid() }).parse(request.params);
+    const input = z.object({
+      operations: z.array(operationSchema).min(1)
+    }).strict().parse(request.body);
+    const active = await options.db.query<{
+      id: string;
+      connector_id: string;
+      operations: string[];
+      encryption: GrantEncryption | null;
+    }>(
+      `SELECT g.id, g.operations, g.encryption, col.connector_id FROM grants g
+       JOIN collections col ON col.id = g.collection_id
+       WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL`,
+      [grantId, user.id]
+    );
+    const current = active.rows[0];
+    if (!current) return reply.code(404).send(apiError("grant_not_found", "Active grant not found."));
+    const operations = [...new Set(input.operations)];
+    if (operations.some((operation) => !current.operations.includes(operation))) {
+      return reply.code(409).send(apiError(
+        "permission_expansion_requires_approval",
+        "Existing access can be narrowed here, but broader access requires a new application request."
+      ));
+    }
+    const updated = await options.db.query<{ id: string; operations: string[] }>(
+      "UPDATE grants SET operations = $2::jsonb WHERE id = $1 RETURNING id, operations",
+      [grantId, JSON.stringify(operations)]
+    );
+    if (current.encryption) await rotateGrantEncryption(options.db, grantId);
+    await relay.pushPolicy(current.connector_id);
+    await audit(options.db, user.id, "grant.narrowed", grantId, {
+      previous_operations: current.operations,
+      operations
+    });
+    return { grant: updated.rows[0] };
   });
 
   app.delete("/v1/grants/:grantId", async (request, reply) => {


### PR DESCRIPTION
## Summary

- add local collection metadata editing, enable/disable controls, validation, and fail-closed enforcement
- add computer naming in the desktop client and hosted portal
- add portal application-access management with permission narrowing and revocation
- keep the desktop and portal information architecture and styling aligned
- document the management model and self-hosting behavior

## Validation

- cargo fmt --all
- cargo test --workspace
- pnpm build
- pnpm typecheck
- pnpm test
- pnpm e2e
- node scripts/sync-e2e.mjs
- desktop and mobile visual smoke testing