### PR TITLE
Expose portable collection metadata

### DIFF
--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -635,6 +635,7 @@ impl CollectionRegistry {
     ) -> Result<CollectionDescription, ConnectError> {
         let mut types = Vec::new();
         let mut contracts = Vec::new();
+        let mut configuration = None;
         if collection.spec_profile == SpecProfile::V03 {
             let report = mdbase::v03::inspect_collection(Path::new(&registered.path));
             if !report.valid {
@@ -645,6 +646,7 @@ impl CollectionRegistry {
                     .unwrap_or_else(|| "Collection type metadata is invalid".to_string());
                 return Err(ConnectError::CollectionOpen(message));
             }
+            configuration = report.config.as_ref().and_then(portable_configuration);
             for type_file in report.types {
                 let description = type_file
                     .frontmatter
@@ -680,6 +682,12 @@ impl CollectionRegistry {
                     name: type_file.name,
                     version: type_file.version,
                     description,
+                    path: Some(type_file.path),
+                    definition: type_file
+                        .frontmatter
+                        .as_object()
+                        .cloned()
+                        .map(Value::Object),
                     schema: type_file.schema,
                     collection: collection_metadata,
                     lifecycle,
@@ -707,6 +715,7 @@ impl CollectionRegistry {
             change_cursor: self.current_change_cursor(registered.id)?,
             types,
             contracts,
+            configuration,
         })
     }
 
@@ -1188,6 +1197,48 @@ fn parse_registry_uuid(value: &str) -> Result<Uuid, ConnectError> {
     })
 }
 
+fn portable_configuration(configuration: &Value) -> Option<Value> {
+    let source = configuration.as_object()?;
+    let mut result = serde_json::Map::new();
+    if let Some(spec_version) = source.get("spec_version") {
+        result.insert("spec_version".to_string(), spec_version.clone());
+    }
+    if let Some(settings) = select_configuration_fields(
+        source.get("settings"),
+        &[
+            "types_folder",
+            "record_extensions",
+            "validation",
+            "explicit_type_keys",
+            "id_field",
+            "include_subfolders",
+            "exclude",
+        ],
+    ) {
+        result.insert("settings".to_string(), settings);
+    }
+    if let Some(runtime) = select_configuration_fields(
+        source.get("runtime"),
+        &["profile_version", "enabled", "contract_mode", "policy"],
+    ) {
+        result.insert("runtime".to_string(), runtime);
+    }
+    Some(Value::Object(result))
+}
+
+fn select_configuration_fields(value: Option<&Value>, fields: &[&str]) -> Option<Value> {
+    let source = value?.as_object()?;
+    let selected = fields
+        .iter()
+        .filter_map(|field| {
+            source
+                .get(*field)
+                .map(|value| ((*field).to_string(), value.clone()))
+        })
+        .collect::<serde_json::Map<_, _>>();
+    Some(Value::Object(selected))
+}
+
 fn required_string<'a>(input: &'a Value, key: &str) -> Result<&'a str, ConnectError> {
     input.get(key).and_then(Value::as_str).ok_or_else(|| {
         ConnectError::AccessDenied(format!("Scoped operation requires a valid '{key}' value."))
@@ -1591,12 +1642,26 @@ x-tasknotes:
     }
 
     #[test]
-    fn describe_exposes_schema_contracts_without_local_paths() {
+    fn describe_exposes_complete_portable_type_metadata_without_absolute_paths() {
         let state = tempdir().unwrap();
         let collection_parent = tempdir().unwrap();
         let root = collection_parent.path().join("tasks");
         let registry = CollectionRegistry::open(state.path()).unwrap();
         let collection = registry.create(&root, Some("Tasks")).unwrap();
+        fs::write(
+            root.join("mdbase.yaml"),
+            r#"spec_version: 0.3.0
+settings:
+  validation: warn
+  x-private: not-for-apps
+runtime:
+  profile_version: 0.1.0
+  enabled: false
+x-private:
+  token: not-for-apps
+"#,
+        )
+        .unwrap();
         fs::write(
             root.join("_types/task.md"),
             r#"---
@@ -1626,9 +1691,27 @@ x-tasknotes:
             description.types[0].schema["properties"]["title"]["type"],
             "string"
         );
+        assert_eq!(description.types[0].path.as_deref(), Some("_types/task.md"));
+        assert_eq!(
+            description.types[0]
+                .definition
+                .as_ref()
+                .and_then(|value| value.pointer("/schema/dialect"))
+                .and_then(Value::as_str),
+            Some("json-schema-2020-12")
+        );
+        assert_eq!(
+            description
+                .configuration
+                .as_ref()
+                .and_then(|value| value.get("spec_version"))
+                .and_then(Value::as_str),
+            Some("0.3.0")
+        );
         assert_eq!(description.contracts[0].id, "tasknotes.task");
         let serialized = serde_json::to_string(&description).unwrap();
         assert!(!serialized.contains(root.to_string_lossy().as_ref()));
+        assert!(!serialized.contains("not-for-apps"));
     }
 
     #[test]

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -221,6 +221,10 @@ pub struct CollectionTypeDescriptor {
     pub version: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition: Option<Value>,
     pub schema: Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collection: Option<Value>,
@@ -248,6 +252,8 @@ pub struct CollectionDescription {
     pub change_cursor: u64,
     pub types: Vec<CollectionTypeDescriptor>,
     pub contracts: Vec<CollectionContractDescriptor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub configuration: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -612,6 +618,7 @@ mod tests {
             change_cursor: 0,
             types: vec![],
             contracts: vec![],
+            configuration: None,
         };
         assert_schema(
             "/$defs/collectionDescription",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,8 +62,10 @@ traversal into other records until the query engine can carry the grant scope
 through link resolution.
 
 `describe` returns the collection's spec version, supported operations, JSON
-Schemas, type metadata, `x-*` extensions, discovered contract declarations,
-and the current change cursor. It does not return the collection path.
+Schemas, collection-relative type paths, complete portable type definitions,
+canonical collection settings, `x-*` type extensions, discovered contract
+declarations, and the current change cursor. It omits absolute paths and
+implementation-specific or extension values from the collection configuration.
 
 ## Change delivery
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -46,8 +46,9 @@ offers compatible collections and derives the record scope from this declaration
 
 The SDK returns the mdbase operation envelope, carries revision tokens in typed
 record results, and accepts `if_revision` on mutations. `describe()` exposes
-JSON Schemas and optional domain contracts. `watch()` resumes from a local
-collection cursor; the Connect server does not store the change feed.
+JSON Schemas, portable type definitions, canonical collection settings, and
+optional domain contracts. `watch()` resumes from a local collection cursor;
+the Connect server does not store the change feed.
 Authorization is retained in `localStorage` by default. Access tokens are
 renewed with rotating refresh tokens; passing a custom `Storage` implementation
 allows a host to choose another persistence boundary.

--- a/packages/protocol/schemas/connect-protocol.v2.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v2.schema.json
@@ -168,7 +168,8 @@
         "operations": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/$defs/operation" } },
         "change_cursor": { "type": "integer", "minimum": 0 },
         "types": { "type": "array", "items": { "$ref": "#/$defs/collectionType" } },
-        "contracts": { "type": "array", "items": { "$ref": "#/$defs/collectionContract" } }
+        "contracts": { "type": "array", "items": { "$ref": "#/$defs/collectionContract" } },
+        "configuration": { "type": "object", "description": "Canonical portable collection settings. Extension and implementation-specific values are omitted." }
       }
     },
     "collectionType": {
@@ -179,6 +180,8 @@
         "name": { "type": "string", "minLength": 1 },
         "version": { "type": "integer", "minimum": 1 },
         "description": { "type": "string" },
+        "path": { "type": "string", "minLength": 1, "description": "Collection-relative source path." },
+        "definition": { "type": "object", "description": "Complete portable type frontmatter, including extension declarations." },
         "schema": { "type": "object" },
         "collection": { "type": "object" },
         "lifecycle": { "type": "object" },

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -252,6 +252,10 @@ export interface CollectionTypeDescriptor {
   name: string;
   version?: number;
   description?: string;
+  /** Collection-relative source path. */
+  path?: string;
+  /** Complete portable type frontmatter, including extension declarations. */
+  definition?: JsonObject;
   schema: JsonObject;
   collection?: JsonObject;
   lifecycle?: JsonObject;
@@ -275,6 +279,8 @@ export interface CollectionDescription {
   change_cursor: number;
   types: CollectionTypeDescriptor[];
   contracts: CollectionContractDescriptor[];
+  /** Canonical collection settings; extension and implementation-specific values are omitted. */
+  configuration?: JsonObject;
 }
 
 export interface CollectionChange {


### PR DESCRIPTION
## What changed

- add optional collection-relative type paths and complete portable type definitions to protocol 2 descriptions
- add canonical portable collection settings to collection descriptions
- keep arbitrary configuration extensions and absolute local paths out of the response
- update Rust and TypeScript protocol shapes, JSON Schema, tests, and client/architecture docs

## Why

Full-access collection tools such as mdbase editor need to inspect type definitions and explain the connected collection without reading excluded type files directly or leaking host-specific metadata.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:oracle`
- `pnpm package:audit`
