### PR TITLE
Add production hosted collections

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10.7.0
+          version: 11.15.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # Workspace packages publish their declarations from dist, so build the
@@ -37,3 +37,36 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: docker build --file deploy/docker/Dockerfile.server --tag mdbase-connect-server:test .
+      - run: docker build --file deploy/docker/Dockerfile.hosted-provider --tag mdbase-connect-hosted-provider:test .
+
+  hosted-provider:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mdbase-connect
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: mdbase-connect
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: callumalpass/mdbase-rs
+          ref: 73372a1f786e20d213be6e9821eb0649ecfcc050
+          path: mdbase-rs
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.15.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: mdbase-connect/pnpm-lock.yaml
+      - run: rustup toolchain install 1.94.0 --profile minimal
+      - run: rustup override set 1.94.0
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm build
+      - run: cp deploy/docker/Cargo.lock.hosted-provider Cargo.lock
+      - run: cargo test --locked -p mdbase-connect-hosted-provider
+      - run: cargo build --locked -p mdbase-connect-hosted-provider
+      - run: node scripts/hosted-provider-e2e.mjs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/connect-core",
   "crates/connect-agent",
   "crates/connect-cli",
+  "crates/connect-hosted-provider",
 ]
 resolver = "2"
 
@@ -15,11 +16,14 @@ repository = "https://github.com/mdbase-dev/mdbase-connect"
 
 [workspace.dependencies]
 aes-gcm = "0.10"
+axum = "0.8.9"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
+chrono = "0.4"
 directories = "6"
 futures-util = "0.3"
 hkdf = "0.12"
+hmac = "0.12"
 mdbase = { path = "../mdbase-rs" }
 notify = "8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -27,6 +31,8 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "uuid", "json", "chrono", "migrate", "macros"] }
+subtle = "2.6.1"
 jsonschema = { version = "0.18", features = ["draft202012"] }
 p256 = { version = "0.13", features = ["ecdh"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
@@ -37,5 +43,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tower-http = { version = "0.7.0", features = ["cors", "limit", "request-id", "trace"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 url = "2"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ encryption; the relay sees routing metadata and ciphertext.
   activity, tray operation, and launch-at-login.
 - `services/server`: Fastify control plane and transient relay backed by
   PostgreSQL.
+- `crates/connect-hosted-provider`: encrypted PostgreSQL authority for hosted
+  collections, with direct app operations and the versioned sync data plane.
 - `apps/portal`: deliberately small account, computer management, secure
   pairing, remote approval, and grant-review surface. Routine collection
   configuration stays in the local controller, and there is no developer
@@ -33,7 +35,8 @@ encryption; the relay sees routing metadata and ciphertext.
 - `packages/devkit`: canonical artifact validation and an explicit frontend
   sandbox over the same typed collection-client boundary.
 - `packages/sync`: the versioned hosted-replication model, offline replica
-  stores and client, HTTP transport, and receive-only Markdown mirror.
+  stores and client, HTTP transport, and receive-only or conflict-safe writable
+  Markdown mirrors.
 - `packages/tasknotes`: portable TaskNotes contract adapter using configurable
   field roles and generic revision-safe operations.
 - `apps/tasknotes`: deliberately small reference frontend for the TaskNotes
@@ -45,7 +48,7 @@ development the Rust workspace uses the adjacent `../mdbase-rs` checkout.
 
 ## Verify the MVP
 
-Prerequisites are a Rust toolchain, Node 22+, and pnpm 10.
+Prerequisites are a Rust toolchain, Node 24 LTS, and pnpm 11.15.1.
 
 ```bash
 pnpm install
@@ -55,6 +58,7 @@ pnpm typecheck
 pnpm test
 pnpm e2e
 pnpm e2e:sync
+pnpm e2e:provider
 ```
 
 `pnpm e2e` launches an ephemeral control plane, a real connector agent, a test
@@ -71,6 +75,15 @@ tamper, replay, and plaintext-downgrade rejection.
 HTTP server, including offline writes, two-client convergence, idempotency,
 contract discovery, conflicts, a receive-only Markdown mirror, cursor reset,
 and revocation.
+
+`pnpm e2e:provider` runs the production Rust provider against disposable
+PostgreSQL 18. It includes a real Chromium portal flow, direct OAuth SDK
+operations, encrypted-at-rest checks, two provider instances racing one write,
+pinned snapshots, writable filesystem mirroring, durable retry receipts,
+compaction, restart recovery, logical backup restoration into a fresh database,
+credential rotation, quotas, and ciphertext tamper detection.
+`pnpm e2e:provider:stress` repeats the path with 10,000 records and enforces the
+documented latency budgets.
 
 To produce and inspect a local desktop bundle:
 
@@ -116,13 +129,14 @@ operation names, timing, and sizes remain visible.
 The private Render deployment uses GitHub OAuth and an allowlist of immutable
 numeric account IDs. The server refuses development authentication on
 non-loopback origins, and development email login must never be exposed
-publicly. The first hosted deployment remains a single-user private preview:
-public registration, hosted collections, horizontal relay scaling, restore
-drills, signed desktop releases, and abuse-response operations remain release
-gates.
+publicly. Hosted Markdown is encrypted under per-collection data keys; record
+paths are represented in PostgreSQL by keyed lookup tokens. Public
+registration, a live Render restore drill, signed desktop releases, and
+abuse-response operations remain release gates.
 
 See [`docs/architecture.md`](docs/architecture.md),
 [`docs/mvp.md`](docs/mvp.md), [`docs/sync.md`](docs/sync.md), and
-[`docs/encryption.md`](docs/encryption.md) for the trust model, acceptance path,
+[`docs/encryption.md`](docs/encryption.md), and
+[`docs/hosted-provider.md`](docs/hosted-provider.md) for the trust model, acceptance path,
 implemented protocol boundaries, and remaining replication and encryption
 work.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,26 +16,26 @@
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit"
   },
   "dependencies": {
-    "@mdbase/connect-ui": "workspace:*",
-    "@fontsource/atkinson-hyperlegible": "^5.2.0",
-    "@fontsource/azeret-mono": "^5.2.0",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "@fontsource/atkinson-hyperlegible": "^5.3.0",
+    "@fontsource/azeret-mono": "^5.3.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "scheduler": "^0.27.0"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^7.11.0",
-    "@electron-forge/maker-deb": "^7.11.0",
-    "@electron-forge/maker-rpm": "^7.11.0",
-    "@electron-forge/maker-squirrel": "^7.11.0",
-    "@electron-forge/maker-zip": "^7.11.0",
-    "@types/node": "^22.0.0",
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^5.0.0",
-    "electron": "^41.0.0",
-    "playwright-core": "^1.58.0",
-    "typescript": "^5.9.0",
-    "vite": "^7.0.0"
+    "@mdbase/connect-ui": "workspace:*",
+    "@electron-forge/cli": "^7.11.2",
+    "@electron-forge/maker-deb": "^7.11.2",
+    "@electron-forge/maker-rpm": "^7.11.2",
+    "@electron-forge/maker-squirrel": "^7.11.2",
+    "@electron-forge/maker-zip": "^7.11.2",
+    "@types/node": "^24.0.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "electron": "^43.1.1",
+    "playwright-core": "^1.61.1",
+    "typescript": "^7.0.2",
+    "vite": "^8.1.5"
   }
 }

--- a/apps/desktop/tsconfig.main.json
+++ b/apps/desktop/tsconfig.main.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist/main",
@@ -12,4 +12,3 @@
   },
   "include": ["src/main/**/*.ts"]
 }
-

--- a/apps/desktop/tsconfig.renderer.json
+++ b/apps/desktop/tsconfig.renderer.json
@@ -5,6 +5,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "types": ["vite/client"],
     "allowImportingTsExtensions": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -15,4 +16,3 @@
   },
   "include": ["src/renderer/**/*.ts", "src/renderer/**/*.tsx"]
 }
-

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -10,17 +10,17 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@fontsource/atkinson-hyperlegible": "^5.3.0",
+    "@fontsource/azeret-mono": "^5.3.0",
     "@mdbase/connect-ui": "workspace:*",
-    "@fontsource/atkinson-hyperlegible": "^5.2.0",
-    "@fontsource/azeret-mono": "^5.2.0",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^5.0.0",
-    "typescript": "^5.9.0",
-    "vite": "^7.0.0"
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^7.0.2",
+    "vite": "^8.1.5"
   }
 }

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -34,6 +34,7 @@ export interface DashboardData {
     contracts: ContractRequirement[];
     last_seen_at: string;
   }>;
+  hosted_collections: HostedCollection[];
   grants: Array<{
     id: string;
     operations: string[];
@@ -42,12 +43,33 @@ export interface DashboardData {
     revoked_at: string | null;
     collection_id: string;
     collection_name: string;
+    collection_kind: "local" | "hosted";
     application_id: string;
     application_name: string;
     homepage: string;
     icon: string | null;
   }>;
   pending_authorizations: PendingAuthorization[];
+}
+
+export interface HostedReplica {
+  id: string;
+  name: string;
+  mode: "read_only" | "read_write";
+  allowed_types: string[];
+  revoked_at: string | null;
+  created_at: string;
+}
+
+export interface HostedCollection {
+  id: string;
+  display_name: string;
+  template: "tasknotes";
+  provider_url: string;
+  spec_version: string;
+  contracts: ContractRequirement[];
+  created_at: string;
+  replicas: HostedReplica[];
 }
 
 export interface PendingAuthorization {
@@ -63,6 +85,7 @@ export interface PendingAuthorization {
 
 export interface AvailableCollection {
   id: string;
+  kind?: "local" | "hosted";
   connector_name: string;
   display_name: string;
   spec_version: string;

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -12,6 +12,7 @@ import {
   type AvailableCollection,
   type ContractRequirement,
   type DashboardData,
+  type HostedCollection,
   type PendingAuthorization
 } from "./api";
 import "./styles.css";
@@ -152,13 +153,24 @@ function Dashboard() {
                 <ApprovalForm
                   request={request}
                   collections={compatibleCollections(
-                    request,
-                    data.collections.filter((collection) => collection.enabled)
+                  request,
+                  [
+                    ...data.collections.filter((collection) => collection.enabled)
+                      .map((collection) => ({ ...collection, kind: "local" as const })),
+                    ...data.hosted_collections.map((collection) => ({
+                      ...collection,
+                      kind: "hosted" as const,
+                      connector_name: "Hosted by mdbase"
+                    }))
+                  ]
                   )}
                   onDecision={refresh}
                 />
               </article>
             ))}</div></>}
+        </section>
+        <section id="hosted">
+          <HostedCollections collections={data.hosted_collections} onChanged={refresh} onError={setError} />
         </section>
         <section id="permissions">
           <SectionHeading title="Application access" note="Review exact permissions, narrow them, or revoke access immediately." count={data.grants.filter((grant) => !grant.revoked_at).length} />
@@ -167,7 +179,7 @@ function Dashboard() {
           ) : (
             <div className="portal-grant-list">{data.grants.filter((grant) => !grant.revoked_at).map((grant) => {
               const collection = data.collections.find((candidate) => candidate.id === grant.collection_id);
-              return <PortalGrant key={grant.id} grant={grant} connectorName={collection?.connector_name ?? "Unknown computer"} onChanged={refresh} onError={setError} />;
+              return <PortalGrant key={grant.id} grant={grant} connectorName={grant.collection_kind === "hosted" ? "Hosted by mdbase" : collection?.connector_name ?? "Unknown computer"} onChanged={refresh} onError={setError} />;
             })}</div>
           )}
         </section>
@@ -188,6 +200,184 @@ function Dashboard() {
       </main>
     </div>
   );
+}
+
+interface ReplicaSecret {
+  replicaId: string;
+  token: string;
+  syncUrl: string;
+  mode: "read_only" | "read_write";
+}
+
+function HostedCollections({ collections, onChanged, onError }: {
+  collections: HostedCollection[];
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("My tasks");
+  const [busy, setBusy] = useState(false);
+
+  async function create(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim()) return;
+    setBusy(true);
+    try {
+      await api("/v1/hosted/collections", {
+        method: "POST",
+        body: JSON.stringify({ display_name: name.trim(), template: "tasknotes" })
+      });
+      setCreating(false);
+      setName("My tasks");
+      await onChanged();
+    } catch (reason) {
+      onError(message(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return <>
+    <SectionHeading
+      title="Hosted collections"
+      note="Keep the authoritative Markdown on mdbase, with optional local mirrors."
+      count={collections.length}
+    />
+    {collections.length === 0 && !creating
+      ? <Empty title="No hosted collections" text="Create a TaskNotes collection whose source of truth stays available without a connected computer." />
+      : <div className="hosted-list">{collections.map((collection) => (
+          <HostedCollectionRow key={collection.id} collection={collection} onChanged={onChanged} onError={onError} />
+        ))}</div>}
+    {creating ? <form className="inline-create" onSubmit={(event) => void create(event)}>
+      <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
+      <p>Starts with the TaskNotes schema. You can receive an exact Markdown mirror on any computer afterward.</p>
+      <div><button type="button" className="quiet-action" disabled={busy} onClick={() => setCreating(false)}>Cancel</button><button className="button primary" disabled={busy || !name.trim()}>{busy ? "Creating…" : "Create collection"}</button></div>
+    </form> : <button className="button secondary" onClick={() => setCreating(true)}>Create hosted collection</button>}
+  </>;
+}
+
+function HostedCollectionRow({ collection, onChanged, onError }: {
+  collection: HostedCollection;
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  const [panel, setPanel] = useState<"mirror" | "rename" | null>(null);
+  const [name, setName] = useState(collection.display_name);
+  const [mirrorName, setMirrorName] = useState("Local mirror");
+  const [mirrorMode, setMirrorMode] = useState<"read_only" | "read_write">("read_only");
+  const [busy, setBusy] = useState(false);
+  const [secret, setSecret] = useState<ReplicaSecret | null>(null);
+  const activeReplicas = collection.replicas.filter((replica) => !replica.revoked_at);
+  useEffect(() => { if (panel !== "rename") setName(collection.display_name); }, [collection.display_name, panel]);
+
+  async function rename(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim()) return;
+    setBusy(true);
+    try {
+      await api(`/v1/hosted/collections/${collection.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ display_name: name.trim() })
+      });
+      setPanel(null);
+      await onChanged();
+    } catch (reason) { onError(message(reason)); }
+    finally { setBusy(false); }
+  }
+
+  async function addMirror(event: React.FormEvent) {
+    event.preventDefault();
+    if (!mirrorName.trim()) return;
+    setBusy(true);
+    try {
+      const enrollment = await api<{
+        replica: { id: string };
+        token: string;
+        sync_url: string;
+      }>(`/v1/hosted/collections/${collection.id}/replicas`, {
+        method: "POST",
+        body: JSON.stringify({ name: mirrorName.trim(), mode: mirrorMode, allowed_types: ["task"] })
+      });
+      setSecret({ replicaId: enrollment.replica.id, token: enrollment.token, syncUrl: enrollment.sync_url, mode: mirrorMode });
+      await onChanged();
+    } catch (reason) { onError(message(reason)); }
+    finally { setBusy(false); }
+  }
+
+  async function remove() {
+    if (!window.confirm(`Delete ${collection.display_name} and all of its hosted Markdown? This cannot be undone.`)) return;
+    setBusy(true);
+    try {
+      await api(`/v1/hosted/collections/${collection.id}`, { method: "DELETE" });
+      await onChanged();
+    } catch (reason) { onError(message(reason)); setBusy(false); }
+  }
+
+  async function revoke(replicaId: string, replicaName: string) {
+    if (!window.confirm(`Revoke ${replicaName}? Its local files remain, but it will no longer receive changes.`)) return;
+    setBusy(true);
+    try {
+      await api(`/v1/hosted/replicas/${replicaId}`, { method: "DELETE" });
+      if (secret?.replicaId === replicaId) setSecret(null);
+      await onChanged();
+    } catch (reason) { onError(message(reason)); }
+    finally { setBusy(false); }
+  }
+
+  async function rotate(replicaId: string) {
+    setBusy(true);
+    try {
+      const value = await api<{ token: string; sync_url: string }>(`/v1/hosted/replicas/${replicaId}/token`, { method: "POST" });
+      const replica = activeReplicas.find((candidate) => candidate.id === replicaId);
+      if (!replica) throw new Error("Mirror is no longer available.");
+      setSecret({ replicaId, token: value.token, syncUrl: value.sync_url, mode: replica.mode });
+    } catch (reason) { onError(message(reason)); }
+    finally { setBusy(false); }
+  }
+
+  return <article className="hosted-row">
+    <div className="hosted-summary">
+      <div><strong>{collection.display_name}</strong><small>TaskNotes · authoritative on mdbase · created {relativeTime(collection.created_at)}</small></div>
+      <span className="availability online"><i />Hosted</span>
+      <span className="replica-count">{activeReplicas.length} {activeReplicas.length === 1 ? "mirror" : "mirrors"}</span>
+      <div className="computer-actions"><button className="quiet-action" disabled={busy} onClick={() => { setSecret(null); setPanel(panel === "mirror" ? null : "mirror"); }}>Add mirror</button><button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button><button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button></div>
+    </div>
+    {panel === "rename" && <form className="hosted-detail hosted-rename" onSubmit={(event) => void rename(event)}>
+      <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
+      <div><button type="button" className="quiet-action" disabled={busy} onClick={() => setPanel(null)}>Cancel</button><button className="button primary" disabled={busy || !name.trim() || name.trim() === collection.display_name}>Save</button></div>
+    </form>}
+    {panel === "mirror" && <div className="hosted-detail">
+      {!secret ? <form className="mirror-form" onSubmit={(event) => void addMirror(event)}>
+        <label><span>Mirror name</span><input autoFocus maxLength={200} value={mirrorName} onChange={(event) => setMirrorName(event.target.value)} /></label>
+        <label><span>Local edits</span><select value={mirrorMode} onChange={(event) => setMirrorMode(event.target.value as "read_only" | "read_write")}><option value="read_only">Receive only</option><option value="read_write">Sync to hosted</option></select></label>
+        <p>{mirrorMode === "read_only" ? "Local edits never overwrite the hosted source of truth." : "Local edits sync conditionally. Concurrent edits stop for an explicit choice—never last-write-wins."}</p>
+        <button className="button primary" disabled={busy || !mirrorName.trim()}>{busy ? "Preparing…" : "Prepare mirror"}</button>
+      </form> : <MirrorSetup collectionId={collection.id} secret={secret} />}
+    </div>}
+    {activeReplicas.length > 0 && <details className="replica-detail">
+      <summary>Manage mirrors</summary>
+      <div>{activeReplicas.map((replica) => <div className="replica-row" key={replica.id}>
+        <div><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Receive-only" : "Two-way"} · added {relativeTime(replica.created_at)}</small></div>
+        <div><button className="quiet-action" disabled={busy} onClick={() => void rotate(replica.id)}>Replace token</button><button className="quiet-danger" disabled={busy} onClick={() => void revoke(replica.id, replica.name)}>Revoke</button></div>
+      </div>)}</div>
+      {secret && panel !== "mirror" && <MirrorSetup collectionId={collection.id} secret={secret} />}
+    </details>}
+  </article>;
+}
+
+function MirrorSetup({ collectionId, secret }: { collectionId: string; secret: ReplicaSecret }) {
+  const command = `mdbase-mirror init ./tasks --server ${secret.syncUrl} --collection ${collectionId} --replica ${secret.replicaId}${secret.mode === "read_write" ? " --writable" : ""}`;
+  const [copied, setCopied] = useState<"token" | "command" | null>(null);
+  async function copy(value: string, kind: "token" | "command") {
+    await navigator.clipboard.writeText(value);
+    setCopied(kind);
+  }
+  return <div className="mirror-setup" aria-live="polite">
+    <p><strong>Save this token now.</strong> It is shown once. The CLI asks for it without echoing it.</p>
+    <div className="copy-row"><code>{secret.token}</code><button className="quiet-action" type="button" onClick={() => void copy(secret.token, "token")}>{copied === "token" ? "Copied" : "Copy token"}</button></div>
+    <p>Install <code>@mdbase/connect-sync</code>, then run:</p>
+    <div className="copy-row"><code>{command}</code><button className="quiet-action" type="button" onClick={() => void copy(command, "command")}>{copied === "command" ? "Copied" : "Copy command"}</button></div>
+  </div>;
 }
 
 function ComputerRow({ connector, collectionCount, availableCount, onChanged, onError }: {

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -123,10 +123,160 @@ h1 {
 }
 
 .computer-list,
+.hosted-list,
 .account-rows,
 .request-list,
 .portal-grant-list {
   border-top: 1px solid var(--line);
+}
+
+.hosted-row {
+  border-bottom: 1px solid var(--line);
+}
+
+.hosted-summary {
+  display: grid;
+  grid-template-columns: minmax(15rem, 1fr) auto auto auto;
+  align-items: center;
+  gap: 1.25rem;
+  min-height: 4.7rem;
+}
+
+.hosted-summary > div:first-child,
+.replica-row > div:first-child {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.hosted-summary strong,
+.replica-row strong {
+  overflow: hidden;
+  font-size: 0.82rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hosted-summary small,
+.replica-row small,
+.replica-count {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+}
+
+.replica-count {
+  white-space: nowrap;
+}
+
+.hosted-detail,
+.inline-create {
+  padding: 1rem 0 1.25rem;
+  border-top: 1px solid var(--line);
+}
+
+.hosted-detail label,
+.inline-create label,
+.mirror-form label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.hosted-detail label > span,
+.inline-create label > span,
+.mirror-form label > span {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.hosted-rename,
+.inline-create,
+.mirror-form {
+  display: grid;
+  grid-template-columns: minmax(14rem, 1fr) minmax(14rem, 1.2fr) auto;
+  align-items: end;
+  gap: 1rem;
+}
+
+.mirror-form {
+  grid-template-columns: minmax(12rem, 0.8fr) minmax(11rem, 0.7fr) minmax(16rem, 1.2fr) auto;
+}
+
+.hosted-rename {
+  grid-template-columns: minmax(14rem, 1fr) auto;
+}
+
+.hosted-rename > div,
+.inline-create > div {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.inline-create p,
+.mirror-form p,
+.mirror-setup p {
+  max-width: 65ch;
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.replica-detail {
+  padding: 0.75rem 0 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.replica-detail > summary {
+  width: fit-content;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  cursor: pointer;
+}
+
+.replica-detail > div {
+  margin-top: 0.65rem;
+}
+
+.replica-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  min-height: 3.4rem;
+  border-top: 1px solid var(--line);
+}
+
+.mirror-setup {
+  display: grid;
+  gap: 0.7rem;
+  max-width: 60rem;
+  padding-top: 0.2rem;
+}
+
+.mirror-setup > p:first-child {
+  color: var(--ink-soft);
+}
+
+.copy-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.copy-row code {
+  overflow-x: auto;
+  padding: 0.65rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink-soft);
+  background: var(--paper-hover);
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  white-space: nowrap;
 }
 
 .computer-row {
@@ -707,6 +857,32 @@ select {
 
   .computer-row {
     grid-template-columns: 1fr auto;
+  }
+
+  .hosted-summary {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem 1rem;
+    padding: 0.85rem 0;
+  }
+
+  .hosted-summary .replica-count,
+  .hosted-summary .computer-actions {
+    grid-column: 1 / -1;
+  }
+
+  .hosted-summary .computer-actions {
+    justify-content: flex-start;
+  }
+
+  .hosted-rename,
+  .inline-create,
+  .mirror-form {
+    grid-template-columns: 1fr;
+  }
+
+  .copy-row,
+  .replica-row {
+    grid-template-columns: 1fr;
   }
 
   .computer-name-form,

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "types": ["vite/client"],
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
@@ -11,4 +12,3 @@
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }
-

--- a/apps/tasknotes/package.json
+++ b/apps/tasknotes/package.json
@@ -13,14 +13,14 @@
   "dependencies": {
     "@mdbase/connect": "workspace:*",
     "@mdbase/tasknotes": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^5.0.0",
-    "typescript": "^5.9.0",
-    "vite": "^7.0.0"
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^7.0.2",
+    "vite": "^8.1.5"
   }
 }

--- a/apps/tasknotes/tsconfig.json
+++ b/apps/tasknotes/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "types": ["vite/client"],
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/crates/connect-hosted-provider/Cargo.toml
+++ b/crates/connect-hosted-provider/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "mdbase-connect-hosted-provider"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+aes-gcm.workspace = true
+axum.workspace = true
+base64.workspace = true
+clap.workspace = true
+chrono.workspace = true
+hmac.workspace = true
+mdbase.workspace = true
+mdbase-connect-protocol = { path = "../connect-protocol" }
+rand_core.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+sqlx.workspace = true
+subtle.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+reqwest.workspace = true

--- a/crates/connect-hosted-provider/migrations/0001_hosted_provider.sql
+++ b/crates/connect-hosted-provider/migrations/0001_hosted_provider.sql
@@ -1,0 +1,123 @@
+CREATE TABLE IF NOT EXISTS hosted_provider_metadata (
+  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+  key_check bytea NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_collections (
+  id uuid PRIMARY KEY,
+  template text NOT NULL,
+  spec_version text NOT NULL,
+  authority_epoch bigint NOT NULL DEFAULT 1 CHECK (authority_epoch > 0),
+  head bigint NOT NULL DEFAULT 0 CHECK (head >= 0),
+  retained_after bigint NOT NULL DEFAULT 0 CHECK (retained_after >= 0),
+  record_count bigint NOT NULL DEFAULT 0 CHECK (record_count >= 0),
+  content_bytes bigint NOT NULL DEFAULT 0 CHECK (content_bytes >= 0),
+  max_records bigint NOT NULL CHECK (max_records > 0),
+  max_content_bytes bigint NOT NULL CHECK (max_content_bytes > 0),
+  max_document_bytes bigint NOT NULL CHECK (max_document_bytes > 0),
+  max_replicas bigint NOT NULL CHECK (max_replicas > 0),
+  resource_revision text NOT NULL,
+  wrapped_data_key bytea NOT NULL,
+  resources_ciphertext bytea NOT NULL,
+  state text NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'importing', 'deleting')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_resources (
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  path text NOT NULL,
+  kind text NOT NULL CHECK (kind IN ('configuration', 'type')),
+  revision text NOT NULL,
+  document_ciphertext bytea NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (collection_id, path)
+);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_records (
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  record_id uuid NOT NULL,
+  path_token bytea NOT NULL,
+  revision text NOT NULL,
+  types text[] NOT NULL DEFAULT '{}',
+  content_bytes bigint NOT NULL CHECK (content_bytes >= 0),
+  payload_ciphertext bytea NOT NULL,
+  sequence bigint NOT NULL CHECK (sequence > 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (collection_id, record_id),
+  UNIQUE (collection_id, path_token)
+);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_record_versions (
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  record_id uuid NOT NULL,
+  sequence bigint NOT NULL CHECK (sequence > 0),
+  revision text NOT NULL,
+  types text[] NOT NULL DEFAULT '{}',
+  payload_ciphertext bytea,
+  deleted boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (collection_id, record_id, sequence)
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_versions_snapshot_idx
+  ON hosted_provider_record_versions (collection_id, record_id, sequence DESC);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_changes (
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  sequence bigint NOT NULL CHECK (sequence > 0),
+  record_id uuid NOT NULL,
+  before_types text[] NOT NULL DEFAULT '{}',
+  after_types text[] NOT NULL DEFAULT '{}',
+  before_ciphertext bytea,
+  after_ciphertext bytea,
+  revision text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (collection_id, sequence)
+);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_replicas (
+  id uuid PRIMARY KEY,
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  purpose text NOT NULL DEFAULT 'mirror' CHECK (purpose IN ('mirror', 'application')),
+  mode text NOT NULL CHECK (mode IN ('read_only', 'read_write')),
+  allowed_types text[] NOT NULL DEFAULT '{}',
+  allowed_operations text[] NOT NULL DEFAULT '{}',
+  allowed_origin text,
+  scope_epoch bigint NOT NULL DEFAULT 1 CHECK (scope_epoch > 0),
+  token_hash bytea NOT NULL UNIQUE,
+  token_expires_at timestamptz NOT NULL DEFAULT (now() + interval '30 days'),
+  acknowledged_sequence bigint NOT NULL DEFAULT 0 CHECK (acknowledged_sequence >= 0),
+  last_seen_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_replicas_collection_idx
+  ON hosted_provider_replicas (collection_id) WHERE revoked_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS hosted_provider_mutation_receipts (
+  replica_id uuid NOT NULL REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
+  mutation_id uuid NOT NULL,
+  mutation_hash bytea NOT NULL,
+  receipt_ciphertext bytea NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (replica_id, mutation_id)
+);
+
+CREATE TABLE IF NOT EXISTS hosted_provider_snapshot_leases (
+  id uuid PRIMARY KEY,
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  replica_id uuid NOT NULL REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
+  scope_epoch bigint NOT NULL CHECK (scope_epoch > 0),
+  cursor bigint NOT NULL CHECK (cursor >= 0),
+  resource_revision text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_snapshot_expiry_idx
+  ON hosted_provider_snapshot_leases (expires_at);

--- a/crates/connect-hosted-provider/src/crypto.rs
+++ b/crates/connect-hosted-provider/src/crypto.rs
@@ -1,0 +1,199 @@
+use aes_gcm::{
+    aead::{Aead, KeyInit, Payload},
+    Aes256Gcm, Nonce,
+};
+use base64::{engine::general_purpose, Engine as _};
+use rand_core::{OsRng, RngCore};
+use serde::{de::DeserializeOwned, Serialize};
+use subtle::ConstantTimeEq;
+
+use crate::error::{ApiError, ApiResult};
+
+const ENVELOPE_VERSION: u8 = 1;
+const KEY_BYTES: usize = 32;
+const NONCE_BYTES: usize = 12;
+const KEY_CHECK_PLAINTEXT: &[u8] = b"mdbase-connect-hosted-provider-key-check-v1";
+const KEY_CHECK_AAD: &[u8] = b"provider-key-check-v1";
+
+#[derive(Clone)]
+pub struct ProviderCrypto {
+    master_key: [u8; KEY_BYTES],
+}
+
+impl ProviderCrypto {
+    pub fn from_base64(value: &str) -> ApiResult<Self> {
+        let decoded = general_purpose::URL_SAFE_NO_PAD
+            .decode(value)
+            .or_else(|_| general_purpose::STANDARD.decode(value))
+            .map_err(|_| invalid_master_key())?;
+        let master_key: [u8; KEY_BYTES] = decoded.try_into().map_err(|_| invalid_master_key())?;
+        Ok(Self { master_key })
+    }
+
+    pub fn generate_data_key(&self) -> [u8; KEY_BYTES] {
+        let mut key = [0_u8; KEY_BYTES];
+        OsRng.fill_bytes(&mut key);
+        key
+    }
+
+    pub fn create_key_check(&self) -> ApiResult<Vec<u8>> {
+        encrypt(&self.master_key, KEY_CHECK_PLAINTEXT, KEY_CHECK_AAD)
+    }
+
+    pub fn verify_key_check(&self, value: &[u8]) -> ApiResult<()> {
+        let plaintext = decrypt(&self.master_key, value, KEY_CHECK_AAD)?;
+        if bool::from(plaintext.ct_eq(KEY_CHECK_PLAINTEXT)) {
+            Ok(())
+        } else {
+            Err(ApiError::internal(
+                "The hosted provider master key does not match this database.",
+            ))
+        }
+    }
+
+    pub fn wrap_data_key(&self, data_key: &[u8; KEY_BYTES], aad: &[u8]) -> ApiResult<Vec<u8>> {
+        encrypt(&self.master_key, data_key, aad)
+    }
+
+    pub fn unwrap_data_key(&self, wrapped: &[u8], aad: &[u8]) -> ApiResult<[u8; KEY_BYTES]> {
+        decrypt(&self.master_key, wrapped, aad)?
+            .try_into()
+            .map_err(|_| ApiError::internal("The hosted collection data key is invalid."))
+    }
+
+    pub fn encrypt_json<T: Serialize>(
+        &self,
+        data_key: &[u8; KEY_BYTES],
+        value: &T,
+        aad: &[u8],
+    ) -> ApiResult<Vec<u8>> {
+        let plaintext = serde_json::to_vec(value).map_err(|error| {
+            ApiError::internal(format!(
+                "Hosted encrypted value could not serialize: {error}"
+            ))
+        })?;
+        encrypt(data_key, &plaintext, aad)
+    }
+
+    pub fn decrypt_json<T: DeserializeOwned>(
+        &self,
+        data_key: &[u8; KEY_BYTES],
+        value: &[u8],
+        aad: &[u8],
+    ) -> ApiResult<T> {
+        let plaintext = decrypt(data_key, value, aad)?;
+        serde_json::from_slice(&plaintext).map_err(|error| {
+            ApiError::internal(format!("Hosted encrypted value is invalid: {error}"))
+        })
+    }
+
+    pub fn encrypt_bytes(
+        &self,
+        data_key: &[u8; KEY_BYTES],
+        value: &[u8],
+        aad: &[u8],
+    ) -> ApiResult<Vec<u8>> {
+        encrypt(data_key, value, aad)
+    }
+
+    pub fn decrypt_bytes(
+        &self,
+        data_key: &[u8; KEY_BYTES],
+        value: &[u8],
+        aad: &[u8],
+    ) -> ApiResult<Vec<u8>> {
+        decrypt(data_key, value, aad)
+    }
+}
+
+fn encrypt(key: &[u8; KEY_BYTES], plaintext: &[u8], aad: &[u8]) -> ApiResult<Vec<u8>> {
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
+    let mut nonce = [0_u8; NONCE_BYTES];
+    OsRng.fill_bytes(&mut nonce);
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|_| ApiError::internal("The hosted value could not be encrypted."))?;
+    let mut envelope = Vec::with_capacity(1 + NONCE_BYTES + ciphertext.len());
+    envelope.push(ENVELOPE_VERSION);
+    envelope.extend_from_slice(&nonce);
+    envelope.extend_from_slice(&ciphertext);
+    Ok(envelope)
+}
+
+fn decrypt(key: &[u8; KEY_BYTES], envelope: &[u8], aad: &[u8]) -> ApiResult<Vec<u8>> {
+    if envelope.len() <= 1 + NONCE_BYTES || envelope[0] != ENVELOPE_VERSION {
+        return Err(ApiError::internal(
+            "The hosted ciphertext envelope is invalid.",
+        ));
+    }
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
+    cipher
+        .decrypt(
+            Nonce::from_slice(&envelope[1..1 + NONCE_BYTES]),
+            Payload {
+                msg: &envelope[1 + NONCE_BYTES..],
+                aad,
+            },
+        )
+        .map_err(|_| ApiError::internal("The hosted ciphertext failed authentication."))
+}
+
+fn invalid_master_key() -> ApiError {
+    ApiError::bad_request(
+        "invalid_master_key",
+        "The hosted provider master key must be a base64-encoded 32-byte value.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn crypto() -> ProviderCrypto {
+        ProviderCrypto::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap()
+    }
+
+    #[test]
+    fn wraps_keys_and_authenticates_payload_identity() {
+        let crypto = crypto();
+        let data_key = crypto.generate_data_key();
+        let wrapped = crypto.wrap_data_key(&data_key, b"collection:one").unwrap();
+        assert_ne!(&wrapped[13..45], data_key.as_slice());
+        let unwrapped = crypto.unwrap_data_key(&wrapped, b"collection:one").unwrap();
+        assert_eq!(unwrapped, data_key);
+        assert!(crypto
+            .unwrap_data_key(&wrapped, b"collection:other")
+            .is_err());
+    }
+
+    #[test]
+    fn rejects_tampering_and_wrong_associated_data() {
+        let crypto = crypto();
+        let key = crypto.generate_data_key();
+        let mut encrypted = crypto
+            .encrypt_json(
+                &key,
+                &serde_json::json!({"secret": "markdown"}),
+                b"record:one",
+            )
+            .unwrap();
+        encrypted[20] ^= 1;
+        assert!(crypto
+            .decrypt_json::<serde_json::Value>(&key, &encrypted, b"record:one")
+            .is_err());
+        let encrypted = crypto
+            .encrypt_bytes(&key, b"markdown", b"record:one")
+            .unwrap();
+        assert!(crypto
+            .decrypt_bytes(&key, &encrypted, b"record:two")
+            .is_err());
+    }
+}

--- a/crates/connect-hosted-provider/src/error.rs
+++ b/crates/connect-hosted-provider/src/error.rs
@@ -1,0 +1,88 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use thiserror::Error;
+
+pub type ApiResult<T> = Result<T, ApiError>;
+
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ApiError {
+    pub fn new(status: StatusCode, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, code, message)
+    }
+
+    pub fn unauthorized(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::UNAUTHORIZED, code, message)
+    }
+
+    pub fn forbidden(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::FORBIDDEN, code, message)
+    }
+
+    pub fn not_found(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_FOUND, code, message)
+    }
+
+    pub fn conflict(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::CONFLICT, code, message)
+    }
+
+    pub fn quota(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::TOO_MANY_REQUESTS, code, message)
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "provider_internal_error",
+            message,
+        )
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(json!({
+                "error": {
+                    "code": self.code,
+                    "message": self.message,
+                }
+            })),
+        )
+            .into_response()
+    }
+}
+
+impl From<sqlx::Error> for ApiError {
+    fn from(error: sqlx::Error) -> Self {
+        tracing::error!(error = %error, "hosted provider database error");
+        Self::internal("The hosted provider could not access its authoritative store.")
+    }
+}
+
+impl From<std::io::Error> for ApiError {
+    fn from(error: std::io::Error) -> Self {
+        tracing::error!(error = %error, "hosted provider working-set error");
+        Self::internal("The hosted provider could not prepare the collection working set.")
+    }
+}

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -1,0 +1,495 @@
+use axum::{
+    extract::{DefaultBodyLimit, Path, Query, Request, State},
+    http::{
+        header::{AUTHORIZATION, CONTENT_TYPE, ORIGIN},
+        HeaderMap, HeaderName, HeaderValue, Method, StatusCode,
+    },
+    middleware::{self, Next},
+    response::Response,
+    routing::{delete, get, patch, post},
+    Json, Router,
+};
+use mdbase_connect_protocol::{
+    SyncChangesPage, SyncMutation, SyncMutationReceipt, SyncSession, SyncSnapshotPage,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use subtle::ConstantTimeEq;
+use tokio::sync::Semaphore;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
+use url::Url;
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    provider::{validate_limit, HostedProvider, RegisterReplica, UpdateApplicationReplica},
+};
+
+// Leave room for the mutation envelope, frontmatter, and JSON escaping around
+// the default 2 MiB canonical-document quota.
+const MAX_BODY_BYTES: usize = 3 * 1024 * 1024;
+
+#[derive(Clone)]
+pub struct AppState {
+    provider: HostedProvider,
+    internal_token_hash: [u8; 32],
+    allowed_origins: Vec<HeaderValue>,
+    request_slots: Arc<Semaphore>,
+}
+
+impl AppState {
+    pub fn new(
+        provider: HostedProvider,
+        internal_token: &str,
+        allowed_origins: impl IntoIterator<Item = String>,
+    ) -> ApiResult<Self> {
+        if internal_token.len() < 32 {
+            return Err(ApiError::bad_request(
+                "invalid_internal_token",
+                "The provider internal credential must contain at least 32 characters.",
+            ));
+        }
+        let allowed_origins = allowed_origins
+            .into_iter()
+            .map(|origin| canonical_origin(&origin))
+            .collect::<ApiResult<Vec<_>>>()?;
+        if allowed_origins.is_empty() {
+            return Err(ApiError::bad_request(
+                "missing_allowed_origins",
+                "At least one browser application origin must be configured.",
+            ));
+        }
+        Ok(Self {
+            provider,
+            internal_token_hash: Sha256::digest(internal_token.as_bytes()).into(),
+            allowed_origins,
+            request_slots: Arc::new(Semaphore::new(128)),
+        })
+    }
+
+    fn authorize_internal(&self, headers: &HeaderMap) -> ApiResult<()> {
+        let token = bearer(headers)?;
+        let candidate: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+        if bool::from(candidate.ct_eq(&self.internal_token_hash)) {
+            Ok(())
+        } else {
+            Err(ApiError::unauthorized(
+                "invalid_internal_token",
+                "The provider internal credential is invalid.",
+            ))
+        }
+    }
+
+    fn authorize_sync_origin(&self, headers: &HeaderMap) -> ApiResult<()> {
+        if let Some(origin) = headers.get(ORIGIN) {
+            if !self.allowed_origins.iter().any(|allowed| allowed == origin) {
+                return Err(ApiError::forbidden(
+                    "origin_denied",
+                    "Browser sync is unavailable from this origin.",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateCollectionRequest {
+    collection_id: Uuid,
+    template: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RotateTokenRequest {
+    token: String,
+    token_ttl_seconds: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompactRequest {
+    through: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotQuery {
+    snapshot_id: Uuid,
+    page: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChangesQuery {
+    after: u64,
+    limit: Option<u32>,
+}
+
+pub fn app(state: AppState) -> Router {
+    let request_id_header = HeaderName::from_static("x-request-id");
+    // Preflight requests contain no bearer credential. Actual application
+    // requests are bound to the origin stored with that provider capability.
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_headers([AUTHORIZATION, CONTENT_TYPE])
+        .allow_methods([Method::GET, Method::POST])
+        .max_age(std::time::Duration::from_secs(600));
+    let internal = Router::new()
+        .route("/internal/v1/collections", post(create_collection))
+        .route(
+            "/internal/v1/collections/{collection_id}",
+            delete(delete_collection),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/replicas",
+            post(register_replica),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/compact",
+            post(compact_collection),
+        )
+        .route(
+            "/internal/v1/replicas/{replica_id}/token",
+            post(rotate_replica_token),
+        )
+        .route(
+            "/internal/v1/replicas/{replica_id}/policy",
+            patch(update_replica_policy),
+        )
+        .route("/internal/v1/replicas/{replica_id}", delete(revoke_replica))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            authorize_internal_request,
+        ));
+    let sync = Router::new()
+        .route(
+            "/v1/hosted/collections/{collection_id}/sync/sessions",
+            post(open_session),
+        )
+        .route(
+            "/v1/hosted/collections/{collection_id}/sync/snapshot",
+            get(snapshot),
+        )
+        .route(
+            "/v1/hosted/collections/{collection_id}/sync/changes",
+            get(changes),
+        )
+        .route(
+            "/v1/hosted/collections/{collection_id}/sync/mutations",
+            post(mutate),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_sync_bearer_request,
+        ));
+    let operations = Router::new()
+        .route(
+            "/v1/hosted/collections/{collection_id}/operations/{operation}",
+            post(operation),
+        )
+        .route_layer(middleware::from_fn(require_bearer_request));
+    Router::new()
+        .route("/health", get(health))
+        .route("/ready", get(ready))
+        .merge(internal)
+        .merge(sync)
+        .merge(operations)
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
+        .layer(cors)
+        .layer(PropagateRequestIdLayer::new(request_id_header.clone()))
+        .layer(SetRequestIdLayer::new(request_id_header, MakeRequestUuid))
+        .layer(TraceLayer::new_for_http())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            limit_concurrent_requests,
+        ))
+        .with_state(state)
+}
+
+async fn limit_concurrent_requests(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> ApiResult<Response> {
+    let _permit = state
+        .request_slots
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            ApiError::new(
+                StatusCode::TOO_MANY_REQUESTS,
+                "provider_busy",
+                "The hosted provider is busy; retry with backoff.",
+            )
+        })?;
+    Ok(next.run(request).await)
+}
+
+async fn authorize_internal_request(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> ApiResult<Response> {
+    state.authorize_internal(request.headers())?;
+    Ok(next.run(request).await)
+}
+
+async fn require_bearer_request(request: Request, next: Next) -> ApiResult<Response> {
+    bearer(request.headers())?;
+    Ok(next.run(request).await)
+}
+
+async fn require_sync_bearer_request(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> ApiResult<Response> {
+    bearer(request.headers())?;
+    state.authorize_sync_origin(request.headers())?;
+    Ok(next.run(request).await)
+}
+
+async fn health() -> Json<Value> {
+    Json(json!({ "status": "ok" }))
+}
+
+async fn ready(State(state): State<AppState>) -> ApiResult<Json<Value>> {
+    state.provider.ready().await?;
+    Ok(Json(json!({ "status": "ready" })))
+}
+
+async fn create_collection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(input): Json<CreateCollectionRequest>,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    state.authorize_internal(&headers)?;
+    let collection = state
+        .provider
+        .create_collection(input.collection_id, &input.template)
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({ "collection": collection })),
+    ))
+}
+
+async fn delete_collection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state.provider.delete_collection(collection_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn register_replica(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<RegisterReplica>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state
+        .provider
+        .register_replica(collection_id, input)
+        .await?;
+    Ok(StatusCode::CREATED)
+}
+
+async fn rotate_replica_token(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(replica_id): Path<Uuid>,
+    Json(input): Json<RotateTokenRequest>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state
+        .provider
+        .rotate_replica_token(replica_id, &input.token, input.token_ttl_seconds)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn revoke_replica(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(replica_id): Path<Uuid>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state.provider.revoke_replica(replica_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn update_replica_policy(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(replica_id): Path<Uuid>,
+    Json(input): Json<UpdateApplicationReplica>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state
+        .provider
+        .update_application_replica(replica_id, input)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn compact_collection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<CompactRequest>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state
+        .provider
+        .compact_through(collection_id, input.through)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn open_session(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+) -> ApiResult<Json<SyncSession>> {
+    let token = bearer(&headers)?;
+    Ok(Json(
+        state.provider.open_session(collection_id, token).await?,
+    ))
+}
+
+async fn snapshot(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Query(query): Query<SnapshotQuery>,
+) -> ApiResult<Json<SyncSnapshotPage>> {
+    let token = bearer(&headers)?;
+    Ok(Json(
+        state
+            .provider
+            .snapshot(
+                collection_id,
+                token,
+                query.snapshot_id,
+                query.page.as_deref(),
+            )
+            .await?,
+    ))
+}
+
+async fn changes(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Query(query): Query<ChangesQuery>,
+) -> ApiResult<Json<SyncChangesPage>> {
+    let token = bearer(&headers)?;
+    let limit = validate_limit(query.limit)?;
+    Ok(Json(
+        state
+            .provider
+            .changes(collection_id, token, query.after, limit)
+            .await?,
+    ))
+}
+
+async fn mutate(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(mutation): Json<SyncMutation>,
+) -> ApiResult<Json<SyncMutationReceipt>> {
+    let token = bearer(&headers)?;
+    Ok(Json(
+        state
+            .provider
+            .mutate(collection_id, token, mutation)
+            .await?,
+    ))
+}
+
+async fn operation(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((collection_id, operation)): Path<(Uuid, String)>,
+    Json(input): Json<Value>,
+) -> ApiResult<Json<Value>> {
+    let token = bearer(&headers)?;
+    let origin = headers.get(ORIGIN).and_then(|value| value.to_str().ok());
+    let result = state
+        .provider
+        .operation(collection_id, token, &operation, input, origin)
+        .await?;
+    Ok(Json(json!({ "ok": true, "result": result })))
+}
+
+fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| {
+            ApiError::unauthorized("missing_bearer_token", "A bearer credential is required.")
+        })
+}
+
+fn canonical_origin(value: &str) -> ApiResult<HeaderValue> {
+    let url = Url::parse(value).map_err(|_| {
+        ApiError::bad_request(
+            "invalid_allowed_origin",
+            "Hosted provider allowed origins must be absolute HTTP(S) origins.",
+        )
+    })?;
+    let loopback = matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
+    if !matches!(url.scheme(), "http" | "https")
+        || (url.scheme() != "https" && !loopback)
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(ApiError::bad_request(
+            "invalid_allowed_origin",
+            "Hosted provider origins must be canonical HTTPS origins outside loopback development.",
+        ));
+    }
+    HeaderValue::from_str(url.origin().ascii_serialization().as_str()).map_err(|_| {
+        ApiError::bad_request(
+            "invalid_allowed_origin",
+            "Hosted provider allowed origin is not a valid HTTP header value.",
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_credentials_are_checked_by_digest() {
+        let hash: [u8; 32] = Sha256::digest(b"a-long-test-token-that-is-over-32-characters").into();
+        assert!(bool::from(hash.ct_eq(&hash)));
+        let other: [u8; 32] = Sha256::digest(b"another-long-test-token-that-is-different").into();
+        assert!(!bool::from(hash.ct_eq(&other)));
+    }
+
+    #[test]
+    fn allowed_origins_are_canonical_and_tls_bound() {
+        assert_eq!(
+            canonical_origin("https://app.example/").unwrap(),
+            "https://app.example"
+        );
+        assert!(canonical_origin("http://app.example").is_err());
+        assert!(canonical_origin("https://app.example/path").is_err());
+        assert!(canonical_origin("http://127.0.0.1:5173").is_ok());
+    }
+}

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -1,0 +1,11 @@
+mod crypto;
+mod error;
+mod http;
+mod provider;
+mod template;
+mod workspace;
+
+pub use crypto::ProviderCrypto;
+pub use error::{ApiError, ApiResult};
+pub use http::{app, AppState};
+pub use provider::{HostedProvider, ProviderLimits, RegisterReplica};

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -1,0 +1,144 @@
+use std::{net::IpAddr, time::Duration};
+
+use clap::Parser;
+use mdbase_connect_hosted_provider::{
+    app, AppState, HostedProvider, ProviderCrypto, ProviderLimits,
+};
+use tokio::{net::TcpListener, signal};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Debug, Parser)]
+#[command(name = "mdbase-connect-hosted-provider")]
+struct Arguments {
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN")]
+    internal_token: String,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY")]
+    master_key: String,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_ALLOWED_ORIGINS")]
+    allowed_origins: String,
+    #[arg(long, env = "HOST", default_value = "127.0.0.1")]
+    host: IpAddr,
+    #[arg(long, env = "PORT", default_value_t = 8790)]
+    port: u16,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_MAX_RECORDS_PER_COLLECTION",
+        default_value_t = 100_000
+    )]
+    max_records_per_collection: u64,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_COLLECTION",
+        default_value_t = 1_073_741_824
+    )]
+    max_bytes_per_collection: u64,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_DOCUMENT",
+        default_value_t = 2_097_152
+    )]
+    max_bytes_per_document: u64,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_MAX_REPLICAS_PER_COLLECTION",
+        default_value_t = 100
+    )]
+    max_replicas_per_collection: u64,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_RETAIN_CHANGES",
+        default_value_t = 100_000
+    )]
+    retain_changes: u64,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_MAINTENANCE_INTERVAL_SECONDS",
+        default_value_t = 300
+    )]
+    maintenance_interval_seconds: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let arguments = Arguments::parse();
+    if arguments.maintenance_interval_seconds == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "hosted maintenance interval must be greater than zero",
+        )
+        .into());
+    }
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .init();
+
+    let crypto = ProviderCrypto::from_base64(&arguments.master_key)?;
+    let limits = ProviderLimits {
+        max_records_per_collection: arguments.max_records_per_collection,
+        max_bytes_per_collection: arguments.max_bytes_per_collection,
+        max_bytes_per_document: arguments.max_bytes_per_document,
+        max_replicas_per_collection: arguments.max_replicas_per_collection,
+    };
+    let provider = HostedProvider::connect(&arguments.database_url, crypto, limits).await?;
+    let allowed_origins = arguments
+        .allowed_origins
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let state = AppState::new(provider.clone(), &arguments.internal_token, allowed_origins)?;
+    let maintenance = tokio::spawn(maintain_history(
+        provider,
+        arguments.retain_changes,
+        Duration::from_secs(arguments.maintenance_interval_seconds),
+    ));
+    let listener = TcpListener::bind((arguments.host, arguments.port)).await?;
+    let address = listener.local_addr()?;
+    println!("HOSTED_PROVIDER_LISTENING=http://{address}");
+    tracing::info!(%address, "hosted provider listening");
+
+    let result = axum::serve(listener, app(state))
+        .with_graceful_shutdown(shutdown_signal())
+        .await;
+    maintenance.abort();
+    let _ = maintenance.await;
+    result?;
+    Ok(())
+}
+
+async fn maintain_history(provider: HostedProvider, retain_changes: u64, period: Duration) {
+    let mut interval = tokio::time::interval(period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        interval.tick().await;
+        match provider.compact_stale_history(retain_changes).await {
+            Ok(0) => {}
+            Ok(collections) => {
+                tracing::info!(collections, retain_changes, "compacted hosted history")
+            }
+            Err(error) => tracing::error!(%error, "hosted history maintenance failed"),
+        }
+    }
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("SIGTERM handler can be installed");
+        tokio::select! {
+            _ = signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = signal::ctrl_c().await;
+    tracing::info!("shutdown requested");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+}

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -1,0 +1,2658 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::http::StatusCode;
+use chrono::Utc;
+use hmac::{Hmac, Mac};
+use mdbase::v03::{Diagnostic, OperationResult};
+use mdbase_connect_protocol::{
+    CollectionChange, CollectionChangesPage, CollectionDescription, SyncChange, SyncChangesPage,
+    SyncCollectionResources, SyncConflict, SyncMutation, SyncMutationError, SyncMutationOperation,
+    SyncMutationReceipt, SyncRecord, SyncReplicaMode, SyncResourceDocument, SyncSession,
+    SyncSnapshotPage, CONTROL_PROTOCOL_VERSION, SYNC_PROTOCOL_VERSION,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use sqlx::{postgres::PgPoolOptions, PgPool, Postgres, Row, Transaction};
+use subtle::ConstantTimeEq;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::{
+    crypto::ProviderCrypto,
+    error::{ApiError, ApiResult},
+    template,
+    workspace::{StoredDocument, WorkingSet},
+};
+
+const SNAPSHOT_PAGE_SIZE: i64 = 200;
+const DATABASE_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+type WorkingSetSlot = Arc<Mutex<Option<CachedCollection>>>;
+type WorkingSetRegistry = Arc<Mutex<HashMap<Uuid, WorkingSetSlot>>>;
+
+#[derive(Debug, Clone)]
+pub struct ProviderLimits {
+    pub max_records_per_collection: u64,
+    pub max_bytes_per_collection: u64,
+    pub max_bytes_per_document: u64,
+    pub max_replicas_per_collection: u64,
+}
+
+impl Default for ProviderLimits {
+    fn default() -> Self {
+        Self {
+            max_records_per_collection: 100_000,
+            max_bytes_per_collection: 1024 * 1024 * 1024,
+            max_bytes_per_document: 2 * 1024 * 1024,
+            max_replicas_per_collection: 100,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HostedProvider {
+    pool: PgPool,
+    crypto: ProviderCrypto,
+    limits: ProviderLimits,
+    working_sets: WorkingSetRegistry,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegisterReplica {
+    pub replica_id: Uuid,
+    pub name: String,
+    #[serde(default)]
+    pub purpose: ReplicaPurpose,
+    pub mode: SyncReplicaMode,
+    #[serde(default)]
+    pub allowed_types: Vec<String>,
+    #[serde(default)]
+    pub allowed_operations: Vec<String>,
+    #[serde(default)]
+    pub allowed_origin: Option<String>,
+    pub token: String,
+    #[serde(default)]
+    pub token_ttl_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateApplicationReplica {
+    pub mode: SyncReplicaMode,
+    pub allowed_operations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplicaPurpose {
+    #[default]
+    Mirror,
+    Application,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderCollection {
+    pub id: Uuid,
+    pub spec_version: String,
+    pub resource_revision: String,
+}
+
+#[derive(Debug, Clone)]
+struct Replica {
+    id: Uuid,
+    mode: SyncReplicaMode,
+    allowed_types: Vec<String>,
+    allowed_operations: Vec<String>,
+    allowed_origin: Option<String>,
+    scope_epoch: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedRecord {
+    record: SyncRecord,
+    document: String,
+}
+
+struct CachedCollection {
+    head: Option<u64>,
+    workspace: WorkingSet,
+    records: BTreeMap<Uuid, PersistedRecord>,
+    query_cache: HashMap<[u8; 32], OperationResult>,
+    query_order: VecDeque<[u8; 32]>,
+}
+
+impl HostedProvider {
+    pub async fn connect(
+        database_url: &str,
+        crypto: ProviderCrypto,
+        limits: ProviderLimits,
+    ) -> ApiResult<Self> {
+        let started = Instant::now();
+        let mut retry_delay = Duration::from_millis(100);
+        loop {
+            match PgPoolOptions::new()
+                .max_connections(20)
+                .min_connections(1)
+                .acquire_timeout(Duration::from_secs(5))
+                .idle_timeout(Duration::from_secs(10 * 60))
+                .max_lifetime(Duration::from_secs(30 * 60))
+                .connect(database_url)
+                .await
+            {
+                Ok(pool) => match sqlx::migrate!("./migrations").run(&pool).await {
+                    Ok(()) => match verify_database_key(&pool, &crypto).await {
+                        Ok(()) => {
+                            return Ok(Self {
+                                pool,
+                                crypto,
+                                limits,
+                                working_sets: Arc::new(Mutex::new(HashMap::new())),
+                            })
+                        }
+                        Err(DatabaseKeyError::Invalid(error)) => {
+                            pool.close().await;
+                            return Err(error);
+                        }
+                        Err(DatabaseKeyError::Database(error))
+                            if started.elapsed() < DATABASE_STARTUP_TIMEOUT =>
+                        {
+                            tracing::warn!(error = %error, "hosted provider key check unavailable; retrying");
+                            pool.close().await;
+                        }
+                        Err(DatabaseKeyError::Database(error)) => {
+                            tracing::error!(error = %error, "hosted provider key check failed");
+                            return Err(ApiError::internal(
+                                "The hosted provider could not verify its authoritative store.",
+                            ));
+                        }
+                    },
+                    Err(error) if started.elapsed() < DATABASE_STARTUP_TIMEOUT => {
+                        tracing::warn!(error = %error, "hosted provider migration unavailable; retrying");
+                        pool.close().await;
+                    }
+                    Err(error) => {
+                        tracing::error!(error = %error, "hosted provider migration failed");
+                        return Err(ApiError::internal(
+                            "The hosted provider database migration failed.",
+                        ));
+                    }
+                },
+                Err(error) if started.elapsed() < DATABASE_STARTUP_TIMEOUT => {
+                    tracing::warn!(error = %error, "hosted provider database unavailable; retrying");
+                }
+                Err(error) => {
+                    tracing::error!(error = %error, "hosted provider database connection failed");
+                    return Err(ApiError::internal(
+                        "The hosted provider could not connect to its authoritative store.",
+                    ));
+                }
+            }
+            tokio::time::sleep(retry_delay).await;
+            retry_delay = (retry_delay * 2).min(Duration::from_secs(2));
+        }
+    }
+
+    pub async fn ready(&self) -> ApiResult<()> {
+        sqlx::query("SELECT 1").execute(&self.pool).await?;
+        Ok(())
+    }
+
+    pub async fn create_collection(
+        &self,
+        collection_id: Uuid,
+        template_name: &str,
+    ) -> ApiResult<ProviderCollection> {
+        let (resources, documents) = template::resources(template_name)?;
+        let data_key = self.crypto.generate_data_key();
+        let wrapped_data_key = self
+            .crypto
+            .wrap_data_key(&data_key, &collection_key_aad(collection_id))?;
+        let resources_ciphertext =
+            self.crypto
+                .encrypt_json(&data_key, &resources, &resources_aad(collection_id))?;
+        let mut transaction = self.pool.begin().await?;
+        let inserted = sqlx::query(
+            r#"INSERT INTO hosted_provider_collections
+                 (id, template, spec_version, resource_revision, wrapped_data_key,
+                  resources_ciphertext, max_records, max_content_bytes,
+                  max_document_bytes, max_replicas)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+               ON CONFLICT (id) DO NOTHING"#,
+        )
+        .bind(collection_id)
+        .bind(template_name)
+        .bind(&resources.spec_version)
+        .bind(&resources.revision)
+        .bind(wrapped_data_key)
+        .bind(resources_ciphertext)
+        .bind(to_i64(
+            self.limits.max_records_per_collection,
+            "record quota",
+        )?)
+        .bind(to_i64(
+            self.limits.max_bytes_per_collection,
+            "collection byte quota",
+        )?)
+        .bind(to_i64(
+            self.limits.max_bytes_per_document,
+            "document byte quota",
+        )?)
+        .bind(to_i64(
+            self.limits.max_replicas_per_collection,
+            "replica quota",
+        )?)
+        .execute(&mut *transaction)
+        .await?;
+        if inserted.rows_affected() == 0 {
+            let existing = sqlx::query(
+                "SELECT template, spec_version, resource_revision FROM hosted_provider_collections WHERE id = $1",
+            )
+            .bind(collection_id)
+            .fetch_one(&mut *transaction)
+            .await?;
+            let existing_template: String = existing.get("template");
+            if existing_template != template_name {
+                return Err(ApiError::conflict(
+                    "hosted_collection_conflict",
+                    "Hosted collection already exists with a different template.",
+                ));
+            }
+            let result = ProviderCollection {
+                id: collection_id,
+                spec_version: existing.get("spec_version"),
+                resource_revision: existing.get("resource_revision"),
+            };
+            transaction.commit().await?;
+            return Ok(result);
+        }
+        for document in documents {
+            sqlx::query(
+                r#"INSERT INTO hosted_provider_resources
+                     (collection_id, path, kind, revision, document_ciphertext)
+                   VALUES ($1, $2, $3, $4, $5)
+                   ON CONFLICT (collection_id, path) DO NOTHING"#,
+            )
+            .bind(collection_id)
+            .bind(document.path)
+            .bind(document.kind)
+            .bind(document.revision)
+            .bind(self.crypto.encrypt_bytes(
+                &data_key,
+                document.document.as_bytes(),
+                &resource_document_aad(collection_id, document.path),
+            )?)
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+        Ok(ProviderCollection {
+            id: collection_id,
+            spec_version: resources.spec_version,
+            resource_revision: resources.revision,
+        })
+    }
+
+    pub async fn delete_collection(&self, collection_id: Uuid) -> ApiResult<()> {
+        sqlx::query("DELETE FROM hosted_provider_collections WHERE id = $1")
+            .bind(collection_id)
+            .execute(&self.pool)
+            .await?;
+        self.working_sets.lock().await.remove(&collection_id);
+        Ok(())
+    }
+
+    pub async fn register_replica(
+        &self,
+        collection_id: Uuid,
+        mut input: RegisterReplica,
+    ) -> ApiResult<()> {
+        if input.name.trim().is_empty() || input.token.len() < 32 {
+            return Err(ApiError::bad_request(
+                "invalid_replica",
+                "Replica name and credential are required.",
+            ));
+        }
+        input.allowed_types.sort();
+        input.allowed_types.dedup();
+        input.allowed_operations.sort();
+        input.allowed_operations.dedup();
+        validate_replica_capability(&input)?;
+        let token_ttl_seconds = input.token_ttl_seconds.unwrap_or(30 * 24 * 60 * 60);
+        if !(60..=30 * 24 * 60 * 60).contains(&token_ttl_seconds) {
+            return Err(ApiError::bad_request(
+                "invalid_replica_ttl",
+                "Replica credential lifetime must be between one minute and 30 days.",
+            ));
+        }
+        let mode = replica_mode(input.mode);
+        let purpose = replica_purpose(input.purpose);
+        let name = input.name.trim().to_string();
+        let requested_token_hash = token_hash(&input.token);
+        let mut transaction = self.pool.begin().await?;
+        let collection = sqlx::query(
+            "SELECT max_replicas FROM hosted_provider_collections WHERE id = $1 FOR UPDATE",
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let max_replicas = number(collection.get::<i64, _>("max_replicas"), "replica quota")?;
+        if let Some(existing) = sqlx::query(
+            r#"SELECT collection_id, name, purpose, mode, allowed_types,
+                      allowed_operations, allowed_origin, token_hash, revoked_at
+               FROM hosted_provider_replicas WHERE id = $1 FOR UPDATE"#,
+        )
+        .bind(input.replica_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        {
+            let existing_hash: Vec<u8> = existing.get("token_hash");
+            let exact_match = existing.get::<Uuid, _>("collection_id") == collection_id
+                && existing.get::<String, _>("name") == name
+                && existing.get::<String, _>("purpose") == purpose
+                && existing.get::<String, _>("mode") == mode
+                && existing.get::<Vec<String>, _>("allowed_types") == input.allowed_types
+                && existing.get::<Vec<String>, _>("allowed_operations") == input.allowed_operations
+                && existing
+                    .get::<Option<String>, _>("allowed_origin")
+                    .as_deref()
+                    == input.allowed_origin.as_deref()
+                && existing
+                    .get::<Option<chrono::DateTime<Utc>>, _>("revoked_at")
+                    .is_none()
+                && existing_hash.len() == requested_token_hash.len()
+                && bool::from(existing_hash.as_slice().ct_eq(&requested_token_hash));
+            if exact_match {
+                transaction.commit().await?;
+                return Ok(());
+            }
+            return Err(ApiError::conflict(
+                "replica_conflict",
+                "Replica already exists with a different capability.",
+            ));
+        }
+        let replica_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM hosted_provider_replicas WHERE collection_id = $1 AND revoked_at IS NULL",
+        )
+        .bind(collection_id)
+        .fetch_one(&mut *transaction)
+        .await?;
+        if number(replica_count, "replica count")? >= max_replicas {
+            return Err(ApiError::quota(
+                "replica_quota_exceeded",
+                "The hosted collection has reached its active replica limit.",
+            ));
+        }
+        let result = sqlx::query(
+            r#"INSERT INTO hosted_provider_replicas
+                 (id, collection_id, name, purpose, mode, allowed_types,
+                  allowed_operations, allowed_origin, token_hash, token_expires_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
+                       now() + ($10 * interval '1 second'))"#,
+        )
+        .bind(input.replica_id)
+        .bind(collection_id)
+        .bind(name)
+        .bind(purpose)
+        .bind(mode)
+        .bind(input.allowed_types)
+        .bind(input.allowed_operations)
+        .bind(input.allowed_origin)
+        .bind(requested_token_hash)
+        .bind(to_i64(token_ttl_seconds, "replica credential lifetime")?)
+        .execute(&mut *transaction)
+        .await;
+        match result {
+            Ok(_) => {
+                transaction.commit().await?;
+                Ok(())
+            }
+            Err(sqlx::Error::Database(error)) if error.is_foreign_key_violation() => {
+                Err(ApiError::not_found(
+                    "hosted_collection_not_found",
+                    "Hosted collection not found.",
+                ))
+            }
+            Err(sqlx::Error::Database(error)) if error.is_unique_violation() => Err(
+                ApiError::conflict("replica_conflict", "Replica already exists."),
+            ),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub async fn rotate_replica_token(
+        &self,
+        replica_id: Uuid,
+        token: &str,
+        token_ttl_seconds: Option<u64>,
+    ) -> ApiResult<()> {
+        if token.len() < 32 {
+            return Err(ApiError::bad_request(
+                "invalid_replica_token",
+                "Replica credential is too short.",
+            ));
+        }
+        let token_ttl_seconds = token_ttl_seconds.unwrap_or(30 * 24 * 60 * 60);
+        if !(60..=30 * 24 * 60 * 60).contains(&token_ttl_seconds) {
+            return Err(ApiError::bad_request(
+                "invalid_replica_ttl",
+                "Replica credential lifetime must be between one minute and 30 days.",
+            ));
+        }
+        let result = sqlx::query(
+            r#"UPDATE hosted_provider_replicas
+               SET token_hash = $2, token_expires_at = now() + ($3 * interval '1 second')
+               WHERE id = $1 AND revoked_at IS NULL"#,
+        )
+        .bind(replica_id)
+        .bind(token_hash(token))
+        .bind(to_i64(token_ttl_seconds, "replica credential lifetime")?)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(ApiError::not_found(
+                "replica_not_found",
+                "Active replica not found.",
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn update_application_replica(
+        &self,
+        replica_id: Uuid,
+        mut input: UpdateApplicationReplica,
+    ) -> ApiResult<()> {
+        input.allowed_operations.sort();
+        input.allowed_operations.dedup();
+        validate_operations(&input.allowed_operations, input.mode)?;
+        if input.allowed_operations.is_empty() {
+            return Err(ApiError::bad_request(
+                "invalid_application_capability",
+                "Application capabilities require at least one operation.",
+            ));
+        }
+        let result = sqlx::query(
+            r#"UPDATE hosted_provider_replicas
+               SET scope_epoch = scope_epoch + CASE
+                     WHEN mode IS DISTINCT FROM $2 OR allowed_operations IS DISTINCT FROM $3
+                     THEN 1 ELSE 0 END,
+                   mode = $2,
+                   allowed_operations = $3
+               WHERE id = $1 AND purpose = 'application' AND revoked_at IS NULL"#,
+        )
+        .bind(replica_id)
+        .bind(replica_mode(input.mode))
+        .bind(input.allowed_operations)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(ApiError::not_found(
+                "replica_not_found",
+                "Active application capability not found.",
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn revoke_replica(&self, replica_id: Uuid) -> ApiResult<()> {
+        sqlx::query(
+            "UPDATE hosted_provider_replicas SET revoked_at = now() WHERE id = $1 AND revoked_at IS NULL",
+        )
+        .bind(replica_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn compact_through(&self, collection_id: Uuid, through: u64) -> ApiResult<()> {
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query("DELETE FROM hosted_provider_snapshot_leases WHERE expires_at <= now()")
+            .execute(&mut *transaction)
+            .await?;
+        let row = sqlx::query(
+            "SELECT head, retained_after FROM hosted_provider_collections WHERE id = $1 FOR UPDATE",
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let head = number(row.get::<i64, _>("head"), "collection head")?;
+        let retained = number(row.get::<i64, _>("retained_after"), "retained cursor")?;
+        if through < retained || through > head {
+            return Err(ApiError::bad_request(
+                "invalid_cursor",
+                "Compaction cursor is outside retained history.",
+            ));
+        }
+        sqlx::query(
+            "UPDATE hosted_provider_collections SET retained_after = $2, updated_at = now() WHERE id = $1",
+        )
+        .bind(collection_id)
+        .bind(to_i64(through, "compaction cursor")?)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "DELETE FROM hosted_provider_changes WHERE collection_id = $1 AND sequence <= $2",
+        )
+        .bind(collection_id)
+        .bind(to_i64(through, "compaction cursor")?)
+        .execute(&mut *transaction)
+        .await?;
+        let through_i64 = to_i64(through, "compaction cursor")?;
+        let oldest_live_snapshot: Option<i64> = sqlx::query_scalar(
+            r#"SELECT min(cursor) FROM hosted_provider_snapshot_leases
+               WHERE collection_id = $1 AND expires_at > now()"#,
+        )
+        .bind(collection_id)
+        .fetch_one(&mut *transaction)
+        .await?;
+        let prune_boundary = oldest_live_snapshot
+            .map(|cursor| cursor.min(through_i64))
+            .unwrap_or(through_i64);
+        sqlx::query(
+            r#"DELETE FROM hosted_provider_record_versions version
+               WHERE version.collection_id = $1
+                 AND version.sequence <= $2
+                 AND version.sequence < (
+                   SELECT max(anchor.sequence)
+                   FROM hosted_provider_record_versions anchor
+                   WHERE anchor.collection_id = version.collection_id
+                     AND anchor.record_id = version.record_id
+                     AND anchor.sequence <= $2
+                 )"#,
+        )
+        .bind(collection_id)
+        .bind(prune_boundary)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    /// Bounds the durable change log without relying on a control-plane cron.
+    /// Replicas behind the retained cursor deliberately use the ordinary
+    /// snapshot-reset path on their next pull.
+    pub async fn compact_stale_history(&self, retain_changes: u64) -> ApiResult<usize> {
+        let rows = sqlx::query(
+            r#"SELECT id, head
+               FROM hosted_provider_collections
+               WHERE state = 'active' AND head - retained_after > $1
+               ORDER BY updated_at"#,
+        )
+        .bind(to_i64(retain_changes, "history retention")?)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut compacted = 0;
+        for row in rows {
+            let collection_id: Uuid = row.get("id");
+            let head = number(row.get::<i64, _>("head"), "collection head")?;
+            self.compact_through(collection_id, head.saturating_sub(retain_changes))
+                .await?;
+            compacted += 1;
+        }
+        Ok(compacted)
+    }
+
+    pub async fn open_session(&self, collection_id: Uuid, token: &str) -> ApiResult<SyncSession> {
+        let replica = self
+            .authenticate_for(collection_id, token, ReplicaPurpose::Mirror)
+            .await?;
+        let row = sqlx::query(
+            r#"SELECT head, retained_after, resource_revision, wrapped_data_key, resources_ciphertext
+               FROM hosted_provider_collections WHERE id = $1 AND state = 'active'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let head = number(row.get::<i64, _>("head"), "collection head")?;
+        let retained_after = number(row.get::<i64, _>("retained_after"), "retained cursor")?;
+        let resource_revision: String = row.get("resource_revision");
+        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let mut resources: SyncCollectionResources = self.crypto.decrypt_json(
+            &data_key,
+            row.get("resources_ciphertext"),
+            &resources_aad(collection_id),
+        )?;
+        resources.documents =
+            load_sync_resource_documents(&self.pool, &self.crypto, &data_key, collection_id)
+                .await?;
+        let snapshot_id = Uuid::new_v4();
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query("DELETE FROM hosted_provider_snapshot_leases WHERE expires_at <= now()")
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(
+            r#"INSERT INTO hosted_provider_snapshot_leases
+                 (id, collection_id, replica_id, scope_epoch, cursor, resource_revision, expires_at)
+               VALUES ($1, $2, $3, $4, $5, $6, now() + interval '15 minutes')"#,
+        )
+        .bind(snapshot_id)
+        .bind(collection_id)
+        .bind(replica.id)
+        .bind(to_i64(replica.scope_epoch, "scope epoch")?)
+        .bind(to_i64(head, "collection head")?)
+        .bind(resource_revision)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(SyncSession {
+            protocol_version: SYNC_PROTOCOL_VERSION,
+            session_id: Uuid::new_v4(),
+            replica_id: replica.id,
+            collection_id,
+            mode: replica.mode,
+            scope_epoch: replica.scope_epoch,
+            retained_after,
+            head,
+            snapshot_id,
+            resources: scoped_resources(resources, &replica.allowed_types),
+        })
+    }
+
+    pub async fn snapshot(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        snapshot_id: Uuid,
+        page: Option<&str>,
+    ) -> ApiResult<SyncSnapshotPage> {
+        let replica = self
+            .authenticate_for(collection_id, token, ReplicaPurpose::Mirror)
+            .await?;
+        let after_record_id = page
+            .map(|value| {
+                Uuid::parse_str(value).map_err(|_| {
+                    ApiError::bad_request("invalid_page", "Snapshot page token is invalid.")
+                })
+            })
+            .transpose()?;
+        let lease = sqlx::query(
+            r#"SELECT lease.cursor, lease.scope_epoch, collection.wrapped_data_key
+               FROM hosted_provider_snapshot_leases lease
+               JOIN hosted_provider_collections collection ON collection.id = lease.collection_id
+               WHERE lease.id = $1 AND lease.collection_id = $2 AND lease.replica_id = $3
+                 AND expires_at > now()"#,
+        )
+        .bind(snapshot_id)
+        .bind(collection_id)
+        .bind(replica.id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::conflict(
+                "snapshot_expired",
+                "The snapshot is unavailable; open a new sync session.",
+            )
+        })?;
+        let cursor = number(lease.get::<i64, _>("cursor"), "snapshot cursor")?;
+        let scope_epoch = number(lease.get::<i64, _>("scope_epoch"), "scope epoch")?;
+        if scope_epoch != replica.scope_epoch {
+            return Err(ApiError::conflict(
+                "snapshot_expired",
+                "The replica scope changed; open a new sync session.",
+            ));
+        }
+        let data_key = self.collection_key(collection_id, lease.get("wrapped_data_key"))?;
+        let rows = sqlx::query(
+            r#"SELECT record_id, revision, types, sequence, payload_ciphertext
+               FROM (
+                 SELECT DISTINCT ON (record_id)
+                   record_id, revision, types, sequence, payload_ciphertext, deleted
+                 FROM hosted_provider_record_versions
+                 WHERE collection_id = $1 AND sequence <= $2
+                 ORDER BY record_id, sequence DESC
+               ) versions
+               WHERE deleted = false
+                 AND (cardinality($3::text[]) = 0 OR types && $3::text[])
+                 AND ($4::uuid IS NULL OR record_id > $4)
+               ORDER BY record_id
+               LIMIT $5"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(cursor, "snapshot cursor")?)
+        .bind(&replica.allowed_types)
+        .bind(after_record_id)
+        .bind(SNAPSHOT_PAGE_SIZE + 1)
+        .fetch_all(&self.pool)
+        .await?;
+        let has_more = rows.len() > SNAPSHOT_PAGE_SIZE as usize;
+        let page_rows = rows
+            .into_iter()
+            .take(SNAPSHOT_PAGE_SIZE as usize)
+            .collect::<Vec<_>>();
+        let next_page = has_more.then(|| {
+            page_rows
+                .last()
+                .expect("a full snapshot page has a final record")
+                .get::<Uuid, _>("record_id")
+                .to_string()
+        });
+        let records = page_rows
+            .into_iter()
+            .map(|row| {
+                let sequence = number(row.get::<i64, _>("sequence"), "record sequence")?;
+                let payload: PersistedRecord = self.crypto.decrypt_json(
+                    &data_key,
+                    row.get("payload_ciphertext"),
+                    &record_version_aad(collection_id, row.get("record_id"), sequence),
+                )?;
+                Ok(payload.record)
+            })
+            .collect::<ApiResult<Vec<_>>>()?;
+        Ok(SyncSnapshotPage {
+            protocol_version: SYNC_PROTOCOL_VERSION,
+            snapshot_id,
+            scope_epoch,
+            cursor,
+            records,
+            next_page,
+        })
+    }
+
+    pub async fn changes(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        after: u64,
+        limit: u32,
+    ) -> ApiResult<SyncChangesPage> {
+        let replica = self
+            .authenticate_for(collection_id, token, ReplicaPurpose::Mirror)
+            .await?;
+        let collection = sqlx::query(
+            "SELECT head, retained_after, wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let head = number(collection.get::<i64, _>("head"), "collection head")?;
+        let retained_after = number(
+            collection.get::<i64, _>("retained_after"),
+            "retained cursor",
+        )?;
+        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        if after < retained_after {
+            return Ok(SyncChangesPage {
+                protocol_version: SYNC_PROTOCOL_VERSION,
+                scope_epoch: replica.scope_epoch,
+                events: Vec::new(),
+                cursor: after,
+                head,
+                has_more: false,
+                reset_required: true,
+            });
+        }
+        if after > head {
+            return Err(ApiError::bad_request(
+                "invalid_cursor",
+                "Change cursor is ahead of the collection authority.",
+            ));
+        }
+        let raw_limit = i64::from(limit.clamp(1, 500));
+        let rows = sqlx::query(
+            r#"SELECT sequence, record_id, before_ciphertext, after_ciphertext, revision
+               FROM hosted_provider_changes
+               WHERE collection_id = $1 AND sequence > $2
+               ORDER BY sequence
+               LIMIT $3"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(after, "change cursor")?)
+        .bind(raw_limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let cursor = rows
+            .last()
+            .map(|row| number(row.get::<i64, _>("sequence"), "change sequence"))
+            .transpose()?
+            .unwrap_or(after);
+        let mut events = Vec::new();
+        for row in rows {
+            let sequence = number(row.get::<i64, _>("sequence"), "change sequence")?;
+            let record_id: Uuid = row.get("record_id");
+            let before = optional_encrypted_record(
+                &self.crypto,
+                &data_key,
+                row.get("before_ciphertext"),
+                &change_record_aad(collection_id, sequence, "before"),
+            )?;
+            let after_record = optional_encrypted_record(
+                &self.crypto,
+                &data_key,
+                row.get("after_ciphertext"),
+                &change_record_aad(collection_id, sequence, "after"),
+            )?;
+            let before_visible = before
+                .as_ref()
+                .is_some_and(|record| visible(record, &replica.allowed_types));
+            let after_visible = after_record
+                .as_ref()
+                .is_some_and(|record| visible(record, &replica.allowed_types));
+            if after_visible {
+                events.push(SyncChange::Put {
+                    sequence,
+                    record: after_record.expect("visibility checked above"),
+                });
+            } else if before_visible {
+                let before = before.expect("visibility checked above");
+                events.push(SyncChange::Remove {
+                    sequence,
+                    record_id,
+                    previous_path: before.path,
+                    revision: row.get("revision"),
+                });
+            }
+        }
+        sqlx::query(
+            r#"UPDATE hosted_provider_replicas
+               SET acknowledged_sequence = GREATEST(acknowledged_sequence, $2), last_seen_at = now()
+               WHERE id = $1"#,
+        )
+        .bind(replica.id)
+        .bind(to_i64(cursor, "change cursor")?)
+        .execute(&self.pool)
+        .await?;
+        Ok(SyncChangesPage {
+            protocol_version: SYNC_PROTOCOL_VERSION,
+            scope_epoch: replica.scope_epoch,
+            events,
+            cursor,
+            head,
+            has_more: cursor < head,
+            reset_required: false,
+        })
+    }
+
+    pub async fn mutate(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        mutation: SyncMutation,
+    ) -> ApiResult<SyncMutationReceipt> {
+        self.mutate_for(collection_id, token, mutation, ReplicaPurpose::Mirror)
+            .await
+    }
+
+    async fn mutate_for(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        mutation: SyncMutation,
+        purpose: ReplicaPurpose,
+    ) -> ApiResult<SyncMutationReceipt> {
+        let mut transaction = self.pool.begin().await?;
+        let replica = authenticate_in(&mut transaction, collection_id, token, purpose).await?;
+        if mutation.replica_id != replica.id {
+            return Err(ApiError::forbidden(
+                "replica_scope_denied",
+                "Mutation belongs to another replica.",
+            ));
+        }
+        let wrapped_data_key: Vec<u8> = sqlx::query_scalar(
+            "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        if let Some(row) = sqlx::query(
+            "SELECT mutation_hash, receipt_ciphertext FROM hosted_provider_mutation_receipts WHERE replica_id = $1 AND mutation_id = $2",
+        )
+        .bind(replica.id)
+        .bind(mutation.mutation_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        {
+            let stored_hash: Vec<u8> = row.get("mutation_hash");
+            let submitted_hash = mutation_hash(&mutation)?;
+            if !bool::from(stored_hash.ct_eq(&submitted_hash)) {
+                return Err(ApiError::conflict(
+                    "mutation_id_reused",
+                    "Mutation ID was already used for a different mutation.",
+                ));
+            }
+            let receipt: SyncMutationReceipt = self.crypto.decrypt_json(
+                &data_key,
+                row.get("receipt_ciphertext"),
+                &receipt_aad(replica.id, mutation.mutation_id),
+            )?;
+            transaction.commit().await?;
+            return Ok(previously_applied(receipt));
+        }
+        if replica.mode != SyncReplicaMode::ReadWrite {
+            return store_rejection(
+                transaction,
+                &self.crypto,
+                &data_key,
+                &mutation,
+                "replica_read_only",
+                "This replica is read-only.",
+            )
+            .await;
+        }
+        if mutation.scope_epoch != replica.scope_epoch {
+            return store_rejection(
+                transaction,
+                &self.crypto,
+                &data_key,
+                &mutation,
+                "scope_epoch_stale",
+                "Replica scope changed; open a new sync session.",
+            )
+            .await;
+        }
+        if let Some(predecessor) = mutation.causal_predecessor {
+            let predecessor_receipt: Option<Vec<u8>> = sqlx::query_scalar(
+                r#"SELECT receipt_ciphertext FROM hosted_provider_mutation_receipts
+                   WHERE replica_id = $1 AND mutation_id = $2"#,
+            )
+            .bind(replica.id)
+            .bind(predecessor)
+            .fetch_optional(&mut *transaction)
+            .await?;
+            let Some(predecessor_receipt) = predecessor_receipt else {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "causal_predecessor_missing",
+                    "The mutation's causal predecessor has not been applied.",
+                )
+                .await;
+            };
+            let predecessor_receipt: SyncMutationReceipt = self.crypto.decrypt_json(
+                &data_key,
+                &predecessor_receipt,
+                &receipt_aad(replica.id, predecessor),
+            )?;
+            if !matches!(
+                predecessor_receipt,
+                SyncMutationReceipt::Applied { .. } | SyncMutationReceipt::PreviouslyApplied { .. }
+            ) {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "causal_predecessor_not_applied",
+                    "The mutation's causal predecessor did not apply.",
+                )
+                .await;
+            }
+        }
+
+        let collection = sqlx::query(
+            r#"SELECT head, record_count, content_bytes, max_records,
+                      max_content_bytes, max_document_bytes
+               FROM hosted_provider_collections
+               WHERE id = $1 AND state = 'active' FOR UPDATE"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let mut head = number(collection.get::<i64, _>("head"), "collection head")?;
+        let record_count = number(collection.get::<i64, _>("record_count"), "record count")?;
+        let content_bytes = number(
+            collection.get::<i64, _>("content_bytes"),
+            "collection content bytes",
+        )?;
+        let max_records = number(collection.get::<i64, _>("max_records"), "record quota")?;
+        let max_content_bytes = number(
+            collection.get::<i64, _>("max_content_bytes"),
+            "collection byte quota",
+        )?;
+        let max_document_bytes = number(
+            collection.get::<i64, _>("max_document_bytes"),
+            "document byte quota",
+        )?;
+        let working_set = self.working_set(collection_id).await;
+        let mut cached = working_set.lock().await;
+        if cached
+            .as_ref()
+            .is_none_or(|working_set| working_set.head != Some(head))
+        {
+            let resources =
+                load_resource_documents(&mut transaction, &self.crypto, &data_key, collection_id)
+                    .await?;
+            let records =
+                load_records(&mut transaction, &self.crypto, &data_key, collection_id).await?;
+            let workspace = WorkingSet::materialize(
+                resources,
+                records.values().map(|record| StoredDocument {
+                    record_id: record.record.record_id,
+                    path: record.record.path.clone(),
+                    document: record.document.clone(),
+                }),
+            )?;
+            *cached = Some(CachedCollection {
+                head: Some(head),
+                workspace,
+                records,
+                query_cache: HashMap::new(),
+                query_order: VecDeque::new(),
+            });
+        }
+        let cached = cached
+            .as_mut()
+            .expect("hosted working set was initialized above");
+        let current = cached.records.get(&mutation.record_id).cloned();
+
+        if mutation.operation == SyncMutationOperation::Create && current.is_some() {
+            return store_rejection(
+                transaction,
+                &self.crypto,
+                &data_key,
+                &mutation,
+                "record_conflict",
+                "The hosted record ID already exists.",
+            )
+            .await;
+        }
+        if mutation.operation != SyncMutationOperation::Create {
+            let Some(current) = &current else {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "record_not_found",
+                    "The hosted record does not exist.",
+                )
+                .await;
+            };
+            if !visible(&current.record, &replica.allowed_types) {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "scope_denied",
+                    "The replica cannot mutate that record.",
+                )
+                .await;
+            }
+            let Some(base_revision) = mutation.base_revision.as_deref() else {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "base_revision_required",
+                    "Conditional mutations require a base revision.",
+                )
+                .await;
+            };
+            if base_revision != current.record.revision {
+                let receipt = SyncMutationReceipt::Conflicted {
+                    mutation_id: mutation.mutation_id,
+                    conflict: SyncConflict {
+                        record_id: mutation.record_id,
+                        mutation: mutation.clone(),
+                        current: Some(current.record.clone()),
+                        current_revision: Some(current.record.revision.clone()),
+                    },
+                };
+                store_receipt(
+                    &mut transaction,
+                    &self.crypto,
+                    &data_key,
+                    replica.id,
+                    &mutation,
+                    &receipt,
+                )
+                .await?;
+                transaction.commit().await?;
+                return Ok(receipt);
+            }
+        }
+
+        cached.head = None;
+        cached.query_cache.clear();
+        cached.query_order.clear();
+        let execution = cached.workspace.execute(&mutation)?;
+        if !execution.envelope.valid {
+            let (code, message) = operation_error(&execution.envelope);
+            return store_rejection(
+                transaction,
+                &self.crypto,
+                &data_key,
+                &mutation,
+                &code,
+                &message,
+            )
+            .await;
+        }
+        if execution.changed.is_empty() {
+            return Err(ApiError::internal(
+                "mdbase-rs accepted a mutation without producing a write set.",
+            ));
+        }
+        for (record_id, after, _) in &execution.changed {
+            let before = cached.records.get(record_id).map(|value| &value.record);
+            if before.is_some_and(|record| !visible(record, &replica.allowed_types))
+                || after
+                    .as_ref()
+                    .is_some_and(|record| !visible(record, &replica.allowed_types))
+            {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "scope_denied",
+                    "The mutation would change a record outside the replica scope.",
+                )
+                .await;
+            }
+        }
+        let mut next_record_count = i128::from(record_count);
+        let mut next_content_bytes = i128::from(content_bytes);
+        for (record_id, after, document) in &execution.changed {
+            let before = cached.records.get(record_id);
+            let before_bytes = before
+                .map(|record| record.document.len() as i128)
+                .unwrap_or_default();
+            let after_bytes = document
+                .as_ref()
+                .map(|value| value.len() as i128)
+                .unwrap_or_default();
+            if after.is_some()
+                && u64::try_from(after_bytes).unwrap_or(u64::MAX) > max_document_bytes
+            {
+                return store_rejection(
+                    transaction,
+                    &self.crypto,
+                    &data_key,
+                    &mutation,
+                    "document_quota_exceeded",
+                    "The canonical Markdown document exceeds the hosted document size limit.",
+                )
+                .await;
+            }
+            next_content_bytes += after_bytes - before_bytes;
+            next_record_count += match (before.is_some(), after.is_some()) {
+                (false, true) => 1,
+                (true, false) => -1,
+                _ => 0,
+            };
+        }
+        if next_record_count < 0
+            || next_record_count > i128::from(max_records)
+            || next_content_bytes < 0
+            || next_content_bytes > i128::from(max_content_bytes)
+        {
+            return store_rejection(
+                transaction,
+                &self.crypto,
+                &data_key,
+                &mutation,
+                "collection_quota_exceeded",
+                "The mutation would exceed the hosted collection quota.",
+            )
+            .await;
+        }
+
+        let mut primary = None;
+        for (record_id, after, document) in execution.changed {
+            head = head.checked_add(1).ok_or_else(|| {
+                ApiError::internal("The hosted collection sequence is exhausted.")
+            })?;
+            let before = cached
+                .records
+                .get(&record_id)
+                .map(|value| value.record.clone());
+            let revision = if let Some(record) = &after {
+                persist_live_record(
+                    &mut transaction,
+                    &self.crypto,
+                    &data_key,
+                    collection_id,
+                    head,
+                    record,
+                    document.as_deref().ok_or_else(|| {
+                        ApiError::internal("The hosted write set omitted its canonical document.")
+                    })?,
+                )
+                .await?;
+                if record_id == execution.primary_record_id {
+                    primary = Some(record.clone());
+                }
+                record.revision.clone()
+            } else {
+                let before = before.as_ref().ok_or_else(|| {
+                    ApiError::internal("The hosted write set deleted an unknown record.")
+                })?;
+                let revision = format!("hosted:1:{head}:tombstone");
+                persist_deleted_record(&mut transaction, collection_id, head, before, &revision)
+                    .await?;
+                revision
+            };
+            let before_ciphertext = before
+                .as_ref()
+                .map(|record| {
+                    self.crypto.encrypt_json(
+                        &data_key,
+                        record,
+                        &change_record_aad(collection_id, head, "before"),
+                    )
+                })
+                .transpose()?;
+            let after_ciphertext = after
+                .as_ref()
+                .map(|record| {
+                    self.crypto.encrypt_json(
+                        &data_key,
+                        record,
+                        &change_record_aad(collection_id, head, "after"),
+                    )
+                })
+                .transpose()?;
+            sqlx::query(
+                r#"INSERT INTO hosted_provider_changes
+                     (collection_id, sequence, record_id, before_types, after_types,
+                      before_ciphertext, after_ciphertext, revision)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#,
+            )
+            .bind(collection_id)
+            .bind(to_i64(head, "change sequence")?)
+            .bind(record_id)
+            .bind(
+                before
+                    .as_ref()
+                    .map(|record| record.types.clone())
+                    .unwrap_or_default(),
+            )
+            .bind(
+                after
+                    .as_ref()
+                    .map(|record| record.types.clone())
+                    .unwrap_or_default(),
+            )
+            .bind(before_ciphertext)
+            .bind(after_ciphertext)
+            .bind(revision)
+            .execute(&mut *transaction)
+            .await?;
+            if let Some(record) = after {
+                cached.records.insert(
+                    record_id,
+                    PersistedRecord {
+                        record,
+                        document: document.ok_or_else(|| {
+                            ApiError::internal(
+                                "The hosted write set omitted its canonical document.",
+                            )
+                        })?,
+                    },
+                );
+            } else {
+                cached.records.remove(&record_id);
+            }
+        }
+        sqlx::query(
+            r#"UPDATE hosted_provider_collections
+               SET head = $2, record_count = $3, content_bytes = $4, updated_at = now()
+               WHERE id = $1"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(head, "collection head")?)
+        .bind(i64::try_from(next_record_count).map_err(|_| {
+            ApiError::internal("The hosted record count is outside the supported range.")
+        })?)
+        .bind(i64::try_from(next_content_bytes).map_err(|_| {
+            ApiError::internal("The hosted content size is outside the supported range.")
+        })?)
+        .execute(&mut *transaction)
+        .await?;
+        let receipt = SyncMutationReceipt::Applied {
+            mutation_id: mutation.mutation_id,
+            sequence: head,
+            record: primary,
+        };
+        store_receipt(
+            &mut transaction,
+            &self.crypto,
+            &data_key,
+            replica.id,
+            &mutation,
+            &receipt,
+        )
+        .await?;
+        transaction.commit().await?;
+        cached.head = Some(head);
+        Ok(receipt)
+    }
+
+    pub async fn operation(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        operation: &str,
+        input: Value,
+        request_origin: Option<&str>,
+    ) -> ApiResult<Value> {
+        let replica = self
+            .authenticate_for(collection_id, token, ReplicaPurpose::Application)
+            .await?;
+        authorize_application_operation(&replica, operation, request_origin)?;
+        match operation {
+            "describe" => self.describe_operation(collection_id, &replica).await,
+            "changes" => {
+                self.changes_operation(collection_id, &replica, &input)
+                    .await
+            }
+            "read" | "query" | "validate" => {
+                let scoped_input = scope_read_input(operation, input, &replica.allowed_types)?;
+                let result = self
+                    .execute_read_operation(collection_id, operation, &scoped_input)
+                    .await?;
+                if matches!(operation, "read" | "validate") {
+                    ensure_operation_result_visible(&result, &replica.allowed_types)?;
+                }
+                serde_json::to_value(result).map_err(|error| {
+                    ApiError::internal(format!("Hosted operation could not serialize: {error}"))
+                })
+            }
+            "create" | "update" | "delete" | "rename" => {
+                self.write_operation(collection_id, token, &replica, operation, input)
+                    .await
+            }
+            _ => Err(ApiError::bad_request(
+                "unsupported_operation",
+                "The hosted provider does not support that collection operation.",
+            )),
+        }
+    }
+
+    async fn describe_operation(&self, collection_id: Uuid, replica: &Replica) -> ApiResult<Value> {
+        let row = sqlx::query(
+            r#"SELECT head, wrapped_data_key, resources_ciphertext
+               FROM hosted_provider_collections WHERE id = $1 AND state = 'active'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let resources: SyncCollectionResources = self.crypto.decrypt_json(
+            &data_key,
+            row.get("resources_ciphertext"),
+            &resources_aad(collection_id),
+        )?;
+        let resources = scoped_resources(resources, &replica.allowed_types);
+        let description = CollectionDescription {
+            protocol_version: CONTROL_PROTOCOL_VERSION,
+            collection_id,
+            display_name: "Hosted collection".to_string(),
+            spec_version: resources.spec_version,
+            operations: replica.allowed_operations.clone(),
+            change_cursor: number(row.get::<i64, _>("head"), "collection head")?,
+            types: resources.types,
+            contracts: resources.contracts,
+            configuration: None,
+        };
+        serde_json::to_value(description).map_err(|error| {
+            ApiError::internal(format!("Hosted description could not serialize: {error}"))
+        })
+    }
+
+    async fn changes_operation(
+        &self,
+        collection_id: Uuid,
+        replica: &Replica,
+        input: &Value,
+    ) -> ApiResult<Value> {
+        let collection = sqlx::query(
+            r#"SELECT head, retained_after, wrapped_data_key
+               FROM hosted_provider_collections WHERE id = $1 AND state = 'active'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let head = number(collection.get::<i64, _>("head"), "collection head")?;
+        let retained_after = number(
+            collection.get::<i64, _>("retained_after"),
+            "retained cursor",
+        )?;
+        let Some(after) = input.get("after").and_then(Value::as_u64) else {
+            return serde_json::to_value(CollectionChangesPage {
+                events: Vec::new(),
+                cursor: head,
+                has_more: false,
+                reset: false,
+            })
+            .map_err(|error| {
+                ApiError::internal(format!("Hosted changes could not serialize: {error}"))
+            });
+        };
+        if after > head {
+            return Err(ApiError::bad_request(
+                "invalid_cursor",
+                "Change cursor is ahead of the hosted collection.",
+            ));
+        }
+        if after < retained_after {
+            return serde_json::to_value(CollectionChangesPage {
+                events: Vec::new(),
+                cursor: head,
+                has_more: false,
+                reset: true,
+            })
+            .map_err(|error| {
+                ApiError::internal(format!("Hosted changes could not serialize: {error}"))
+            });
+        }
+        let limit = input
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(100)
+            .clamp(1, 500);
+        let rows = sqlx::query(
+            r#"SELECT sequence, before_ciphertext, after_ciphertext, created_at::text AS occurred_at
+               FROM hosted_provider_changes
+               WHERE collection_id = $1 AND sequence > $2
+                 AND (cardinality($3::text[]) = 0
+                      OR before_types && $3::text[] OR after_types && $3::text[])
+               ORDER BY sequence LIMIT $4"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(after, "change cursor")?)
+        .bind(&replica.allowed_types)
+        .bind(to_i64(limit + 1, "change page limit")?)
+        .fetch_all(&self.pool)
+        .await?;
+        let has_more = rows.len() > limit as usize;
+        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let mut events = Vec::new();
+        for row in rows.into_iter().take(limit as usize) {
+            let sequence = number(row.get::<i64, _>("sequence"), "change sequence")?;
+            let before = optional_encrypted_record(
+                &self.crypto,
+                &data_key,
+                row.get("before_ciphertext"),
+                &change_record_aad(collection_id, sequence, "before"),
+            )?;
+            let after_record = optional_encrypted_record(
+                &self.crypto,
+                &data_key,
+                row.get("after_ciphertext"),
+                &change_record_aad(collection_id, sequence, "after"),
+            )?;
+            if !before
+                .as_ref()
+                .is_some_and(|record| visible(record, &replica.allowed_types))
+                && !after_record
+                    .as_ref()
+                    .is_some_and(|record| visible(record, &replica.allowed_types))
+            {
+                continue;
+            }
+            let (event_type, payload) = application_change(before.as_ref(), after_record.as_ref());
+            events.push(CollectionChange {
+                cursor: sequence,
+                event_type: event_type.to_string(),
+                occurred_at: row.get("occurred_at"),
+                payload,
+            });
+        }
+        let cursor = events.last().map(|event| event.cursor).unwrap_or_else(|| {
+            if has_more {
+                after
+            } else {
+                head
+            }
+        });
+        serde_json::to_value(CollectionChangesPage {
+            events,
+            cursor,
+            has_more,
+            reset: false,
+        })
+        .map_err(|error| ApiError::internal(format!("Hosted changes could not serialize: {error}")))
+    }
+
+    async fn execute_read_operation(
+        &self,
+        collection_id: Uuid,
+        operation: &str,
+        input: &Value,
+    ) -> ApiResult<OperationResult> {
+        let mut transaction = self.pool.begin().await?;
+        let collection = sqlx::query(
+            r#"SELECT head, wrapped_data_key FROM hosted_provider_collections
+               WHERE id = $1 AND state = 'active'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let head = number(collection.get::<i64, _>("head"), "collection head")?;
+        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let working_set = self.working_set(collection_id).await;
+        let mut cached = working_set.lock().await;
+        if cached
+            .as_ref()
+            .is_none_or(|working_set| working_set.head != Some(head))
+        {
+            let resources =
+                load_resource_documents(&mut transaction, &self.crypto, &data_key, collection_id)
+                    .await?;
+            let records =
+                load_records(&mut transaction, &self.crypto, &data_key, collection_id).await?;
+            let workspace = WorkingSet::materialize(
+                resources,
+                records.values().map(|record| StoredDocument {
+                    record_id: record.record.record_id,
+                    path: record.record.path.clone(),
+                    document: record.document.clone(),
+                }),
+            )?;
+            *cached = Some(CachedCollection {
+                head: Some(head),
+                workspace,
+                records,
+                query_cache: HashMap::new(),
+                query_order: VecDeque::new(),
+            });
+        }
+        let cached = cached
+            .as_mut()
+            .expect("hosted working set was initialized above");
+        let result = if operation == "query" {
+            let cache_key: [u8; 32] =
+                Sha256::digest(serde_json::to_vec(input).map_err(|error| {
+                    ApiError::internal(format!("Hosted query input could not serialize: {error}"))
+                })?)
+                .into();
+            if let Some(result) = cached.query_cache.get(&cache_key) {
+                result.clone()
+            } else {
+                let result = cached.workspace.read_operation(operation, input)?;
+                if cached.query_order.len() >= 128 {
+                    if let Some(expired) = cached.query_order.pop_front() {
+                        cached.query_cache.remove(&expired);
+                    }
+                }
+                cached.query_order.push_back(cache_key);
+                cached.query_cache.insert(cache_key, result.clone());
+                result
+            }
+        } else {
+            cached.workspace.read_operation(operation, input)?
+        };
+        transaction.commit().await?;
+        Ok(result)
+    }
+
+    async fn write_operation(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        replica: &Replica,
+        operation: &str,
+        input: Value,
+    ) -> ApiResult<Value> {
+        let mut operation_input = input.as_object().cloned().ok_or_else(|| {
+            ApiError::bad_request(
+                "invalid_operation_input",
+                "Hosted operation input must be an object.",
+            )
+        })?;
+        let (mutation_operation, record_id, base_revision, previous_path) = match operation {
+            "create" => (SyncMutationOperation::Create, Uuid::new_v4(), None, None),
+            "update" | "delete" | "rename" => {
+                let path_key = if operation == "rename" {
+                    "from"
+                } else {
+                    "path"
+                };
+                let path = operation_input
+                    .get(path_key)
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        ApiError::bad_request(
+                            "invalid_operation_input",
+                            format!("Hosted {operation} requires {path_key}."),
+                        )
+                    })?
+                    .to_string();
+                let wrapped_data_key: Vec<u8> = sqlx::query_scalar(
+                    "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
+                )
+                .bind(collection_id)
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::not_found(
+                        "hosted_collection_not_found",
+                        "Hosted collection not found.",
+                    )
+                })?;
+                let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+                let current = sqlx::query(
+                    r#"SELECT record_id, revision, types FROM hosted_provider_records
+                       WHERE collection_id = $1 AND path_token = $2"#,
+                )
+                .bind(collection_id)
+                .bind(path_token(&data_key, &path))
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or_else(|| {
+                    ApiError::not_found("record_not_found", "The hosted record does not exist.")
+                })?;
+                let types: Vec<String> = current.get("types");
+                if !replica.allowed_types.is_empty()
+                    && !types
+                        .iter()
+                        .any(|record_type| replica.allowed_types.contains(record_type))
+                {
+                    return Err(ApiError::forbidden(
+                        "scope_denied",
+                        "The requested record is outside this application's record scope.",
+                    ));
+                }
+                let current_revision: String = current.get("revision");
+                let requested_revision = operation_input
+                    .get("if_revision")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or(current_revision);
+                if operation == "rename" {
+                    let target = operation_input
+                        .get("to")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| {
+                            ApiError::bad_request(
+                                "invalid_operation_input",
+                                "Hosted rename requires to.",
+                            )
+                        })?
+                        .to_string();
+                    operation_input.insert("path".to_string(), Value::String(target));
+                }
+                (
+                    match operation {
+                        "update" => SyncMutationOperation::Update,
+                        "delete" => SyncMutationOperation::Delete,
+                        "rename" => SyncMutationOperation::Rename,
+                        _ => unreachable!(),
+                    },
+                    current.get("record_id"),
+                    Some(requested_revision),
+                    Some(path),
+                )
+            }
+            _ => unreachable!(),
+        };
+        let mutation = SyncMutation {
+            mutation_id: Uuid::new_v4(),
+            replica_id: replica.id,
+            scope_epoch: replica.scope_epoch,
+            operation: mutation_operation,
+            record_id,
+            base_revision,
+            input: operation_input,
+            created_at: Utc::now().to_rfc3339(),
+            causal_predecessor: None,
+        };
+        let receipt = self
+            .mutate_for(collection_id, token, mutation, ReplicaPurpose::Application)
+            .await?;
+        let result = match receipt {
+            SyncMutationReceipt::Applied { record, .. }
+            | SyncMutationReceipt::PreviouslyApplied { record, .. } => {
+                if operation == "delete" {
+                    OperationResult {
+                        valid: true,
+                        result: json!({
+                            "path": previous_path,
+                            "deleted": true,
+                        }),
+                        diagnostics: Vec::new(),
+                    }
+                } else {
+                    let record = record.ok_or_else(|| {
+                        ApiError::internal(
+                            "The hosted operation did not return its resulting record.",
+                        )
+                    })?;
+                    let mut value = Map::from_iter([
+                        ("path".to_string(), Value::String(record.path.clone())),
+                        (
+                            "revision".to_string(),
+                            Value::String(record.revision.clone()),
+                        ),
+                        (
+                            "frontmatter".to_string(),
+                            Value::Object(record.frontmatter.clone()),
+                        ),
+                        (
+                            "raw_frontmatter".to_string(),
+                            Value::Object(record.frontmatter),
+                        ),
+                        ("body".to_string(), Value::String(record.body)),
+                        (
+                            "types".to_string(),
+                            Value::Array(record.types.into_iter().map(Value::String).collect()),
+                        ),
+                    ]);
+                    if operation == "rename" {
+                        value.insert(
+                            "from".to_string(),
+                            Value::String(previous_path.unwrap_or_default()),
+                        );
+                        value.insert("to".to_string(), Value::String(record.path));
+                    }
+                    OperationResult {
+                        valid: true,
+                        result: Value::Object(value),
+                        diagnostics: Vec::new(),
+                    }
+                }
+            }
+            SyncMutationReceipt::Rejected { error, .. } => {
+                invalid_operation_result(&error.code, &error.message, previous_path, None)
+            }
+            SyncMutationReceipt::Conflicted { conflict, .. } => invalid_operation_result(
+                "concurrent_modification",
+                "The hosted record changed after it was read.",
+                previous_path,
+                Some(json!({ "current_revision": conflict.current_revision })),
+            ),
+        };
+        serde_json::to_value(result).map_err(|error| {
+            ApiError::internal(format!("Hosted operation could not serialize: {error}"))
+        })
+    }
+
+    async fn authenticate_for(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        purpose: ReplicaPurpose,
+    ) -> ApiResult<Replica> {
+        let row = sqlx::query(
+            r#"SELECT id, purpose, mode, allowed_types, allowed_operations,
+                      allowed_origin, scope_epoch
+               FROM hosted_provider_replicas
+               WHERE collection_id = $1 AND token_hash = $2 AND purpose = $3
+                 AND revoked_at IS NULL AND token_expires_at > now()"#,
+        )
+        .bind(collection_id)
+        .bind(token_hash(token))
+        .bind(replica_purpose(purpose))
+        .fetch_optional(&self.pool)
+        .await?;
+        replica_from_row(row)
+    }
+
+    fn collection_key(&self, collection_id: Uuid, wrapped: &[u8]) -> ApiResult<[u8; 32]> {
+        self.crypto
+            .unwrap_data_key(wrapped, &collection_key_aad(collection_id))
+    }
+
+    async fn working_set(&self, collection_id: Uuid) -> WorkingSetSlot {
+        let mut working_sets = self.working_sets.lock().await;
+        working_sets
+            .entry(collection_id)
+            .or_insert_with(|| Arc::new(Mutex::new(None)))
+            .clone()
+    }
+}
+
+enum DatabaseKeyError {
+    Database(sqlx::Error),
+    Invalid(ApiError),
+}
+
+async fn verify_database_key(
+    pool: &PgPool,
+    crypto: &ProviderCrypto,
+) -> Result<(), DatabaseKeyError> {
+    let candidate = crypto
+        .create_key_check()
+        .map_err(DatabaseKeyError::Invalid)?;
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_metadata (singleton, key_check)
+           VALUES (true, $1) ON CONFLICT (singleton) DO NOTHING"#,
+    )
+    .bind(candidate)
+    .execute(pool)
+    .await
+    .map_err(DatabaseKeyError::Database)?;
+    let key_check: Vec<u8> =
+        sqlx::query_scalar("SELECT key_check FROM hosted_provider_metadata WHERE singleton = true")
+            .fetch_one(pool)
+            .await
+            .map_err(DatabaseKeyError::Database)?;
+    crypto
+        .verify_key_check(&key_check)
+        .map_err(DatabaseKeyError::Invalid)
+}
+
+async fn authenticate_in(
+    transaction: &mut Transaction<'_, Postgres>,
+    collection_id: Uuid,
+    token: &str,
+    purpose: ReplicaPurpose,
+) -> ApiResult<Replica> {
+    let row = sqlx::query(
+        r#"SELECT id, purpose, mode, allowed_types, allowed_operations,
+                  allowed_origin, scope_epoch
+           FROM hosted_provider_replicas
+           WHERE collection_id = $1 AND token_hash = $2 AND purpose = $3
+             AND revoked_at IS NULL AND token_expires_at > now()
+           FOR SHARE"#,
+    )
+    .bind(collection_id)
+    .bind(token_hash(token))
+    .bind(replica_purpose(purpose))
+    .fetch_optional(&mut **transaction)
+    .await?;
+    replica_from_row(row)
+}
+
+fn replica_from_row(row: Option<sqlx::postgres::PgRow>) -> ApiResult<Replica> {
+    let row = row.ok_or_else(|| {
+        ApiError::unauthorized(
+            "invalid_replica_token",
+            "Replica credential is invalid, expired, or revoked.",
+        )
+    })?;
+    let mode: String = row.get("mode");
+    let purpose: String = row.get("purpose");
+    if !matches!(purpose.as_str(), "mirror" | "application") {
+        return Err(ApiError::internal("Stored replica purpose is invalid."));
+    }
+    Ok(Replica {
+        id: row.get("id"),
+        mode: match mode.as_str() {
+            "read_only" => SyncReplicaMode::ReadOnly,
+            "read_write" => SyncReplicaMode::ReadWrite,
+            _ => return Err(ApiError::internal("Stored replica mode is invalid.")),
+        },
+        allowed_types: row.get("allowed_types"),
+        allowed_operations: row.get("allowed_operations"),
+        allowed_origin: row.get("allowed_origin"),
+        scope_epoch: number(row.get::<i64, _>("scope_epoch"), "scope epoch")?,
+    })
+}
+
+async fn load_resource_documents(
+    transaction: &mut Transaction<'_, Postgres>,
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    collection_id: Uuid,
+) -> ApiResult<Vec<(String, String)>> {
+    let rows = sqlx::query(
+        "SELECT path, document_ciphertext FROM hosted_provider_resources WHERE collection_id = $1 ORDER BY path",
+    )
+    .bind(collection_id)
+    .fetch_all(&mut **transaction)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            let path: String = row.get("path");
+            let plaintext = crypto.decrypt_bytes(
+                data_key,
+                row.get("document_ciphertext"),
+                &resource_document_aad(collection_id, &path),
+            )?;
+            let document = String::from_utf8(plaintext).map_err(|_| {
+                ApiError::internal("The hosted resource document is not valid UTF-8.")
+            })?;
+            Ok((path, document))
+        })
+        .collect()
+}
+
+async fn load_sync_resource_documents(
+    pool: &PgPool,
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    collection_id: Uuid,
+) -> ApiResult<Vec<SyncResourceDocument>> {
+    let rows = sqlx::query(
+        r#"SELECT path, kind, revision, document_ciphertext
+           FROM hosted_provider_resources WHERE collection_id = $1 ORDER BY path"#,
+    )
+    .bind(collection_id)
+    .fetch_all(pool)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            let path: String = row.get("path");
+            let plaintext = crypto.decrypt_bytes(
+                data_key,
+                row.get("document_ciphertext"),
+                &resource_document_aad(collection_id, &path),
+            )?;
+            let document = String::from_utf8(plaintext).map_err(|_| {
+                ApiError::internal("The hosted resource document is not valid UTF-8.")
+            })?;
+            Ok(SyncResourceDocument {
+                path,
+                kind: row.get("kind"),
+                revision: row.get("revision"),
+                document,
+            })
+        })
+        .collect()
+}
+
+async fn load_records(
+    transaction: &mut Transaction<'_, Postgres>,
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    collection_id: Uuid,
+) -> ApiResult<BTreeMap<Uuid, PersistedRecord>> {
+    let rows = sqlx::query(
+        r#"SELECT record_id, sequence, payload_ciphertext
+           FROM hosted_provider_records WHERE collection_id = $1 ORDER BY record_id"#,
+    )
+    .bind(collection_id)
+    .fetch_all(&mut **transaction)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            let record_id = row.get("record_id");
+            let sequence = number(row.get::<i64, _>("sequence"), "record sequence")?;
+            let persisted: PersistedRecord = crypto.decrypt_json(
+                data_key,
+                row.get("payload_ciphertext"),
+                &current_record_aad(collection_id, record_id, sequence),
+            )?;
+            if persisted.record.record_id != record_id {
+                return Err(ApiError::internal(
+                    "The hosted encrypted record identity does not match its metadata.",
+                ));
+            }
+            Ok((record_id, persisted))
+        })
+        .collect()
+}
+
+async fn persist_live_record(
+    transaction: &mut Transaction<'_, Postgres>,
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    collection_id: Uuid,
+    sequence: u64,
+    record: &SyncRecord,
+    document: &str,
+) -> ApiResult<()> {
+    let payload = PersistedRecord {
+        record: record.clone(),
+        document: document.to_string(),
+    };
+    let current_ciphertext = crypto.encrypt_json(
+        data_key,
+        &payload,
+        &current_record_aad(collection_id, record.record_id, sequence),
+    )?;
+    let version_ciphertext = crypto.encrypt_json(
+        data_key,
+        &payload,
+        &record_version_aad(collection_id, record.record_id, sequence),
+    )?;
+    let sequence_number = to_i64(sequence, "record sequence")?;
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_records
+             (collection_id, record_id, path_token, revision, types, content_bytes, payload_ciphertext, sequence)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           ON CONFLICT (collection_id, record_id) DO UPDATE SET
+             path_token = EXCLUDED.path_token,
+             revision = EXCLUDED.revision,
+             types = EXCLUDED.types,
+             content_bytes = EXCLUDED.content_bytes,
+             payload_ciphertext = EXCLUDED.payload_ciphertext,
+             sequence = EXCLUDED.sequence,
+             updated_at = now()"#,
+    )
+    .bind(collection_id)
+    .bind(record.record_id)
+    .bind(path_token(data_key, &record.path))
+    .bind(&record.revision)
+    .bind(&record.types)
+    .bind(to_i64(document.len() as u64, "document size")?)
+    .bind(current_ciphertext)
+    .bind(sequence_number)
+    .execute(&mut **transaction)
+    .await?;
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_record_versions
+             (collection_id, record_id, sequence, revision, types, payload_ciphertext, deleted)
+           VALUES ($1, $2, $3, $4, $5, $6, false)"#,
+    )
+    .bind(collection_id)
+    .bind(record.record_id)
+    .bind(sequence_number)
+    .bind(&record.revision)
+    .bind(&record.types)
+    .bind(version_ciphertext)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+async fn persist_deleted_record(
+    transaction: &mut Transaction<'_, Postgres>,
+    collection_id: Uuid,
+    sequence: u64,
+    before: &SyncRecord,
+    revision: &str,
+) -> ApiResult<()> {
+    let sequence = to_i64(sequence, "record sequence")?;
+    sqlx::query("DELETE FROM hosted_provider_records WHERE collection_id = $1 AND record_id = $2")
+        .bind(collection_id)
+        .bind(before.record_id)
+        .execute(&mut **transaction)
+        .await?;
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_record_versions
+             (collection_id, record_id, sequence, revision, types, deleted)
+           VALUES ($1, $2, $3, $4, $5, true)"#,
+    )
+    .bind(collection_id)
+    .bind(before.record_id)
+    .bind(sequence)
+    .bind(revision)
+    .bind(&before.types)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+async fn store_rejection(
+    mut transaction: Transaction<'_, Postgres>,
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    mutation: &SyncMutation,
+    code: &str,
+    message: &str,
+) -> ApiResult<SyncMutationReceipt> {
+    let receipt = SyncMutationReceipt::Rejected {
+        mutation_id: mutation.mutation_id,
+        error: SyncMutationError {
+            code: code.to_string(),
+            message: message.to_string(),
+        },
+    };
+    store_receipt(
+        &mut transaction,
+        crypto,
+        data_key,
+        mutation.replica_id,
+        mutation,
+        &receipt,
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(receipt)
+}
+
+async fn store_receipt(
+    transaction: &mut Transaction<'_, Postgres>,
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    replica_id: Uuid,
+    mutation: &SyncMutation,
+    receipt: &SyncMutationReceipt,
+) -> ApiResult<()> {
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_mutation_receipts
+             (replica_id, mutation_id, mutation_hash, receipt_ciphertext)
+           VALUES ($1, $2, $3, $4)"#,
+    )
+    .bind(replica_id)
+    .bind(mutation.mutation_id)
+    .bind(mutation_hash(mutation)?)
+    .bind(crypto.encrypt_json(
+        data_key,
+        receipt,
+        &receipt_aad(replica_id, mutation.mutation_id),
+    )?)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+fn authorize_application_operation(
+    replica: &Replica,
+    operation: &str,
+    request_origin: Option<&str>,
+) -> ApiResult<()> {
+    if !replica
+        .allowed_operations
+        .iter()
+        .any(|allowed| allowed == operation)
+    {
+        return Err(ApiError::forbidden(
+            "insufficient_access",
+            "The application is not allowed to perform this operation.",
+        ));
+    }
+    if let Some(origin) = request_origin {
+        if replica.allowed_origin.as_deref() != Some(origin) {
+            return Err(ApiError::forbidden(
+                "origin_denied",
+                "The application origin does not match this capability.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn scope_read_input(operation: &str, input: Value, allowed_types: &[String]) -> ApiResult<Value> {
+    if operation != "query" || allowed_types.is_empty() {
+        return Ok(input);
+    }
+    let mut scoped = input.as_object().cloned().ok_or_else(|| {
+        ApiError::forbidden("scope_denied", "Scoped query input must be an object.")
+    })?;
+    if query_crosses_record_boundary(&Value::Object(scoped.clone())) {
+        return Err(ApiError::forbidden(
+            "scope_denied",
+            "Cross-record traversal is unavailable to a scoped application.",
+        ));
+    }
+    if let Some(requested) = scoped.get("types") {
+        let requested = requested.as_array().ok_or_else(|| {
+            ApiError::forbidden("scope_denied", "Scoped query types must be a list.")
+        })?;
+        if requested.is_empty() {
+            scoped.insert(
+                "types".to_string(),
+                Value::Array(allowed_types.iter().cloned().map(Value::String).collect()),
+            );
+        } else if requested.iter().any(|value| {
+            value
+                .as_str()
+                .is_none_or(|name| !allowed_types.iter().any(|allowed| allowed == name))
+        }) {
+            return Err(ApiError::forbidden(
+                "scope_denied",
+                "The query requests a record type outside this application's scope.",
+            ));
+        }
+    } else {
+        scoped.insert(
+            "types".to_string(),
+            Value::Array(allowed_types.iter().cloned().map(Value::String).collect()),
+        );
+    }
+    Ok(Value::Object(scoped))
+}
+
+fn query_crosses_record_boundary(value: &Value) -> bool {
+    match value {
+        Value::String(source) => {
+            let compact = source
+                .chars()
+                .filter(|character| !character.is_whitespace())
+                .collect::<String>();
+            compact.contains(".asFile") || compact.contains(".backlinks")
+        }
+        Value::Array(values) => values.iter().any(query_crosses_record_boundary),
+        Value::Object(values) => values.values().any(query_crosses_record_boundary),
+        _ => false,
+    }
+}
+
+fn ensure_operation_result_visible(
+    result: &OperationResult,
+    allowed_types: &[String],
+) -> ApiResult<()> {
+    if allowed_types.is_empty() || !result.valid {
+        return Ok(());
+    }
+    let visible = result
+        .result
+        .get("types")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .any(|record_type| allowed_types.iter().any(|allowed| allowed == record_type));
+    if visible {
+        Ok(())
+    } else {
+        Err(ApiError::forbidden(
+            "scope_denied",
+            "The requested record is outside this application's record scope.",
+        ))
+    }
+}
+
+fn application_change(
+    before: Option<&SyncRecord>,
+    after: Option<&SyncRecord>,
+) -> (&'static str, Value) {
+    match (before, after) {
+        (None, Some(record)) => (
+            "mdbase.record.created",
+            json!({ "path": record.path, "types": record.types }),
+        ),
+        (Some(record), None) => (
+            "mdbase.record.deleted",
+            json!({ "path": record.path, "previous_types": record.types }),
+        ),
+        (Some(before), Some(after)) if before.path != after.path => (
+            "mdbase.record.renamed",
+            json!({
+                "from": before.path,
+                "to": after.path,
+                "types": after.types,
+                "previous_types": before.types,
+            }),
+        ),
+        (_, Some(record)) => (
+            "mdbase.record.modified",
+            json!({ "path": record.path, "types": record.types }),
+        ),
+        (None, None) => ("mdbase.record.modified", json!({})),
+    }
+}
+
+fn invalid_operation_result(
+    code: &str,
+    message: &str,
+    path: Option<String>,
+    details: Option<Value>,
+) -> OperationResult {
+    let mut diagnostic = Diagnostic::error(code, message, path);
+    diagnostic.details = details;
+    OperationResult {
+        valid: false,
+        result: json!({}),
+        diagnostics: vec![diagnostic],
+    }
+}
+
+fn operation_error(envelope: &OperationResult) -> (String, String) {
+    let diagnostic = envelope.diagnostics.first();
+    let code = diagnostic
+        .map(|value| value.code.as_str())
+        .unwrap_or("validation_failed")
+        .to_string();
+    let message = diagnostic
+        .map(|value| value.message.as_str())
+        .unwrap_or("The hosted collection rejected the mutation.")
+        .to_string();
+    (code, message)
+}
+
+fn previously_applied(receipt: SyncMutationReceipt) -> SyncMutationReceipt {
+    match receipt {
+        SyncMutationReceipt::Applied {
+            mutation_id,
+            sequence,
+            record,
+        }
+        | SyncMutationReceipt::PreviouslyApplied {
+            mutation_id,
+            sequence,
+            record,
+        } => SyncMutationReceipt::PreviouslyApplied {
+            mutation_id,
+            sequence,
+            record,
+        },
+        receipt => receipt,
+    }
+}
+
+fn scoped_resources(
+    mut resources: SyncCollectionResources,
+    allowed_types: &[String],
+) -> SyncCollectionResources {
+    if allowed_types.is_empty() {
+        return resources;
+    }
+    let allowed = allowed_types.iter().collect::<BTreeSet<_>>();
+    resources.types.retain(|item| allowed.contains(&item.name));
+    resources
+        .contracts
+        .retain(|item| allowed.contains(&item.type_name));
+    resources.documents.retain(|document| {
+        document.kind == "configuration"
+            || document
+                .path
+                .strip_prefix("_types/")
+                .and_then(|path| path.strip_suffix(".md"))
+                .is_some_and(|type_name| {
+                    allowed.iter().any(|allowed| allowed.as_str() == type_name)
+                })
+    });
+    resources
+}
+
+fn visible(record: &SyncRecord, allowed_types: &[String]) -> bool {
+    allowed_types.is_empty()
+        || record
+            .types
+            .iter()
+            .any(|record_type| allowed_types.contains(record_type))
+}
+
+fn optional_encrypted_record(
+    crypto: &ProviderCrypto,
+    data_key: &[u8; 32],
+    value: Option<&[u8]>,
+    aad: &[u8],
+) -> ApiResult<Option<SyncRecord>> {
+    value
+        .map(|value| crypto.decrypt_json(data_key, value, aad))
+        .transpose()
+}
+
+fn collection_key_aad(collection_id: Uuid) -> Vec<u8> {
+    aad(("collection_key", collection_id))
+}
+
+fn resources_aad(collection_id: Uuid) -> Vec<u8> {
+    aad(("resources", collection_id))
+}
+
+fn resource_document_aad(collection_id: Uuid, path: &str) -> Vec<u8> {
+    aad(("resource_document", collection_id, path))
+}
+
+fn current_record_aad(collection_id: Uuid, record_id: Uuid, sequence: u64) -> Vec<u8> {
+    aad(("current_record", collection_id, record_id, sequence))
+}
+
+fn record_version_aad(collection_id: Uuid, record_id: Uuid, sequence: u64) -> Vec<u8> {
+    aad(("record_version", collection_id, record_id, sequence))
+}
+
+fn change_record_aad(collection_id: Uuid, sequence: u64, side: &str) -> Vec<u8> {
+    aad(("change_record", collection_id, sequence, side))
+}
+
+fn receipt_aad(replica_id: Uuid, mutation_id: Uuid) -> Vec<u8> {
+    aad(("mutation_receipt", replica_id, mutation_id))
+}
+
+fn aad(value: impl Serialize) -> Vec<u8> {
+    serde_json::to_vec(&value).expect("hosted ciphertext identity serializes")
+}
+
+fn replica_mode(mode: SyncReplicaMode) -> &'static str {
+    match mode {
+        SyncReplicaMode::ReadOnly => "read_only",
+        SyncReplicaMode::ReadWrite => "read_write",
+    }
+}
+
+fn replica_purpose(purpose: ReplicaPurpose) -> &'static str {
+    match purpose {
+        ReplicaPurpose::Mirror => "mirror",
+        ReplicaPurpose::Application => "application",
+    }
+}
+
+fn validate_replica_capability(input: &RegisterReplica) -> ApiResult<()> {
+    validate_operations(&input.allowed_operations, input.mode)?;
+    match input.purpose {
+        ReplicaPurpose::Mirror => {
+            if !input.allowed_operations.is_empty() || input.allowed_origin.is_some() {
+                return Err(ApiError::bad_request(
+                    "invalid_mirror_capability",
+                    "Mirror replicas cannot contain browser application policy.",
+                ));
+            }
+        }
+        ReplicaPurpose::Application => {
+            if input.allowed_operations.is_empty() {
+                return Err(ApiError::bad_request(
+                    "invalid_application_capability",
+                    "Application capabilities require at least one operation.",
+                ));
+            }
+            if let Some(origin) = input.allowed_origin.as_deref() {
+                let url = url::Url::parse(origin).map_err(|_| {
+                    ApiError::bad_request(
+                        "invalid_application_origin",
+                        "Application origin must be an absolute HTTP(S) origin.",
+                    )
+                })?;
+                if !matches!(url.scheme(), "http" | "https")
+                    || !url.username().is_empty()
+                    || url.password().is_some()
+                    || url.path() != "/"
+                    || url.query().is_some()
+                    || url.fragment().is_some()
+                    || url.origin().ascii_serialization() != origin
+                {
+                    return Err(ApiError::bad_request(
+                        "invalid_application_origin",
+                        "Application origin must be a canonical HTTP(S) origin.",
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_operations(operations: &[String], mode: SyncReplicaMode) -> ApiResult<()> {
+    const OPERATIONS: &[&str] = &[
+        "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
+    ];
+    const WRITES: &[&str] = &["create", "update", "delete", "rename"];
+    if operations
+        .iter()
+        .any(|operation| !OPERATIONS.contains(&operation.as_str()))
+    {
+        return Err(ApiError::bad_request(
+            "invalid_replica_operation",
+            "Application capabilities contain an unsupported collection operation.",
+        ));
+    }
+    if mode == SyncReplicaMode::ReadOnly
+        && operations
+            .iter()
+            .any(|operation| WRITES.contains(&operation.as_str()))
+    {
+        return Err(ApiError::bad_request(
+            "invalid_application_capability",
+            "A read-only application capability cannot contain write operations.",
+        ));
+    }
+    Ok(())
+}
+
+fn token_hash(token: &str) -> Vec<u8> {
+    Sha256::digest(token.as_bytes()).to_vec()
+}
+
+fn path_token(data_key: &[u8; 32], path: &str) -> Vec<u8> {
+    let mut mac = Hmac::<Sha256>::new_from_slice(data_key)
+        .expect("a 256-bit collection key is a valid HMAC key");
+    mac.update(b"mdbase-connect/hosted-path/v1\0");
+    mac.update(path.as_bytes());
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn mutation_hash(mutation: &SyncMutation) -> ApiResult<Vec<u8>> {
+    let bytes = serde_json::to_vec(mutation).map_err(|error| {
+        ApiError::internal(format!("Hosted mutation could not serialize: {error}"))
+    })?;
+    Ok(Sha256::digest(bytes).to_vec())
+}
+
+fn number(value: i64, name: &'static str) -> ApiResult<u64> {
+    value
+        .try_into()
+        .map_err(|_| ApiError::internal(format!("Stored {name} is outside the supported range.")))
+}
+
+fn to_i64(value: u64, name: &'static str) -> ApiResult<i64> {
+    value
+        .try_into()
+        .map_err(|_| ApiError::bad_request("numeric_range", format!("{name} is too large.")))
+}
+
+pub fn validate_limit(limit: Option<u32>) -> ApiResult<u32> {
+    let limit = limit.unwrap_or(200);
+    if limit == 0 || limit > 500 {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "invalid_limit",
+            "Change page limit must be between 1 and 500.",
+        ));
+    }
+    Ok(limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scopes_resources_and_records_consistently() {
+        let (resources, _) = template::resources("tasknotes").unwrap();
+        let scoped = scoped_resources(resources, &["other".to_string()]);
+        assert!(scoped.types.is_empty());
+        assert!(scoped.contracts.is_empty());
+        let record = SyncRecord {
+            record_id: Uuid::new_v4(),
+            path: "tasks/one.md".to_string(),
+            revision: "sha256:one".to_string(),
+            frontmatter: Default::default(),
+            body: String::new(),
+            types: vec!["task".to_string()],
+        };
+        assert!(visible(&record, &[]));
+        assert!(visible(&record, &["task".to_string()]));
+        assert!(!visible(&record, &["other".to_string()]));
+    }
+
+    #[test]
+    fn applied_receipts_become_replays_without_changing_the_sequence() {
+        let mutation_id = Uuid::new_v4();
+        let receipt = previously_applied(SyncMutationReceipt::Applied {
+            mutation_id,
+            sequence: 9,
+            record: None,
+        });
+        assert!(matches!(
+            receipt,
+            SyncMutationReceipt::PreviouslyApplied {
+                mutation_id: id,
+                sequence: 9,
+                ..
+            } if id == mutation_id
+        ));
+    }
+
+    #[test]
+    fn application_capabilities_bind_operations_mode_and_origin() {
+        let capability = RegisterReplica {
+            replica_id: Uuid::new_v4(),
+            name: "Tasks app".to_string(),
+            purpose: ReplicaPurpose::Application,
+            mode: SyncReplicaMode::ReadOnly,
+            allowed_types: vec!["task".to_string()],
+            allowed_operations: vec!["query".to_string()],
+            allowed_origin: Some("https://tasks.example".to_string()),
+            token: "x".repeat(40),
+            token_ttl_seconds: Some(3600),
+        };
+        validate_replica_capability(&capability).unwrap();
+        let replica = Replica {
+            id: capability.replica_id,
+            mode: capability.mode,
+            allowed_types: capability.allowed_types,
+            allowed_operations: capability.allowed_operations,
+            allowed_origin: capability.allowed_origin,
+            scope_epoch: 1,
+        };
+        authorize_application_operation(&replica, "query", Some("https://tasks.example")).unwrap();
+        assert_eq!(
+            authorize_application_operation(&replica, "create", None)
+                .unwrap_err()
+                .code,
+            "insufficient_access"
+        );
+        assert_eq!(
+            authorize_application_operation(&replica, "query", Some("https://evil.example"))
+                .unwrap_err()
+                .code,
+            "origin_denied"
+        );
+    }
+
+    #[test]
+    fn rejects_write_operations_on_read_only_application_capabilities() {
+        let capability = RegisterReplica {
+            replica_id: Uuid::new_v4(),
+            name: "Tasks app".to_string(),
+            purpose: ReplicaPurpose::Application,
+            mode: SyncReplicaMode::ReadOnly,
+            allowed_types: vec!["task".to_string()],
+            allowed_operations: vec!["create".to_string()],
+            allowed_origin: Some("https://tasks.example".to_string()),
+            token: "x".repeat(40),
+            token_ttl_seconds: Some(3600),
+        };
+        assert_eq!(
+            validate_replica_capability(&capability).unwrap_err().code,
+            "invalid_application_capability"
+        );
+    }
+}

--- a/crates/connect-hosted-provider/src/template.rs
+++ b/crates/connect-hosted-provider/src/template.rs
@@ -1,0 +1,106 @@
+use mdbase_connect_protocol::{
+    CollectionContractDescriptor, CollectionTypeDescriptor, SyncCollectionResources,
+};
+use serde_json::{json, Map};
+
+use crate::error::{ApiError, ApiResult};
+
+#[derive(Debug, Clone)]
+pub struct ResourceDocument {
+    pub path: &'static str,
+    pub kind: &'static str,
+    pub revision: &'static str,
+    pub document: &'static str,
+}
+
+pub fn resources(template: &str) -> ApiResult<(SyncCollectionResources, Vec<ResourceDocument>)> {
+    match template {
+        "tasknotes" => Ok(tasknotes()),
+        _ => Err(ApiError::bad_request(
+            "unsupported_template",
+            "The hosted provider does not support that collection template.",
+        )),
+    }
+}
+
+fn tasknotes() -> (SyncCollectionResources, Vec<ResourceDocument>) {
+    let contract = json!({
+        "contract": "tasknotes.task",
+        "version": 1,
+        "field_roles": { "title": "title", "status": "status" },
+        "status": { "completed_values": ["done"], "default": "open" }
+    });
+    let mut extensions = Map::new();
+    extensions.insert("x-tasknotes".to_string(), contract.clone());
+    let resources = SyncCollectionResources {
+        revision: "tasknotes-template:1".to_string(),
+        spec_version: "0.3.0".to_string(),
+        types: vec![CollectionTypeDescriptor {
+            name: "task".to_string(),
+            version: Some(1),
+            description: Some("A TaskNotes-compatible task.".to_string()),
+            path: Some("_types/task.md".to_string()),
+            definition: None,
+            schema: json!({
+                "type": "object",
+                "required": ["type", "title"],
+                "additionalProperties": true,
+                "properties": {
+                    "type": { "const": "task" },
+                    "title": { "type": "string", "minLength": 1 },
+                    "status": { "enum": ["open", "done"] }
+                }
+            }),
+            collection: Some(json!({ "path": { "folder": "tasks" } })),
+            lifecycle: None,
+            extensions,
+        }],
+        contracts: vec![CollectionContractDescriptor {
+            id: "tasknotes.task".to_string(),
+            version: 1,
+            type_name: "task".to_string(),
+            extension: "x-tasknotes".to_string(),
+            configuration: contract,
+        }],
+        documents: Vec::new(),
+    };
+    let documents = vec![
+        ResourceDocument {
+            path: "mdbase.yaml",
+            kind: "configuration",
+            revision: "tasknotes-config:1",
+            document: "spec_version: 0.3.0\nsettings:\n  types_folder: _types\n  default_validation: error\n",
+        },
+        ResourceDocument {
+            path: "_types/task.md",
+            kind: "type",
+            revision: "tasknotes-type:1",
+            document: r#"---
+kind: mdbase.type
+name: task
+version: 1
+description: A TaskNotes-compatible task.
+collection:
+  path:
+    folder: tasks
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [type, title]
+    additionalProperties: true
+    properties:
+      type: { const: task }
+      title: { type: string, minLength: 1 }
+      status: { enum: [open, done] }
+x-tasknotes:
+  contract: tasknotes.task
+  version: 1
+  field_roles: { title: title, status: status }
+  status: { completed_values: [done], default: open }
+---
+"#,
+        },
+    ];
+    (resources, documents)
+}

--- a/crates/connect-hosted-provider/src/workspace.rs
+++ b/crates/connect-hosted-provider/src/workspace.rs
@@ -1,0 +1,420 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use mdbase::{
+    v03::{Diagnostic, OperationResult},
+    Collection,
+};
+use mdbase_connect_protocol::{SyncMutation, SyncMutationOperation, SyncRecord};
+use serde_json::{json, Map, Value};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use crate::error::{ApiError, ApiResult};
+
+#[derive(Debug, Clone)]
+pub struct StoredDocument {
+    pub record_id: Uuid,
+    pub path: String,
+    pub document: String,
+}
+
+pub struct WorkingSet {
+    directory: TempDir,
+    records_by_path: BTreeMap<String, Uuid>,
+}
+
+#[derive(Debug)]
+pub struct Execution {
+    pub envelope: OperationResult,
+    pub primary_record_id: Uuid,
+    pub changed: Vec<(Uuid, Option<SyncRecord>, Option<String>)>,
+}
+
+impl WorkingSet {
+    pub fn materialize(
+        resources: impl IntoIterator<Item = (String, String)>,
+        records: impl IntoIterator<Item = StoredDocument>,
+    ) -> ApiResult<Self> {
+        let directory = tempfile::tempdir()?;
+        for (path, document) in resources {
+            write_document(directory.path(), &path, &document)?;
+        }
+        let mut records_by_path = BTreeMap::new();
+        for record in records {
+            write_document(directory.path(), &record.path, &record.document)?;
+            records_by_path.insert(record.path, record.record_id);
+        }
+        Collection::open(directory.path()).map_err(|error| {
+            ApiError::internal(format!(
+                "The hosted collection working set is invalid: {error}"
+            ))
+        })?;
+        Ok(Self {
+            directory,
+            records_by_path,
+        })
+    }
+
+    pub fn execute(&mut self, mutation: &SyncMutation) -> ApiResult<Execution> {
+        let collection = Collection::open(self.directory.path()).map_err(|error| {
+            ApiError::internal(format!(
+                "The hosted collection working set is invalid: {error}"
+            ))
+        })?;
+        let operations = collection.v03_operations().map_err(|diagnostic| {
+            ApiError::internal(format!(
+                "The hosted collection could not open: {}",
+                diagnostic.message
+            ))
+        })?;
+        let current_path = self
+            .records_by_path
+            .iter()
+            .find_map(|(path, id)| (*id == mutation.record_id).then(|| path.clone()));
+        let (input, primary_before_path) = operation_input(mutation, current_path.as_deref())?;
+        let envelope = match mutation.operation {
+            SyncMutationOperation::Create => operations.create(&input),
+            SyncMutationOperation::Update => operations.update(&input),
+            SyncMutationOperation::Rename => operations.rename(&input),
+            SyncMutationOperation::Delete => operations.delete(&input),
+        };
+        if !envelope.valid {
+            return Ok(Execution {
+                envelope,
+                primary_record_id: mutation.record_id,
+                changed: Vec::new(),
+            });
+        }
+
+        let primary_after_path = match mutation.operation {
+            SyncMutationOperation::Create => input.get("path").and_then(Value::as_str),
+            SyncMutationOperation::Update => current_path.as_deref(),
+            SyncMutationOperation::Rename => input.get("to").and_then(Value::as_str),
+            SyncMutationOperation::Delete => None,
+        };
+        let mut affected = BTreeSet::new();
+        if let Some(path) = primary_after_path {
+            affected.insert((path.to_string(), mutation.record_id));
+        }
+        if let Some(references) = envelope
+            .result
+            .get("references_updated")
+            .and_then(Value::as_array)
+        {
+            for reference in references {
+                if let Some(path) = reference.get("path").and_then(Value::as_str) {
+                    if let Some(record_id) = self.records_by_path.get(path) {
+                        affected.insert((path.to_string(), *record_id));
+                    }
+                }
+            }
+        }
+
+        let collection = Collection::open(self.directory.path()).map_err(|error| {
+            ApiError::internal(format!(
+                "The mutated hosted collection could not open: {error}"
+            ))
+        })?;
+        let operations = collection.v03_operations().map_err(|diagnostic| {
+            ApiError::internal(format!(
+                "The mutated hosted collection could not open: {}",
+                diagnostic.message
+            ))
+        })?;
+        let mut changed = Vec::new();
+        if mutation.operation == SyncMutationOperation::Delete {
+            changed.push((mutation.record_id, None, primary_before_path.clone()));
+        }
+        for (path, record_id) in affected {
+            let read = operations.read(&json!({ "path": path }));
+            if !read.valid {
+                return Err(ApiError::internal(
+                    "mdbase-rs accepted a mutation but could not read its resulting record.",
+                ));
+            }
+            let record = sync_record(record_id, &read.result)?;
+            let document = fs::read_to_string(safe_path(self.directory.path(), &record.path)?)?;
+            changed.push((record_id, Some(record), Some(document)));
+        }
+        changed.sort_by_key(|(record_id, _, _)| (*record_id != mutation.record_id, *record_id));
+        for (record_id, after, _) in &changed {
+            self.records_by_path
+                .retain(|_, candidate| candidate != record_id);
+            if let Some(record) = after {
+                self.records_by_path.insert(record.path.clone(), *record_id);
+            }
+        }
+        Ok(Execution {
+            envelope,
+            primary_record_id: mutation.record_id,
+            changed,
+        })
+    }
+
+    pub fn read_operation(&self, operation: &str, input: &Value) -> ApiResult<OperationResult> {
+        let collection = Collection::open(self.directory.path()).map_err(|error| {
+            ApiError::internal(format!(
+                "The hosted collection working set is invalid: {error}"
+            ))
+        })?;
+        let operations = collection.v03_operations().map_err(|diagnostic| {
+            ApiError::internal(format!(
+                "The hosted collection could not open: {}",
+                diagnostic.message
+            ))
+        })?;
+        match operation {
+            "read" => Ok(operations.read(input)),
+            // Query execution remains entirely in mdbase-rs. Its v0.3 query
+            // facade is newer than the minimum path dependency supported by
+            // the hosted build, so only the common legacy envelope is adapted
+            // at this storage boundary.
+            "query" => Ok(query_result(&collection, input)),
+            "validate" => Ok(operations.validate(input)),
+            _ => Err(ApiError::bad_request(
+                "unsupported_operation",
+                "The hosted provider does not support that read operation.",
+            )),
+        }
+    }
+}
+
+fn query_result(collection: &Collection, input: &Value) -> OperationResult {
+    let legacy = collection.query(input);
+    let mut result = legacy.as_object().cloned().unwrap_or_default();
+    let diagnostic = result.get("error").map(|error| {
+        let code = error
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("query_failed");
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("The hosted query failed.");
+        Diagnostic::error(code, message, None)
+    });
+    for key in ["valid", "error", "issues", "validation", "warnings"] {
+        result.remove(key);
+    }
+    if input.get("include_body").and_then(Value::as_bool) != Some(true) {
+        if let Some(records) = result.get_mut("results").and_then(Value::as_array_mut) {
+            for record in records {
+                if let Some(object) = record.as_object_mut() {
+                    object.remove("body");
+                }
+            }
+        }
+    }
+    OperationResult {
+        valid: diagnostic.is_none(),
+        result: Value::Object(result),
+        diagnostics: diagnostic.into_iter().collect(),
+    }
+}
+
+fn operation_input(
+    mutation: &SyncMutation,
+    current_path: Option<&str>,
+) -> ApiResult<(Value, Option<String>)> {
+    let value = Value::Object(mutation.input.clone());
+    match mutation.operation {
+        SyncMutationOperation::Create => {
+            let path = required_string(&value, "path")?;
+            safe_relative(path)?;
+            let mut input = mutation.input.clone();
+            input.remove("types");
+            Ok((Value::Object(input), None))
+        }
+        SyncMutationOperation::Update => {
+            let path = current_path.ok_or_else(|| {
+                ApiError::not_found("record_not_found", "The hosted record does not exist.")
+            })?;
+            let mut input = mutation.input.clone();
+            input.insert("path".to_string(), Value::String(path.to_string()));
+            if let Some(revision) = &mutation.base_revision {
+                input.insert("if_revision".to_string(), Value::String(revision.clone()));
+            }
+            Ok((Value::Object(input), Some(path.to_string())))
+        }
+        SyncMutationOperation::Rename => {
+            let from = current_path.ok_or_else(|| {
+                ApiError::not_found("record_not_found", "The hosted record does not exist.")
+            })?;
+            let to = required_string(&value, "path")?;
+            safe_relative(to)?;
+            let mut input = Map::from_iter([
+                ("from".to_string(), Value::String(from.to_string())),
+                ("to".to_string(), Value::String(to.to_string())),
+                ("update_refs".to_string(), Value::Bool(true)),
+            ]);
+            if let Some(revision) = &mutation.base_revision {
+                input.insert("if_revision".to_string(), Value::String(revision.clone()));
+            }
+            Ok((Value::Object(input), Some(from.to_string())))
+        }
+        SyncMutationOperation::Delete => {
+            let path = current_path.ok_or_else(|| {
+                ApiError::not_found("record_not_found", "The hosted record does not exist.")
+            })?;
+            let mut input = Map::from_iter([("path".to_string(), Value::String(path.to_string()))]);
+            if let Some(revision) = &mutation.base_revision {
+                input.insert("if_revision".to_string(), Value::String(revision.clone()));
+            }
+            Ok((Value::Object(input), Some(path.to_string())))
+        }
+    }
+}
+
+fn sync_record(record_id: Uuid, result: &Value) -> ApiResult<SyncRecord> {
+    let path = required_string(result, "path")?.to_string();
+    safe_relative(&path)?;
+    let revision = required_string(result, "revision")?.to_string();
+    let frontmatter = result
+        .get("raw_frontmatter")
+        .or_else(|| result.get("frontmatter"))
+        .and_then(Value::as_object)
+        .cloned()
+        .ok_or_else(|| ApiError::internal("mdbase-rs returned invalid record frontmatter."))?;
+    let body = result
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let types = result
+        .get("types")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect();
+    Ok(SyncRecord {
+        record_id,
+        path,
+        revision,
+        frontmatter,
+        body,
+        types,
+    })
+}
+
+fn required_string<'a>(value: &'a Value, field: &str) -> ApiResult<&'a str> {
+    value.get(field).and_then(Value::as_str).ok_or_else(|| {
+        ApiError::bad_request(
+            "invalid_mutation",
+            format!("Hosted mutation input requires {field}."),
+        )
+    })
+}
+
+fn write_document(root: &Path, relative: &str, document: &str) -> ApiResult<()> {
+    let path = safe_path(root, relative)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, document)?;
+    Ok(())
+}
+
+fn safe_path(root: &Path, relative: &str) -> ApiResult<PathBuf> {
+    safe_relative(relative)?;
+    Ok(root.join(relative))
+}
+
+fn safe_relative(relative: &str) -> ApiResult<()> {
+    let path = Path::new(relative);
+    if relative.is_empty()
+        || relative.contains('\\')
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir
+                    | Component::CurDir
+                    | Component::RootDir
+                    | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(ApiError::bad_request(
+            "invalid_path",
+            "Hosted record paths must be safe collection-relative paths.",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resources() -> Vec<(String, String)> {
+        crate::template::resources("tasknotes")
+            .unwrap()
+            .1
+            .into_iter()
+            .map(|resource| (resource.path.to_string(), resource.document.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn executes_create_through_the_canonical_engine() {
+        let mut workspace = WorkingSet::materialize(resources(), []).unwrap();
+        let mutation = SyncMutation {
+            mutation_id: Uuid::new_v4(),
+            replica_id: Uuid::new_v4(),
+            scope_epoch: 1,
+            operation: SyncMutationOperation::Create,
+            record_id: Uuid::new_v4(),
+            base_revision: None,
+            input: Map::from_iter([
+                ("path".to_string(), json!("tasks/first.md")),
+                (
+                    "frontmatter".to_string(),
+                    json!({"type": "task", "title": "First"}),
+                ),
+                ("body".to_string(), json!("Body")),
+                ("types".to_string(), json!(["task"])),
+            ]),
+            created_at: "2026-07-21T00:00:00Z".to_string(),
+            causal_predecessor: None,
+        };
+        let execution = workspace.execute(&mutation).unwrap();
+        assert!(execution.envelope.valid);
+        assert_eq!(execution.changed.len(), 1);
+        assert_eq!(execution.changed[0].1.as_ref().unwrap().types, ["task"]);
+        assert!(execution.changed[0]
+            .2
+            .as_ref()
+            .unwrap()
+            .contains("title: First"));
+    }
+
+    #[test]
+    fn rejects_paths_that_could_escape_the_working_set() {
+        let mut workspace = WorkingSet::materialize(resources(), []).unwrap();
+        let mutation = SyncMutation {
+            mutation_id: Uuid::new_v4(),
+            replica_id: Uuid::new_v4(),
+            scope_epoch: 1,
+            operation: SyncMutationOperation::Create,
+            record_id: Uuid::new_v4(),
+            base_revision: None,
+            input: Map::from_iter([
+                ("path".to_string(), json!("../escape.md")),
+                (
+                    "frontmatter".to_string(),
+                    json!({"type": "task", "title": "Escape"}),
+                ),
+            ]),
+            created_at: "2026-07-21T00:00:00Z".to_string(),
+            causal_predecessor: None,
+        };
+        let error = workspace.execute(&mutation).unwrap_err();
+        assert_eq!(error.code, "invalid_path");
+    }
+}

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -6,6 +6,7 @@ pub mod crypto;
 
 pub const CONTROL_PROTOCOL_VERSION: u32 = 2;
 pub const ENCRYPTED_RELAY_PROTOCOL_VERSION: u32 = 3;
+pub const SYNC_PROTOCOL_VERSION: u32 = 1;
 pub const RELAY_ENCRYPTION_SUITE: &str = "P256-HKDF-SHA256-AES256GCM";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -300,6 +301,157 @@ pub struct CollectionChangesPage {
     pub reset: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyncRecord {
+    pub record_id: Uuid,
+    pub path: String,
+    pub revision: String,
+    pub frontmatter: serde_json::Map<String, Value>,
+    pub body: String,
+    pub types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncCollectionResources {
+    pub revision: String,
+    pub spec_version: String,
+    pub types: Vec<CollectionTypeDescriptor>,
+    pub contracts: Vec<CollectionContractDescriptor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub documents: Vec<SyncResourceDocument>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncResourceDocument {
+    pub path: String,
+    pub kind: String,
+    pub revision: String,
+    pub document: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncReplicaMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSession {
+    pub protocol_version: u32,
+    pub session_id: Uuid,
+    pub replica_id: Uuid,
+    pub collection_id: Uuid,
+    pub mode: SyncReplicaMode,
+    pub scope_epoch: u64,
+    pub retained_after: u64,
+    pub head: u64,
+    pub snapshot_id: Uuid,
+    pub resources: SyncCollectionResources,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSnapshotPage {
+    pub protocol_version: u32,
+    pub snapshot_id: Uuid,
+    pub scope_epoch: u64,
+    pub cursor: u64,
+    pub records: Vec<SyncRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_page: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SyncChange {
+    Put {
+        sequence: u64,
+        record: SyncRecord,
+    },
+    Remove {
+        sequence: u64,
+        record_id: Uuid,
+        previous_path: String,
+        revision: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncChangesPage {
+    pub protocol_version: u32,
+    pub scope_epoch: u64,
+    pub events: Vec<SyncChange>,
+    pub cursor: u64,
+    pub head: u64,
+    pub has_more: bool,
+    pub reset_required: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncMutationOperation {
+    Create,
+    Update,
+    Rename,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyncMutation {
+    pub mutation_id: Uuid,
+    pub replica_id: Uuid,
+    pub scope_epoch: u64,
+    pub operation: SyncMutationOperation,
+    pub record_id: Uuid,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_revision: Option<String>,
+    pub input: serde_json::Map<String, Value>,
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causal_predecessor: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyncConflict {
+    pub record_id: Uuid,
+    pub mutation: SyncMutation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current: Option<SyncRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyncMutationError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SyncMutationReceipt {
+    Applied {
+        mutation_id: Uuid,
+        sequence: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        record: Option<SyncRecord>,
+    },
+    PreviouslyApplied {
+        mutation_id: Uuid,
+        sequence: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        record: Option<SyncRecord>,
+    },
+    Conflicted {
+        mutation_id: Uuid,
+        conflict: SyncConflict,
+    },
+    Rejected {
+        mutation_id: Uuid,
+        error: SyncMutationError,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApplicationSummary {
     pub id: Uuid,
@@ -546,6 +698,31 @@ mod tests {
         );
     }
 
+    fn assert_sync_schema(reference: &str, value: Value) {
+        let mut schema: Value = serde_json::from_str(include_str!(
+            "../../../packages/protocol/schemas/sync.v1.schema.json"
+        ))
+        .unwrap();
+        if !reference.is_empty() {
+            let object = schema.as_object_mut().unwrap();
+            object.remove("oneOf");
+            object.insert("$ref".to_string(), Value::String(format!("#{reference}")));
+        }
+        let validator = jsonschema::JSONSchema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .compile(&schema)
+            .unwrap();
+        let errors = validator
+            .validate(&value)
+            .err()
+            .map(|errors| errors.map(|error| error.to_string()).collect::<Vec<_>>())
+            .unwrap_or_default();
+        assert!(
+            errors.is_empty(),
+            "sync schema errors: {errors:#?}\nvalue: {value:#}"
+        );
+    }
+
     #[test]
     fn control_request_has_stable_wire_shape() {
         let request = ControlRequest {
@@ -651,5 +828,110 @@ mod tests {
             "/$defs/collectionDescription",
             serde_json::to_value(description).unwrap(),
         );
+    }
+
+    #[test]
+    fn rust_sync_messages_match_the_canonical_wire_schema() {
+        let collection_id = Uuid::parse_str("01911111-1111-7111-8111-111111111111").unwrap();
+        let replica_id = Uuid::parse_str("01922222-2222-7222-8222-222222222222").unwrap();
+        let session_id = Uuid::parse_str("01933333-3333-7333-8333-333333333333").unwrap();
+        let snapshot_id = Uuid::parse_str("01944444-4444-7444-8444-444444444444").unwrap();
+        let record_id = Uuid::parse_str("01955555-5555-7555-8555-555555555555").unwrap();
+        let mutation_id = Uuid::parse_str("01966666-6666-7666-8666-666666666666").unwrap();
+        let resources = SyncCollectionResources {
+            revision: "resources:1".to_string(),
+            spec_version: "0.3.0".to_string(),
+            types: Vec::new(),
+            contracts: Vec::new(),
+            documents: Vec::new(),
+        };
+        let record = SyncRecord {
+            record_id,
+            path: "tasks/example.md".to_string(),
+            revision: "sha256:record".to_string(),
+            frontmatter: serde_json::Map::from_iter([
+                ("type".to_string(), Value::String("task".to_string())),
+                ("title".to_string(), Value::String("Example".to_string())),
+            ]),
+            body: "Body".to_string(),
+            types: vec!["task".to_string()],
+        };
+        let mutation = SyncMutation {
+            mutation_id,
+            replica_id,
+            scope_epoch: 1,
+            operation: SyncMutationOperation::Update,
+            record_id,
+            base_revision: Some(record.revision.clone()),
+            input: serde_json::Map::from_iter([(
+                "patch".to_string(),
+                serde_json::json!({"status": "done"}),
+            )]),
+            created_at: "2026-07-21T00:00:00Z".to_string(),
+            causal_predecessor: None,
+        };
+
+        for (reference, value) in [
+            (
+                "/$defs/session",
+                serde_json::to_value(SyncSession {
+                    protocol_version: SYNC_PROTOCOL_VERSION,
+                    session_id,
+                    replica_id,
+                    collection_id,
+                    mode: SyncReplicaMode::ReadWrite,
+                    scope_epoch: 1,
+                    retained_after: 0,
+                    head: 1,
+                    snapshot_id,
+                    resources: resources.clone(),
+                })
+                .unwrap(),
+            ),
+            (
+                "/$defs/snapshotPage",
+                serde_json::to_value(SyncSnapshotPage {
+                    protocol_version: SYNC_PROTOCOL_VERSION,
+                    snapshot_id,
+                    scope_epoch: 1,
+                    cursor: 1,
+                    records: vec![record.clone()],
+                    next_page: None,
+                })
+                .unwrap(),
+            ),
+            (
+                "/$defs/changesPage",
+                serde_json::to_value(SyncChangesPage {
+                    protocol_version: SYNC_PROTOCOL_VERSION,
+                    scope_epoch: 1,
+                    events: vec![SyncChange::Put {
+                        sequence: 1,
+                        record: record.clone(),
+                    }],
+                    cursor: 1,
+                    head: 1,
+                    has_more: false,
+                    reset_required: false,
+                })
+                .unwrap(),
+            ),
+            ("/$defs/mutation", serde_json::to_value(&mutation).unwrap()),
+            (
+                "/$defs/receipt",
+                serde_json::to_value(SyncMutationReceipt::Conflicted {
+                    mutation_id,
+                    conflict: SyncConflict {
+                        record_id,
+                        mutation,
+                        current_revision: Some(record.revision.clone()),
+                        current: Some(record),
+                    },
+                })
+                .unwrap(),
+            ),
+        ] {
+            assert_sync_schema(reference, value);
+        }
     }
 }

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -356,15 +356,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -572,7 +572,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1435,9 +1435,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "libredox"
@@ -1526,7 +1526,6 @@ dependencies = [
  "fancy-regex 0.14.0",
  "glob",
  "jsonschema",
- "notify",
  "rand 0.8.7",
  "regex",
  "rusqlite",
@@ -2407,14 +2406,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2811,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2870,7 +2869,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2884,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2904,9 +2903,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2939,9 +2938,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3203,7 +3202,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -3674,18 +3673,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -1,0 +1,33 @@
+FROM rust:1.94.0-bookworm AS build
+
+ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
+ARG MDBASE_RS_REVISION=73372a1f786e20d213be6e9821eb0649ecfcc050
+
+RUN git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
+ && git -C /build/mdbase-rs checkout --detach "$MDBASE_RS_REVISION"
+
+WORKDIR /build/mdbase-connect
+COPY Cargo.toml ./
+# Local v0.3 development intentionally follows the adjacent in-progress
+# mdbase-rs checkout. Releases use a second lock generated against the pinned,
+# published revision above so a dirty sibling cannot affect the image graph.
+COPY deploy/docker/Cargo.lock.hosted-provider ./Cargo.lock
+COPY crates crates
+RUN cargo build --locked --release -p mdbase-connect-hosted-provider
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+ && apt-get install --yes --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --create-home --uid 10001 mdbase
+
+COPY --from=build /build/mdbase-connect/target/release/mdbase-connect-hosted-provider /usr/local/bin/
+
+ENV HOST=0.0.0.0 \
+    PORT=8790 \
+    RUST_LOG=mdbase_connect_hosted_provider=info,tower_http=debug
+
+EXPOSE 8790
+USER mdbase
+CMD ["mdbase-connect-hosted-provider"]

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 
 RUN corepack enable
 WORKDIR /app
@@ -25,7 +25,7 @@ RUN pnpm --filter @mdbase/connect-protocol build \
  && pnpm --filter @mdbase/connect-portal build \
  && pnpm --filter @mdbase/connect-server build
 
-FROM node:22-bookworm-slim AS runtime
+FROM node:24-bookworm-slim AS runtime
 
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -1,66 +1,108 @@
 # Private Render deployment
 
-The repository includes a Render Blueprint for a single-user, relay-only
-deployment at `connect.mdbase.dev`. It creates one Singapore web service and
-one private PostgreSQL database. Hosted collection routes and public
-registration remain unavailable.
+The Render Blueprint provisions two public services in Singapore:
+
+- `mdbase-connect`, the account/control plane and transient encrypted relay;
+- `mdbase-connect-hosted-provider`, the Rust hosted data plane at
+  `sync.mdbase.dev`.
+
+Each service has its own paid, private PostgreSQL database. Hosted record
+payloads never pass through or persist in the control-plane database. The data
+plane database stores encrypted canonical records and change payloads; record
+paths use keyed lookup tokens. Render-generated 256-bit secrets bind the two
+services and protect the provider's wrapped per-collection data keys.
 
 ## Before creating the Blueprint
 
-Create a GitHub OAuth app with these exact values:
+Create a GitHub OAuth app with:
 
-- Application name: `mdbase connect`
-- Homepage URL: `https://connect.mdbase.dev`
-- Authorization callback URL:
-  `https://connect.mdbase.dev/auth/github/callback`
+- Homepage: `https://connect.mdbase.dev`
+- Callback: `https://connect.mdbase.dev/auth/github/callback`
 - Device flow: disabled
 
-Keep the client secret out of the repository. GitHub usernames can change, so
-the deployment allowlist uses numeric GitHub account IDs. The initial allowed
-ID for `callumalpass` is `12558714`.
+Keep the client secret out of the repository. The private-preview allowlist
+uses immutable numeric GitHub account IDs rather than usernames.
 
-## Create the services
+The hosted container intentionally builds against the pinned, published
+`mdbase-rs` revision in `Dockerfile.hosted-provider`. Update that SHA only after
+running its conformance suite and `pnpm e2e:provider:stress` against the new
+revision. Regenerate `deploy/docker/Cargo.lock.hosted-provider` against that
+clean revision at the same time. The repository-root lock remains the local
+v0.3 development lock for the intentionally in-progress sibling checkout.
 
-In Render, choose **New → Blueprint**, select
-`mdbase-dev/mdbase-connect`, and use the repository's `render.yaml`. Confirm
-the paid web-service and database plans. Render asks for three values during
-the initial creation:
+## Create or update the services
+
+In Render, create a Blueprint from `mdbase-dev/mdbase-connect` and
+`render.yaml`. On first creation, provide:
 
 - `MDBASE_CONNECT_GITHUB_CLIENT_ID`
 - `MDBASE_CONNECT_GITHUB_CLIENT_SECRET`
-- `MDBASE_CONNECT_ALLOWED_GITHUB_USER_IDS` (`12558714` initially)
+- `MDBASE_CONNECT_ALLOWED_GITHUB_USER_IDS`
 
-The Blueprint runs migrations before each deployment, waits for `/ready`, and
-deploys commits only after GitHub checks pass. Keep the web service at one
-instance: relay connections and in-flight request coordination are currently
-process-local.
+The Blueprint generates the provider internal token and master key. Do not
+replace the master key on an existing provider database: startup deliberately
+fails if it cannot decrypt the durable key check. Key rotation must rewrap every
+collection data key transactionally before the old key is retired.
 
-## Attach the domain
+Both databases deny public network connections. The hosted database uses paid
+PostgreSQL 18 with storage autoscaling and point-in-time recovery. Automatic
+deploys wait for GitHub checks, and both services use `/ready` as a database-aware
+health check.
 
-Render lists the DNS target for `connect.mdbase.dev` after service creation.
-Create the corresponding `connect` CNAME at the DNS provider. If the provider
-offers HTTP proxying, leave it disabled until Render has verified the domain
-and issued its certificate.
+## Domains
 
-The generated `onrender.com` hostname remains useful for initial diagnostics,
-but GitHub sign-in is intentionally bound to `https://connect.mdbase.dev`.
+Attach and verify both DNS names before testing browser OAuth:
 
-## Verify the deployment
+- `connect.mdbase.dev` → control-plane Render hostname
+- `sync.mdbase.dev` → hosted-provider Render hostname
 
-1. Confirm `/health` and `/ready` both return HTTP 200.
-2. Open `/login` and sign in with the allowlisted GitHub account.
-3. Confirm `/dashboard` shows the expected GitHub username.
-4. Pair a fresh desktop installation against `https://connect.mdbase.dev`.
-5. Approve a test app, perform one encrypted read and write, then revoke it.
-6. Confirm the revoked grant cannot reconnect or refresh.
+Render terminates TLS. The control plane refuses a non-HTTPS public origin, and
+the provider binds browser capabilities to each application's exact manifest
+origin. CLI mirrors have no `Origin` header and authenticate with their own
+collection-scoped replica credential.
 
-## Operations
+## Acceptance check
 
-Render manages database snapshots and point-in-time recovery according to the
-selected PostgreSQL plan. Before inviting another user or enabling hosted
-collections, perform and document a restore drill, add external monitoring,
-and decide how security and abuse reports will be handled.
+Before any invitation:
 
-Do not set `MDBASE_CONNECT_HOSTED_COLLECTIONS=1` for the initial deployment.
-That mode introduces stored encrypted collection state and a larger operational
-and recovery surface.
+1. Confirm `/health` and `/ready` on both services.
+2. Sign in through GitHub and create a hosted TaskNotes collection.
+3. Authorize the current `mdbase-editor` build and perform create, read, query,
+   update, rename, and delete operations.
+4. Add one receive-only and one writable mirror. Verify config, type resources,
+   rename identity, conflict persistence, explicit resolution, token rotation,
+   and revocation.
+5. Inspect control-plane PostgreSQL and confirm it contains hosted metadata but
+   no record payloads, hashes, frontmatter, bodies, or local paths.
+6. Trigger a Render logical export, restore it into a separate database, start a
+   provider with the same master key, and compare collection heads and complete
+   snapshots. Record recovery time and the tested recovery point.
+7. Run an external uptime check against both `/ready` endpoints and alert on
+   sustained 5xx responses or database exhaustion.
+
+Render provides continuous PITR for paid PostgreSQL. PITR is not a substitute
+for the restore drill: recovery creates another database and the service must be
+deliberately repointed only after snapshot verification.
+
+## Scaling and incident boundaries
+
+The hosted provider is horizontally correct: PostgreSQL row locks order writes,
+working sets are disposable and head-checked, and the E2E suite races two
+processes on one revision. Start with one instance while traffic is private;
+scale after repeating the 10,000-record budget in-region.
+
+The provider also compacts each collection to the most recent 10,000 changes
+every five minutes. A replica behind that cursor automatically performs a
+snapshot reset; it does not prevent retention indefinitely. Tune
+`MDBASE_CONNECT_HOSTED_RETAIN_CHANGES` only after measuring database growth and
+reset frequency in the production region.
+
+The relay still coordinates live WebSockets and in-flight requests in process,
+so keep the control plane at one instance until relay routing moves to shared
+infrastructure. Hosted data-plane scaling does not change that constraint.
+
+Provider logs include request IDs, routes, statuses, durations, and internal
+errors through structured tracing. They must never log authorization headers,
+mutation bodies, frontmatter values, query source, decrypted Markdown, or the
+master key. Rotate/revoke a suspected replica or grant immediately; rotate the
+internal control-plane credential on both services together.

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -1,0 +1,128 @@
+# Hosted provider architecture
+
+Status: accepted implementation architecture for the production hosted path
+
+## Boundaries
+
+The hosted provider is a Rust data-plane service. PostgreSQL is the durable
+authority. A provider process may keep a derived working set for a collection,
+but the working set is disposable and is valid only for the PostgreSQL head it
+was built from.
+
+The Connect control plane owns accounts, applications, grants, and replica
+enrollment. It issues short-lived, grant-bound capabilities to the provider.
+Record payloads go directly between an authorized client and the provider; the
+control plane does not proxy or persist them. The provider rechecks collection,
+operation, mode, contract scope, scope epoch, expiry, and revocation before it
+opens authoritative state.
+
+`mdbase-rs` remains the only collection-semantics implementation. The provider
+materializes a collection working set from canonical PostgreSQL documents and
+resources, invokes the normative v0.3 operation facade, captures the resulting
+write set, and commits it with replication state. This is an adapter around the
+engine, not a second implementation of matching, validation, querying, links,
+or lifecycle behavior.
+
+## Durable model
+
+The production schema is normalized around these relations:
+
+- `hosted_collections`: owner, provider, authority epoch, head sequence,
+  resource revision, wrapped data key, state, and quota counters;
+- `hosted_resources`: versioned `mdbase.yaml`, type definitions, and other
+  collection resources;
+- `hosted_records`: stable record ID, current path token/path ciphertext,
+  revision, encrypted canonical Markdown, matched type labels, size, and
+  current sequence;
+- `hosted_record_versions`: retained record versions and tombstones needed for
+  pinned snapshots and conflict responses;
+- `hosted_changes`: the ordered per-collection replication log;
+- `hosted_mutation_receipts`: durable idempotency results keyed by replica and
+  mutation ID;
+- `hosted_replicas`: mode, contract/type scope, scope epoch, acknowledgement,
+  credential state, and revocation;
+- `hosted_snapshot_leases`: bounded leases pinning an authority sequence and
+  resource revision while pages are downloaded.
+
+Canonical documents and retained content are encrypted with a per-collection
+data key. Type labels, identifiers, revisions, sequences, sizes, deletion state,
+and keyed path tokens may remain visible as documented routing metadata.
+
+## Mutation transaction
+
+Every mutation follows one failure-atomic transaction:
+
+1. Verify the provider capability and current replica/grant state.
+2. Return the recorded receipt when the mutation ID already exists.
+3. Lock the collection head and verify authority and scope epochs.
+4. Bring the disposable working set to that exact head or rebuild it.
+5. Verify the submitted base revision.
+6. Execute the operation through `mdbase-rs` and capture all changed documents,
+   including reference rewrites.
+7. Validate the complete write set and calculate revisions/type membership.
+8. Persist current records, retained versions, the ordered change, quota deltas,
+   and mutation receipt.
+9. Advance the collection head and commit once.
+10. Mark the working set valid for the new head only after commit.
+
+A process failure before commit leaves no authoritative change. A failure after
+commit may leave a stale working set, which is detected from its head and
+rebuilt or incrementally refreshed. Provider instances never coordinate through
+process-local locks alone.
+
+## Reads, queries, and snapshots
+
+Point reads can load one encrypted document by stable ID or keyed path token.
+Queries use a revision-keyed warm working set and the canonical `mdbase-rs`
+query engine. Type scope selects candidates without exposing frontmatter.
+
+Snapshots are pinned to an authority sequence. Pages select record versions
+visible at that sequence; they are not copied into process memory. Snapshot
+leases expire and compaction never removes versions needed by a live lease.
+Change pages advance across invisible changes so scoped replicas cannot stall.
+Each provider process also runs idempotent retention maintenance. It compacts
+collections past `MDBASE_CONNECT_HOSTED_RETAIN_CHANGES`; a replica older than
+that boundary takes the ordinary snapshot-reset path instead of pinning an
+unbounded log. `MDBASE_CONNECT_HOSTED_MAINTENANCE_INTERVAL_SECONDS` controls the
+scan interval.
+
+## Mirrors and authority transfer
+
+Application caches and filesystem mirrors are replicas. Receive-only mirrors
+materialize configuration, types, and canonical Markdown with atomic writes.
+Local divergence is reported before replacement. Writable mirrors translate
+filesystem changes into conditional mutations and never resolve conflicts with
+implicit last-write-wins behavior.
+
+A writable mirror imports existing ordinary Markdown through the same
+conditional mutation path during its first sync. A future atomic bulk-import
+path will instead build an uncommitted hosted collection, validate it through
+`mdbase-rs`, and commit sequence zero only after the source manifest is still
+current. Export is already available by enrolling a receive-only directory
+mirror, which reconstructs a complete ordinary directory. Future promotion in
+either direction creates a new authority epoch.
+
+## Initial performance budgets
+
+Measure these in the same deployment region with 10,000 ordinary Markdown
+records and realistic type/query fixtures:
+
+- point read p95 below 100 ms;
+- mutation p95 below 200 ms;
+- warm query p95 below 300 ms;
+- 200-event change page p95 below 150 ms;
+- initial 10,000-record snapshot below 10 seconds;
+- incremental mirror convergence below two seconds after notification;
+- two provider instances preserve correctness and remain horizontally usable.
+
+Budgets are gates, not promises. Benchmark results may change them, but a code
+path may not silently regress them.
+
+## Deliberate non-goals for the first hosted release
+
+- multi-owner collaboration;
+- attachments and object storage;
+- billing;
+- private/zero-knowledge hosted collections;
+- peer-to-peer or multi-authority merging;
+- plaintext frontmatter indexes that weaken the documented encryption model.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,6 +1,8 @@
 # Hosted collections and sync
 
-Status: executable vertical slice; production hosted provider remains in design
+Status: production provider and filesystem-mirror path implemented for private
+preview; writable initialization can import existing Markdown, while atomic
+control-plane import and authority transfer remain later administration features
 
 ## Purpose
 
@@ -36,27 +38,29 @@ reference path through a real HTTP server:
 - an executable authority state machine with stable record IDs, ordered
   revisions, projection by type scope, scope epochs, cursor compaction,
   idempotent retries, and revocation;
-- versioned PostgreSQL persistence with compare-and-swap writes, including
-  retries when independent server processes race;
+- a normalized Rust/PostgreSQL authority with encrypted canonical payloads,
+  keyed record-path lookup, quotas, pinned snapshot leases, compactable history,
+  and durable idempotency receipts;
 - replica registration and hashed bearer credentials on the Connect server;
+- direct hosted OAuth capabilities in the browser SDK, without routing record
+  payloads through the control plane;
 - a durable-store abstraction with memory and IndexedDB implementations, plus
   an offline client for optimistic create, update, rename, and delete;
 - TaskNotes contract discovery from each hosted sync session, an adapter over
-  the offline replica, and a receive-only Markdown directory mirror with atomic
-  writes and local-divergence detection.
+  the offline replica, and receive-only or writable Markdown directory mirrors
+  with atomic writes, durable journals, and explicit conflict resolution.
 
 The network end-to-end test creates a hosted TaskNotes collection, queues work
 offline, synchronizes two clients, materializes Markdown, returns a stale-write
 conflict, recovers an expired cursor without losing pending work, and enforces
 replica revocation and token-renewal denial.
 
-The authority in this slice is a TypeScript reference implementation. It keeps
-one versioned state document per collection and applies a narrow TaskNotes
-validator. It establishes and tests the replication contract; it is not the
-production mdbase cloud provider. General mdbase validation and queries,
-normalized record/change tables, incremental resource changes, quotas,
-encrypted hosted storage, backups, durable snapshot recovery, and operational
-administration remain for the Rust provider.
+The TypeScript authority remains a deterministic protocol test double. The
+production route uses `mdbase-connect-hosted-provider`, and hosted validation,
+matching, queries, lifecycle behavior, and reference rewrites run through
+`mdbase-rs`. Paid PostgreSQL point-in-time recovery is provisioned on Render; a
+restore drill and long-retention logical-export procedure remain operational
+launch gates.
 
 ## Design commitments
 
@@ -368,16 +372,14 @@ Incoming documents use temporary files and atomic rename where the platform
 supports them. The watcher recognizes writes made by the mirror from the saved
 revision and avoids uploading them again.
 
-The first mirror is receive-only. If a user edits a mirrored file, Connect
-pauses that record and reports local divergence before applying another remote
-version. This provides useful Markdown availability while the outbound mutation
-path is developed.
-
-Writable mirroring follows in a separate milestone. Its watcher converts local
-create, document replacement, rename, and delete activity into conditional
-mutations. Changes to collection configuration and type definitions require an
-explicit whole-collection administration permission and their own resource
-revision checks.
+Receive-only mirrors pause on any local record or resource divergence before
+applying another remote version. Writable mirrors scan ordinary Markdown,
+preserve stable identity for exact renames, and convert creates, updates,
+renames, and deletes into journaled conditional mutations. Lost responses replay
+the same mutation ID. Concurrent edits persist a structured conflict beneath
+`.mdbase/conflicts/` and require an explicit local or remote resolution.
+Configuration and type documents remain receive-only until a separate
+whole-collection administration capability is introduced.
 
 ## Application cache behavior
 
@@ -413,8 +415,10 @@ POST /v1/hosted/collections/{collection}/sync/mutations
 The session response declares protocol version, replica mode, scope epoch,
 retained cursor boundary, and current head. Snapshot pages use opaque
 continuation tokens. Mutation responses return one durable receipt per mutation
-with applied, conflicted, rejected, or previously-applied status. Capability,
-resource, acknowledgement, and batch-mutation endpoints remain to be added.
+with applied, conflicted, rejected, or previously-applied status. Replica
+capabilities and versioned resource documents are included in session and
+mutation enforcement. Mutations are currently submitted individually; durable
+causal links preserve local ordering.
 
 Replication is versioned independently from the mdbase spec, Connect relay
 protocol, app manifest, and domain contracts. Shared Rust and TypeScript

--- a/package.json
+++ b/package.json
@@ -2,25 +2,19 @@
   "name": "mdbase-connect",
   "version": "0.1.0-alpha.1",
   "private": true,
-  "packageManager": "pnpm@10.7.0",
+  "packageManager": "pnpm@11.15.1",
   "scripts": {
     "build": "pnpm -r build",
     "e2e": "pnpm build && cargo build --workspace && node scripts/e2e.mjs",
     "e2e:sync": "pnpm build && node scripts/sync-e2e.mjs",
+    "e2e:provider": "pnpm build && cargo build -p mdbase-connect-hosted-provider && node scripts/hosted-provider-e2e.mjs",
+    "e2e:provider:stress": "MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT=10000 pnpm e2e:provider",
     "e2e:oracle": "pnpm build && cargo build --workspace && node scripts/oracle-e2e.mjs",
     "package:audit": "pnpm build && node scripts/package-audit.mjs",
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck"
   },
-  "pnpm": {
-    "overrides": {
-      "tar@<7.5.19": "7.5.19",
-      "tmp@<0.2.6": "0.2.7"
-    },
-    "onlyBuiltDependencies": [
-      "electron",
-      "electron-winstaller",
-      "esbuild"
-    ]
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -59,6 +59,13 @@ IndexedDB, encrypts operation inputs for the connector, and decrypts connector
 results locally. Set `relayEncryption: "disabled"` only for an explicit private
 protocol-2 migration; an encrypted grant never falls back to plaintext.
 
+For a hosted collection, the same authorization exchange returns a short-lived,
+grant-bound provider capability. The SDK routes operations directly to the
+hosted Rust data plane, binds browser requests to the manifest origin, and does
+not send record payloads through the Connect control plane. Refresh rotation,
+permission narrowing, and revocation keep the same public SDK behavior across
+local and hosted authorities.
+
 Record-facing code can depend on `MdbaseCollectionClient` instead of the OAuth
 client. It accepts a small `MdbaseCollectionTransport`, which is the stable seam
 used by Connect, the developer sandbox, and future hosted providers. This keeps

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,7 +17,10 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "dependencies": {
     "@mdbase/connect-protocol": "workspace:*"
   },
@@ -27,7 +30,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -57,6 +57,45 @@ describe("provider-neutral collection client", () => {
 });
 
 describe("authorization renewal", () => {
+  it("sends hosted operations directly to the provider with its scoped capability", async () => {
+    const storage = new MemoryStorage();
+    const serverUrl = "https://connect.example";
+    const providerUrl = "https://provider.example";
+    const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
+    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+      accessToken: "mdb_control",
+      refreshToken: "ref_current",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      collectionId: "00000000-0000-0000-0000-000000000002",
+      operations: ["query"],
+      scope: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+      expiresAt: Date.now() + 60_000,
+      refreshExpiresAt: Date.now() + 120_000,
+      hosted: {
+        providerUrl,
+        replicaId: "00000000-0000-0000-0000-000000000003",
+        accessToken: "hsa_direct"
+      }
+    }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      result: { valid: true, result: { results: [] }, diagnostics: [] }
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const connect = new MdbaseConnect({
+      serverUrl,
+      manifestUrl,
+      redirectUri: "https://tasks.example/callback",
+      storage
+    });
+
+    expect((await connect.query()).valid).toBe(true);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      `${providerUrl}/v1/hosted/collections/00000000-0000-0000-0000-000000000002/operations/query`
+    );
+    expect((fetchMock.mock.calls[0][1]?.headers as Record<string, string>).authorization)
+      .toBe("Bearer hsa_direct");
+  });
+
   it("rotates an expired access token and retries with the renewed credential", async () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -243,6 +243,11 @@ interface StoredToken {
   grantId?: string;
   encryption?: GrantEncryption;
   keyHandle?: string;
+  hosted?: {
+    providerUrl: string;
+    replicaId: string;
+    accessToken: string;
+  };
 }
 
 const DEFAULT_OPERATIONS: CollectionOperation[] = ["describe", "changes", "read", "query"];
@@ -350,7 +355,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     });
     const body = await response.json();
     if (!response.ok) throw apiError(body, "token_exchange_failed", "Authorization could not be completed.");
-    if (pending.relayEncryption === "required" && (
+    if (pending.relayEncryption === "required" && !body.hosted && (
       !body.encryption
       || !pending.keyHandle
       || body.encryption.application_public_key !== pending.applicationPublicKey
@@ -362,7 +367,12 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
         "Authorization did not establish the required encrypted relay grant."
       );
     }
-    const token = this.storeTokenResponse(body, pending.clientId, pending.keyHandle);
+    if (body.hosted && pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
+    const token = this.storeTokenResponse(
+      body,
+      pending.clientId,
+      body.hosted ? undefined : pending.keyHandle
+    );
     this.storage.removeItem(this.pendingKey());
     return { collectionId: token.collectionId, operations: token.operations, scope: token.scope };
   }
@@ -482,7 +492,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   }> {
     let body: unknown = input ?? {};
     let encryptedRequest: Awaited<ReturnType<typeof encryptRelayRequest>> | undefined;
-    if (token.encryption) {
+    if (token.encryption && !token.hosted) {
       if (!token.grantId || !token.keyHandle) {
         throw new MdbaseConnectError("missing_grant_key", "Reconnect this application to restore encrypted access.");
       }
@@ -500,12 +510,15 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       }
       body = encryptedRequest;
     }
+    const operationUrl = token.hosted
+      ? `${stripTrailingSlash(token.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`
+      : `${this.serverUrl}/v1/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`;
     const response = await fetch(
-      `${this.serverUrl}/v1/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`,
+      operationUrl,
       {
         method: "POST",
         headers: {
-          authorization: `Bearer ${token.accessToken}`,
+          authorization: `Bearer ${token.hosted?.accessToken ?? token.accessToken}`,
           "content-type": "application/json"
         },
         body: JSON.stringify(body)
@@ -589,7 +602,12 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
         : undefined,
       grantId: body.grant_id,
       encryption: body.encryption ?? undefined,
-      keyHandle
+      keyHandle,
+      hosted: body.hosted ? {
+        providerUrl: body.hosted.provider_url,
+        replicaId: body.hosted.replica_id,
+        accessToken: body.hosted.access_token
+      } : undefined
     };
     this.storage.setItem(this.tokenKey(), JSON.stringify(token));
     return token;

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -19,11 +19,14 @@
   "bin": {
     "mdbase-connect-dev": "./dist/cli.js"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "dependencies": {
     "@mdbase/connect": "workspace:*",
     "@mdbase/connect-protocol": "workspace:*",
-    "ajv": "^8.17.1"
+    "ajv": "^8.20.0"
   },
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
@@ -31,8 +34,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,15 +18,18 @@
     },
     "./schemas/*": "./schemas/*"
   },
-  "files": ["dist", "schemas"],
+  "files": [
+    "dist",
+    "schemas"
+  ],
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "node --test test/*.test.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "ajv": "^8.17.1",
+    "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "typescript": "^5.9.0"
+    "typescript": "^7.0.2"
   }
 }

--- a/packages/protocol/schemas/sync.v1.schema.json
+++ b/packages/protocol/schemas/sync.v1.schema.json
@@ -45,7 +45,19 @@
         "revision": { "type": "string", "minLength": 1 },
         "spec_version": { "type": "string", "minLength": 1 },
         "types": { "type": "array", "items": { "$ref": "#/$defs/collectionType" } },
-        "contracts": { "type": "array", "items": { "$ref": "#/$defs/contract" } }
+        "contracts": { "type": "array", "items": { "$ref": "#/$defs/contract" } },
+        "documents": { "type": "array", "items": { "$ref": "#/$defs/resourceDocument" } }
+      }
+    },
+    "resourceDocument": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind", "revision", "document"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["configuration", "type"] },
+        "revision": { "type": "string", "minLength": 1 },
+        "document": { "type": "string" }
       }
     },
     "record": {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -121,6 +121,14 @@ export interface SyncCollectionResources {
   spec_version: string;
   types: CollectionTypeDescriptor[];
   contracts: CollectionContractDescriptor[];
+  documents?: SyncResourceDocument[];
+}
+
+export interface SyncResourceDocument {
+  path: string;
+  kind: "configuration" | "type";
+  revision: string;
+  document: string;
 }
 
 export interface SyncSession {

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -3,11 +3,32 @@
 Provider-neutral replication protocol and executable reference state machine for
 hosted mdbase collections. It models stable record identity, pinned snapshots,
 scoped ordered changes, conditional idempotent mutations, conflicts, cursor
-reset, revocation, offline queues, and receive-only Markdown mirrors.
+reset, revocation, offline queues, and receive-only or writable Markdown
+mirrors.
 
-The reference authority is intended for contract tests and local development.
-The Connect server persists it as a versioned PostgreSQL state document with
-optimistic compare-and-swap and exposes the protocol over authenticated HTTP.
-That is enough for the tested TaskNotes vertical slice. The production hosted
-provider will implement the same `SyncTransport` boundary with normalized
-transactional storage and `mdbase-rs` operation execution.
+The in-process reference authority remains useful for deterministic contract
+tests. Production uses `mdbase-connect-hosted-provider`: normalized encrypted
+PostgreSQL storage, durable receipts and snapshot leases, and canonical
+operation execution through `mdbase-rs`.
+
+```bash
+# Receive-only mirror
+mdbase-mirror init ./tasks --server https://sync.mdbase.dev \
+  --collection <collection-id> --replica <replica-id>
+
+# Writable mirror (must be enrolled with read_write mode)
+mdbase-mirror init ./tasks --server https://sync.mdbase.dev \
+  --collection <collection-id> --replica <replica-id> --writable
+
+mdbase-mirror sync ./tasks
+mdbase-mirror resolve ./tasks <record-id> --use local
+```
+
+The token is read from a hidden prompt or
+`MDBASE_CONNECT_REPLICA_TOKEN`. Configuration and type documents are
+materialized but never uploaded as ordinary records. Writable changes use
+base revisions and a durable mutation journal; concurrent edits stop with a
+persisted conflict until the user explicitly chooses local or remote content.
+When `--writable` initializes an existing directory, the first sync establishes
+the remote baseline and uploads previously unmanaged Markdown in the same run.
+Remote/path collisions and resource differences still stop for explicit review.

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -11,6 +11,9 @@
   },
   "homepage": "https://mdbase.dev",
   "sideEffects": false,
+  "bin": {
+    "mdbase-mirror": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -21,10 +24,13 @@
       "import": "./dist/node.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "dependencies": {
     "@mdbase/connect-protocol": "workspace:*",
-    "yaml": "^2.8.1"
+    "yaml": "^2.9.0"
   },
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
@@ -32,8 +38,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/sync/src/cli.ts
+++ b/packages/sync/src/cli.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { parseArgs } from "node:util";
+import { HttpSyncTransport } from "./index.js";
+import { DirectoryMirror, WritableDirectoryMirror } from "./node.js";
+
+interface MirrorConfiguration {
+  protocol_version: 1;
+  provider_url: string;
+  collection_id: string;
+  replica_id: string;
+  replica_token: string;
+  mode: "read_only" | "read_write";
+}
+
+const parsed = parseArgs({
+  allowPositionals: true,
+  options: {
+    server: { type: "string" },
+    collection: { type: "string" },
+    replica: { type: "string" },
+    interval: { type: "string", default: "2000" },
+    writable: { type: "boolean", default: false },
+    use: { type: "string" },
+    help: { type: "boolean", short: "h" }
+  }
+});
+
+if (parsed.values.help || parsed.positionals.length === 0) {
+  usage();
+  process.exit(parsed.values.help ? 0 : 1);
+}
+
+const [command, directoryValue] = parsed.positionals;
+if (!directoryValue || !["init", "sync", "watch", "resolve"].includes(command)) {
+  usage();
+  process.exit(1);
+}
+
+const root = resolve(directoryValue);
+
+try {
+  if (command === "init") {
+    const providerUrlValue = required(parsed.values.server, "--server");
+    const collectionId = required(parsed.values.collection, "--collection");
+    const replicaId = required(parsed.values.replica, "--replica");
+    const token = process.env.MDBASE_CONNECT_REPLICA_TOKEN ?? await hiddenTokenPrompt();
+    if (token.length < 32) throw new Error("Replica token is missing or invalid.");
+    const mode = parsed.values.writable ? "read_write" : "read_only";
+    const providerUrl = canonicalProviderUrl(providerUrlValue);
+    const transport = new HttpSyncTransport(providerUrl, collectionId, token);
+    const session = await transport.openSession();
+    if (session.replica_id !== replicaId || session.mode !== mode) {
+      throw new Error(`Replica is not the requested ${mode.replace("_", "-")} mirror capability.`);
+    }
+    await mkdir(join(root, ".mdbase"), { recursive: true });
+    const configPath = await configurationPath(root);
+    await atomicWrite(
+      configPath,
+      `${JSON.stringify({
+        protocol_version: 1,
+        provider_url: providerUrl,
+        collection_id: collectionId,
+        replica_id: replicaId,
+        replica_token: token,
+        mode
+      } satisfies MirrorConfiguration, null, 2)}\n`
+    );
+    await sync(root);
+    process.stdout.write(`Mirror initialized at ${root}\n`);
+  } else if (command === "sync") {
+    await sync(root);
+    process.stdout.write("Mirror is up to date.\n");
+  } else if (command === "resolve") {
+    const recordId = parsed.positionals[2];
+    const resolution = parsed.values.use;
+    if (!recordId || !["local", "remote"].includes(resolution ?? "")) {
+      throw new Error("resolve requires a record ID and --use local or --use remote.");
+    }
+    const configuration = await loadConfiguration(root);
+    if (configuration.mode !== "read_write") throw new Error("This mirror is receive-only.");
+    const mirror = mirrorFor(root, configuration);
+    await mirror.resolveConflict(recordId, resolution as "local" | "remote");
+    process.stdout.write(`Conflict ${recordId} resolved using ${resolution} content.\n`);
+  } else {
+    const interval = Number(parsed.values.interval);
+    if (!Number.isInteger(interval) || interval < 250) {
+      throw new Error("--interval must be an integer of at least 250 milliseconds.");
+    }
+    process.stdout.write(`Watching hosted collection into ${root}. Press Ctrl+C to stop.\n`);
+    while (true) {
+      await sync(root);
+      await delay(interval);
+    }
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}
+
+async function sync(root: string): Promise<void> {
+  const configuration = await loadConfiguration(root);
+  await mirrorFor(root, configuration).sync();
+}
+
+function mirrorFor(root: string, configuration: MirrorConfiguration) {
+  const transport = new HttpSyncTransport(
+    configuration.provider_url,
+    configuration.collection_id,
+    configuration.replica_token
+  );
+  return configuration.mode === "read_write"
+    ? new WritableDirectoryMirror(root, configuration.replica_id, transport)
+    : new DirectoryMirror(root, configuration.replica_id, transport);
+}
+
+async function loadConfiguration(root: string): Promise<MirrorConfiguration> {
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(await configurationPath(root), "utf8"));
+  } catch {
+    throw new Error(`Mirror configuration is missing or invalid. Run mdbase-mirror init ${root} first.`);
+  }
+  if (!value || typeof value !== "object") throw new Error("Mirror configuration is invalid.");
+  const config = value as Partial<MirrorConfiguration>;
+  if (
+    config.protocol_version !== 1
+    || typeof config.provider_url !== "string"
+    || typeof config.collection_id !== "string"
+    || typeof config.replica_id !== "string"
+    || typeof config.replica_token !== "string"
+  ) {
+    throw new Error("Mirror configuration is invalid.");
+  }
+  const mode = config.mode ?? "read_only";
+  if (!(["read_only", "read_write"] as const).includes(mode)) {
+    throw new Error("Mirror configuration mode is invalid.");
+  }
+  return {
+    ...config,
+    mode,
+    provider_url: canonicalProviderUrl(config.provider_url)
+  } as MirrorConfiguration;
+}
+
+async function hiddenTokenPrompt(): Promise<string> {
+  if (!process.stdin.isTTY || typeof process.stdin.setRawMode !== "function") {
+    return new Promise((resolveToken, reject) => {
+      let value = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => { value += chunk; });
+      process.stdin.on("end", () => resolveToken(value.trim()));
+      process.stdin.on("error", reject);
+    });
+  }
+  process.stdout.write("Replica token (input hidden): ");
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding("utf8");
+  return new Promise((resolveToken, reject) => {
+    let value = "";
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      process.stdin.removeListener("data", onData);
+      process.stdin.removeListener("error", onError);
+      process.stdout.write("\n");
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onData = (chunk: string) => {
+      for (const character of chunk) {
+        if (character === "\u0003") {
+          cleanup();
+          reject(new Error("Cancelled."));
+          return;
+        }
+        if (character === "\r" || character === "\n") {
+          cleanup();
+          resolveToken(value);
+          return;
+        }
+        if (character === "\u007f") value = value.slice(0, -1);
+        else value += character;
+      }
+    };
+    process.stdin.on("data", onData);
+    process.stdin.on("error", onError);
+  });
+}
+
+async function atomicWrite(path: string, value: string): Promise<void> {
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  await writeFile(temporary, value, { mode: 0o600 });
+  await rename(temporary, path);
+}
+
+async function configurationPath(root: string): Promise<string> {
+  const canonicalRoot = await realpath(root);
+  const metadataDirectory = join(canonicalRoot, ".mdbase");
+  const metadata = await lstat(metadataDirectory);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error("Mirror metadata must be an ordinary directory inside the mirror root.");
+  }
+  const path = join(metadataDirectory, "connect-mirror.json");
+  try {
+    if ((await lstat(path)).isSymbolicLink()) {
+      throw new Error("Mirror configuration cannot be a symbolic link.");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return path;
+}
+
+function canonicalProviderUrl(value: string): string {
+  const url = new URL(value);
+  if (url.pathname !== "/" || url.search || url.hash || url.username || url.password) {
+    throw new Error("Provider URL must be an origin without credentials, path, query, or fragment.");
+  }
+  const loopback = ["localhost", "127.0.0.1", "[::1]", "::1"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error("Provider URL must use HTTPS outside loopback development.");
+  }
+  return url.origin;
+}
+
+function required(value: string | undefined, name: string): string {
+  if (!value) throw new Error(`${name} is required for mirror initialization.`);
+  return value;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+function usage(): void {
+  process.stderr.write(`Usage:
+  mdbase-mirror init <directory> --server <origin> --collection <uuid> --replica <uuid> [--writable]
+  mdbase-mirror sync <directory>
+  mdbase-mirror watch <directory> [--interval <milliseconds>]
+  mdbase-mirror resolve <directory> <record-id> --use <local|remote>
+
+The init command prompts for the one-time replica token without echoing it.
+For automation, pass the token through MDBASE_CONNECT_REPLICA_TOKEN.
+`);
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -921,6 +921,11 @@ function scopedResources(resources: SyncCollectionResources, replica: ReplicaSta
     types: resources.types.filter((type) => replica.allowedTypes.has(type.name)).map(clone),
     contracts: resources.contracts
       .filter((contract) => replica.allowedTypes.has(contract.type_name))
+      .map(clone),
+    documents: resources.documents
+      ?.filter((document) => document.kind === "configuration"
+        || (document.kind === "type"
+          && replica.allowedTypes.has(document.path.replace(/^_types\//, "").replace(/\.md$/, ""))))
       .map(clone)
   };
 }

--- a/packages/sync/src/node.test.ts
+++ b/packages/sync/src/node.test.ts
@@ -1,15 +1,33 @@
-import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MemoryHostedAuthority } from "./index.js";
-import { DirectoryMirror, MirrorDivergenceError } from "./node.js";
+import {
+  DirectoryMirror,
+  MirrorDivergenceError,
+  WritableDirectoryMirror,
+  WritableMirrorConflictError
+} from "./node.js";
 
 describe("receive-only Markdown mirror", () => {
   it("materializes stable records, renames them, and pauses on local divergence", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-sync-mirror-"));
     try {
-      const hosted = new MemoryHostedAuthority();
+      const hosted = new MemoryHostedAuthority({
+        resources: {
+          revision: "resources:1",
+          spec_version: "0.3.0",
+          types: [],
+          contracts: [],
+          documents: [{
+            path: "mdbase.yaml",
+            kind: "configuration",
+            revision: "config:1",
+            document: "spec_version: 0.3.0\n"
+          }]
+        }
+      });
       const writer = hosted.registerReplica({ name: "Writer", mode: "read_write", allowedTypes: ["task"] });
       const mirrorId = hosted.registerReplica({ name: "Laptop mirror", mode: "read_only" });
       const recordId = crypto.randomUUID();
@@ -22,6 +40,7 @@ describe("receive-only Markdown mirror", () => {
       if (created.status !== "applied" || !created.record) throw new Error("create failed");
       const mirror = new DirectoryMirror(root, mirrorId, hosted.transport(mirrorId));
       await mirror.sync();
+      expect(await readFile(join(root, "mdbase.yaml"), "utf8")).toBe("spec_version: 0.3.0\n");
       expect(await readFile(join(root, "tasks/one.md"), "utf8")).toContain("title: One");
       await hosted.transport(writer).mutate({
         mutation_id: crypto.randomUUID(), replica_id: writer, scope_epoch: 1,
@@ -74,6 +93,204 @@ describe("receive-only Markdown mirror", () => {
       await mirror.sync();
       await writeFile(join(root, ".mdbase/connect-sync.json"), JSON.stringify({ protocol_version: 1, replica_id: "another" }));
       await expect(mirror.sync()).rejects.toMatchObject({ code: "invalid_mirror_state" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("never follows a record-path symlink outside the mirror root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-mirror-"));
+    const outside = await mkdtemp(join(tmpdir(), "mdbase-sync-outside-"));
+    try {
+      const hosted = new MemoryHostedAuthority();
+      const writer = hosted.registerReplica({ name: "Writer", mode: "read_write", allowedTypes: ["task"] });
+      const mirrorId = hosted.registerReplica({ name: "Laptop mirror", mode: "read_only" });
+      await hosted.transport(writer).mutate({
+        mutation_id: crypto.randomUUID(), replica_id: writer, scope_epoch: 1,
+        operation: "create", record_id: crypto.randomUUID(),
+        input: { path: "linked/escape.md", frontmatter: { type: "task", title: "Escape" }, types: ["task"] },
+        created_at: new Date().toISOString()
+      });
+      await symlink(outside, join(root, "linked"), "dir");
+      const mirror = new DirectoryMirror(root, mirrorId, hosted.transport(mirrorId));
+      await expect(mirror.sync()).rejects.toMatchObject({ code: "symlink_denied" });
+      await expect(readFile(join(outside, "escape.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("never follows a symlinked mirror metadata directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-mirror-"));
+    const outside = await mkdtemp(join(tmpdir(), "mdbase-sync-outside-"));
+    try {
+      const hosted = new MemoryHostedAuthority();
+      const mirrorId = hosted.registerReplica({ name: "Laptop mirror", mode: "read_only" });
+      await symlink(outside, join(root, ".mdbase"), "dir");
+      const mirror = new DirectoryMirror(root, mirrorId, hosted.transport(mirrorId));
+      await expect(mirror.sync()).rejects.toMatchObject({ code: "symlink_denied" });
+      await expect(readFile(join(outside, "connect-sync.json"), "utf8"))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("writable Markdown mirror", () => {
+  it("imports existing local Markdown during initialization", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-writable-"));
+    try {
+      const hosted = new MemoryHostedAuthority();
+      const replicaId = hosted.registerReplica({ name: "Writable laptop", mode: "read_write", allowedTypes: ["task"] });
+      await writeFile(join(root, "existing.md"), "---\ntype: task\ntitle: Existing local note\n---\nLocal body");
+      const mirror = new WritableDirectoryMirror(root, replicaId, hosted.transport(replicaId));
+      await mirror.sync();
+      const session = await hosted.transport(replicaId).openSession();
+      expect((await hosted.transport(replicaId).snapshot(session.snapshot_id)).records).toEqual([
+        expect.objectContaining({
+          path: "existing.md",
+          frontmatter: { type: "task", title: "Existing local note" },
+          body: "Local body"
+        })
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uploads local updates, creates, exact renames, and deletes with stable identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-writable-"));
+    try {
+      const hosted = new MemoryHostedAuthority();
+      const replicaId = hosted.registerReplica({ name: "Writable laptop", mode: "read_write", allowedTypes: ["task"] });
+      const mirror = new WritableDirectoryMirror(root, replicaId, hosted.transport(replicaId));
+      await mirror.sync();
+      await writeFile(join(root, "first.md"), "---\ntype: task\ntitle: First\n---\nLocal body");
+      await mirror.sync();
+      let session = await hosted.transport(replicaId).openSession();
+      let records = (await hosted.transport(replicaId).snapshot(session.snapshot_id)).records;
+      expect(records).toHaveLength(1);
+      const recordId = records[0]!.record_id;
+      await writeFile(join(root, "first.md"), "---\ntype: task\ntitle: Updated\n---\nChanged body");
+      await mirror.sync();
+      session = await hosted.transport(replicaId).openSession();
+      records = (await hosted.transport(replicaId).snapshot(session.snapshot_id)).records;
+      expect(records[0]).toMatchObject({
+        record_id: recordId,
+        frontmatter: { type: "task", title: "Updated" },
+        body: "Changed body"
+      });
+      await rename(join(root, "first.md"), join(root, "renamed.md"));
+      await mirror.sync();
+      session = await hosted.transport(replicaId).openSession();
+      records = (await hosted.transport(replicaId).snapshot(session.snapshot_id)).records;
+      expect(records[0]).toMatchObject({ record_id: recordId, path: "renamed.md" });
+      await unlink(join(root, "renamed.md"));
+      await mirror.sync();
+      session = await hosted.transport(replicaId).openSession();
+      expect((await hosted.transport(replicaId).snapshot(session.snapshot_id)).records).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves local content on conflict and supports explicit local resolution", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-writable-"));
+    try {
+      const hosted = new MemoryHostedAuthority();
+      const writer = hosted.registerReplica({ name: "Remote writer", mode: "read_write", allowedTypes: ["task"] });
+      const replicaId = hosted.registerReplica({ name: "Writable laptop", mode: "read_write", allowedTypes: ["task"] });
+      const recordId = crypto.randomUUID();
+      const created = await hosted.transport(writer).mutate({
+        mutation_id: crypto.randomUUID(), replica_id: writer, scope_epoch: 1,
+        operation: "create", record_id: recordId,
+        input: { path: "task.md", frontmatter: { type: "task", title: "Base" }, types: ["task"] },
+        created_at: new Date().toISOString()
+      });
+      if (created.status !== "applied" || !created.record) throw new Error("create failed");
+      const mirror = new WritableDirectoryMirror(root, replicaId, hosted.transport(replicaId));
+      await mirror.sync();
+      await writeFile(join(root, "task.md"), "---\ntype: task\ntitle: Local\n---\n");
+      await hosted.transport(writer).mutate({
+        mutation_id: crypto.randomUUID(), replica_id: writer, scope_epoch: 1,
+        operation: "update", record_id: recordId, base_revision: created.record.revision,
+        input: { patch: { title: "Remote" } }, created_at: new Date().toISOString()
+      });
+      await expect(mirror.sync()).rejects.toBeInstanceOf(WritableMirrorConflictError);
+      expect(await readFile(join(root, "task.md"), "utf8")).toContain("title: Local");
+      expect(await readFile(join(root, ".mdbase", "conflicts", `${recordId}.json`), "utf8"))
+        .toContain('"status": "conflicted"');
+      await expect(mirror.sync()).rejects.toBeInstanceOf(WritableMirrorConflictError);
+      await mirror.resolveConflict(recordId, "local");
+      await mirror.sync();
+      const session = await hosted.transport(replicaId).openSession();
+      const current = (await hosted.transport(replicaId).snapshot(session.snapshot_id)).records[0]!;
+      expect(current.frontmatter.title).toBe("Local");
+      await expect(readFile(join(root, ".mdbase", "conflicts", `${recordId}.json`), "utf8"))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("replays a journaled mutation after the server commits but the response is lost", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-writable-"));
+    try {
+      const hosted = new MemoryHostedAuthority();
+      const replicaId = hosted.registerReplica({ name: "Writable laptop", mode: "read_write", allowedTypes: ["task"] });
+      const upstream = hosted.transport(replicaId);
+      let loseResponse = true;
+      const unreliable = {
+        openSession: () => upstream.openSession(),
+        snapshot: (snapshotId: string, page?: string) => upstream.snapshot(snapshotId, page),
+        changes: (after: number, limit?: number) => upstream.changes(after, limit),
+        async mutate(mutation: Parameters<typeof upstream.mutate>[0]) {
+          const receipt = await upstream.mutate(mutation);
+          if (loseResponse) {
+            loseResponse = false;
+            throw new Error("connection reset after commit");
+          }
+          return receipt;
+        }
+      };
+      const mirror = new WritableDirectoryMirror(root, replicaId, unreliable);
+      await mirror.sync();
+      await writeFile(join(root, "task.md"), "---\ntype: task\ntitle: Durable\n---\n");
+      await expect(mirror.sync()).rejects.toThrow("connection reset after commit");
+      await mirror.sync();
+      const session = await upstream.openSession();
+      expect(session.head).toBe(1);
+      expect((await upstream.snapshot(session.snapshot_id)).records).toHaveLength(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("never treats schema resources as writable record changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-sync-writable-"));
+    try {
+      const hosted = new MemoryHostedAuthority({
+        resources: {
+          revision: "resources:1",
+          spec_version: "0.3.0",
+          types: [],
+          contracts: [],
+          documents: [{
+            path: "mdbase.yaml",
+            kind: "configuration",
+            revision: "config:1",
+            document: "spec_version: 0.3.0\n"
+          }]
+        }
+      });
+      const replicaId = hosted.registerReplica({ name: "Writable laptop", mode: "read_write" });
+      const mirror = new WritableDirectoryMirror(root, replicaId, hosted.transport(replicaId));
+      await mirror.sync();
+      await writeFile(join(root, "mdbase.yaml"), "spec_version: 0.4.0\n");
+      await expect(mirror.sync()).rejects.toBeInstanceOf(MirrorDivergenceError);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/sync/src/node.ts
+++ b/packages/sync/src/node.ts
@@ -1,8 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
-import { dirname, join, resolve, sep } from "node:path";
-import { stringify } from "yaml";
-import type { JsonObject, SyncRecord } from "@mdbase/connect-protocol";
+import { lstat, mkdir, readFile, readdir, realpath, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { parse, stringify } from "yaml";
+import type { JsonObject, SyncMutation, SyncMutationReceipt, SyncRecord } from "@mdbase/connect-protocol";
 import type { SyncTransport } from "./index.js";
 import { SyncError } from "./index.js";
 
@@ -10,6 +10,13 @@ interface MirrorEntry {
   path: string;
   revision: string;
   hash: string;
+  record?: SyncRecord;
+}
+
+interface PendingMirrorMutation {
+  mutation: SyncMutation;
+  local_path: string;
+  local_hash: string | null;
 }
 
 interface MirrorState {
@@ -18,29 +25,48 @@ interface MirrorState {
   scope_epoch: number;
   cursor: number;
   records: Record<string, MirrorEntry>;
+  resources?: Record<string, MirrorEntry>;
+  mode?: "read_only" | "read_write";
+  pending?: PendingMirrorMutation[];
+  conflicts?: Record<string, SyncMutationReceipt>;
 }
 
 /** Receive-only materialization of a sync replica into ordinary Markdown files. */
 export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
   private readonly root: string;
-  private readonly statePath: string;
 
   constructor(
     root: string,
     private readonly replicaId: string,
-    private readonly transport: SyncTransport<Frontmatter>
+    private readonly transport: SyncTransport<Frontmatter>,
+    private readonly mode: "read_only" | "read_write" = "read_only"
   ) {
     this.root = resolve(root);
-    this.statePath = join(this.root, ".mdbase", "connect-sync.json");
   }
 
   async sync(): Promise<void> {
     const state = await this.readState();
     if (!state) {
       await this.rebuild();
+      // A writable first sync is also the import path for an existing local
+      // directory: rebuild establishes the remote baseline, then a normal
+      // pass journals and conditionally uploads files that were not remote.
+      if (this.mode === "read_write") await this.sync();
       return;
     }
-    await this.assertUndiverged(state);
+    if (this.mode === "read_write") {
+      if (Object.keys(state.conflicts ?? {}).length) {
+        throw new WritableMirrorConflictError(
+          Object.keys(state.conflicts ?? {})[0]!,
+          "A local conflict must be resolved before writable sync can continue."
+        );
+      }
+      await this.flushPending(state);
+      await this.captureLocalChanges(state);
+      await this.flushPending(state);
+    } else {
+      await this.assertUndiverged(state);
+    }
     while (true) {
       const page = await this.transport.changes(state.cursor, 200);
       if (page.scope_epoch !== state.scope_epoch || page.reset_required) {
@@ -59,16 +85,26 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
 
   private async rebuild(prior?: MirrorState): Promise<void> {
     const session = await this.transport.openSession();
-    if (session.replica_id !== this.replicaId || session.mode !== "read_only") {
-      throw new SyncError("invalid_mirror_session", "Filesystem mirrors require their own read-only replica.");
+    if (session.replica_id !== this.replicaId || session.mode !== this.mode) {
+      throw new SyncError(
+        "invalid_mirror_session",
+        `Filesystem mirror requires its own ${this.mode.replace("_", "-")} replica.`
+      );
     }
     const state: MirrorState = {
       protocol_version: 1,
       replica_id: this.replicaId,
       scope_epoch: session.scope_epoch,
       cursor: session.head,
-      records: {}
+      records: {},
+      resources: {},
+      mode: this.mode,
+      pending: [],
+      conflicts: {}
     };
+    for (const resource of session.resources.documents ?? []) {
+      await this.putResource(state, resource, prior);
+    }
     let page: string | undefined;
     do {
       const snapshot = await this.transport.snapshot(session.snapshot_id, page);
@@ -79,6 +115,9 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
       for (const [recordId, entry] of Object.entries(prior.records)) {
         if (!state.records[recordId]) await this.remove(prior, recordId, entry.path);
       }
+      for (const [path, entry] of Object.entries(prior.resources ?? {})) {
+        if (!state.resources?.[path]) await this.removeResource(prior, path, entry);
+      }
     }
     await this.writeState(state);
   }
@@ -86,14 +125,19 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
   private async put(
     state: MirrorState,
     record: SyncRecord<Frontmatter>,
-    managedState: MirrorState | undefined = state
+    managedState: MirrorState | undefined = state,
+    acceptedHash?: string | null
   ): Promise<void> {
-    const path = this.safePath(record.path);
+    const path = await this.safePath(record.path);
     const document = markdown(record);
     const existing = await readOptional(path);
     const prior = managedState?.records[record.record_id];
     if (existing !== null && existing !== document) {
-      if (!prior || prior.path !== record.path || digest(existing) !== prior.hash) {
+      const existingHash = digest(existing);
+      if (
+        (!prior || prior.path !== record.path || existingHash !== prior.hash)
+        && (acceptedHash === undefined || existingHash !== acceptedHash)
+      ) {
         throw new MirrorDivergenceError(record.record_id, record.path);
       }
     }
@@ -105,13 +149,14 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     state.records[record.record_id] = {
       path: record.path,
       revision: record.revision,
-      hash: digest(document)
+      hash: digest(document),
+      record
     };
   }
 
   private async remove(state: MirrorState, recordId: string, pathValue: string): Promise<void> {
     const entry = state.records[recordId];
-    const path = this.safePath(entry?.path ?? pathValue);
+    const path = await this.safePath(entry?.path ?? pathValue);
     const existing = await readOptional(path);
     if (existing !== null && entry && digest(existing) !== entry.hash) {
       throw new MirrorDivergenceError(recordId, entry.path);
@@ -120,39 +165,326 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     delete state.records[recordId];
   }
 
-  private safePath(relative: string): string {
+  private async putResource(
+    state: MirrorState,
+    resource: { path: string; revision: string; document: string },
+    managedState?: MirrorState
+  ): Promise<void> {
+    const path = await this.safePath(resource.path);
+    const existing = await readOptional(path);
+    const prior = managedState?.resources?.[resource.path];
+    if (existing !== null && existing !== resource.document && (!prior || digest(existing) !== prior.hash)) {
+      throw new MirrorDivergenceError(`resource:${resource.path}`, resource.path);
+    }
+    await mkdir(dirname(path), { recursive: true });
+    await atomicWrite(path, resource.document);
+    state.resources ??= {};
+    state.resources[resource.path] = {
+      path: resource.path,
+      revision: resource.revision,
+      hash: digest(resource.document)
+    };
+  }
+
+  private async removeResource(state: MirrorState, pathValue: string, entry: MirrorEntry): Promise<void> {
+    const path = await this.safePath(pathValue);
+    const existing = await readOptional(path);
+    if (existing !== null && digest(existing) !== entry.hash) {
+      throw new MirrorDivergenceError(`resource:${pathValue}`, pathValue);
+    }
+    if (existing !== null) await unlink(path);
+    if (state.resources) delete state.resources[pathValue];
+  }
+
+  async resolveConflict(recordId: string, resolution: "local" | "remote"): Promise<void> {
+    if (this.mode !== "read_write") {
+      throw new SyncError("mirror_read_only", "Receive-only mirrors do not contain writable conflicts.");
+    }
+    const state = await this.readState();
+    const receipt = state?.conflicts?.[recordId];
+    if (!state || !receipt) {
+      throw new SyncError("mirror_conflict_not_found", "Writable mirror conflict was not found.");
+    }
+    if (receipt.status === "rejected") {
+      throw new WritableMirrorRejectedError(recordId, receipt.error.code, receipt.error.message);
+    }
+    if (receipt.status === "conflicted") {
+      const current = receipt.conflict.current;
+      if (resolution === "remote") {
+        if (current) {
+          const currentPath = await this.safePath(current.path);
+          const existing = await readOptional(currentPath);
+          await this.put(
+            state,
+            current as SyncRecord<Frontmatter>,
+            state,
+            existing === null ? null : digest(existing)
+          );
+        } else {
+          const entry = state.records[recordId];
+          if (entry) {
+            const path = await this.safePath(entry.path);
+            if (await readOptional(path) !== null) await unlink(path);
+            delete state.records[recordId];
+          }
+        }
+      } else if (current) {
+        state.records[recordId] = {
+          path: current.path,
+          revision: current.revision,
+          hash: digest(markdown(current)),
+          record: current
+        };
+      } else {
+        delete state.records[recordId];
+      }
+    }
+    if (state.pending?.[0]?.mutation.causal_predecessor === receipt.mutation_id) {
+      delete state.pending[0].mutation.causal_predecessor;
+    }
+    delete state.conflicts![recordId];
+    const conflictPath = await this.conflictPath(recordId);
+    if (await readOptional(conflictPath) !== null) await unlink(conflictPath);
+    await this.writeState(state);
+  }
+
+  private async captureLocalChanges(state: MirrorState): Promise<void> {
+    const resourcePaths = new Set(Object.keys(state.resources ?? {}));
+    for (const [path, entry] of Object.entries(state.resources ?? {})) {
+      const value = await readOptional(await this.safePath(path));
+      if (value === null || digest(value) !== entry.hash) {
+        throw new MirrorDivergenceError(`resource:${path}`, path);
+      }
+    }
+    const files = await markdownFiles(this.root, resourcePaths);
+    const local = new Map<string, { document: string; hash: string }>();
+    for (const path of files) {
+      const document = await readFile(await this.safePath(path), "utf8");
+      local.set(path, { document, hash: digest(document) });
+    }
+    const managedPaths = new Map(
+      Object.entries(state.records).map(([recordId, entry]) => [entry.path, recordId])
+    );
+    const untracked = new Set([...local.keys()].filter((path) => !managedPaths.has(path)));
+    const missing = new Set(
+      Object.entries(state.records)
+        .filter(([, entry]) => !local.has(entry.path))
+        .map(([recordId]) => recordId)
+    );
+    const queued: PendingMirrorMutation[] = [];
+    let predecessor: string | undefined;
+    const queue = (
+      mutation: Omit<SyncMutation, "mutation_id" | "replica_id" | "scope_epoch" | "created_at">,
+      localPath: string,
+      localHash: string | null
+    ) => {
+      const mutationId = randomUUID();
+      queued.push({
+        mutation: {
+          ...mutation,
+          mutation_id: mutationId,
+          replica_id: this.replicaId,
+          scope_epoch: state.scope_epoch,
+          created_at: new Date().toISOString(),
+          ...(predecessor ? { causal_predecessor: predecessor } : {})
+        },
+        local_path: localPath,
+        local_hash: localHash
+      });
+      predecessor = mutationId;
+    };
+
+    for (const recordId of [...missing]) {
+      const entry = state.records[recordId]!;
+      const candidates = [...untracked].filter((path) => local.get(path)?.hash === entry.hash);
+      if (candidates.length !== 1) continue;
+      const target = candidates[0]!;
+      queue({
+        operation: "rename",
+        record_id: recordId,
+        base_revision: entry.revision,
+        input: { path: target }
+      }, target, local.get(target)!.hash);
+      missing.delete(recordId);
+      untracked.delete(target);
+    }
+
+    for (const [recordId, entry] of Object.entries(state.records)) {
+      if (missing.has(recordId)) continue;
+      const value = local.get(entry.path);
+      if (!value || value.hash === entry.hash) continue;
+      const record = entry.record;
+      if (!record) {
+        throw new SyncError(
+          "mirror_state_upgrade_required",
+          "Run a receive sync before editing this older writable mirror."
+        );
+      }
+      const parsed = parseMarkdown(value.document, entry.path);
+      queue({
+        operation: "update",
+        record_id: recordId,
+        base_revision: entry.revision,
+        input: {
+          patch: frontmatterPatch(record.frontmatter, parsed.frontmatter),
+          body: parsed.body
+        }
+      }, entry.path, value.hash);
+    }
+
+    for (const recordId of missing) {
+      const entry = state.records[recordId]!;
+      queue({
+        operation: "delete",
+        record_id: recordId,
+        base_revision: entry.revision,
+        input: {}
+      }, entry.path, null);
+    }
+
+    for (const path of untracked) {
+      const value = local.get(path)!;
+      const parsed = parseMarkdown(value.document, path);
+      queue({
+        operation: "create",
+        record_id: randomUUID(),
+        input: { path, frontmatter: parsed.frontmatter, body: parsed.body }
+      }, path, value.hash);
+    }
+    if (queued.length) {
+      state.pending!.push(...queued);
+      await this.writeState(state);
+    }
+  }
+
+  private async flushPending(state: MirrorState): Promise<void> {
+    while (state.pending?.length) {
+      const pending = state.pending[0]!;
+      const localPath = await this.safePath(pending.local_path);
+      const localDocument = await readOptional(localPath);
+      const localHash = localDocument === null ? null : digest(localDocument);
+      if (localHash !== pending.local_hash) {
+        throw new SyncError(
+          "pending_local_changed",
+          `Local edits at ${pending.local_path} changed while an earlier upload was pending.`
+        );
+      }
+      const receipt = await this.transport.mutate(pending.mutation);
+      if (receipt.status === "applied" || receipt.status === "previously_applied") {
+        if (receipt.record) {
+          await this.put(
+            state,
+            receipt.record,
+            state,
+            pending.local_hash
+          );
+        } else {
+          delete state.records[pending.mutation.record_id];
+        }
+        state.pending.shift();
+        await this.writeState(state);
+        continue;
+      }
+      state.pending.shift();
+      state.conflicts ??= {};
+      state.conflicts[pending.mutation.record_id] = receipt;
+      const conflictPath = await this.conflictPath(pending.mutation.record_id);
+      await mkdir(dirname(conflictPath), { recursive: true });
+      await atomicWrite(
+        conflictPath,
+        `${JSON.stringify(receipt, null, 2)}\n`
+      );
+      await this.writeState(state);
+      if (receipt.status === "conflicted") {
+        throw new WritableMirrorConflictError(
+          pending.mutation.record_id,
+          `Hosted and local changes conflict at ${pending.local_path}.`
+        );
+      }
+      if (receipt.status !== "rejected") {
+        throw new SyncError("invalid_mutation_receipt", "Hosted provider returned an invalid mutation receipt.");
+      }
+      throw new WritableMirrorRejectedError(
+        pending.mutation.record_id,
+        receipt.error.code,
+        receipt.error.message
+      );
+    }
+  }
+
+  private conflictPath(recordId: string): Promise<string> {
+    return this.safePath(`.mdbase/conflicts/${recordId}.json`);
+  }
+
+  private async safePath(relative: string): Promise<string> {
     if (relative.startsWith("/") || relative.includes("\\") || relative.split("/").some((part) => !part || part === "." || part === "..")) {
       throw new SyncError("invalid_path", "Mirror received an unsafe record path.");
     }
-    const path = resolve(this.root, relative);
-    if (path !== this.root && !path.startsWith(`${this.root}${sep}`)) {
+    const root = await realpath(this.root);
+    const path = resolve(root, relative);
+    if (path !== root && !path.startsWith(`${root}${sep}`)) {
       throw new SyncError("path_traversal", "Mirror path escaped its collection root.");
+    }
+    const parts = relative.split("/");
+    let candidate = root;
+    for (const [index, part] of parts.entries()) {
+      candidate = join(candidate, part);
+      try {
+        const metadata = await lstat(candidate);
+        if (metadata.isSymbolicLink()) {
+          throw new SyncError("symlink_denied", "Mirror paths cannot traverse symbolic links.");
+        }
+        if (index < parts.length - 1 && !metadata.isDirectory()) {
+          throw new SyncError("invalid_path", "Mirror path parent is not a directory.");
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") break;
+        throw error;
+      }
     }
     return path;
   }
 
   private async readState(): Promise<MirrorState | null> {
-    const value = await readOptional(this.statePath);
+    const value = await readOptional(await this.safePath(".mdbase/connect-sync.json"));
     if (value === null) return null;
     try {
       const state = JSON.parse(value) as MirrorState;
       if (state.protocol_version !== 1 || state.replica_id !== this.replicaId) throw new Error();
+      state.resources ??= {};
+      state.pending ??= [];
+      state.conflicts ??= {};
+      state.mode ??= "read_only";
+      if (state.mode !== this.mode) {
+        throw new SyncError(
+          "mirror_mode_mismatch",
+          `Mirror metadata belongs to a ${state.mode.replace("_", "-")} replica.`
+        );
+      }
       return state;
-    } catch {
+    } catch (error) {
+      if (error instanceof SyncError) throw error;
       throw new SyncError("invalid_mirror_state", "Mirror metadata is corrupt or belongs to another replica.");
     }
   }
 
   private async writeState(state: MirrorState): Promise<void> {
-    await mkdir(dirname(this.statePath), { recursive: true });
-    await atomicWrite(this.statePath, `${JSON.stringify(state, null, 2)}\n`);
+    const statePath = await this.safePath(".mdbase/connect-sync.json");
+    await mkdir(dirname(statePath), { recursive: true });
+    await atomicWrite(statePath, `${JSON.stringify(state, null, 2)}\n`);
   }
 
   private async assertUndiverged(state: MirrorState): Promise<void> {
     for (const [recordId, entry] of Object.entries(state.records)) {
-      const value = await readOptional(this.safePath(entry.path));
+      const value = await readOptional(await this.safePath(entry.path));
       if (value === null || digest(value) !== entry.hash) {
         throw new MirrorDivergenceError(recordId, entry.path);
+      }
+    }
+    for (const [path, entry] of Object.entries(state.resources ?? {})) {
+      const value = await readOptional(await this.safePath(entry.path));
+      if (value === null || digest(value) !== entry.hash) {
+        throw new MirrorDivergenceError(`resource:${path}`, entry.path);
       }
     }
   }
@@ -164,10 +496,76 @@ export class MirrorDivergenceError extends SyncError {
   }
 }
 
+export class WritableDirectoryMirror<Frontmatter extends JsonObject = JsonObject>
+  extends DirectoryMirror<Frontmatter> {
+  constructor(root: string, replicaId: string, transport: SyncTransport<Frontmatter>) {
+    super(root, replicaId, transport, "read_write");
+  }
+}
+
+export class WritableMirrorConflictError extends SyncError {
+  constructor(public readonly recordId: string, message: string) {
+    super("writable_mirror_conflict", message);
+  }
+}
+
+export class WritableMirrorRejectedError extends SyncError {
+  constructor(
+    public readonly recordId: string,
+    public readonly rejectionCode: string,
+    message: string
+  ) {
+    super("writable_mirror_rejected", `${rejectionCode}: ${message}`);
+  }
+}
+
 function markdown(record: SyncRecord): string {
   const yaml = stringify(record.frontmatter, { lineWidth: 0 }).trimEnd();
   const body = record.body ? `\n${record.body.replace(/^\n/, "")}` : "";
   return `---\n${yaml}\n---\n${body}`;
+}
+
+function parseMarkdown(document: string, path: string): { frontmatter: JsonObject; body: string } {
+  const match = document.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/);
+  if (!match) {
+    throw new SyncError("invalid_markdown", `Writable mirror file ${path} requires YAML frontmatter.`);
+  }
+  let frontmatter: unknown;
+  try {
+    frontmatter = parse(match[1]!);
+  } catch {
+    throw new SyncError("invalid_frontmatter", `Writable mirror file ${path} has invalid YAML frontmatter.`);
+  }
+  if (!frontmatter || typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
+    throw new SyncError("invalid_frontmatter", `Writable mirror file ${path} requires object frontmatter.`);
+  }
+  return { frontmatter: frontmatter as JsonObject, body: match[2] ?? "" };
+}
+
+function frontmatterPatch(before: JsonObject, after: JsonObject): JsonObject {
+  const patch: JsonObject = { ...after };
+  for (const field of Object.keys(before)) {
+    if (!(field in after)) patch[field] = null;
+  }
+  return patch;
+}
+
+async function markdownFiles(root: string, excluded: Set<string>): Promise<string[]> {
+  const files: string[] = [];
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (entry.name === ".mdbase") continue;
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile() && entry.name.endsWith(".md")) {
+        const pathValue = relative(root, path).split(sep).join("/");
+        if (!excluded.has(pathValue)) files.push(pathValue);
+      }
+    }
+  }
+  await visit(root);
+  files.sort();
+  return files;
 }
 
 async function readOptional(path: string): Promise<string | null> {

--- a/packages/tasknotes/package.json
+++ b/packages/tasknotes/package.json
@@ -17,7 +17,10 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
     "test": "vitest run",
@@ -29,7 +32,7 @@
     "@mdbase/connect-sync": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/tasknotes/tsconfig.json
+++ b/packages/tasknotes/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "skipLibCheck": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,107 +5,112 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@electron/rebuild': 4.2.0
   tar@<7.5.19: 7.5.19
   tmp@<0.2.6: 0.2.7
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
 
   apps/desktop:
     dependencies:
       '@fontsource/atkinson-hyperlegible':
-        specifier: ^5.2.0
+        specifier: ^5.3.0
         version: 5.3.0
       '@fontsource/azeret-mono':
-        specifier: ^5.2.0
+        specifier: ^5.3.0
         version: 5.3.0
-      '@mdbase/connect-ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       scheduler:
         specifier: ^0.27.0
         version: 0.27.0
     devDependencies:
       '@electron-forge/cli':
-        specifier: ^7.11.0
-        version: 7.11.2(encoding@0.1.13)
+        specifier: ^7.11.2
+        version: 7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)
       '@electron-forge/maker-deb':
-        specifier: ^7.11.0
-        version: 7.11.2
+        specifier: ^7.11.2
+        version: 7.11.2(supports-color@8.1.1)
       '@electron-forge/maker-rpm':
-        specifier: ^7.11.0
-        version: 7.11.2
+        specifier: ^7.11.2
+        version: 7.11.2(supports-color@8.1.1)
       '@electron-forge/maker-squirrel':
-        specifier: ^7.11.0
-        version: 7.11.2
+        specifier: ^7.11.2
+        version: 7.11.2(supports-color@8.1.1)
       '@electron-forge/maker-zip':
-        specifier: ^7.11.0
-        version: 7.11.2
+        specifier: ^7.11.2
+        version: 7.11.2(supports-color@8.1.1)
+      '@mdbase/connect-ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.1
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
-        specifier: ^19.2.0
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.2.0
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^5.0.0
-        version: 5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       electron:
-        specifier: ^41.0.0
-        version: 41.10.2
+        specifier: ^43.1.1
+        version: 43.1.1(supports-color@8.1.1)
       playwright-core:
-        specifier: ^1.58.0
+        specifier: ^1.61.1
         version: 1.61.1
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
-        specifier: ^7.0.0
-        version: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   apps/portal:
     dependencies:
       '@fontsource/atkinson-hyperlegible':
-        specifier: ^5.2.0
+        specifier: ^5.3.0
         version: 5.3.0
       '@fontsource/azeret-mono':
-        specifier: ^5.2.0
+        specifier: ^5.3.0
         version: 5.3.0
       '@mdbase/connect-ui':
         specifier: workspace:*
         version: link:../../packages/ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.0
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.2.0
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^5.0.0
-        version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
-        specifier: ^7.0.0
-        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   apps/tasknotes:
     dependencies:
@@ -116,27 +121,27 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tasknotes
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.0
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.2.0
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^5.0.0
-        version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
-        specifier: ^7.0.0
-        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/client:
     dependencies:
@@ -145,11 +150,11 @@ importers:
         version: link:../protocol
     devDependencies:
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
-        specifier: ^4.0.0
-        version: 4.1.10(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/devkit:
     dependencies:
@@ -160,30 +165,30 @@ importers:
         specifier: workspace:*
         version: link:../protocol
       ajv:
-        specifier: ^8.17.1
+        specifier: ^8.20.0
         version: 8.20.0
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.1
+        specifier: ^24.0.0
+        version: 24.13.3
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
-        specifier: ^4.0.0
-        version: 4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/protocol:
     devDependencies:
       ajv:
-        specifier: ^8.17.1
+        specifier: ^8.20.0
         version: 8.20.0
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   packages/sync:
     dependencies:
@@ -191,18 +196,18 @@ importers:
         specifier: workspace:*
         version: link:../protocol
       yaml:
-        specifier: ^2.8.1
+        specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.1
+        specifier: ^24.0.0
+        version: 24.13.3
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
-        specifier: ^4.0.0
-        version: 4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/tasknotes:
     dependencies:
@@ -217,24 +222,24 @@ importers:
         version: link:../sync
     devDependencies:
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
-        specifier: ^4.0.0
-        version: 4.1.10(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/ui: {}
 
   services/server:
     dependencies:
       '@fastify/cookie':
-        specifier: ^11.0.0
+        specifier: ^11.1.2
         version: 11.1.2
       '@fastify/cors':
-        specifier: ^11.0.0
+        specifier: ^11.3.0
         version: 11.3.0
       '@fastify/formbody':
-        specifier: ^8.0.0
+        specifier: ^8.0.2
         version: 8.0.2
       '@fastify/helmet':
         specifier: ^13.1.0
@@ -243,10 +248,10 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       '@fastify/static':
-        specifier: ^9.1.1
-        version: 9.3.0
+        specifier: ^10.1.0
+        version: 10.1.0
       '@fastify/websocket':
-        specifier: ^11.0.0
+        specifier: ^11.3.0
         version: 11.3.0
       '@mdbase/connect-protocol':
         specifier: workspace:*
@@ -255,124 +260,41 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       fastify:
-        specifier: ^5.0.0
+        specifier: ^5.10.0
         version: 5.10.0
       pg:
-        specifier: ^8.0.0
+        specifier: ^8.22.0
         version: 8.22.0
       pg-mem:
-        specifier: ^3.0.0
+        specifier: ^3.0.14
         version: 3.0.14
       ws:
-        specifier: ^8.0.0
+        specifier: ^8.21.1
         version: 8.21.1
       zod:
-        specifier: ^4.0.0
+        specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.20.1
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/pg':
-        specifier: ^8.0.0
+        specifier: ^8.20.0
         version: 8.20.0
       '@types/ws':
-        specifier: ^8.0.0
+        specifier: ^8.18.1
         version: 8.18.1
       tsx:
-        specifier: ^4.0.0
+        specifier: ^4.23.1
         version: 4.23.1
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
-        specifier: ^4.0.0
-        version: 4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
-
-  '@babel/code-frame@7.29.7':
-    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.7':
-    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.7':
-    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.29.7':
-    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.29.7':
-    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.29.7':
-    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.29.7':
-    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-plugin-utils@7.29.7':
-    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.29.7':
-    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.29.7':
-    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.29.7':
-    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7':
-    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7':
-    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/template@7.29.7':
-    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
-    engines: {node: '>=6.9.0'}
 
   '@electron-forge/cli@7.11.2':
     resolution: {integrity: sha512-c+C4ndLfHbxwZuCn9G8iT9wD/woLdaVkoSVjAIbj+0nJhi8UmiVsz/+Gxlj4cvhMRTzBMBxudstLU7RocMikfg==}
@@ -460,12 +382,6 @@ packages:
     resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
     engines: {node: '>=22.12.0'}
 
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
-    version: 10.2.0-electron.1
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
     engines: {node: '>= 10.0.0'}
@@ -480,9 +396,9 @@ packages:
     engines: {node: '>= 16.13.0'}
     hasBin: true
 
-  '@electron/rebuild@3.7.2':
-    resolution: {integrity: sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==}
-    engines: {node: '>=12.13.0'}
+  '@electron/rebuild@4.2.0':
+    resolution: {integrity: sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
   '@electron/universal@2.0.3':
@@ -493,6 +409,15 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -689,8 +614,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.3.0':
-    resolution: {integrity: sha512-9YMYRpCOtMBrqKYWcqiw7ykOrn4D0jogHpJrFS0KGeSuOwzKMM5/mjj7B0CFLVoQ6htqKYw//Zs7APn9DBq05w==}
+  '@fastify/static@10.1.0':
+    resolution: {integrity: sha512-iK/8TvRM/EgNOyQL+EpWu+x3aR6o4GWt+UI+27zmE7w6t/6d80mXqOtWLdEKQ13vL/g1Jry0ae2icj6GP7tGzA==}
 
   '@fastify/websocket@11.3.0':
     resolution: {integrity: sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==}
@@ -700,9 +625,6 @@ packages:
 
   '@fontsource/azeret-mono@5.3.0':
     resolution: {integrity: sha512-Ag/+gN67fUry7i1yLlTnk16Rr1nnTQI2YefA/G7tYcCSr/+TC/ayMrE8Km7O0OKRgI/B5Mfel46Gq9IGY50Uaw==}
-
-  '@gar/promisify@1.1.3':
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@inquirer/checkbox@3.0.1':
     resolution: {integrity: sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==}
@@ -771,9 +693,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -805,6 +724,12 @@ packages:
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -817,145 +742,114 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@npmcli/fs@2.1.2':
-    resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
-  '@npmcli/move-file@2.0.1':
-    resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This functionality has been moved to @npmcli/fs
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
-  '@rollup/rollup-android-arm-eabi@4.62.2':
-    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.62.2':
-    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.62.2':
-    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.62.2':
-    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.62.2':
-    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.62.2':
-    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
-    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.62.2':
-    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.62.2':
-    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.2':
-    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.62.2':
-    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.62.2':
-    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.62.2':
-    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.62.2':
-    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.62.2':
-    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.62.2':
-    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.62.2':
-    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.62.2':
-    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -968,21 +862,8 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tootallnate/once@2.0.1':
-    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
-    engines: {node: '>= 10'}
-
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -1040,11 +921,138 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@vitejs/plugin-react@5.2.0':
-    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -1133,8 +1141,9 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -1149,18 +1158,6 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -1244,9 +1241,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
@@ -1278,13 +1272,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  cacache@16.1.3:
-    resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -1320,10 +1307,6 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -1332,21 +1315,9 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-
-  cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
 
   cli-truncate@3.1.0:
     resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
@@ -1359,16 +1330,8 @@ packages:
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
-
-  clone@1.0.4:
-    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
-    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1402,8 +1365,8 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
@@ -1455,9 +1418,6 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
-
-  defaults@1.0.4:
-    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
@@ -1525,8 +1485,8 @@ packages:
     resolution: {integrity: sha512-j9ETcBGJaXxAY/b6UBpR7LZfjdU4BAO+yvr4ifqHEdyuc3UNCy91PDGkWKY5UQ4coHNYfnwFggrqD6QPeFGAlg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.10.2:
-    resolution: {integrity: sha512-vzSetbn05LPfg0gW0p9txpqmkkFyTXzdSHvKIXbtmsK362hkgUQJu+x19GSSS9v/VXeFi5UJI5TYJ1a+Os3CpA==}
+  electron@43.1.1:
+    resolution: {integrity: sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -1536,14 +1496,11 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.24.2:
-    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
+  enhanced-resolve@5.24.3:
+    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
   env-paths@2.2.1:
@@ -1742,12 +1699,13 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1767,10 +1725,6 @@ packages:
   gar@1.0.4:
     resolution: {integrity: sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1810,11 +1764,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
@@ -1869,45 +1818,16 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
-
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   immutable@4.3.9:
     resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-
-  infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -1923,10 +1843,6 @@ packages:
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -1955,13 +1871,6 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-interactive@1.0.0:
-    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
-
-  is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
-
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -1984,20 +1893,16 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
-    hasBin: true
-
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2015,11 +1920,6 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2039,6 +1939,80 @@ packages:
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
 
   listr2@7.0.2:
     resolution: {integrity: sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==}
@@ -2083,23 +2057,12 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  make-fetch-happen@10.2.1:
-    resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   map-age-cleaner@0.1.3:
     resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
@@ -2156,10 +2119,6 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2210,37 +2169,9 @@ packages:
       uglify-js:
         optional: true
 
-  minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-
-  minipass-fetch@2.1.2:
-    resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
-  minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
-
-  minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-
-  minipass-sized@1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
-    engines: {node: '>=8'}
-
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -2248,11 +2179,6 @@ packages:
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
     hasBin: true
 
   moment@2.30.1:
@@ -2280,19 +2206,15 @@ packages:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
 
-  negotiator@0.6.4:
-    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
-  node-abi@3.94.0:
-    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
-    engines: {node: '>=10'}
+  node-abi@4.33.0:
+    resolution: {integrity: sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==}
+    engines: {node: '>=22.12.0'}
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
@@ -2306,13 +2228,18 @@ packages:
       encoding:
         optional: true
 
+  node-gyp@12.4.0:
+    resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
-  nopt@6.0.0:
-    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-package-data@2.5.0:
@@ -2349,10 +2276,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  ora@5.4.1:
-    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
-    engines: {node: '>=10'}
-
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -2383,10 +2306,6 @@ packages:
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
-
-  p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
   p-try@1.0.0:
@@ -2544,6 +2463,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
@@ -2578,9 +2502,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  proc-log@2.0.1:
-    resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
@@ -2591,14 +2515,6 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-
-  promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -2628,10 +2544,6 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
-
-  react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -2687,10 +2599,6 @@ packages:
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
-  restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
-
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2719,18 +2627,13 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   roarr@2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rollup@4.62.2:
-    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -2820,18 +2723,6 @@ packages:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
 
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@7.0.0:
-    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
-    engines: {node: '>= 10'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -2864,10 +2755,6 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
-
-  ssri@9.0.1:
-    resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2994,6 +2881,9 @@ packages:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
     engines: {node: '>=0.10.0'}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
@@ -3016,9 +2906,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@6.21.0:
@@ -3027,17 +2917,13 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
-
-  unique-filename@2.0.1:
-    resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
-  unique-slug@3.0.0:
-    resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3063,15 +2949,16 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  vite@7.3.6:
-    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -3082,11 +2969,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -3148,9 +3037,6 @@ packages:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
-  wcwidth@1.0.1:
-    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -3178,6 +3064,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -3228,9 +3119,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -3255,10 +3143,6 @@ packages:
     resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
     engines: {node: '>=10'}
 
-  yargs@17.7.3:
-    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
-    engines: {node: '>=12'}
-
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
@@ -3275,129 +3159,17 @@ packages:
 
 snapshots:
 
-  '@babel/code-frame@7.29.7':
+  '@electron-forge/cli@7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)':
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.7':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/helper-compilation-targets@7.29.7':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.6
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.29.7': {}
-
-  '@babel/helper-module-imports@7.29.7':
-    dependencies:
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-plugin-utils@7.29.7': {}
-
-  '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.29.7':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/template@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/traverse@7.29.7':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/types@7.29.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-
-  '@electron-forge/cli@7.11.2(encoding@0.1.13)':
-    dependencies:
-      '@electron-forge/core': 7.11.2(encoding@0.1.13)
-      '@electron-forge/core-utils': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
-      '@electron/get': 3.1.0
+      '@electron-forge/core': 7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)
+      '@electron-forge/core-utils': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron/get': 3.1.0(supports-color@8.1.1)
       '@inquirer/prompts': 6.0.1
       '@listr2/prompt-adapter-inquirer': 2.0.22(@inquirer/prompts@6.0.1)
       chalk: 4.1.2
       commander: 11.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       listr2: 7.0.2
       log-symbols: 4.1.0
@@ -3407,7 +3179,6 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - bluebird
       - clean-css
       - cssnano
       - csso
@@ -3420,42 +3191,41 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@electron-forge/core-utils@7.11.2':
+  '@electron-forge/core-utils@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
-      '@electron/rebuild': 3.7.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron/rebuild': 4.2.0(supports-color@8.1.1)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       find-up: 5.0.0
       fs-extra: 10.1.0
       log-symbols: 4.1.0
       parse-author: 2.0.0
       semver: 7.8.5
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/core@7.11.2(encoding@0.1.13)':
+  '@electron-forge/core@7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/core-utils': 7.11.2
-      '@electron-forge/maker-base': 7.11.2
-      '@electron-forge/plugin-base': 7.11.2
-      '@electron-forge/publisher-base': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
-      '@electron-forge/template-base': 7.11.2
-      '@electron-forge/template-vite': 7.11.2
-      '@electron-forge/template-vite-typescript': 7.11.2
-      '@electron-forge/template-webpack': 7.11.2
-      '@electron-forge/template-webpack-typescript': 7.11.2
+      '@electron-forge/core-utils': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/maker-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/plugin-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/publisher-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-vite': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-vite-typescript': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-webpack': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-webpack-typescript': 7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)
       '@electron-forge/tracer': 7.11.2
-      '@electron/get': 3.1.0
-      '@electron/packager': 18.4.4
-      '@electron/rebuild': 3.7.2
+      '@electron/get': 3.1.0(supports-color@8.1.1)
+      '@electron/packager': 18.4.4(supports-color@8.1.1)
+      '@electron/rebuild': 4.2.0(supports-color@8.1.1)
       '@malept/cross-spawn-promise': 2.0.0
       '@vscode/sudo-prompt': 9.3.2
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       eta: 3.5.0
       fast-glob: 3.3.3
       filenamify: 4.3.0
@@ -3467,7 +3237,7 @@ snapshots:
       jiti: 2.7.0
       listr2: 7.0.2
       log-symbols: 4.1.0
-      node-fetch: 2.7.0(encoding@0.1.13)
+      node-fetch: 2.7.0
       rechoir: 0.8.0
       semver: 7.8.5
       source-map-support: 0.5.21
@@ -3477,7 +3247,6 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - bluebird
       - clean-css
       - cssnano
       - csso
@@ -3490,125 +3259,113 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@electron-forge/maker-base@7.11.2':
+  '@electron-forge/maker-base@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
       fs-extra: 10.1.0
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-deb@7.11.2':
+  '@electron-forge/maker-deb@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/maker-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
     optionalDependencies:
-      electron-installer-debian: 3.2.0
+      electron-installer-debian: 3.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-rpm@7.11.2':
+  '@electron-forge/maker-rpm@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/maker-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
     optionalDependencies:
-      electron-installer-redhat: 3.4.0
+      electron-installer-redhat: 3.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-squirrel@7.11.2':
+  '@electron-forge/maker-squirrel@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/maker-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
       fs-extra: 10.1.0
     optionalDependencies:
-      electron-winstaller: 5.4.4
+      electron-winstaller: 5.4.4(supports-color@8.1.1)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-zip@7.11.2':
+  '@electron-forge/maker-zip@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/maker-base': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
       cross-zip: 4.0.1
       fs-extra: 10.1.0
       got: 11.8.6
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/plugin-base@7.11.2':
+  '@electron-forge/plugin-base@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/publisher-base@7.11.2':
+  '@electron-forge/publisher-base@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/shared-types@7.11.2':
+  '@electron-forge/shared-types@7.11.2(supports-color@8.1.1)':
     dependencies:
       '@electron-forge/tracer': 7.11.2
-      '@electron/packager': 18.4.4
-      '@electron/rebuild': 3.7.2
+      '@electron/packager': 18.4.4(supports-color@8.1.1)
+      '@electron/rebuild': 4.2.0(supports-color@8.1.1)
       listr2: 7.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-base@7.11.2':
+  '@electron-forge/template-base@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/core-utils': 7.11.2
-      '@electron-forge/shared-types': 7.11.2
+      '@electron-forge/core-utils': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       semver: 7.8.5
       username: 5.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-vite-typescript@7.11.2':
+  '@electron-forge/template-vite-typescript@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
-      '@electron-forge/template-base': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-base': 7.11.2(supports-color@8.1.1)
       fs-extra: 10.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-vite@7.11.2':
+  '@electron-forge/template-vite@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
-      '@electron-forge/template-base': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-base': 7.11.2(supports-color@8.1.1)
       fs-extra: 10.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-webpack-typescript@7.11.2':
+  '@electron-forge/template-webpack-typescript@7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
-      '@electron-forge/template-base': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-base': 7.11.2(supports-color@8.1.1)
       fs-extra: 10.1.0
       typescript: 5.4.5
-      webpack: 5.108.4
+      webpack: 5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - bluebird
       - clean-css
       - cssnano
       - csso
@@ -3620,13 +3377,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@electron-forge/template-webpack@7.11.2':
+  '@electron-forge/template-webpack@7.11.2(supports-color@8.1.1)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2
-      '@electron-forge/template-base': 7.11.2
+      '@electron-forge/shared-types': 7.11.2(supports-color@8.1.1)
+      '@electron-forge/template-base': 7.11.2(supports-color@8.1.1)
       fs-extra: 10.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
   '@electron-forge/tracer@7.11.2':
@@ -3641,61 +3397,45 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  '@electron/get@3.1.0':
+  '@electron/get@3.1.0(supports-color@8.1.1)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@8.1.1)
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@5.0.0':
+  '@electron/get@5.0.0(supports-color@8.1.1)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
       semver: 7.8.5
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@8.1.1)
     optionalDependencies:
       undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+  '@electron/notarize@2.5.0(supports-color@8.1.1)':
     dependencies:
-      env-paths: 2.2.1
-      exponential-backoff: 3.1.3
-      glob: 8.1.0
-      graceful-fs: 4.2.11
-      make-fetch-happen: 10.2.1
-      nopt: 6.0.0
-      proc-log: 2.0.1
-      semver: 7.8.5
-      tar: 7.5.19
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-
-  '@electron/notarize@2.5.0':
-    dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/osx-sign@1.3.3':
+  '@electron/osx-sign@1.3.3(supports-color@8.1.1)':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -3703,21 +3443,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/packager@18.4.4':
+  '@electron/packager@18.4.4(supports-color@8.1.1)':
     dependencies:
       '@electron/asar': 3.4.1
-      '@electron/get': 3.1.0
-      '@electron/notarize': 2.5.0
-      '@electron/osx-sign': 1.3.3
-      '@electron/universal': 2.0.3
-      '@electron/windows-sign': 1.2.2
+      '@electron/get': 3.1.0(supports-color@8.1.1)
+      '@electron/notarize': 2.5.0(supports-color@8.1.1)
+      '@electron/osx-sign': 1.3.3(supports-color@8.1.1)
+      '@electron/universal': 2.0.3(supports-color@8.1.1)
+      '@electron/windows-sign': 1.2.2(supports-color@8.1.1)
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
-      extract-zip: 2.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      extract-zip: 2.0.1(supports-color@8.1.1)
       filenamify: 4.3.0
       fs-extra: 11.3.6
-      galactus: 1.0.0
-      get-package-info: 1.0.0
+      galactus: 1.0.0(supports-color@8.1.1)
+      get-package-info: 1.0.0(supports-color@8.1.1)
       junk: 3.1.0
       parse-author: 2.0.0
       plist: 3.1.1
@@ -3729,31 +3469,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@3.7.2':
+  '@electron/rebuild@4.2.0(supports-color@8.1.1)':
     dependencies:
-      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
-      chalk: 4.1.2
-      debug: 4.4.3
-      detect-libc: 2.1.2
-      fs-extra: 10.1.0
-      got: 11.8.6
-      node-abi: 3.94.0
+      debug: 4.4.3(supports-color@8.1.1)
+      node-abi: 4.33.0
       node-api-version: 0.2.1
-      ora: 5.4.1
-      read-binary-file-arch: 1.0.6
-      semver: 7.8.5
-      tar: 7.5.19
-      yargs: 17.7.3
+      node-gyp: 12.4.0
+      read-binary-file-arch: 1.0.6(supports-color@8.1.1)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron/universal@2.0.3':
+  '@electron/universal@2.0.3(supports-color@8.1.1)':
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       dir-compare: 4.2.0
       fs-extra: 11.3.6
       minimatch: 9.0.9
@@ -3761,15 +3492,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/windows-sign@1.2.2':
+  '@electron/windows-sign@1.2.2(supports-color@8.1.1)':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.6
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
       - supports-color
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -3908,11 +3655,12 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@9.3.0':
+  '@fastify/static@10.1.0':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
+      '@fastify/error': 4.2.0
       '@fastify/send': 4.1.0
-      content-disposition: 1.1.0
+      content-disposition: 2.0.1
       fastify-plugin: 6.0.0
       fastq: 1.20.1
       glob: 13.0.6
@@ -3929,8 +3677,6 @@ snapshots:
   '@fontsource/atkinson-hyperlegible@5.3.0': {}
 
   '@fontsource/azeret-mono@5.3.0': {}
-
-  '@gar/promisify@1.1.3': {}
 
   '@inquirer/checkbox@3.0.1':
     dependencies:
@@ -4041,11 +3787,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.11':
@@ -4076,6 +3817,13 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4088,94 +3836,64 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/fs@2.1.2':
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.8.5
-
-  '@npmcli/move-file@2.0.1':
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
+  '@oxc-project/types@0.139.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.3': {}
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
-  '@rollup/rollup-android-arm-eabi@4.62.2':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.62.2':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.62.2':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.62.2':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.62.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.62.2':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.62.2':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.62.2':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.62.2':
-    optional: true
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -4185,34 +3903,16 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tootallnate/once@2.0.1': {}
-
-  '@types/babel__core@7.20.5':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.7
+      tslib: 2.8.1
+    optional: true
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -4226,7 +3926,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
     optional: true
 
   '@types/http-cache-semantics@4.2.0': {}
@@ -4235,11 +3935,11 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/node@22.20.1':
     dependencies:
@@ -4251,7 +3951,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -4265,42 +3965,83 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/wrap-ansi@3.0.0': {}
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
     optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@vitejs/plugin-react@6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -4311,21 +4052,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -4435,7 +4168,7 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  abbrev@1.1.1: {}
+  abbrev@4.0.0: {}
 
   abstract-logging@2.0.1: {}
 
@@ -4444,21 +4177,6 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -4519,12 +4237,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.43: {}
 
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   bluebird@3.7.2: {}
 
   boolean@3.2.0:
@@ -4558,34 +4270,6 @@ snapshots:
   buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  cacache@16.1.3:
-    dependencies:
-      '@npmcli/fs': 2.1.2
-      '@npmcli/move-file': 2.0.1
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 8.1.0
-      infer-owner: 1.0.4
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 9.0.1
-      tar: 7.5.19
-      unique-filename: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
 
   cacheable-lookup@5.0.4: {}
 
@@ -4627,23 +4311,13 @@ snapshots:
 
   chardet@0.7.0: {}
 
-  chownr@2.0.0: {}
-
   chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 
-  clean-stack@2.2.0: {}
-
-  cli-cursor@3.1.0:
-    dependencies:
-      restore-cursor: 3.1.0
-
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
-
-  cli-spinners@2.9.2: {}
 
   cli-truncate@3.1.0:
     dependencies:
@@ -4659,17 +4333,9 @@ snapshots:
       wrap-ansi: 7.0.0
     optional: true
 
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
-
-  clone@1.0.4: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -4691,7 +4357,7 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  content-disposition@1.1.0: {}
+  content-disposition@2.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4719,21 +4385,21 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-
-  defaults@1.0.4:
-    dependencies:
-      clone: 1.0.4
 
   defer-to-connect@2.0.1: {}
 
@@ -4781,11 +4447,11 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-installer-common@0.10.4:
+  electron-installer-common@0.10.4(supports-color@8.1.1):
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 9.1.0
       glob: 7.2.3
       lodash: 4.18.1
@@ -4798,11 +4464,11 @@ snapshots:
       - supports-color
     optional: true
 
-  electron-installer-debian@3.2.0:
+  electron-installer-debian@3.2.0(supports-color@8.1.1):
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
-      electron-installer-common: 0.10.4
+      debug: 4.4.3(supports-color@8.1.1)
+      electron-installer-common: 0.10.4(supports-color@8.1.1)
       fs-extra: 9.1.0
       get-folder-size: 2.0.1
       lodash: 4.18.1
@@ -4812,11 +4478,11 @@ snapshots:
       - supports-color
     optional: true
 
-  electron-installer-redhat@3.4.0:
+  electron-installer-redhat@3.4.0(supports-color@8.1.1):
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
-      electron-installer-common: 0.10.4
+      debug: 4.4.3(supports-color@8.1.1)
+      electron-installer-common: 0.10.4(supports-color@8.1.1)
       fs-extra: 9.1.0
       lodash: 4.18.1
       word-wrap: 1.2.5
@@ -4827,24 +4493,24 @@ snapshots:
 
   electron-to-chromium@1.5.393: {}
 
-  electron-winstaller@5.4.4:
+  electron-winstaller@5.4.4(supports-color@8.1.1):
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 7.0.1
       lodash: 4.18.1
       semver: 7.8.5
       temp: 0.9.4
     optionalDependencies:
-      '@electron/windows-sign': 1.2.2
+      '@electron/windows-sign': 1.2.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  electron@41.10.2:
+  electron@43.1.1(supports-color@8.1.1):
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
-      '@electron/get': 5.0.0
+      '@electron/get': 5.0.0(supports-color@8.1.1)
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - supports-color
@@ -4853,16 +4519,11 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  encoding@0.1.13:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
-
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.24.2:
+  enhanced-resolve@5.24.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -4971,9 +4632,9 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.2.7
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -5071,9 +4732,9 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flora-colossus@2.0.0:
+  flora-colossus@2.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - supports-color
@@ -5110,11 +4771,10 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5123,10 +4783,10 @@ snapshots:
 
   functional-red-black-tree@1.0.1: {}
 
-  galactus@1.0.0:
+  galactus@1.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
-      flora-colossus: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      flora-colossus: 2.0.0(supports-color@8.1.1)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - supports-color
@@ -5134,9 +4794,8 @@ snapshots:
   gar@1.0.4:
     optional: true
 
-  gensync@1.0.0-beta.2: {}
-
-  get-caller-file@2.0.5: {}
+  get-caller-file@2.0.5:
+    optional: true
 
   get-folder-size@2.0.1:
     dependencies:
@@ -5157,10 +4816,10 @@ snapshots:
       hasown: 2.0.4
       math-intrinsics: 1.1.0
 
-  get-package-info@1.0.0:
+  get-package-info@1.0.0(supports-color@8.1.1):
     dependencies:
       bluebird: 3.7.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       lodash.get: 4.4.2
       read-pkg-up: 2.0.0
     transitivePeerDependencies:
@@ -5197,14 +4856,6 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  glob@8.1.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
 
   global-agent@3.0.0:
     dependencies:
@@ -5270,48 +4921,16 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0:
-    dependencies:
-      '@tootallnate/once': 2.0.1
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   http2-wrapper@1.0.3:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-    optional: true
-
-  ieee754@1.2.1: {}
-
   immutable@4.3.9: {}
-
-  imurmurhash@0.1.4: {}
-
-  indent-string@4.0.0: {}
-
-  infer-owner@1.0.4: {}
 
   inflight@1.0.6:
     dependencies:
@@ -5323,8 +4942,6 @@ snapshots:
   ini@2.0.0: {}
 
   interpret@3.1.1: {}
-
-  ip-address@10.2.0: {}
 
   ipaddr.js@2.4.0: {}
 
@@ -5344,10 +4961,6 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-interactive@1.0.0: {}
-
-  is-lambda@1.0.1: {}
-
   is-number@7.0.0: {}
 
   is-stream@1.1.0: {}
@@ -5360,17 +4973,15 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 24.13.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jiti@2.7.0: {}
-
-  js-tokens@4.0.0: {}
-
-  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -5390,8 +5001,6 @@ snapshots:
 
   json-stringify-safe@5.0.1:
     optional: true
-
-  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -5416,6 +5025,55 @@ snapshots:
       cookie: 1.1.1
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   listr2@7.0.2:
     dependencies:
@@ -5466,41 +5124,13 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
-
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
 
-  lru-cache@7.18.3: {}
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  make-fetch-happen@10.2.1:
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 16.1.3
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 2.1.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 7.0.0
-      ssri: 9.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
 
   map-age-cleaner@0.1.3:
     dependencies:
@@ -5546,58 +5176,25 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.16
 
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.2
-
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(webpack@5.108.4):
+  minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4
-
-  minipass-collect@1.0.2:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-fetch@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
+      webpack: 5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)
     optionalDependencies:
-      encoding: 0.1.13
-
-  minipass-flush@1.0.7:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-pipeline@1.2.4:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-sized@1.0.3:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
+      esbuild: 0.28.1
+      lightningcss: 1.33.0
+      postcss: 8.5.20
 
   minipass@7.1.3: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
 
   minizlib@3.1.0:
     dependencies:
@@ -5607,8 +5204,6 @@ snapshots:
     dependencies:
       minimist: 1.2.8
     optional: true
-
-  mkdirp@1.0.4: {}
 
   moment@2.30.1: {}
 
@@ -5629,13 +5224,11 @@ snapshots:
       railroad-diagrams: 1.0.0
       randexp: 0.4.6
 
-  negotiator@0.6.4: {}
-
   neo-async@2.6.2: {}
 
   nice-try@1.0.5: {}
 
-  node-abi@3.94.0:
+  node-abi@4.33.0:
     dependencies:
       semver: 7.8.5
 
@@ -5643,17 +5236,28 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  node-fetch@2.7.0(encoding@0.1.13):
+  node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
+
+  node-gyp@12.4.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.8.5
+      tar: 7.5.19
+      tinyglobby: 0.2.17
+      undici: 6.27.0
+      which: 6.0.1
 
   node-releases@2.0.51: {}
 
-  nopt@6.0.0:
+  nopt@9.0.0:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 4.0.0
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -5684,18 +5288,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  ora@5.4.1:
-    dependencies:
-      bl: 4.1.0
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.9.2
-      is-interactive: 1.0.0
-      is-unicode-supported: 0.1.0
-      log-symbols: 4.1.0
-      strip-ansi: 6.0.1
-      wcwidth: 1.0.1
-
   p-cancelable@2.1.1: {}
 
   p-defer@1.0.0: {}
@@ -5719,10 +5311,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-map@4.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
 
   p-try@1.0.0: {}
 
@@ -5841,6 +5429,12 @@ snapshots:
 
   playwright-core@1.61.1: {}
 
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   plist@3.1.1:
     dependencies:
       '@xmldom/xmldom': 0.9.10
@@ -5869,15 +5463,13 @@ snapshots:
 
   prettier@3.9.5: {}
 
-  proc-log@2.0.1: {}
+  proc-log@6.1.0: {}
 
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
 
   progress@2.0.3: {}
-
-  promise-inflight@1.0.1: {}
 
   promise-retry@2.0.1:
     dependencies:
@@ -5907,13 +5499,11 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-refresh@0.18.0: {}
-
   react@19.2.7: {}
 
-  read-binary-file-arch@1.0.6:
+  read-binary-file-arch@1.0.6(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5942,7 +5532,8 @@ snapshots:
     dependencies:
       resolve: 1.22.12
 
-  require-directory@2.1.1: {}
+  require-directory@2.1.1:
+    optional: true
 
   require-from-string@2.0.2: {}
 
@@ -5962,11 +5553,6 @@ snapshots:
   responselike@2.0.1:
     dependencies:
       lowercase-keys: 2.0.0
-
-  restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
 
   restore-cursor@4.0.0:
     dependencies:
@@ -5988,10 +5574,6 @@ snapshots:
       glob: 7.2.3
     optional: true
 
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-
   roarr@2.15.4:
     dependencies:
       boolean: 3.2.0
@@ -6002,36 +5584,26 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  rollup@4.62.2:
+  rolldown@1.1.5:
     dependencies:
-      '@types/estree': 1.0.9
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.62.2
-      '@rollup/rollup-android-arm64': 4.62.2
-      '@rollup/rollup-darwin-arm64': 4.62.2
-      '@rollup/rollup-darwin-x64': 4.62.2
-      '@rollup/rollup-freebsd-arm64': 4.62.2
-      '@rollup/rollup-freebsd-x64': 4.62.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
-      '@rollup/rollup-linux-arm64-gnu': 4.62.2
-      '@rollup/rollup-linux-arm64-musl': 4.62.2
-      '@rollup/rollup-linux-loong64-gnu': 4.62.2
-      '@rollup/rollup-linux-loong64-musl': 4.62.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
-      '@rollup/rollup-linux-ppc64-musl': 4.62.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
-      '@rollup/rollup-linux-riscv64-musl': 4.62.2
-      '@rollup/rollup-linux-s390x-gnu': 4.62.2
-      '@rollup/rollup-linux-x64-gnu': 4.62.2
-      '@rollup/rollup-linux-x64-musl': 4.62.2
-      '@rollup/rollup-openbsd-x64': 4.62.2
-      '@rollup/rollup-openharmony-arm64': 4.62.2
-      '@rollup/rollup-win32-arm64-msvc': 4.62.2
-      '@rollup/rollup-win32-ia32-msvc': 4.62.2
-      '@rollup/rollup-win32-x64-gnu': 4.62.2
-      '@rollup/rollup-win32-x64-msvc': 4.62.2
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   run-parallel@1.2.0:
     dependencies:
@@ -6108,21 +5680,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@7.0.0:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -6154,10 +5711,6 @@ snapshots:
 
   sprintf-js@1.1.3:
     optional: true
-
-  ssri@9.0.1:
-    dependencies:
-      minipass: 3.3.6
 
   stackback@0.0.2: {}
 
@@ -6199,9 +5752,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  sumchecker@3.0.1:
+  sumchecker@3.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6277,6 +5830,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
+  tslib@2.8.1:
+    optional: true
+
   tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
@@ -6292,22 +5848,37 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.9.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 
+  undici@6.27.0: {}
+
   undici@7.28.0:
     optional: true
-
-  unique-filename@2.0.1:
-    dependencies:
-      unique-slug: 3.0.0
-
-  unique-slug@3.0.0:
-    dependencies:
-      imurmurhash: 0.1.4
 
   universalify@0.1.2: {}
 
@@ -6331,42 +5902,26 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.5)
+      lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.20
-      rollup: 4.62.2
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.20.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.49.0
-      tsx: 4.23.1
-      yaml: 2.9.0
-
-  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
-      postcss: 8.5.20
-      rollup: 4.62.2
+      rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.49.0
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@22.20.1)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -6383,34 +5938,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.20.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.10(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
@@ -6421,15 +5949,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
-  wcwidth@1.0.1:
-    dependencies:
-      defaults: 1.0.4
-
   webidl-conversions@3.0.1: {}
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.108.4:
+  webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -6440,14 +5964,14 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.6
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.2
+      enhanced-resolve: 5.24.3
       es-module-lexer: 2.3.1
       eslint-scope: 5.1.1
       events: 3.3.0
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(webpack@5.108.4)
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -6480,6 +6004,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -6499,6 +6027,7 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
   wrap-ansi@8.1.0:
     dependencies:
@@ -6514,9 +6043,8 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  y18n@5.0.8: {}
-
-  yallist@3.1.1: {}
+  y18n@5.0.8:
+    optional: true
 
   yallist@4.0.0: {}
 
@@ -6539,16 +6067,6 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 20.2.9
     optional: true
-
-  yargs@17.7.3:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   yauzl@2.10.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,24 @@ packages:
   - "packages/*"
   - "services/*"
 
-onlyBuiltDependencies:
-  - electron
-  - electron-winstaller
-  - esbuild
+# Electron Forge packages the desktop app from the physical dependency tree.
+# Its pnpm integration requires a hoisted linker rather than isolated symlinks.
+nodeLinker: hoisted
+hoistingLimits: workspaces
+verifyDepsBeforeRun: false
+
+supportedArchitectures:
+  os:
+    - current
+  cpu:
+    - current
+
+allowBuilds:
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+
+overrides:
+  "@electron/rebuild": "4.2.0"
+  "tar@<7.5.19": "7.5.19"
+  "tmp@<0.2.6": "0.2.7"

--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,45 @@
 previews:
-  generation: off
+  generation: "off"
 
 services:
+  - type: web
+    name: mdbase-connect-hosted-provider
+    runtime: docker
+    repo: https://github.com/mdbase-dev/mdbase-connect
+    branch: main
+    plan: starter
+    region: singapore
+    dockerfilePath: ./deploy/docker/Dockerfile.hosted-provider
+    dockerContext: .
+    healthCheckPath: /ready
+    maxShutdownDelaySeconds: 60
+    autoDeployTrigger: checksPass
+    domains:
+      - sync.mdbase.dev
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: mdbase-connect-hosted-db
+          property: connectionString
+      - key: MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN
+        generateValue: true
+      - key: MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY
+        generateValue: true
+      - key: MDBASE_CONNECT_HOSTED_PROVIDER_ALLOWED_ORIGINS
+        value: https://connect.mdbase.dev
+      - key: MDBASE_CONNECT_HOSTED_MAX_RECORDS_PER_COLLECTION
+        value: "100000"
+      - key: MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_COLLECTION
+        value: "1073741824"
+      - key: MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_DOCUMENT
+        value: "2097152"
+      - key: MDBASE_CONNECT_HOSTED_MAX_REPLICAS_PER_COLLECTION
+        value: "100"
+      - key: MDBASE_CONNECT_HOSTED_RETAIN_CHANGES
+        value: "10000"
+      - key: MDBASE_CONNECT_HOSTED_MAINTENANCE_INTERVAL_SECONDS
+        value: "300"
+
   - type: web
     name: mdbase-connect
     runtime: docker
@@ -35,13 +73,30 @@ services:
       - key: MDBASE_CONNECT_ALLOWED_GITHUB_USER_IDS
         sync: false
       - key: MDBASE_CONNECT_HOSTED_COLLECTIONS
-        value: "0"
+        value: "1"
+      - key: MDBASE_CONNECT_HOSTED_PROVIDER_URL
+        value: https://sync.mdbase.dev
+      - key: MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN
+        fromService:
+          type: web
+          name: mdbase-connect-hosted-provider
+          envVarKey: MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN
       - key: MDBASE_CONNECT_TRUST_PROXY
         value: "1"
       - key: MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS
         value: "0"
 
 databases:
+  - name: mdbase-connect-hosted-db
+    region: singapore
+    plan: basic-1gb
+    diskSizeGB: 15
+    storageAutoscalingEnabled: true
+    postgresMajorVersion: "18"
+    databaseName: mdbase_connect_hosted
+    user: mdbase_connect_hosted
+    ipAllowList: []
+
   - name: mdbase-connect-db
     region: singapore
     plan: basic-256mb

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1,0 +1,1331 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { mkdtemp, readFile, rename, rm, stat, symlink, unlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { chromium, expect } from "@playwright/test";
+
+process.env.NODE_ENV = "test";
+const execute = promisify(execFile);
+const repoRoot = resolve(import.meta.dirname, "..");
+const providerBinary = join(repoRoot, "target", "debug", "mdbase-connect-hosted-provider");
+const postgresContainer = `mdbase-connect-provider-e2e-${process.pid}`;
+const databasePassword = `test-${crypto.randomUUID()}`;
+const internalToken = `internal-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+const masterKey = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64url");
+const mirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-mirror-"));
+const writableMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-writable-mirror-"));
+const importMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-import-mirror-"));
+const children = new Set();
+let postgresStarted = false;
+let controlApp;
+let controlDatabase;
+let manifestServer;
+
+const { HttpSyncTransport, MemoryReplicaStore, OfflineReplica, SyncError } =
+  await import("../packages/sync/dist/index.js");
+const { DirectoryMirror, MirrorDivergenceError } = await import("../packages/sync/dist/node.js");
+const { resolveTasknotesSyncContract, TasknotesCollection, TasknotesOfflineCollection } =
+  await import("../packages/tasknotes/dist/index.js");
+const { MdbaseConnect, MemoryGrantKeyStore } = await import("../packages/client/dist/index.js");
+const { buildApp } = await import("../services/server/dist/app.js");
+const { createDatabase } = await import("../services/server/dist/db.js");
+const { HostedProviderClient } = await import("../services/server/dist/hosted-provider.js");
+
+try {
+  phase("starting disposable PostgreSQL 18");
+  const databaseUrl = await startPostgres();
+  let provider = await startProvider(databaseUrl);
+  await assert.rejects(
+    () => startProvider(
+      databaseUrl,
+      0,
+      Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64url")
+    ),
+    /Provider exited during startup/
+  );
+
+  phase("checking HTTP and credential boundaries");
+  assert.equal((await rawRequest(provider.url, "/health")).status, 200);
+  assert.equal((await rawRequest(provider.url, "/ready")).status, 200);
+  assert.equal(
+    (await rawRequest(provider.url, "/internal/v1/collections", { method: "POST", body: {} })).status,
+    401
+  );
+  const preflight = await rawRequest(provider.url, syncPath(crypto.randomUUID(), "sessions"), {
+    method: "OPTIONS",
+    headers: {
+      origin: "http://127.0.0.1",
+      "access-control-request-method": "POST",
+      "access-control-request-headers": "authorization,content-type"
+    }
+  });
+  assert.ok([200, 204].includes(preflight.status));
+  assert.equal(preflight.headers.get("access-control-allow-origin"), "*");
+  const publicPreflight = await rawRequest(provider.url, syncPath(crypto.randomUUID(), "sessions"), {
+    method: "OPTIONS",
+    headers: {
+      origin: "https://evil.example",
+      "access-control-request-method": "POST"
+    }
+  });
+  assert.equal(publicPreflight.headers.get("access-control-allow-origin"), "*");
+
+  phase("enforcing durable collection, document, and replica quotas");
+  const quotaProvider = await startProvider(databaseUrl, 0, masterKey, {
+    MDBASE_CONNECT_HOSTED_MAX_RECORDS_PER_COLLECTION: "1",
+    MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_COLLECTION: "1024",
+    MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_DOCUMENT: "512",
+    MDBASE_CONNECT_HOSTED_MAX_REPLICAS_PER_COLLECTION: "1"
+  });
+  const quotaCollectionId = crypto.randomUUID();
+  const quotaReplicaId = crypto.randomUUID();
+  const quotaToken = `quota-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+  await internalRequest(quotaProvider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: { collection_id: quotaCollectionId, template: "tasknotes" }
+  });
+  await internalRequest(quotaProvider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: { collection_id: quotaCollectionId, template: "tasknotes" }
+  });
+  await internalRequest(
+    quotaProvider.url,
+    `/internal/v1/collections/${quotaCollectionId}/replicas`,
+    {
+      method: "POST",
+      body: {
+        replica_id: quotaReplicaId,
+        name: "Quota writer",
+        mode: "read_write",
+        allowed_types: ["task"],
+        token: quotaToken
+      }
+    }
+  );
+  await internalRequest(
+    quotaProvider.url,
+    `/internal/v1/collections/${quotaCollectionId}/replicas`,
+    {
+      method: "POST",
+      body: {
+        replica_id: quotaReplicaId,
+        name: "Quota writer",
+        mode: "read_write",
+        allowed_types: ["task"],
+        token: quotaToken
+      }
+    }
+  );
+  const changedReplicaRetry = await rawRequest(
+    quotaProvider.url,
+    `/internal/v1/collections/${quotaCollectionId}/replicas`,
+    {
+      method: "POST",
+      token: internalToken,
+      body: {
+        replica_id: quotaReplicaId,
+        name: "Changed retry",
+        mode: "read_write",
+        allowed_types: ["task"],
+        token: quotaToken
+      }
+    }
+  );
+  assert.equal(changedReplicaRetry.status, 409);
+  assert.equal(changedReplicaRetry.body.error.code, "replica_conflict");
+  const replicaQuota = await rawRequest(
+    quotaProvider.url,
+    `/internal/v1/collections/${quotaCollectionId}/replicas`,
+    {
+      method: "POST",
+      token: internalToken,
+      body: {
+        replica_id: crypto.randomUUID(),
+        name: "Too many",
+        mode: "read_only",
+        allowed_types: ["task"],
+        token: `quota-${crypto.randomUUID()}-${crypto.randomUUID()}`
+      }
+    }
+  );
+  assert.equal(replicaQuota.status, 429);
+  assert.equal(replicaQuota.body.error.code, "replica_quota_exceeded");
+  const quotaTransport = new HttpSyncTransport(quotaProvider.url, quotaCollectionId, quotaToken);
+  const quotaRecordId = crypto.randomUUID();
+  const quotaCreate = await quotaTransport.mutate(
+    createMutation(quotaReplicaId, quotaRecordId, "tasks/within-quota.md", "Within quota")
+  );
+  assert.equal(quotaCreate.status, "applied");
+  const recordQuota = await quotaTransport.mutate(
+    createMutation(quotaReplicaId, crypto.randomUUID(), "tasks/too-many.md", "Too many")
+  );
+  assert.equal(recordQuota.status, "rejected");
+  assert.equal(recordQuota.error.code, "collection_quota_exceeded");
+  const documentQuota = await quotaTransport.mutate({
+    ...updateMutation(quotaReplicaId, quotaCreate.record, { title: "Too large" }),
+    input: { patch: { title: "Too large" }, body: "x".repeat(600) }
+  });
+  assert.equal(documentQuota.status, "rejected");
+  assert.equal(documentQuota.error.code, "document_quota_exceeded");
+  await stopProvider(quotaProvider);
+
+  phase("automatically bounding retained change history");
+  await execute("docker", [
+    "exec",
+    postgresContainer,
+    "createdb",
+    "--username", "mdbase",
+    "mdbase_maintenance"
+  ]);
+  const maintenanceDatabaseUrl = databaseUrl.replace(/\/mdbase$/, "/mdbase_maintenance");
+  const maintenanceProvider = await startProvider(maintenanceDatabaseUrl, 0, masterKey, {
+    MDBASE_CONNECT_HOSTED_RETAIN_CHANGES: "1",
+    MDBASE_CONNECT_HOSTED_MAINTENANCE_INTERVAL_SECONDS: "1"
+  });
+  const maintenanceCollectionId = crypto.randomUUID();
+  const maintenanceReplicaId = crypto.randomUUID();
+  const maintenanceToken = `maintenance-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+  await internalRequest(maintenanceProvider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: { collection_id: maintenanceCollectionId, template: "tasknotes" }
+  });
+  await internalRequest(
+    maintenanceProvider.url,
+    `/internal/v1/collections/${maintenanceCollectionId}/replicas`,
+    {
+      method: "POST",
+      body: {
+        replica_id: maintenanceReplicaId,
+        name: "Retention probe",
+        mode: "read_write",
+        allowed_types: ["task"],
+        token: maintenanceToken
+      }
+    }
+  );
+  const maintenanceTransport = transport(maintenanceProvider.url, maintenanceCollectionId, {
+    token: maintenanceToken
+  });
+  for (let index = 0; index < 3; index += 1) {
+    const receipt = await maintenanceTransport.mutate(createMutation(
+      maintenanceReplicaId,
+      crypto.randomUUID(),
+      `tasks/retention-${index}.md`,
+      `Retention ${index}`
+    ));
+    assert.equal(receipt.status, "applied");
+  }
+  await waitFor(async () => (await maintenanceTransport.changes(0, 200)).reset_required, (
+    "Provider did not compact retained history on schedule"
+  ));
+  await stopProvider(maintenanceProvider);
+
+  phase("provisioning collections and replicas through the Node control plane");
+  controlDatabase = await createDatabase("memory");
+  const controlPort = await availablePort();
+  const controlUrl = `http://127.0.0.1:${controlPort}`;
+  ({ app: controlApp } = await buildApp({
+    db: controlDatabase,
+    devAuth: true,
+    hostedCollections: true,
+    hostedProvider: new HostedProviderClient({ url: provider.url, internalToken }),
+    publicUrl: controlUrl,
+    portalDist: join(repoRoot, "apps", "portal", "dist"),
+    allowInsecureManifests: true
+  }));
+  await controlApp.listen({ host: "127.0.0.1", port: controlPort });
+  const login = await rawRequest(controlUrl, "/v1/dev/session", {
+    method: "POST",
+    body: { name: "Hosted E2E", email: "hosted-e2e@example.com" }
+  });
+  assert.equal(login.status, 200);
+  const cookie = login.headers.get("set-cookie")?.split(";", 1)[0];
+  assert.ok(cookie);
+  const created = await controlRequest(controlUrl, "/v1/hosted/collections", cookie, {
+    method: "POST",
+    body: { display_name: "Hosted tasks", template: "tasknotes" }
+  });
+  const collectionId = created.collection.id;
+  assert.equal(created.collection.sync_url, provider.url);
+  const other = await controlRequest(controlUrl, "/v1/hosted/collections", cookie, {
+    method: "POST",
+    body: { display_name: "Other hosted tasks", template: "tasknotes" }
+  });
+  const otherCollectionId = other.collection.id;
+  const writer = await registerReplica(controlUrl, cookie, collectionId, "Writer", "read_write", ["task"]);
+  const reader = await registerReplica(controlUrl, cookie, collectionId, "Reader", "read_write", ["task"]);
+  const mirror = await registerReplica(controlUrl, cookie, collectionId, "Mirror", "read_only", ["task"]);
+  const writableMirror = await registerReplica(controlUrl, cookie, collectionId, "Writable mirror", "read_write", ["task"]);
+  const importMirror = await registerReplica(controlUrl, cookie, collectionId, "Import mirror", "read_write", ["task"]);
+  const readOnly = await registerReplica(controlUrl, cookie, collectionId, "Read only", "read_only", ["task"]);
+  const hidden = await registerReplica(controlUrl, cookie, collectionId, "Hidden scope", "read_only", ["note"]);
+  const recovery = await registerReplica(controlUrl, cookie, collectionId, "Recovery", "read_write", ["task"]);
+  assert.equal(writer.syncUrl, provider.url);
+  const deniedBrowserSync = await rawRequest(provider.url, syncPath(collectionId, "sessions"), {
+    method: "POST",
+    token: writer.token,
+    headers: { origin: "https://evil.example" }
+  });
+  assert.equal(deniedBrowserSync.status, 403);
+  assert.equal(deniedBrowserSync.body.error.code, "origin_denied");
+
+  const payloadTable = await controlDatabase.query(
+    "SELECT table_name FROM information_schema.tables WHERE table_name = 'hosted_authority_states'"
+  );
+  assert.equal(payloadTable.rows.length, 0);
+  const metadata = await controlDatabase.query(
+    "SELECT provider_url FROM hosted_collections WHERE id = $1",
+    [collectionId]
+  );
+  assert.equal(metadata.rows[0].provider_url, provider.url);
+  const credentialMetadata = await controlDatabase.query(
+    "SELECT token_hash FROM hosted_replicas WHERE id = $1",
+    [writer.id]
+  );
+  assert.equal(credentialMetadata.rows[0].token_hash, null);
+  assert.equal(
+    (
+      await rawRequest(controlUrl, syncPath(collectionId, "mutations"), {
+        method: "POST",
+        token: writer.token,
+        bodyText: "{not-json"
+      })
+    ).status,
+    421
+  );
+
+  phase("exercising hosted lifecycle and writable enrollment in a real browser");
+  await portalLifecycleE2E(controlUrl);
+
+  assert.equal(
+    (await rawRequest(provider.url, syncPath(collectionId, "sessions"), { method: "POST" })).status,
+    401
+  );
+
+  phase("authorizing the browser SDK directly against the hosted data plane");
+  const manifest = await openManifestServer();
+  manifestServer = manifest.server;
+  const storage = memoryStorage();
+  let authorizationUrl;
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { assign: (value) => { authorizationUrl = value; } }
+  });
+  const hostedSdk = new MdbaseConnect({
+    serverUrl: controlUrl,
+    manifestUrl: manifest.manifestUrl,
+    redirectUri: manifest.redirectUri,
+    storage,
+    keyStore: new MemoryGrantKeyStore()
+  });
+  void hostedSdk.authorize(["describe", "changes", "read", "query", "create", "update"]);
+  await waitFor(() => authorizationUrl, "SDK did not start hosted authorization");
+  const authorize = await fetch(authorizationUrl, { headers: { cookie }, redirect: "manual" });
+  assert.equal(authorize.status, 302);
+  const authorizationId = authorize.headers.get("location")?.split("/").at(-1);
+  assert.ok(authorizationId);
+  await controlRequest(
+    controlUrl,
+    `/v1/authorization-requests/${authorizationId}/approve`,
+    cookie,
+    {
+      method: "POST",
+      body: {
+        collection_id: collectionId,
+        operations: ["describe", "changes", "read", "query", "create", "update"]
+      }
+    }
+  );
+  const authorizationStatus = await controlRequest(
+    controlUrl,
+    `/v1/authorization-requests/${authorizationId}/status`,
+    cookie
+  );
+  assert.equal(authorizationStatus.status, "approved");
+  await hostedSdk.completeAuthorization(authorizationStatus.redirect_uri);
+  const storedHostedToken = storage.token();
+  assert.equal(storedHostedToken.hosted.providerUrl, provider.url);
+  assert.equal(storedHostedToken.encryption, undefined);
+  const appToken = storedHostedToken.hosted.accessToken;
+  const appReplicaId = storedHostedToken.hosted.replicaId;
+  const appSync = await rawRequest(provider.url, syncPath(collectionId, "sessions"), {
+    method: "POST",
+    token: appToken
+  });
+  assert.equal(appSync.status, 401);
+  const wrongOrigin = await rawRequest(
+    provider.url,
+    `/v1/hosted/collections/${collectionId}/operations/query`,
+    {
+      method: "POST",
+      token: appToken,
+      headers: { origin: "https://evil.example" },
+      body: { types: ["task"] }
+    }
+  );
+  assert.equal(wrongOrigin.status, 403);
+  assert.equal(wrongOrigin.body.error.code, "origin_denied");
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, init = {}) => {
+    const url = String(input);
+    if (!url.startsWith(`${provider.url}/v1/hosted/`)) return originalFetch(input, init);
+    const headers = new Headers(init.headers);
+    headers.set("origin", manifest.origin);
+    return originalFetch(input, { ...init, headers });
+  };
+  const description = await hostedSdk.describe();
+  assert.equal(description.contracts[0].id, "tasknotes.task");
+  const hostedTasknotes = new TasknotesCollection(hostedSdk);
+  const sdkCreated = await hostedTasknotes.create({ title: "Created through hosted SDK" });
+  assert.ok(sdkCreated.revision);
+  assert.equal((await hostedTasknotes.list()).some((task) => task.title === "Created through hosted SDK"), true);
+  await hostedTasknotes.setCompleted(sdkCreated.path, true);
+  assert.equal(
+    (await hostedTasknotes.list()).find((task) => task.title === "Created through hosted SDK").completed,
+    true
+  );
+  globalThis.fetch = originalFetch;
+  const dashboardWithApp = await controlRequest(controlUrl, "/v1/me", cookie);
+  const hostedGrant = dashboardWithApp.grants.find((grant) => grant.collection_id === collectionId);
+  assert.ok(hostedGrant);
+  assert.equal(hostedGrant.collection_kind, "hosted");
+  assert.equal(
+    dashboardWithApp.hosted_collections
+      .find((collection) => collection.id === collectionId)
+      .replicas.some((replica) => replica.id === appReplicaId),
+    false
+  );
+  await controlRequest(controlUrl, `/v1/grants/${hostedGrant.id}`, cookie, {
+    method: "PATCH",
+    body: { operations: ["describe", "read", "query"] }
+  });
+  const deniedWrite = await rawRequest(
+    provider.url,
+    `/v1/hosted/collections/${collectionId}/operations/create`,
+    {
+      method: "POST",
+      token: appToken,
+      headers: { origin: manifest.origin },
+      body: {
+        path: "tasks/permission-expansion.md",
+        frontmatter: { type: "task", title: "Must not exist" }
+      }
+    }
+  );
+  assert.equal(deniedWrite.status, 403);
+  assert.equal(deniedWrite.body.error.code, "insufficient_access");
+  await controlRequest(controlUrl, `/v1/grants/${hostedGrant.id}`, cookie, { method: "DELETE" });
+  const revokedApp = await rawRequest(
+    provider.url,
+    `/v1/hosted/collections/${collectionId}/operations/query`,
+    { method: "POST", token: appToken, headers: { origin: manifest.origin }, body: {} }
+  );
+  assert.equal(revokedApp.status, 401);
+  assert.equal(
+    (
+      await rawRequest(provider.url, syncPath(otherCollectionId, "sessions"), {
+        method: "POST",
+        token: writer.token
+      })
+    ).status,
+    401
+  );
+
+  phase("driving the Rust authority through the public TypeScript SDK");
+  const writerTransport = transport(provider.url, collectionId, writer);
+  const readerTransport = transport(provider.url, collectionId, reader);
+  const recoveryTransport = transport(provider.url, collectionId, recovery);
+  const writerClient = replica(writerTransport, writer.id);
+  const readerClient = replica(readerTransport, reader.id);
+  const recoveryStore = store(recovery.id);
+  const recoveryClient = new OfflineReplica(recoveryTransport, recoveryStore);
+  await Promise.all([writerClient.initialize(), readerClient.initialize(), recoveryClient.initialize()]);
+
+  const resources = await writerClient.collectionResources();
+  assert.ok(resources);
+  const tasknotes = new TasknotesOfflineCollection(
+    writerClient,
+    resolveTasknotesSyncContract(resources)
+  );
+  const recordId = await tasknotes.create({
+    title: "Created offline",
+    path: "tasks/offline.md",
+    body: "Created without a network round trip."
+  });
+  const originalMutation = structuredClone((await writerClient.pending())[0]);
+  await tasknotes.sync();
+  await readerClient.pull();
+  assert.equal(findRecord(await readerClient.records(), recordId).frontmatter.title, "Created offline");
+  const forbiddenPlaintextColumns = await postgresQuery(
+    `SELECT table_name || '.' || column_name
+     FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name LIKE 'hosted_provider_%'
+       AND column_name IN ('document', 'frontmatter', 'body', 'receipt')`
+  );
+  assert.equal(forbiddenPlaintextColumns, "");
+  const encryptedPayload = await postgresQuery(
+    `SELECT encode(payload_ciphertext, 'hex')
+     FROM hosted_provider_records
+     WHERE collection_id = '${collectionId}' AND record_id = '${recordId}'`
+  );
+  assert.ok(encryptedPayload.length > 64);
+  assert.ok(!encryptedPayload.includes(Buffer.from("Created offline").toString("hex")));
+  const plaintextRecordPaths = await postgresQuery(
+    `SELECT table_name || '.' || column_name
+     FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name IN ('hosted_provider_records', 'hosted_provider_record_versions')
+       AND column_name = 'path'`
+  );
+  assert.equal(plaintextRecordPaths, "");
+
+  const replay = await writerTransport.mutate(originalMutation);
+  assert.equal(replay.status, "previously_applied");
+  assert.equal(replay.record?.path, "tasks/offline.md");
+  await expectSyncError(
+    () => writerTransport.mutate({
+      ...originalMutation,
+      input: { ...originalMutation.input, path: "tasks/reused-id.md" }
+    }),
+    "mutation_id_reused"
+  );
+
+  const readOnlyReceipt = await transport(provider.url, collectionId, readOnly).mutate(
+    createMutation(readOnly.id, crypto.randomUUID(), "tasks/forbidden.md", "Forbidden")
+  );
+  assert.equal(readOnlyReceipt.status, "rejected");
+  assert.equal(readOnlyReceipt.error.code, "replica_read_only");
+
+  const duplicateRecord = await writerTransport.mutate(
+    createMutation(writer.id, recordId, "tasks/duplicate-id.md", "Duplicate ID")
+  );
+  assert.equal(duplicateRecord.status, "rejected");
+  assert.equal(duplicateRecord.error.code, "record_conflict");
+
+  const missingPredecessor = await writerTransport.mutate({
+    ...updateMutation(writer.id, findRecord(await writerClient.records(), recordId), { status: "done" }),
+    causal_predecessor: crypto.randomUUID()
+  });
+  assert.equal(missingPredecessor.status, "rejected");
+  assert.equal(missingPredecessor.error.code, "causal_predecessor_missing");
+
+  phase("checking pinned snapshots, scope projection, and optimistic conflicts");
+  const pinned = await readerTransport.openSession();
+  const pinnedBefore = findRecord(await snapshotAll(readerTransport, pinned), recordId);
+  await writerClient.queueUpdate({ recordId, patch: { status: "done" } });
+  await writerClient.sync();
+  const pinnedAfterMutation = findRecord(await snapshotAll(readerTransport, pinned), recordId);
+  assert.equal(pinnedAfterMutation.revision, pinnedBefore.revision);
+  assert.equal(pinnedAfterMutation.frontmatter.status, "open");
+
+  const stale = findRecord(await readerClient.records(), recordId);
+  await readerClient.queueUpdate({
+    recordId,
+    patch: { title: "Stale tablet edit" },
+    baseRevision: stale.revision
+  });
+  await readerClient.sync();
+  assert.equal((await readerClient.conflicts())[0].status, "conflicted");
+  assert.equal((await readerClient.conflicts())[0].conflict.current.frontmatter.status, "done");
+  const conflictedMutationId = (await readerClient.conflicts())[0].conflict.mutation.mutation_id;
+  const afterConflict = await readerTransport.mutate({
+    ...createMutation(reader.id, crypto.randomUUID(), "tasks/after-conflict.md", "After conflict"),
+    causal_predecessor: conflictedMutationId
+  });
+  assert.equal(afterConflict.status, "rejected");
+  assert.equal(afterConflict.error.code, "causal_predecessor_not_applied");
+
+  const hiddenTransport = transport(provider.url, collectionId, hidden);
+  const hiddenSession = await hiddenTransport.openSession();
+  assert.deepEqual(hiddenSession.resources.types, []);
+  assert.deepEqual((await snapshotAll(hiddenTransport, hiddenSession)), []);
+  const hiddenChanges = await hiddenTransport.changes(0, 200);
+  assert.deepEqual(hiddenChanges.events, []);
+  assert.equal(hiddenChanges.cursor, hiddenChanges.head);
+
+  phase("racing writers through two provider instances");
+  const secondProvider = await startProvider(databaseUrl);
+  const authority = findRecord(
+    await snapshotAll(writerTransport, await writerTransport.openSession()),
+    recordId
+  );
+  const [left, right] = await Promise.all([
+    writerTransport.mutate(updateMutation(writer.id, authority, { title: "Writer one" })),
+    transport(secondProvider.url, collectionId, reader).mutate(
+      updateMutation(reader.id, authority, { title: "Writer two" })
+    )
+  ]);
+  assert.deepEqual(
+    [left.status, right.status].sort(),
+    ["applied", "conflicted"]
+  );
+  const afterRace = await writerTransport.openSession();
+  assert.equal(afterRace.head, authoritySequence(left, right));
+  await stopProvider(secondProvider);
+
+  phase("materializing, updating, renaming, and protecting a filesystem mirror");
+  const symlinkMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-symlink-mirror-"));
+  const symlinkOutsideRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-symlink-outside-"));
+  try {
+    await symlink(symlinkOutsideRoot, join(symlinkMirrorRoot, ".mdbase"), "dir");
+    await assert.rejects(
+      () => execute(process.execPath, [
+        join(repoRoot, "packages", "sync", "dist", "cli.js"),
+        "init",
+        symlinkMirrorRoot,
+        "--server", provider.url,
+        "--collection", collectionId,
+        "--replica", mirror.id
+      ], {
+        env: { ...process.env, MDBASE_CONNECT_REPLICA_TOKEN: mirror.token }
+      }),
+      (error) => /ordinary directory inside the mirror root/.test(error.stderr ?? "")
+    );
+    await assert.rejects(
+      () => readFile(join(symlinkOutsideRoot, "connect-mirror.json"), "utf8"),
+      { code: "ENOENT" }
+    );
+  } finally {
+    await rm(symlinkMirrorRoot, { recursive: true, force: true });
+    await rm(symlinkOutsideRoot, { recursive: true, force: true });
+  }
+  await execute(process.execPath, [
+    join(repoRoot, "packages", "sync", "dist", "cli.js"),
+    "init",
+    mirrorRoot,
+    "--server", provider.url,
+    "--collection", collectionId,
+    "--replica", mirror.id
+  ], {
+    env: { ...process.env, MDBASE_CONNECT_REPLICA_TOKEN: mirror.token }
+  });
+  const configurationMode = (await stat(join(mirrorRoot, ".mdbase", "connect-mirror.json"))).mode & 0o777;
+  assert.equal(configurationMode, 0o600);
+  assert.match(await readFile(join(mirrorRoot, "mdbase.yaml"), "utf8"), /spec_version: 0\.3\.0/);
+  assert.match(await readFile(join(mirrorRoot, "_types", "task.md"), "utf8"), /x-tasknotes:/);
+  const directoryMirror = new DirectoryMirror(
+    mirrorRoot,
+    mirror.id,
+    transport(provider.url, collectionId, mirror)
+  );
+  const originalMirror = await readFile(join(mirrorRoot, "tasks", "offline.md"), "utf8");
+  assert.match(originalMirror, /status: done/);
+  await writeFile(join(mirrorRoot, "tasks", "offline.md"), `${originalMirror}\nlocal divergence\n`);
+  await assert.rejects(() => directoryMirror.sync(), MirrorDivergenceError);
+  await writeFile(join(mirrorRoot, "tasks", "offline.md"), originalMirror);
+
+  await writerClient.initialize();
+  await writerClient.queueRename({ recordId, path: "tasks/renamed.md" });
+  await writerClient.sync();
+  await directoryMirror.sync();
+  await assert.rejects(() => readFile(join(mirrorRoot, "tasks", "offline.md"), "utf8"), { code: "ENOENT" });
+  assert.match(await readFile(join(mirrorRoot, "tasks", "renamed.md"), "utf8"), /type: task/);
+
+  phase("round-tripping writable files with stable identity and explicit conflict resolution");
+  const mirrorCli = join(repoRoot, "packages", "sync", "dist", "cli.js");
+  await writeFile(
+    join(importMirrorRoot, "imported-before-init.md"),
+    "---\ntype: task\ntitle: Imported during init\nstatus: open\n---\nAlready local.\n"
+  );
+  await execute(process.execPath, [
+    mirrorCli,
+    "init",
+    importMirrorRoot,
+    "--server", provider.url,
+    "--collection", collectionId,
+    "--replica", importMirror.id,
+    "--writable"
+  ], {
+    env: { ...process.env, MDBASE_CONNECT_REPLICA_TOKEN: importMirror.token }
+  });
+  assert.equal(
+    (await snapshotAll(writerTransport, await writerTransport.openSession()))
+      .some((record) => record.path === "imported-before-init.md"),
+    true
+  );
+  await execute(process.execPath, [
+    mirrorCli,
+    "init",
+    writableMirrorRoot,
+    "--server", provider.url,
+    "--collection", collectionId,
+    "--replica", writableMirror.id,
+    "--writable"
+  ], {
+    env: { ...process.env, MDBASE_CONNECT_REPLICA_TOKEN: writableMirror.token }
+  });
+  assert.equal(
+    (await stat(join(writableMirrorRoot, ".mdbase", "connect-mirror.json"))).mode & 0o777,
+    0o600
+  );
+  const writableOriginal = await readFile(join(writableMirrorRoot, "tasks", "renamed.md"), "utf8");
+  const locallyUpdated = writableOriginal.replace(/title: .*\n/, "title: Edited on disk\n");
+  await writeFile(join(writableMirrorRoot, "tasks", "renamed.md"), locallyUpdated);
+  await execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]);
+  let writableAuthority = findRecord(
+    await snapshotAll(writerTransport, await writerTransport.openSession()),
+    recordId
+  );
+  assert.equal(writableAuthority.frontmatter.title, "Edited on disk");
+
+  await rename(
+    join(writableMirrorRoot, "tasks", "renamed.md"),
+    join(writableMirrorRoot, "tasks", "disk-renamed.md")
+  );
+  await execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]);
+  writableAuthority = findRecord(
+    await snapshotAll(writerTransport, await writerTransport.openSession()),
+    recordId
+  );
+  assert.equal(writableAuthority.path, "tasks/disk-renamed.md");
+
+  const localCreatedPath = join(writableMirrorRoot, "tasks", "local-created.md");
+  await writeFile(localCreatedPath, "---\ntype: task\ntitle: Local creation\nstatus: open\n---\nCreated locally.\n");
+  await execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]);
+  let recordsAfterLocalCreate = await snapshotAll(writerTransport, await writerTransport.openSession());
+  const locallyCreated = recordsAfterLocalCreate.find((record) => record.path === "tasks/local-created.md");
+  assert.ok(locallyCreated);
+  assert.equal(locallyCreated.body, "Created locally.\n");
+
+  const localBeforeConflict = await readFile(join(writableMirrorRoot, "tasks", "disk-renamed.md"), "utf8");
+  await writeFile(
+    join(writableMirrorRoot, "tasks", "disk-renamed.md"),
+    localBeforeConflict.replace(/title: .*\n/, "title: Local conflict winner\n")
+  );
+  const remoteDuringConflict = await writerTransport.mutate(
+    updateMutation(writer.id, writableAuthority, { title: "Remote concurrent edit" })
+  );
+  assert.equal(remoteDuringConflict.status, "applied");
+  await assert.rejects(
+    () => execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]),
+    (error) => /Hosted and local changes conflict/.test(error.stderr ?? "")
+  );
+  assert.equal(
+    JSON.parse(await readFile(join(writableMirrorRoot, ".mdbase", "conflicts", `${recordId}.json`), "utf8")).status,
+    "conflicted"
+  );
+  await execute(process.execPath, [
+    mirrorCli, "resolve", writableMirrorRoot, recordId, "--use", "local"
+  ]);
+  await execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]);
+  writableAuthority = findRecord(
+    await snapshotAll(writerTransport, await writerTransport.openSession()),
+    recordId
+  );
+  assert.equal(writableAuthority.frontmatter.title, "Local conflict winner");
+
+  await unlink(localCreatedPath);
+  await execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]);
+  recordsAfterLocalCreate = await snapshotAll(writerTransport, await writerTransport.openSession());
+  assert.equal(recordsAfterLocalCreate.some((record) => record.record_id === locallyCreated.record_id), false);
+
+  const resourceDocument = await readFile(join(writableMirrorRoot, "_types", "task.md"), "utf8");
+  await writeFile(join(writableMirrorRoot, "_types", "task.md"), `${resourceDocument}\nunsafe local schema edit\n`);
+  await assert.rejects(
+    () => execute(process.execPath, [mirrorCli, "sync", writableMirrorRoot]),
+    (error) => /must be resolved before the mirror can continue/.test(error.stderr ?? "")
+  );
+  await writeFile(join(writableMirrorRoot, "_types", "task.md"), resourceDocument);
+
+  phase("forcing pagination and validating a restart against durable state");
+  const bulkCount = Number(process.env.MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT ?? 205);
+  assert.ok(Number.isInteger(bulkCount) && bulkCount >= 205 && bulkCount <= 20_000);
+  const stressRun = bulkCount >= 10_000;
+  let finalBulkRecordId;
+  const recordsBeforeBulk = (
+    await snapshotAll(writerTransport, await writerTransport.openSession())
+  ).length;
+  const mutationLatencies = [];
+  for (let index = 0; index < bulkCount; index += 1) {
+    const bulkRecordId = crypto.randomUUID();
+    if (index === bulkCount - 1) finalBulkRecordId = bulkRecordId;
+    const mutationStarted = performance.now();
+    const receipt = await writerTransport.mutate(
+      createMutation(
+        writer.id,
+        bulkRecordId,
+        `tasks/bulk-${String(index).padStart(3, "0")}.md`,
+        `Bulk ${index}`
+      )
+    );
+    mutationLatencies.push(performance.now() - mutationStarted);
+    assert.equal(receipt.status, "applied");
+  }
+  const pagedSession = await writerTransport.openSession();
+  let pages = 0;
+  let pagedRecords = [];
+  let page;
+  const snapshotStarted = performance.now();
+  do {
+    const snapshot = await writerTransport.snapshot(pagedSession.snapshot_id, page);
+    pages += 1;
+    pagedRecords.push(...snapshot.records);
+    page = snapshot.next_page;
+  } while (page);
+  const snapshotMs = performance.now() - snapshotStarted;
+  assert.equal(pages, Math.ceil((bulkCount + recordsBeforeBulk) / 200));
+  assert.equal(pagedRecords.length, bulkCount + recordsBeforeBulk);
+
+  if (stressRun) {
+    const changeLatencies = [];
+    let changeCursor = 0;
+    while (changeCursor < pagedSession.head) {
+      const changesStarted = performance.now();
+      const changes = await writerTransport.changes(changeCursor, 200);
+      changeLatencies.push(performance.now() - changesStarted);
+      assert.ok(changes.cursor > changeCursor);
+      changeCursor = changes.cursor;
+    }
+    const benchmarkReplicaId = crypto.randomUUID();
+    const benchmarkToken = `benchmark-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+    await internalRequest(provider.url, `/internal/v1/collections/${collectionId}/replicas`, {
+      method: "POST",
+      body: {
+        replica_id: benchmarkReplicaId,
+        name: "Performance probe",
+        purpose: "application",
+        mode: "read_only",
+        allowed_types: ["task"],
+        allowed_operations: ["read", "query"],
+        token: benchmarkToken,
+        token_ttl_seconds: 600
+      }
+    });
+    const readLatencies = [];
+    const queryLatencies = [];
+    for (let index = 0; index < 25; index += 1) {
+      let started = performance.now();
+      const read = await rawRequest(
+        provider.url,
+        `/v1/hosted/collections/${collectionId}/operations/read`,
+        { method: "POST", token: benchmarkToken, body: { path: "tasks/bulk-204.md" } }
+      );
+      readLatencies.push(performance.now() - started);
+      assert.equal(read.status, 200);
+      started = performance.now();
+      const query = await rawRequest(
+        provider.url,
+        `/v1/hosted/collections/${collectionId}/operations/query`,
+        { method: "POST", token: benchmarkToken, body: { types: ["task"], limit: 20 } }
+      );
+      queryLatencies.push(performance.now() - started);
+      assert.equal(query.status, 200);
+    }
+    const result = {
+      records: pagedRecords.length,
+      mutation_p95_ms: percentile(mutationLatencies, 0.95),
+      snapshot_ms: snapshotMs,
+      change_page_p95_ms: percentile(changeLatencies, 0.95),
+      warm_read_p95_ms: percentile(readLatencies, 0.95),
+      warm_query_p95_ms: percentile(queryLatencies, 0.95)
+    };
+    process.stdout.write(`[provider-e2e] performance ${JSON.stringify(result)}\n`);
+    assert.ok(result.mutation_p95_ms < 200, `mutation p95 budget exceeded: ${result.mutation_p95_ms}`);
+    assert.ok(result.snapshot_ms < 10_000, `snapshot budget exceeded: ${result.snapshot_ms}`);
+    assert.ok(result.change_page_p95_ms < 150, `change page p95 budget exceeded: ${result.change_page_p95_ms}`);
+    assert.ok(result.warm_read_p95_ms < 100, `warm read p95 budget exceeded: ${result.warm_read_p95_ms}`);
+    assert.ok(result.warm_query_p95_ms < 300, `warm query p95 budget exceeded: ${result.warm_query_p95_ms}`);
+  }
+
+  const durableHead = pagedSession.head;
+  await stopProvider(provider);
+  provider = await startProvider(databaseUrl, Number(new URL(provider.url).port));
+  const restartedWriter = transport(provider.url, collectionId, writer);
+  assert.equal((await restartedWriter.openSession()).head, durableHead);
+  assert.equal(
+    (await snapshotAll(restartedWriter, await restartedWriter.openSession())).length,
+    bulkCount + recordsBeforeBulk
+  );
+
+  phase("restoring a logical backup into a fresh database");
+  const providerPort = Number(new URL(provider.url).port);
+  await stopProvider(provider);
+  await execute("docker", [
+    "exec",
+    postgresContainer,
+    "pg_dump",
+    "--username", "mdbase",
+    "--dbname", "mdbase",
+    "--format", "custom",
+    "--file", "/tmp/mdbase-provider.dump"
+  ]);
+  await execute("docker", [
+    "exec",
+    postgresContainer,
+    "createdb",
+    "--username", "mdbase",
+    "mdbase_restore"
+  ]);
+  await execute("docker", [
+    "exec",
+    postgresContainer,
+    "pg_restore",
+    "--username", "mdbase",
+    "--dbname", "mdbase_restore",
+    "--exit-on-error",
+    "/tmp/mdbase-provider.dump"
+  ]);
+  const restoredDatabaseUrl = databaseUrl.replace(/\/mdbase$/, "/mdbase_restore");
+  provider = await startProvider(restoredDatabaseUrl, providerPort);
+  const restoredWriter = transport(provider.url, collectionId, writer);
+  assert.equal((await restoredWriter.openSession()).head, durableHead);
+  assert.equal(
+    (await snapshotAll(restoredWriter, await restoredWriter.openSession())).length,
+    bulkCount + recordsBeforeBulk
+  );
+  await stopProvider(provider);
+  provider = await startProvider(databaseUrl, providerPort);
+
+  phase("checking reset recovery, token rotation, revocation, and body limits");
+  const restartedRecoveryTransport = transport(provider.url, collectionId, recovery);
+  const restartedRecoveryClient = new OfflineReplica(restartedRecoveryTransport, recoveryStore);
+  const queuedId = crypto.randomUUID();
+  await restartedRecoveryClient.queueCreate({
+    mutationId: queuedId,
+    path: "tasks/queued-during-reset.md",
+    frontmatter: { type: "task", title: "Still queued" },
+    types: ["task"]
+  });
+  const restartedWriterClient = replica(restartedWriter, writer.id);
+  await restartedWriterClient.initialize();
+  const leasedBeforeCompaction = await restartedWriter.openSession();
+  const leasedRecord = findRecord(
+    await snapshotAll(restartedWriter, leasedBeforeCompaction),
+    recordId
+  );
+  const postLeaseUpdate = await restartedWriter.mutate(
+    updateMutation(writer.id, leasedRecord, { title: "Changed after snapshot lease" })
+  );
+  assert.equal(postLeaseUpdate.status, "applied");
+  await restartedWriterClient.queueCreate({
+    path: "tasks/advance-head.md",
+    frontmatter: { type: "task", title: "Advance head" },
+    types: ["task"]
+  });
+  await restartedWriterClient.sync();
+  const compactHead = (await restartedWriter.openSession()).head;
+  await controlRequest(
+    controlUrl,
+    `/v1/hosted/collections/${collectionId}/maintenance/compact`,
+    cookie,
+    { method: "POST", body: { through: compactHead } }
+  );
+  const pinnedAfterCompaction = findRecord(
+    await snapshotAll(restartedWriter, leasedBeforeCompaction),
+    recordId
+  );
+  assert.equal(pinnedAfterCompaction.revision, leasedRecord.revision);
+  assert.notEqual(pinnedAfterCompaction.frontmatter.title, "Changed after snapshot lease");
+  await restartedRecoveryClient.pull();
+  assert.ok((await restartedRecoveryClient.pending()).some((item) => item.mutation_id === queuedId));
+
+  const rotation = await controlRequest(
+    controlUrl,
+    `/v1/hosted/replicas/${recovery.id}/token`,
+    cookie,
+    { method: "POST" }
+  );
+  const rotatedToken = rotation.token;
+  assert.equal(rotation.sync_url, provider.url);
+  await expectSyncError(() => restartedRecoveryTransport.openSession(), "invalid_replica_token");
+  await new HttpSyncTransport(provider.url, collectionId, rotatedToken).openSession();
+  await controlRequest(controlUrl, `/v1/hosted/replicas/${recovery.id}`, cookie, {
+    method: "DELETE"
+  });
+  await expectSyncError(
+    () => new HttpSyncTransport(provider.url, collectionId, rotatedToken).openSession(),
+    "invalid_replica_token"
+  );
+
+  const oversized = await rawRequest(provider.url, syncPath(collectionId, "mutations"), {
+    method: "POST",
+    token: writer.token,
+    bodyText: JSON.stringify({ oversized: "x".repeat(3 * 1024 * 1024 + 1) })
+  });
+  assert.equal(oversized.status, 413);
+
+  await postgresQuery(
+    `UPDATE hosted_provider_record_versions
+     SET payload_ciphertext = set_byte(
+       payload_ciphertext,
+       20,
+       get_byte(payload_ciphertext, 20) # 1
+     )
+     WHERE collection_id = '${collectionId}' AND record_id = '${finalBulkRecordId}'`
+  );
+  await expectSyncError(
+    async () => snapshotAll(restartedWriter, await restartedWriter.openSession()),
+    "provider_internal_error"
+  );
+
+  process.stdout.write("mdbase PostgreSQL hosted provider e2e passed\n");
+} finally {
+  delete globalThis.location;
+  if (manifestServer) await new Promise((resolveClose) => manifestServer.close(resolveClose));
+  if (controlApp) await controlApp.close();
+  if (controlDatabase) await controlDatabase.end();
+  for (const child of [...children]) await stopProvider(child);
+  if (postgresStarted) {
+    await execute("docker", ["rm", "-f", postgresContainer]).catch(() => {});
+  }
+  await rm(mirrorRoot, { recursive: true, force: true });
+  await rm(writableMirrorRoot, { recursive: true, force: true });
+  await rm(importMirrorRoot, { recursive: true, force: true });
+}
+
+function phase(message) {
+  process.stdout.write(`[provider-e2e] ${message}\n`);
+}
+
+async function portalLifecycleE2E(controlUrl) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`${controlUrl}/login`);
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByRole("heading", { name: "Your connections." })).toBeVisible();
+
+    await page.getByRole("button", { name: "Create hosted collection" }).click();
+    await page.getByLabel("Collection name").fill("Browser E2E tasks");
+    await page.getByRole("button", { name: "Create collection" }).click();
+    const row = page.locator("article.hosted-row").filter({ hasText: "Browser E2E tasks" });
+    await expect(row).toBeVisible();
+
+    await row.getByRole("button", { name: "Add mirror" }).click();
+    await row.getByLabel("Mirror name").fill("Browser writable mirror");
+    await row.getByLabel("Local edits").selectOption("read_write");
+    await expect(row).toContainText("never last-write-wins");
+    await row.getByRole("button", { name: "Prepare mirror" }).click();
+    await expect(row.locator("code").filter({ hasText: "mdbase-mirror init" })).toContainText("--writable");
+    await expect(row).toContainText("Save this token now");
+
+    await row.getByRole("button", { name: "Add mirror" }).click();
+    await row.getByText("Manage mirrors").click();
+    await expect(row).toContainText("Browser writable mirror");
+    await expect(row).toContainText("Two-way");
+    await row.getByRole("button", { name: "Replace token" }).click();
+    await expect(row).toContainText("Save this token now");
+    page.once("dialog", (dialog) => dialog.accept());
+    await row.getByRole("button", { name: "Revoke" }).click();
+    await expect(row).not.toContainText("Browser writable mirror");
+
+    await row.getByRole("button", { name: "Rename" }).click();
+    await row.getByLabel("Collection name").fill("Browser renamed tasks");
+    await row.getByRole("button", { name: "Save" }).click();
+    const renamedRow = page.locator("article.hosted-row").filter({ hasText: "Browser renamed tasks" });
+    await expect(renamedRow).toBeVisible();
+    page.once("dialog", (dialog) => dialog.accept());
+    await renamedRow.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByText("Browser renamed tasks", { exact: true })).toHaveCount(0);
+  } finally {
+    await browser.close();
+  }
+}
+
+async function startPostgres() {
+  await execute("docker", [
+    "run", "--rm", "--detach", "--name", postgresContainer,
+    "--env", "POSTGRES_USER=mdbase",
+    "--env", `POSTGRES_PASSWORD=${databasePassword}`,
+    "--env", "POSTGRES_DB=mdbase",
+    "--publish", "127.0.0.1::5432",
+    "postgres:18-alpine"
+  ]);
+  postgresStarted = true;
+  const { stdout } = await execute("docker", ["port", postgresContainer, "5432/tcp"]);
+  const port = stdout.trim().match(/:(\d+)$/)?.[1];
+  if (!port) throw new Error(`Could not resolve PostgreSQL port from ${stdout}`);
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const ready = await execute(
+      "docker",
+      ["exec", postgresContainer, "pg_isready", "--username", "mdbase", "--dbname", "mdbase"]
+    ).then(() => true, () => false);
+    if (ready) return `postgres://mdbase:${databasePassword}@127.0.0.1:${port}/mdbase`;
+    await delay(250);
+  }
+  throw new Error("PostgreSQL did not become ready");
+}
+
+async function availablePort() {
+  const server = createServer();
+  await new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not reserve a local port");
+  await new Promise((resolveClose) => server.close(resolveClose));
+  return address.port;
+}
+
+async function startProvider(
+  databaseUrl,
+  port = 0,
+  providerMasterKey = masterKey,
+  extraEnvironment = {}
+) {
+  const child = spawn(providerBinary, [], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: internalToken,
+      MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY: providerMasterKey,
+      MDBASE_CONNECT_HOSTED_PROVIDER_ALLOWED_ORIGINS: "http://127.0.0.1",
+      HOST: "127.0.0.1",
+      PORT: String(port),
+      RUST_LOG: "warn",
+      ...extraEnvironment
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  children.add(child);
+  let logs = "";
+  child.stderr.on("data", (chunk) => { logs += chunk; });
+  const url = await new Promise((resolveUrl, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Provider startup timed out:\n${logs}`)), 20_000);
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Provider exited during startup (${code}):\n${logs}`));
+    });
+    child.stdout.on("data", (chunk) => {
+      logs += chunk;
+      const match = logs.match(/HOSTED_PROVIDER_LISTENING=(http:\/\/[^\s]+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolveUrl(match[1]);
+      }
+    });
+  });
+  child.url = url;
+  child.logs = () => logs;
+  return child;
+}
+
+async function stopProvider(child) {
+  if (!child || !children.has(child)) return;
+  children.delete(child);
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  await new Promise((resolveExit) => {
+    if (child.exitCode !== null || child.signalCode !== null) resolveExit();
+    else child.once("exit", resolveExit);
+  });
+}
+
+async function postgresQuery(sql) {
+  const { stdout } = await execute("docker", [
+    "exec",
+    postgresContainer,
+    "psql",
+    "--username", "mdbase",
+    "--dbname", "mdbase",
+    "--tuples-only",
+    "--no-align",
+    "--command", sql
+  ]);
+  return stdout.trim();
+}
+
+async function registerReplica(url, cookie, collectionId, name, mode, allowedTypes) {
+  const response = await controlRequest(url, `/v1/hosted/collections/${collectionId}/replicas`, cookie, {
+    method: "POST",
+    body: {
+      name,
+      mode,
+      allowed_types: allowedTypes
+    }
+  });
+  return {
+    id: response.replica.id,
+    token: response.token,
+    syncUrl: response.sync_url
+  };
+}
+
+function transport(url, collectionId, replicaValue) {
+  return new HttpSyncTransport(url, collectionId, replicaValue.token);
+}
+
+function store(replicaId) {
+  return new MemoryReplicaStore({ replicaId, records: {}, pending: [], conflicts: {} });
+}
+
+function replica(syncTransport, replicaId) {
+  return new OfflineReplica(syncTransport, store(replicaId));
+}
+
+function syncPath(collectionId, endpoint) {
+  return `/v1/hosted/collections/${collectionId}/sync/${endpoint}`;
+}
+
+function createMutation(replicaId, recordId, path, title) {
+  return {
+    mutation_id: crypto.randomUUID(),
+    replica_id: replicaId,
+    scope_epoch: 1,
+    operation: "create",
+    record_id: recordId,
+    input: {
+      path,
+      frontmatter: { type: "task", title, status: "open" },
+      body: "",
+      types: ["task"]
+    },
+    created_at: new Date().toISOString()
+  };
+}
+
+function updateMutation(replicaId, record, patch) {
+  return {
+    mutation_id: crypto.randomUUID(),
+    replica_id: replicaId,
+    scope_epoch: 1,
+    operation: "update",
+    record_id: record.record_id,
+    base_revision: record.revision,
+    input: { patch },
+    created_at: new Date().toISOString()
+  };
+}
+
+async function snapshotAll(syncTransport, session) {
+  const records = [];
+  let page;
+  do {
+    const snapshot = await syncTransport.snapshot(session.snapshot_id, page);
+    assert.equal(snapshot.cursor, session.head);
+    records.push(...snapshot.records);
+    page = snapshot.next_page;
+  } while (page);
+  return records;
+}
+
+function findRecord(records, recordId) {
+  const record = records.find((candidate) => candidate.record_id === recordId);
+  assert.ok(record, `Record ${recordId} was not found`);
+  return record;
+}
+
+function authoritySequence(left, right) {
+  const applied = [left, right].find((receipt) => receipt.status === "applied");
+  assert.ok(applied);
+  return applied.sequence;
+}
+
+async function internalRequest(url, path, options = {}) {
+  const response = await rawRequest(url, path, { ...options, token: internalToken });
+  if (!response.ok) {
+    throw new Error(`${path} returned HTTP ${response.status}: ${JSON.stringify(response.body)}`);
+  }
+  return response.body;
+}
+
+async function controlRequest(url, path, cookie, options = {}) {
+  const response = await rawRequest(url, path, { ...options, cookie });
+  if (!response.ok) {
+    throw new Error(`${path} returned HTTP ${response.status}: ${JSON.stringify(response.body)}`);
+  }
+  return response.body;
+}
+
+async function rawRequest(url, path, options = {}) {
+  const headers = { ...(options.headers ?? {}) };
+  if (options.token) headers.authorization = `Bearer ${options.token}`;
+  if (options.cookie) headers.cookie = options.cookie;
+  let body;
+  if (options.bodyText !== undefined) {
+    body = options.bodyText;
+    headers["content-type"] = "application/json";
+  } else if (options.body !== undefined) {
+    body = JSON.stringify(options.body);
+    headers["content-type"] = "application/json";
+  }
+  const response = await fetch(`${url}${path}`, {
+    method: options.method ?? "GET",
+    headers,
+    body
+  });
+  const text = await response.text();
+  let responseBody;
+  try {
+    responseBody = text ? JSON.parse(text) : undefined;
+  } catch {
+    responseBody = text;
+  }
+  return {
+    ok: response.ok,
+    status: response.status,
+    body: responseBody,
+    headers: response.headers
+  };
+}
+
+async function expectSyncError(action, code) {
+  await assert.rejects(action, (error) => error instanceof SyncError && error.code === code);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+function percentile(values, quantile) {
+  const ordered = [...values].sort((left, right) => left - right);
+  return Number(ordered[Math.min(ordered.length - 1, Math.floor(ordered.length * quantile))].toFixed(2));
+}
+
+async function waitFor(action, message) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const value = await action();
+    if (value) return value;
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+async function openManifestServer() {
+  const server = createServer((_request, response) => {
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Manifest server is unavailable");
+    const origin = `http://127.0.0.1:${address.port}`;
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({
+      manifest_version: 1,
+      name: "Hosted SDK E2E",
+      homepage: origin,
+      redirect_uris: [`${origin}/auth/mdbase/callback`],
+      requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] }
+    }));
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Manifest server is unavailable");
+  const origin = `http://127.0.0.1:${address.port}`;
+  return {
+    server,
+    origin,
+    manifestUrl: `${origin}/.well-known/mdbase-app.json`,
+    redirectUri: `${origin}/auth/mdbase/callback`
+  };
+}
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    get length() { return values.size; },
+    clear() { values.clear(); },
+    getItem(key) { return values.get(key) ?? null; },
+    key(index) { return [...values.keys()][index] ?? null; },
+    removeItem(key) { values.delete(key); },
+    setItem(key, value) { values.set(key, String(value)); },
+    token() {
+      const value = [...values.entries()]
+        .find(([key]) => key.startsWith("mdbase-connect:token:"))?.[1];
+      assert.ok(value, "SDK did not persist a hosted token");
+      return JSON.parse(value);
+    }
+  };
+}

--- a/scripts/sync-e2e.mjs
+++ b/scripts/sync-e2e.mjs
@@ -22,6 +22,7 @@ const { app } = await buildApp({
   db: database,
   devAuth: true,
   hostedCollections: true,
+  hostedReferenceAuthority: true,
   allowInsecureManifests: true,
   publicUrl: "http://127.0.0.1"
 });

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -12,27 +12,27 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@fastify/cookie": "^11.0.0",
-    "@fastify/cors": "^11.0.0",
-    "@fastify/formbody": "^8.0.0",
+    "@fastify/cookie": "^11.1.2",
+    "@fastify/cors": "^11.3.0",
+    "@fastify/formbody": "^8.0.2",
     "@fastify/helmet": "^13.1.0",
     "@fastify/rate-limit": "^11.1.0",
-    "@fastify/static": "^9.1.1",
-    "@fastify/websocket": "^11.0.0",
+    "@fastify/static": "^10.1.0",
+    "@fastify/websocket": "^11.3.0",
     "@mdbase/connect-protocol": "workspace:*",
     "@mdbase/connect-sync": "workspace:*",
-    "fastify": "^5.0.0",
-    "pg": "^8.0.0",
-    "pg-mem": "^3.0.0",
-    "ws": "^8.0.0",
-    "zod": "^4.0.0"
+    "fastify": "^5.10.0",
+    "pg": "^8.22.0",
+    "pg-mem": "^3.0.14",
+    "ws": "^8.21.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "@types/pg": "^8.0.0",
-    "@types/ws": "^8.0.0",
-    "tsx": "^4.0.0",
-    "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "@types/node": "^24.0.0",
+    "@types/pg": "^8.20.0",
+    "@types/ws": "^8.18.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -26,7 +26,12 @@ import type { DatabasePool, DatabaseQueryable } from "./db.js";
 import { fetchManifest } from "./manifest.js";
 import { ConnectorOperationError, RelayHub, RelayUnavailableError } from "./relay.js";
 import { pkceChallenge, randomToken, safeEqual, tokenHash } from "./security.js";
-import { asSyncMutation, HostedAuthorityRegistry } from "./hosted.js";
+import { asSyncMutation, HostedAuthorityRegistry, tasknotesContracts } from "./hosted.js";
+import {
+  HostedProviderClient,
+  HostedProviderResponseError,
+  HostedProviderUnavailableError
+} from "./hosted-provider.js";
 import {
   exchangeGitHubCode,
   externalUserId,
@@ -73,6 +78,8 @@ interface BuildOptions {
   tailscaleAuth?: boolean;
   githubAuth?: GitHubAuthConfig;
   hostedCollections?: boolean;
+  hostedProvider?: HostedProviderClient;
+  hostedReferenceAuthority?: boolean;
   publicUrl?: string;
   portalDist?: string;
   allowInsecureManifests?: boolean;
@@ -103,7 +110,15 @@ export async function buildApp(options: BuildOptions) {
   });
   const publicUrl = options.publicUrl ?? "http://127.0.0.1:8787";
   const relay = new RelayHub(options.db);
-  const hosted = new HostedAuthorityRegistry(options.db);
+  if (options.hostedProvider && options.hostedReferenceAuthority) {
+    throw new Error("Hosted provider and reference authority modes are mutually exclusive.");
+  }
+  if (options.hostedCollections && !options.hostedProvider && !options.hostedReferenceAuthority) {
+    throw new Error("Hosted collections require a configured storage provider.");
+  }
+  const hostedReference = options.hostedReferenceAuthority
+    ? new HostedAuthorityRegistry(options.db)
+    : undefined;
 
   await app.register(cookie);
   await app.register(helmet, {
@@ -137,6 +152,19 @@ export async function buildApp(options: BuildOptions) {
       return reply.code(404).send(apiError("not_found", "Not found."));
     }
     if (
+      options.hostedProvider
+      && request.url.startsWith("/v1/hosted/collections/")
+      && request.url.includes("/sync/")
+    ) {
+      return reply.code(421).send({
+        ...apiError(
+          "sync_provider_direct_required",
+          "Connect directly to the collection's hosted storage provider."
+        ),
+        sync_url: options.hostedProvider.url
+      });
+    }
+    if (
       !["GET", "HEAD", "OPTIONS"].includes(request.method)
       && sessionToken(request)
       && request.headers.origin
@@ -157,6 +185,20 @@ export async function buildApp(options: BuildOptions) {
       const denied = error.code === "replica_revoked" || error.code === "scope_denied" || error.code === "read_only_replica";
       return reply.code(denied ? 403 : 400).send(apiError(error.code, error.message));
     }
+    if (error instanceof HostedProviderResponseError) {
+      if ([400, 404, 409, 429].includes(error.status)) {
+        return reply.code(error.status).send(apiError(error.code, error.message));
+      }
+      request.log.error({ provider_status: error.status, provider_code: error.code }, "Hosted provider rejected control request");
+      return reply.code(502).send(apiError(
+        "hosted_provider_error",
+        "The hosted storage provider could not complete the request."
+      ));
+    }
+    if (error instanceof HostedProviderUnavailableError) {
+      request.log.error({ error: error.cause }, "Hosted provider is unavailable");
+      return reply.code(503).send(apiError("hosted_provider_unavailable", error.message));
+    }
     if (error instanceof GitHubIdentityError) {
       request.log.warn({ error: error.message }, "GitHub authentication failed");
       return reply.code(502).send(apiError(
@@ -172,6 +214,9 @@ export async function buildApp(options: BuildOptions) {
   app.get("/ready", async (_request, reply) => {
     try {
       await options.db.query("SELECT 1");
+      if (options.hostedCollections && options.hostedProvider) {
+        await options.hostedProvider.ready();
+      }
       return { ok: true, service: "mdbase-connect" };
     } catch {
       return reply.code(503).send({ ok: false, service: "mdbase-connect" });
@@ -442,13 +487,46 @@ export async function buildApp(options: BuildOptions) {
        WHERE c.user_id = $1 ORDER BY col.display_name`,
       [user.id]
     );
+    const hostedCollections = options.hostedCollections
+      ? await options.db.query<{
+          id: string;
+          display_name: string;
+          template: string;
+          provider_url: string | null;
+          created_at: string;
+        }>(
+          `SELECT id, display_name, template, provider_url, created_at
+           FROM hosted_collections WHERE user_id = $1 ORDER BY display_name`,
+          [user.id]
+        )
+      : { rows: [] };
+    const hostedReplicas = hostedCollections.rows.length
+      ? await options.db.query<{
+          id: string;
+          collection_id: string;
+          name: string;
+          mode: "read_only" | "read_write";
+          allowed_types: string[];
+          revoked_at: string | null;
+          created_at: string;
+        }>(
+          `SELECT r.id, r.collection_id, r.name, r.mode, r.allowed_types,
+                  r.revoked_at, r.created_at
+           FROM hosted_replicas r JOIN hosted_collections c ON c.id = r.collection_id
+           WHERE c.user_id = $1 AND r.purpose = 'mirror' ORDER BY r.created_at`,
+          [user.id]
+        )
+      : { rows: [] };
     const grants = await options.db.query(
-      `SELECT g.id, g.operations, g.scope, g.created_at, g.revoked_at, g.collection_id,
+      `SELECT g.id, g.operations, g.scope, g.created_at, g.revoked_at,
+              COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
-              col.display_name AS collection_name
+              COALESCE(col.display_name, hosted.display_name) AS collection_name,
+              CASE WHEN g.hosted_collection_id IS NULL THEN 'local' ELSE 'hosted' END AS collection_kind
        FROM grants g
        JOIN applications a ON a.id = g.application_id
-       JOIN collections col ON col.id = g.collection_id
+       LEFT JOIN collections col ON col.id = g.collection_id
+       LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
        WHERE g.user_id = $1 ORDER BY g.created_at DESC`,
       [user.id]
     );
@@ -470,6 +548,13 @@ export async function buildApp(options: BuildOptions) {
       },
       connectors: connectors.rows,
       collections: collections.rows,
+      hosted_collections: hostedCollections.rows.map((collection) => ({
+        ...collection,
+        provider_url: collection.provider_url ?? publicUrl,
+        spec_version: "0.3.0",
+        contracts: tasknotesContracts(),
+        replicas: hostedReplicas.rows.filter((replica) => replica.collection_id === collection.id)
+      })),
       grants: grants.rows,
       pending_authorizations: pendingAuthorizations.rows
     };
@@ -766,15 +851,25 @@ export async function buildApp(options: BuildOptions) {
       template: z.literal("tasknotes").default("tasknotes")
     }).strict().parse(request.body);
     const collectionId = randomUUID();
-    await options.db.query(
-      `INSERT INTO hosted_collections (id, user_id, display_name, template)
-       VALUES ($1, $2, $3, $4)`,
-      [collectionId, user.id, input.display_name, input.template]
-    );
     try {
-      await hosted.create(collectionId);
+      if (options.hostedProvider) {
+        await options.hostedProvider.createCollection(collectionId, input.template);
+      } else {
+        await hostedReference!.create(collectionId);
+      }
+      await options.db.query(
+        `INSERT INTO hosted_collections (id, user_id, display_name, template, provider_url)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [collectionId, user.id, input.display_name, input.template, options.hostedProvider?.url ?? null]
+      );
     } catch (error) {
-      await options.db.query("DELETE FROM hosted_collections WHERE id = $1", [collectionId]);
+      if (options.hostedProvider) {
+        await options.hostedProvider.deleteCollection(collectionId).catch((cleanupError) => {
+          request.log.error({ cleanupError, collectionId }, "Failed to compensate hosted collection creation");
+        });
+      } else {
+        await hostedReference!.delete(collectionId).catch(() => undefined);
+      }
       throw error;
     }
     await audit(options.db, user.id, "hosted_collection.created", collectionId, { template: input.template });
@@ -783,7 +878,8 @@ export async function buildApp(options: BuildOptions) {
         id: collectionId,
         display_name: input.display_name,
         template: input.template,
-        spec_version: "0.3.0"
+        spec_version: "0.3.0",
+        sync_url: options.hostedProvider?.url ?? publicUrl
       }
     });
   });
@@ -802,20 +898,38 @@ export async function buildApp(options: BuildOptions) {
     }
     const replicaId = randomUUID();
     const token = randomToken("hsr");
-    await hosted.registerReplica(collectionId, {
-      id: replicaId,
-      name: input.name,
-      mode: input.mode,
-      allowedTypes: input.allowed_types
-    });
+    if (options.hostedProvider) {
+      await options.hostedProvider.registerReplica(collectionId, {
+        id: replicaId,
+        name: input.name,
+        mode: input.mode,
+        allowedTypes: input.allowed_types,
+        token
+      });
+    } else {
+      await hostedReference!.registerReplica(collectionId, {
+        id: replicaId,
+        name: input.name,
+        mode: input.mode,
+        allowedTypes: input.allowed_types
+      });
+    }
     try {
       await options.db.query(
         `INSERT INTO hosted_replicas (id, collection_id, name, mode, allowed_types, token_hash)
          VALUES ($1, $2, $3, $4, $5::jsonb, $6)`,
-        [replicaId, collectionId, input.name, input.mode, JSON.stringify(input.allowed_types), tokenHash(token)]
+        [
+          replicaId,
+          collectionId,
+          input.name,
+          input.mode,
+          JSON.stringify(input.allowed_types),
+          options.hostedProvider ? null : tokenHash(token)
+        ]
       );
     } catch (error) {
-      await hosted.revokeReplica(collectionId, replicaId);
+      if (options.hostedProvider) await options.hostedProvider.revokeReplica(replicaId);
+      else await hostedReference!.revokeReplica(collectionId, replicaId);
       throw error;
     }
     await audit(options.db, user.id, "hosted_replica.created", replicaId, {
@@ -824,9 +938,65 @@ export async function buildApp(options: BuildOptions) {
       allowed_types: input.allowed_types
     });
     return reply.code(201).send({
-      replica: { id: replicaId, collection_id: collectionId, name: input.name, mode: input.mode },
-      token
+      replica: {
+        id: replicaId,
+        collection_id: collectionId,
+        name: input.name,
+        mode: input.mode
+      },
+      token,
+      sync_url: options.hostedProvider?.url ?? publicUrl
     });
+  });
+
+  app.patch("/v1/hosted/collections/:collectionId", async (request, reply) => {
+    const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
+    if (!user) return;
+    const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
+    const input = z.object({ display_name: z.string().trim().min(1).max(200) }).strict().parse(request.body);
+    const renamed = await options.db.query<{ id: string; display_name: string }>(
+      `UPDATE hosted_collections SET display_name = $3
+       WHERE id = $1 AND user_id = $2 RETURNING id, display_name`,
+      [collectionId, user.id, input.display_name]
+    );
+    if (!renamed.rows[0]) {
+      return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
+    }
+    await audit(options.db, user.id, "hosted_collection.renamed", collectionId, {
+      display_name: input.display_name
+    });
+    return { collection: renamed.rows[0] };
+  });
+
+  app.delete("/v1/hosted/collections/:collectionId", async (request, reply) => {
+    const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
+    if (!user) return;
+    const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
+    if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
+      return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
+    }
+    if (options.hostedProvider) await options.hostedProvider.deleteCollection(collectionId);
+    else await hostedReference!.delete(collectionId);
+    const connection = await options.db.connect();
+    try {
+      await connection.query("BEGIN");
+      await connection.query(
+        "DELETE FROM grants WHERE hosted_collection_id = $1 AND user_id = $2",
+        [collectionId, user.id]
+      );
+      await connection.query(
+        "DELETE FROM hosted_collections WHERE id = $1 AND user_id = $2",
+        [collectionId, user.id]
+      );
+      await audit(connection, user.id, "hosted_collection.deleted", collectionId, {});
+      await connection.query("COMMIT");
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+    return { ok: true };
   });
 
   app.post("/v1/hosted/replicas/:replicaId/token", async (request, reply) => {
@@ -840,8 +1010,12 @@ export async function buildApp(options: BuildOptions) {
     );
     if (!active.rows[0]) return reply.code(404).send(apiError("replica_not_found", "Active replica not found."));
     const token = randomToken("hsr");
-    await options.db.query("UPDATE hosted_replicas SET token_hash = $2 WHERE id = $1", [replicaId, tokenHash(token)]);
-    return { token };
+    if (options.hostedProvider) {
+      await options.hostedProvider.rotateReplicaToken(replicaId, token);
+    } else {
+      await options.db.query("UPDATE hosted_replicas SET token_hash = $2 WHERE id = $1", [replicaId, tokenHash(token)]);
+    }
+    return { token, sync_url: options.hostedProvider?.url ?? publicUrl };
   });
 
   app.delete("/v1/hosted/replicas/:replicaId", async (request, reply) => {
@@ -849,14 +1023,18 @@ export async function buildApp(options: BuildOptions) {
     if (!user) return;
     const { replicaId } = z.object({ replicaId: z.uuid() }).parse(request.params);
     const active = await options.db.query<{ collection_id: string }>(
-      `UPDATE hosted_replicas SET revoked_at = now()
-       WHERE id = $1 AND revoked_at IS NULL AND collection_id IN
-         (SELECT id FROM hosted_collections WHERE user_id = $2)
-       RETURNING collection_id`,
+      `SELECT r.collection_id FROM hosted_replicas r
+       JOIN hosted_collections c ON c.id = r.collection_id
+       WHERE r.id = $1 AND r.revoked_at IS NULL AND c.user_id = $2`,
       [replicaId, user.id]
     );
     if (!active.rows[0]) return reply.code(404).send(apiError("replica_not_found", "Active replica not found."));
-    await hosted.revokeReplica(active.rows[0].collection_id, replicaId);
+    if (options.hostedProvider) await options.hostedProvider.revokeReplica(replicaId);
+    else await hostedReference!.revokeReplica(active.rows[0].collection_id, replicaId);
+    await options.db.query(
+      "UPDATE hosted_replicas SET revoked_at = now(), token_hash = NULL WHERE id = $1",
+      [replicaId]
+    );
     await audit(options.db, user.id, "hosted_replica.revoked", replicaId, {});
     return { ok: true };
   });
@@ -869,7 +1047,11 @@ export async function buildApp(options: BuildOptions) {
     if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
     }
-    await hosted.compactThrough(collectionId, input.through);
+    if (options.hostedProvider) {
+      await options.hostedProvider.compactThrough(collectionId, input.through);
+    } else {
+      await hostedReference!.compactThrough(collectionId, input.through);
+    }
     return { ok: true };
   });
 
@@ -878,7 +1060,7 @@ export async function buildApp(options: BuildOptions) {
     if (!replica) return;
     const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
     if (collectionId !== replica.collection_id) return reply.code(403).send(apiError("replica_scope_denied", "Replica belongs to another collection."));
-    return (await hosted.transport(collectionId, replica.id)).openSession();
+    return (await hostedReference!.transport(collectionId, replica.id)).openSession();
   });
 
   app.get("/v1/hosted/collections/:collectionId/sync/snapshot", async (request, reply) => {
@@ -887,7 +1069,7 @@ export async function buildApp(options: BuildOptions) {
     const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
     const query = z.object({ snapshot_id: z.uuid(), page: z.string().regex(/^[1-9][0-9]*$/).optional() }).parse(request.query);
     if (collectionId !== replica.collection_id) return reply.code(403).send(apiError("replica_scope_denied", "Replica belongs to another collection."));
-    return (await hosted.transport(collectionId, replica.id)).snapshot(query.snapshot_id, query.page);
+    return (await hostedReference!.transport(collectionId, replica.id)).snapshot(query.snapshot_id, query.page);
   });
 
   app.get("/v1/hosted/collections/:collectionId/sync/changes", async (request, reply) => {
@@ -899,7 +1081,7 @@ export async function buildApp(options: BuildOptions) {
       limit: z.coerce.number().int().positive().max(500).default(200)
     }).parse(request.query);
     if (collectionId !== replica.collection_id) return reply.code(403).send(apiError("replica_scope_denied", "Replica belongs to another collection."));
-    return (await hosted.transport(collectionId, replica.id)).changes(query.after, query.limit);
+    return (await hostedReference!.transport(collectionId, replica.id)).changes(query.after, query.limit);
   });
 
   app.post("/v1/hosted/collections/:collectionId/sync/mutations", async (request, reply) => {
@@ -910,7 +1092,7 @@ export async function buildApp(options: BuildOptions) {
     if (collectionId !== replica.collection_id || mutation.replica_id !== replica.id) {
       return reply.code(403).send(apiError("replica_scope_denied", "Mutation belongs to another replica."));
     }
-    return (await hosted.transport(collectionId, replica.id)).mutate(asSyncMutation(mutation));
+    return (await hostedReference!.transport(collectionId, replica.id)).mutate(asSyncMutation(mutation));
   });
 
   app.get("/v1/relay", { websocket: true }, async (socket, request) => {
@@ -926,7 +1108,7 @@ export async function buildApp(options: BuildOptions) {
     const input = z.object({ manifest_url: z.url() }).parse(request.body);
     const discovered = await fetchManifest(input.manifest_url, options.allowInsecureManifests);
     const application = await upsertApplication(options.db, discovered);
-    await reconcileApplicationGrants(options.db, relay, application);
+    await reconcileApplicationGrants(options.db, relay, options.hostedProvider, application);
     return { application };
   });
 
@@ -978,12 +1160,13 @@ export async function buildApp(options: BuildOptions) {
     }).strict().parse(request.body);
     const active = await options.db.query<{
       id: string;
-      connector_id: string;
+      connector_id: string | null;
+      hosted_replica_id: string | null;
       operations: string[];
       encryption: GrantEncryption | null;
     }>(
-      `SELECT g.id, g.operations, g.encryption, col.connector_id FROM grants g
-       JOIN collections col ON col.id = g.collection_id
+      `SELECT g.id, g.operations, g.encryption, col.connector_id, g.hosted_replica_id
+       FROM grants g LEFT JOIN collections col ON col.id = g.collection_id
        WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL`,
       [grantId, user.id]
     );
@@ -996,12 +1179,22 @@ export async function buildApp(options: BuildOptions) {
         "Existing access can be narrowed here, but broader access requires a new application request."
       ));
     }
+    if (current.hosted_replica_id) {
+      if (!options.hostedProvider) {
+        return reply.code(503).send(apiError("hosted_provider_unavailable", "Hosted application access is temporarily unavailable."));
+      }
+      const write = operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
+      await options.hostedProvider.updateApplicationReplica(current.hosted_replica_id, {
+        mode: write ? "read_write" : "read_only",
+        allowedOperations: operations
+      });
+    }
     const updated = await options.db.query<{ id: string; operations: string[] }>(
       "UPDATE grants SET operations = $2::jsonb WHERE id = $1 RETURNING id, operations",
       [grantId, JSON.stringify(operations)]
     );
     if (current.encryption) await rotateGrantEncryption(options.db, grantId);
-    await relay.pushPolicy(current.connector_id);
+    if (current.connector_id) await relay.pushPolicy(current.connector_id);
     await audit(options.db, user.id, "grant.narrowed", grantId, {
       previous_operations: current.operations,
       operations
@@ -1013,17 +1206,31 @@ export async function buildApp(options: BuildOptions) {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
     const { grantId } = z.object({ grantId: z.uuid() }).parse(request.params);
-    const active = await options.db.query<{ id: string; connector_id: string }>(
-      `SELECT g.id, col.connector_id FROM grants g
-       JOIN collections col ON col.id = g.collection_id
+    const active = await options.db.query<{
+      id: string;
+      connector_id: string | null;
+      hosted_replica_id: string | null;
+    }>(
+      `SELECT g.id, col.connector_id, g.hosted_replica_id FROM grants g
+       LEFT JOIN collections col ON col.id = g.collection_id
        WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL`,
       [grantId, user.id]
     );
     if (!active.rows[0]) return reply.code(404).send(apiError("grant_not_found", "Active grant not found."));
+    if (active.rows[0].hosted_replica_id) {
+      if (!options.hostedProvider) {
+        return reply.code(503).send(apiError("hosted_provider_unavailable", "Hosted application access is temporarily unavailable."));
+      }
+      await options.hostedProvider.revokeReplica(active.rows[0].hosted_replica_id);
+      await options.db.query(
+        "UPDATE hosted_replicas SET revoked_at = now() WHERE id = $1",
+        [active.rows[0].hosted_replica_id]
+      );
+    }
     await options.db.query("UPDATE grants SET revoked_at = now() WHERE id = $1", [grantId]);
     await options.db.query("UPDATE access_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
     await options.db.query("UPDATE refresh_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
-    await relay.pushPolicy(active.rows[0].connector_id);
+    if (active.rows[0].connector_id) await relay.pushPolicy(active.rows[0].connector_id);
     await audit(options.db, user.id, "grant.revoked", grantId, {});
     return { ok: true };
   });
@@ -1105,7 +1312,31 @@ export async function buildApp(options: BuildOptions) {
        WHERE c.user_id = $1 AND col.enabled = true ORDER BY col.display_name`,
       [user.id]
     );
-    return { authorization: authorization.rows[0], collections: collections.rows };
+    const hosted = options.hostedCollections
+      ? await options.db.query<{
+          id: string;
+          display_name: string;
+          spec_version?: string;
+          contracts?: ContractRequirement[];
+        }>(
+          `SELECT id, display_name FROM hosted_collections
+           WHERE user_id = $1 ORDER BY display_name`,
+          [user.id]
+        )
+      : { rows: [] };
+    return {
+      authorization: authorization.rows[0],
+      collections: [
+        ...collections.rows.map((collection) => ({ ...collection, kind: "local" })),
+        ...hosted.rows.map((collection) => ({
+          ...collection,
+          kind: "hosted",
+          connector_name: "Hosted by mdbase",
+          spec_version: "0.3.0",
+          contracts: tasknotesContracts()
+        }))
+      ]
+    };
   });
 
   app.get("/v1/authorization-requests/:requestId/status", async (request, reply) => {
@@ -1155,15 +1386,32 @@ export async function buildApp(options: BuildOptions) {
        WHERE col.id = $1 AND c.user_id = $2 AND col.enabled = true`,
       [input.collection_id, user.id]
     );
-    if (!collection.rows[0]) return reply.code(404).send(apiError("collection_not_found", "Collection not found."));
-    const approved = await approveAuthorization(options.db, relay, {
-      requestId,
-      userId: user.id,
-      connectorId: collection.rows[0].connector_id,
-      collectionId: input.collection_id,
-      operations: input.operations,
-      source: "portal"
-    });
+    let approved: boolean;
+    if (collection.rows[0]) {
+      approved = await approveAuthorization(options.db, relay, {
+        requestId,
+        userId: user.id,
+        connectorId: collection.rows[0].connector_id,
+        collectionId: input.collection_id,
+        operations: input.operations,
+        source: "portal"
+      });
+    } else {
+      const hosted = await options.db.query<{ id: string; template: string }>(
+        "SELECT id, template FROM hosted_collections WHERE id = $1 AND user_id = $2",
+        [input.collection_id, user.id]
+      );
+      if (!hosted.rows[0] || !options.hostedProvider) {
+        return reply.code(404).send(apiError("collection_not_found", "Collection not found."));
+      }
+      approved = await approveHostedAuthorization(options.db, options.hostedProvider, {
+        requestId,
+        userId: user.id,
+        collectionId: input.collection_id,
+        operations: input.operations,
+        template: hosted.rows[0].template
+      });
+    }
     if (!approved) return reply.code(404).send(apiError("authorization_not_found", "Authorization request expired or was not found."));
     return { ok: true };
   });
@@ -1223,7 +1471,7 @@ export async function buildApp(options: BuildOptions) {
       if (!consumed.rows[0]) {
         return reply.code(400).send(apiError("invalid_grant", "Authorization code has already been used."));
       }
-      return issueApplicationTokens(options.db, authorizationCode.grant_id);
+      return issueApplicationTokens(options.db, options.hostedProvider, authorizationCode.grant_id);
     }
 
     const refresh = await options.db.query<{ id: string; grant_id: string }>(
@@ -1246,7 +1494,7 @@ export async function buildApp(options: BuildOptions) {
     if (!rotated.rows[0]) {
       return reply.code(400).send(apiError("invalid_grant", "Refresh token has already been used."));
     }
-    return issueApplicationTokens(options.db, current.grant_id);
+    return issueApplicationTokens(options.db, options.hostedProvider, current.grant_id);
   });
 
   app.post("/v1/collections/:collectionId/operations/:operation", async (request, reply) => {
@@ -1435,30 +1683,47 @@ async function createOrUpdateGrant(
 async function reconcileApplicationGrants(
   db: DatabasePool,
   relay: RelayHub,
+  hostedProvider: HostedProviderClient | undefined,
   application: { id: string; requirements: ApplicationRequirements }
 ): Promise<void> {
   const desiredScope = scopeForRequirements(application.requirements);
   const grants = await db.query<{
     id: string;
     user_id: string;
-    connector_id: string;
-    contracts: ContractRequirement[];
+    connector_id: string | null;
+    hosted_replica_id: string | null;
+    operations: string[];
+    contracts: ContractRequirement[] | null;
+    template: string | null;
     scope: GrantScope;
   }>(
-    `SELECT g.id, g.user_id, col.connector_id, col.contracts, g.scope
+    `SELECT g.id, g.user_id, col.connector_id, g.hosted_replica_id,
+            g.operations, col.contracts, hosted.template, g.scope
      FROM grants g
-     JOIN collections col ON col.id = g.collection_id
+     LEFT JOIN collections col ON col.id = g.collection_id
+     LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
      WHERE g.application_id = $1 AND g.revoked_at IS NULL`,
     [application.id]
   );
   const changedConnectors = new Set<string>();
   for (const grant of grants.rows) {
-    const collectionCompatible = contractsSatisfy(grant.contracts, desiredScope.contracts);
+    const availableContracts = grant.template === "tasknotes"
+      ? tasknotesContracts()
+      : grant.contracts ?? [];
+    const collectionCompatible = contractsSatisfy(availableContracts, desiredScope.contracts);
     if (scopesEqual(grant.scope, desiredScope) && collectionCompatible) continue;
     const mayNarrow = desiredScope.contracts.length > 0
       && (grant.scope.contracts.length === 0
         || isContractSubset(desiredScope.contracts, grant.scope.contracts));
     if (mayNarrow && collectionCompatible) {
+      if (grant.hosted_replica_id) {
+        if (!hostedProvider) throw new Error("Hosted provider unavailable during grant reconciliation.");
+        const write = grant.operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
+        await hostedProvider.updateApplicationReplica(grant.hosted_replica_id, {
+          mode: write ? "read_write" : "read_only",
+          allowedOperations: grant.operations
+        });
+      }
       await db.query("UPDATE grants SET scope = $2::jsonb WHERE id = $1", [
         grant.id,
         JSON.stringify(desiredScope)
@@ -1469,6 +1734,13 @@ async function reconcileApplicationGrants(
         scope: desiredScope
       });
     } else {
+      if (grant.hosted_replica_id) {
+        if (!hostedProvider) throw new Error("Hosted provider unavailable during grant reconciliation.");
+        await hostedProvider.revokeReplica(grant.hosted_replica_id);
+        await db.query("UPDATE hosted_replicas SET revoked_at = now() WHERE id = $1", [
+          grant.hosted_replica_id
+        ]);
+      }
       await db.query("UPDATE grants SET revoked_at = now() WHERE id = $1", [grant.id]);
       await db.query("UPDATE access_tokens SET revoked_at = now() WHERE grant_id = $1", [grant.id]);
       await db.query("UPDATE refresh_tokens SET revoked_at = now() WHERE grant_id = $1", [grant.id]);
@@ -1478,7 +1750,7 @@ async function reconcileApplicationGrants(
         required_scope: desiredScope
       });
     }
-    changedConnectors.add(grant.connector_id);
+    if (grant.connector_id) changedConnectors.add(grant.connector_id);
   }
   for (const connectorId of changedConnectors) await relay.pushPolicy(connectorId);
 }
@@ -1590,6 +1862,124 @@ async function approveAuthorization(
   return true;
 }
 
+async function approveHostedAuthorization(
+  db: DatabasePool,
+  provider: HostedProviderClient,
+  input: {
+    requestId: string;
+    userId: string;
+    collectionId: string;
+    operations: string[];
+    template: string;
+  }
+): Promise<boolean> {
+  const connection = await db.connect();
+  let replicaId: string | null = null;
+  try {
+    await connection.query("BEGIN");
+    const authorization = await connection.query<{
+      application_id: string;
+      application_name: string;
+      application_homepage: string;
+      requested_operations: string[];
+      requirements: ApplicationRequirements;
+    }>(
+      `SELECT ar.application_id, a.name AS application_name, a.homepage AS application_homepage,
+              ar.requested_operations,
+              a.requirements
+       FROM authorization_requests ar
+       JOIN applications a ON a.id = ar.application_id
+       WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
+         AND ar.expires_at > now()
+       FOR UPDATE`,
+      [input.requestId, input.userId]
+    );
+    const pending = authorization.rows[0];
+    if (!pending) {
+      await connection.query("ROLLBACK");
+      return false;
+    }
+    if (input.operations.some((operation) => !pending.requested_operations.includes(operation))) {
+      throw new RequestValidationError("Approved operations must be requested by the application.");
+    }
+    if (input.template !== "tasknotes") {
+      throw new RequestValidationError("The hosted collection template is unavailable.");
+    }
+    const scope = scopeForRequirements(pending.requirements);
+    if (!contractsSatisfy(tasknotesContracts(), scope.contracts)) {
+      throw new RequestValidationError(
+        "This hosted collection does not provide the contracts required by the application."
+      );
+    }
+    const operations = [...new Set(input.operations)];
+    const write = operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
+    const applicationUrl = new URL(pending.application_homepage);
+    const allowedOrigin = ["http:", "https:"].includes(applicationUrl.protocol)
+      ? applicationUrl.origin
+      : undefined;
+    replicaId = randomUUID();
+    const bootstrapToken = randomToken("hsa");
+    await provider.registerReplica(input.collectionId, {
+      id: replicaId,
+      name: `${pending.application_name} application access`,
+      purpose: "application",
+      mode: write ? "read_write" : "read_only",
+      allowedTypes: ["task"],
+      allowedOperations: operations,
+      allowedOrigin,
+      token: bootstrapToken,
+      tokenTtlSeconds: 3_600
+    });
+    const grantId = randomUUID();
+    await connection.query(
+      `INSERT INTO hosted_replicas
+         (id, collection_id, name, purpose, mode, allowed_types, token_hash)
+       VALUES ($1, $2, $3, 'application', $4, $5::jsonb, NULL)`,
+      [
+        replicaId,
+        input.collectionId,
+        `${pending.application_name} application access`,
+        write ? "read_write" : "read_only",
+        JSON.stringify(["task"])
+      ]
+    );
+    await connection.query(
+      `INSERT INTO grants
+         (id, user_id, application_id, hosted_collection_id, hosted_replica_id,
+          operations, scope, encryption)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL)`,
+      [
+        grantId,
+        input.userId,
+        pending.application_id,
+        input.collectionId,
+        replicaId,
+        JSON.stringify(operations),
+        JSON.stringify(scope)
+      ]
+    );
+    await connection.query(
+      `UPDATE authorization_requests SET completed_at = now(), grant_id = $2
+       WHERE id = $1 AND completed_at IS NULL`,
+      [input.requestId, grantId]
+    );
+    await audit(connection, input.userId, "authorization.approved", input.requestId, {
+      hosted_collection_id: input.collectionId,
+      operations,
+      scope,
+      source: "portal"
+    });
+    await connection.query("COMMIT");
+    return true;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    if (replicaId) await provider.revokeReplica(replicaId).catch(() => undefined);
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
 async function denyAuthorization(
   db: DatabasePool,
   input: {
@@ -1645,7 +2035,11 @@ async function createAuthorizationRedirect(
   return redirect.href;
 }
 
-async function issueApplicationTokens(db: DatabasePool, grantId: string): Promise<{
+async function issueApplicationTokens(
+  db: DatabasePool,
+  hostedProvider: HostedProviderClient | undefined,
+  grantId: string
+): Promise<{
   access_token: string;
   refresh_token: string;
   token_type: "Bearer";
@@ -1656,19 +2050,45 @@ async function issueApplicationTokens(db: DatabasePool, grantId: string): Promis
   scope: GrantScope;
   grant_id: string;
   encryption: GrantEncryption | null;
+  hosted?: {
+    provider_url: string;
+    replica_id: string;
+    access_token: string;
+  };
 }> {
   const grant = await db.query<{
     collection_id: string;
+    hosted_collection_id: string | null;
+    hosted_replica_id: string | null;
+    provider_url: string | null;
     operations: string[];
     scope: GrantScope;
     encryption: GrantEncryption | null;
   }>(
-    "SELECT collection_id, operations, scope, encryption FROM grants WHERE id = $1 AND revoked_at IS NULL",
+    `SELECT COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
+            g.hosted_collection_id, g.hosted_replica_id, hosted.provider_url,
+            g.operations, g.scope, g.encryption
+     FROM grants g
+     LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
+     WHERE g.id = $1 AND g.revoked_at IS NULL`,
     [grantId]
   );
   if (!grant.rows[0]) throw new RequestValidationError("The application grant is no longer active.");
   const accessToken = randomToken("mdb");
   const refreshToken = randomToken("ref");
+  let hosted: { provider_url: string; replica_id: string; access_token: string } | undefined;
+  if (grant.rows[0].hosted_collection_id) {
+    if (!hostedProvider || !grant.rows[0].hosted_replica_id || !grant.rows[0].provider_url) {
+      throw new RequestValidationError("The hosted application capability is unavailable.");
+    }
+    const providerToken = randomToken("hsa");
+    await hostedProvider.rotateReplicaToken(grant.rows[0].hosted_replica_id, providerToken, 3_600);
+    hosted = {
+      provider_url: grant.rows[0].provider_url,
+      replica_id: grant.rows[0].hosted_replica_id,
+      access_token: providerToken
+    };
+  }
   await db.query(
     `INSERT INTO access_tokens (id, token_hash, grant_id, expires_at)
      VALUES ($1, $2, $3, now() + interval '1 hour')`,
@@ -1689,7 +2109,8 @@ async function issueApplicationTokens(db: DatabasePool, grantId: string): Promis
     operations: grant.rows[0].operations,
     scope: grant.rows[0].scope,
     grant_id: grantId,
-    encryption: grant.rows[0].encryption
+    encryption: grant.rows[0].encryption,
+    ...(hosted ? { hosted } : {})
   };
 }
 

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -90,6 +90,25 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       last_seen_at timestamptz NOT NULL DEFAULT now(),
       UNIQUE(connector_id, local_id)
     );
+    CREATE TABLE IF NOT EXISTS hosted_collections (
+      id uuid PRIMARY KEY,
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      display_name text NOT NULL,
+      template text NOT NULL,
+      provider_url text,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS hosted_replicas (
+      id uuid PRIMARY KEY,
+      collection_id uuid NOT NULL REFERENCES hosted_collections(id) ON DELETE CASCADE,
+      name text NOT NULL,
+      purpose text NOT NULL DEFAULT 'mirror' CHECK (purpose IN ('mirror', 'application')),
+      mode text NOT NULL CHECK (mode IN ('read_only', 'read_write')),
+      allowed_types jsonb NOT NULL DEFAULT '[]'::jsonb,
+      token_hash text UNIQUE,
+      revoked_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
     CREATE TABLE IF NOT EXISTS applications (
       id uuid PRIMARY KEY,
       canonical_identity text NOT NULL UNIQUE,
@@ -106,12 +125,15 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       id uuid PRIMARY KEY,
       user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       application_id uuid NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
-      collection_id uuid NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+      collection_id uuid REFERENCES collections(id) ON DELETE CASCADE,
+      hosted_collection_id uuid REFERENCES hosted_collections(id) ON DELETE CASCADE,
+      hosted_replica_id uuid REFERENCES hosted_replicas(id) ON DELETE SET NULL,
       operations jsonb NOT NULL,
       scope jsonb NOT NULL DEFAULT '{"contracts":[]}'::jsonb,
       encryption jsonb,
       created_at timestamptz NOT NULL DEFAULT now(),
-      revoked_at timestamptz
+      revoked_at timestamptz,
+      CHECK ((collection_id IS NULL) <> (hosted_collection_id IS NULL))
     );
     CREATE TABLE IF NOT EXISTS authorization_requests (
       id uuid PRIMARY KEY,
@@ -173,29 +195,6 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
       created_at timestamptz NOT NULL DEFAULT now()
     );
-    CREATE TABLE IF NOT EXISTS hosted_collections (
-      id uuid PRIMARY KEY,
-      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-      display_name text NOT NULL,
-      template text NOT NULL,
-      created_at timestamptz NOT NULL DEFAULT now()
-    );
-    CREATE TABLE IF NOT EXISTS hosted_authority_states (
-      collection_id uuid PRIMARY KEY REFERENCES hosted_collections(id) ON DELETE CASCADE,
-      state jsonb NOT NULL,
-      version bigint NOT NULL DEFAULT 1,
-      updated_at timestamptz NOT NULL DEFAULT now()
-    );
-    CREATE TABLE IF NOT EXISTS hosted_replicas (
-      id uuid PRIMARY KEY,
-      collection_id uuid NOT NULL REFERENCES hosted_collections(id) ON DELETE CASCADE,
-      name text NOT NULL,
-      mode text NOT NULL CHECK (mode IN ('read_only', 'read_write')),
-      allowed_types jsonb NOT NULL DEFAULT '[]'::jsonb,
-      token_hash text NOT NULL UNIQUE,
-      revoked_at timestamptz,
-      created_at timestamptz NOT NULL DEFAULT now()
-    );
   `);
   const authorizationColumns = await db.query<{ column_name: string }>(
     `SELECT column_name FROM information_schema.columns
@@ -229,6 +228,55 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   await ensureColumn(db, "grants", "encryption", "ALTER TABLE grants ADD COLUMN encryption jsonb");
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
+  await ensureColumn(db, "hosted_collections", "provider_url", "ALTER TABLE hosted_collections ADD COLUMN provider_url text");
+  await ensureColumn(
+    db,
+    "grants",
+    "hosted_collection_id",
+    "ALTER TABLE grants ADD COLUMN hosted_collection_id uuid"
+  );
+  await ensureColumn(db, "grants", "hosted_replica_id", "ALTER TABLE grants ADD COLUMN hosted_replica_id uuid");
+  await ensureColumn(
+    db,
+    "hosted_replicas",
+    "purpose",
+    "ALTER TABLE hosted_replicas ADD COLUMN purpose text NOT NULL DEFAULT 'mirror'"
+  );
+  const grantCollection = await db.query<{ is_nullable: string }>(
+    `SELECT is_nullable FROM information_schema.columns
+     WHERE table_name = 'grants' AND column_name = 'collection_id'`
+  );
+  if (grantCollection.rows[0]?.is_nullable === "NO") {
+    await db.query("ALTER TABLE grants ALTER COLUMN collection_id DROP NOT NULL");
+  }
+  const hostedReplicaToken = await db.query<{ is_nullable: string }>(
+    `SELECT is_nullable FROM information_schema.columns
+     WHERE table_name = 'hosted_replicas' AND column_name = 'token_hash'`
+  );
+  if (hostedReplicaToken.rows[0]?.is_nullable === "NO") {
+    await db.query("ALTER TABLE hosted_replicas ALTER COLUMN token_hash DROP NOT NULL");
+  }
+  await ensureConstraint(
+    db,
+    "grants",
+    "grants_hosted_collection_id_fkey",
+    `ALTER TABLE grants ADD CONSTRAINT grants_hosted_collection_id_fkey
+     FOREIGN KEY (hosted_collection_id) REFERENCES hosted_collections(id) ON DELETE CASCADE`
+  );
+  await ensureConstraint(
+    db,
+    "grants",
+    "grants_hosted_replica_id_fkey",
+    `ALTER TABLE grants ADD CONSTRAINT grants_hosted_replica_id_fkey
+     FOREIGN KEY (hosted_replica_id) REFERENCES hosted_replicas(id) ON DELETE SET NULL`
+  );
+  await ensureConstraint(
+    db,
+    "grants",
+    "grants_collection_target_check",
+    `ALTER TABLE grants ADD CONSTRAINT grants_collection_target_check
+     CHECK ((collection_id IS NULL) <> (hosted_collection_id IS NULL))`
+  );
 }
 
 async function ensureColumn(
@@ -240,6 +288,20 @@ async function ensureColumn(
   const result = await db.query<{ column_name: string }>(
     `SELECT column_name FROM information_schema.columns WHERE table_name = $1 AND column_name = $2`,
     [table, column]
+  );
+  if (!result.rows[0]) await db.query(statement);
+}
+
+async function ensureConstraint(
+  db: DatabaseQueryable,
+  table: string,
+  constraint: string,
+  statement: string
+): Promise<void> {
+  const result = await db.query<{ constraint_name: string }>(
+    `SELECT constraint_name FROM information_schema.table_constraints
+     WHERE table_name = $1 AND constraint_name = $2`,
+    [table, constraint]
   );
   if (!result.rows[0]) await db.query(statement);
 }

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HostedProviderClient,
+  HostedProviderResponseError,
+  HostedProviderUnavailableError
+} from "./hosted-provider.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("hosted provider control client", () => {
+  it("uses only the internal bearer credential and expected provider document", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(undefined, { status: 201 })
+    );
+    const provider = new HostedProviderClient({
+      url: "https://provider.example/path-is-discarded",
+      internalToken: "internal-secret"
+    });
+    await provider.registerReplica("collection", {
+      id: "replica",
+      name: "Laptop",
+      mode: "read_only",
+      allowedTypes: ["task"],
+      token: "replica-secret"
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://provider.example/internal/v1/collections/collection/replicas",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          authorization: "Bearer internal-secret",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          replica_id: "replica",
+          name: "Laptop",
+          purpose: "mirror",
+          mode: "read_only",
+          allowed_types: ["task"],
+          allowed_operations: [],
+          token: "replica-secret"
+        })
+      })
+    );
+  });
+
+  it("preserves safe provider errors and normalizes network failures", async () => {
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(JSON.stringify({
+      error: { code: "replica_conflict", message: "Replica already exists." }
+    }), { status: 409 }));
+    await expect(provider.revokeReplica("replica")).rejects.toEqual(
+      new HostedProviderResponseError(409, "replica_conflict", "Replica already exists.")
+    );
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("secret network detail"));
+    await expect(provider.ready()).rejects.toBeInstanceOf(HostedProviderUnavailableError);
+  });
+
+  it("updates and rotates application capabilities with bounded credentials", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(undefined, { status: 204 })
+    );
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    await provider.updateApplicationReplica("replica", {
+      mode: "read_only",
+      allowedOperations: ["read", "query"]
+    });
+    await provider.rotateReplicaToken("replica", "new-token", 3600);
+    expect(fetchMock.mock.calls.map(([url, init]) => [url, init?.method, init?.body])).toEqual([
+      [
+        "https://provider.example/internal/v1/replicas/replica/policy",
+        "PATCH",
+        JSON.stringify({ mode: "read_only", allowed_operations: ["read", "query"] })
+      ],
+      [
+        "https://provider.example/internal/v1/replicas/replica/token",
+        "POST",
+        JSON.stringify({ token: "new-token", token_ttl_seconds: 3600 })
+      ]
+    ]);
+  });
+
+  it("retries bounded transient failures with the identical provisioning document", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("response lost"))
+      .mockResolvedValueOnce(new Response(undefined, { status: 201 }));
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    await provider.createCollection("collection", "tasknotes");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(fetchMock.mock.calls[1]?.[1]?.body);
+  });
+});

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -1,0 +1,177 @@
+export interface HostedProviderConfig {
+  url: string;
+  internalToken: string;
+}
+
+export interface HostedReplicaEnrollment {
+  id: string;
+  name: string;
+  purpose?: "mirror" | "application";
+  mode: "read_only" | "read_write";
+  allowedTypes: string[];
+  allowedOperations?: string[];
+  allowedOrigin?: string;
+  token: string;
+  tokenTtlSeconds?: number;
+}
+
+export class HostedProviderClient {
+  readonly url: string;
+  private readonly internalToken: string;
+
+  constructor(config: HostedProviderConfig) {
+    this.url = new URL(config.url).origin;
+    this.internalToken = config.internalToken;
+  }
+
+  async ready(): Promise<void> {
+    await this.request("GET", "/ready", undefined, false);
+  }
+
+  async createCollection(collectionId: string, template: string): Promise<void> {
+    await this.request("POST", "/internal/v1/collections", {
+      collection_id: collectionId,
+      template
+    });
+  }
+
+  async deleteCollection(collectionId: string): Promise<void> {
+    await this.request("DELETE", `/internal/v1/collections/${encodeURIComponent(collectionId)}`);
+  }
+
+  async registerReplica(collectionId: string, replica: HostedReplicaEnrollment): Promise<void> {
+    await this.request(
+      "POST",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/replicas`,
+      {
+        replica_id: replica.id,
+        name: replica.name,
+        purpose: replica.purpose ?? "mirror",
+        mode: replica.mode,
+        allowed_types: replica.allowedTypes,
+        allowed_operations: replica.allowedOperations ?? [],
+        ...(replica.allowedOrigin ? { allowed_origin: replica.allowedOrigin } : {}),
+        token: replica.token,
+        ...(replica.tokenTtlSeconds ? { token_ttl_seconds: replica.tokenTtlSeconds } : {})
+      }
+    );
+  }
+
+  async rotateReplicaToken(replicaId: string, token: string, tokenTtlSeconds?: number): Promise<void> {
+    await this.request(
+      "POST",
+      `/internal/v1/replicas/${encodeURIComponent(replicaId)}/token`,
+      { token, ...(tokenTtlSeconds ? { token_ttl_seconds: tokenTtlSeconds } : {}) }
+    );
+  }
+
+  async updateApplicationReplica(
+    replicaId: string,
+    policy: { mode: "read_only" | "read_write"; allowedOperations: string[] }
+  ): Promise<void> {
+    await this.request(
+      "PATCH",
+      `/internal/v1/replicas/${encodeURIComponent(replicaId)}/policy`,
+      { mode: policy.mode, allowed_operations: policy.allowedOperations }
+    );
+  }
+
+  async revokeReplica(replicaId: string): Promise<void> {
+    await this.request("DELETE", `/internal/v1/replicas/${encodeURIComponent(replicaId)}`);
+  }
+
+  async compactThrough(collectionId: string, through: number): Promise<void> {
+    await this.request(
+      "POST",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/compact`,
+      { through }
+    );
+  }
+
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+    authenticated = true
+  ): Promise<unknown> {
+    let unavailable: unknown;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      let response: Response;
+      try {
+        response = await fetch(`${this.url}${path}`, {
+          method,
+          headers: {
+            ...(authenticated ? { authorization: `Bearer ${this.internalToken}` } : {}),
+            ...(body === undefined ? {} : { "content-type": "application/json" })
+          },
+          ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+          signal: AbortSignal.timeout(15_000)
+        });
+      } catch (error) {
+        unavailable = error;
+        if (attempt < 2) {
+          await delay(100 * 2 ** attempt);
+          continue;
+        }
+        break;
+      }
+      if (response.ok) return readResponse(response);
+      const value = await readResponse(response);
+      if ([429, 502, 503, 504].includes(response.status) && attempt < 2) {
+        await delay(100 * 2 ** attempt);
+        continue;
+      }
+      const providerError = asProviderError(value);
+      throw new HostedProviderResponseError(
+        response.status,
+        providerError.code,
+        providerError.message
+      );
+    }
+    throw new HostedProviderUnavailableError(unavailable);
+  }
+}
+
+export class HostedProviderResponseError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export class HostedProviderUnavailableError extends Error {
+  constructor(public readonly cause: unknown) {
+    super("The hosted storage provider is temporarily unavailable.");
+  }
+}
+
+async function readResponse(response: Response): Promise<unknown> {
+  if (response.status === 204) return undefined;
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function asProviderError(value: unknown): { code: string; message: string } {
+  const body = value && typeof value === "object" ? value as Record<string, unknown> : {};
+  const error = body.error && typeof body.error === "object"
+    ? body.error as Record<string, unknown>
+    : {};
+  return {
+    code: typeof error.code === "string" ? error.code : "hosted_provider_error",
+    message: typeof error.message === "string"
+      ? error.message
+      : "The hosted storage provider rejected the request."
+  };
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/services/server/src/hosted.ts
+++ b/services/server/src/hosted.ts
@@ -23,10 +23,21 @@ interface CachedAuthority {
 export class HostedAuthorityRegistry {
   private readonly cache = new Map<string, CachedAuthority>();
   private readonly gates = new Map<string, Promise<void>>();
+  private readonly schemaReady: Promise<unknown>;
 
-  constructor(private readonly db: DatabasePool) {}
+  constructor(private readonly db: DatabasePool) {
+    this.schemaReady = db.query(`
+      CREATE TABLE IF NOT EXISTS hosted_authority_states (
+        collection_id uuid,
+        state jsonb,
+        version bigint,
+        updated_at timestamptz
+      )
+    `);
+  }
 
   async create(collectionId: string): Promise<void> {
+    await this.schemaReady;
     const authority = new MemoryHostedAuthority({
       id: collectionId,
       validate: validateTasknotes,
@@ -38,6 +49,18 @@ export class HostedAuthorityRegistry {
       [collectionId, JSON.stringify(authority.serialize())]
     );
     this.cache.set(collectionId, { authority, version: 1 });
+  }
+
+  async delete(collectionId: string): Promise<void> {
+    await this.schemaReady;
+    const removed = await this.db.query(
+      "DELETE FROM hosted_authority_states WHERE collection_id = $1 RETURNING collection_id",
+      [collectionId]
+    );
+    if (!removed.rows[0]) {
+      throw new SyncError("hosted_collection_not_found", "Hosted collection not found.");
+    }
+    this.cache.delete(collectionId);
   }
 
   async registerReplica(collectionId: string, options: ReplicaOptions): Promise<string> {
@@ -124,6 +147,7 @@ export class HostedAuthorityRegistry {
   }
 
   private async load(collectionId: string, refresh = false): Promise<CachedAuthority> {
+    await this.schemaReady;
     const present = this.cache.get(collectionId);
     if (present && !refresh) return present;
     const result = await this.db.query<{ state: SerializedHostedAuthority; version: string | number }>(
@@ -193,6 +217,45 @@ export function tasknotesResources(): SyncCollectionResources {
       type_name: "task",
       extension: "x-tasknotes",
       configuration: contract
+    }],
+    documents: [{
+      path: "mdbase.yaml",
+      kind: "configuration",
+      revision: "tasknotes-config:1",
+      document: "spec_version: 0.3.0\nsettings:\n  types_folder: _types\n  default_validation: error\n"
+    }, {
+      path: "_types/task.md",
+      kind: "type",
+      revision: "tasknotes-type:1",
+      document: `---
+kind: mdbase.type
+name: task
+version: 1
+description: A TaskNotes-compatible task.
+collection:
+  path:
+    folder: tasks
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [type, title]
+    additionalProperties: true
+    properties:
+      type: { const: task }
+      title: { type: string, minLength: 1 }
+      status: { enum: [open, done] }
+x-tasknotes:
+  contract: tasknotes.task
+  version: 1
+  field_roles: { title: title, status: status }
+  status: { completed_values: [done], default: open }
+---
+`
     }]
   };
+}
+
+export function tasknotesContracts(): Array<{ id: string; version: number }> {
+  return tasknotesResources().contracts.map(({ id, version }) => ({ id, version }));
 }

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
 import { runtimeConfigFromEnv } from "./runtime-config.js";
+import { HostedProviderClient } from "./hosted-provider.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const runtime = runtimeConfigFromEnv(process.env);
@@ -15,6 +16,9 @@ const { app } = await buildApp({
   tailscaleAuth: runtime.tailscaleAuth,
   githubAuth: runtime.githubAuth ?? undefined,
   hostedCollections: runtime.hostedCollections,
+  hostedProvider: runtime.hostedProvider
+    ? new HostedProviderClient(runtime.hostedProvider)
+    : undefined,
   trustProxy: runtime.trustProxy,
   allowInsecureManifests: process.env.MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS === "1"
 });

--- a/services/server/src/production-auth.test.ts
+++ b/services/server/src/production-auth.test.ts
@@ -178,6 +178,81 @@ describe("production GitHub authentication", () => {
     });
     expect(response.statusCode).toBe(404);
   });
+
+  it("manages the complete hosted collection and receive-only mirror lifecycle", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedReferenceAuthority: true,
+      publicUrl: "http://127.0.0.1:8787"
+    });
+    resources.push(() => app.close());
+    const login = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Hosted user", email: "hosted@example.com" }
+    });
+    const cookie = cookiePair(responseCookies(login)[0]);
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/hosted/collections",
+      headers: { cookie },
+      payload: { display_name: "Tasks", template: "tasknotes" }
+    });
+    expect(created.statusCode).toBe(201);
+    const collectionId = created.json().collection.id as string;
+    const enrolled = await app.inject({
+      method: "POST",
+      url: `/v1/hosted/collections/${collectionId}/replicas`,
+      headers: { cookie },
+      payload: {
+        name: "Laptop mirror",
+        mode: "read_only",
+        allowed_types: ["task"]
+      }
+    });
+    expect(enrolled.statusCode).toBe(201);
+    expect(enrolled.json().token).toMatch(/^hsr_/);
+    const replicaId = enrolled.json().replica.id as string;
+    const dashboard = await app.inject({ method: "GET", url: "/v1/me", headers: { cookie } });
+    expect(dashboard.json().hosted_collections).toEqual([
+      expect.objectContaining({
+        id: collectionId,
+        display_name: "Tasks",
+        contracts: [{ id: "tasknotes.task", version: 1 }],
+        replicas: [expect.objectContaining({ id: replicaId, mode: "read_only" })]
+      })
+    ]);
+    const renamed = await app.inject({
+      method: "PATCH",
+      url: `/v1/hosted/collections/${collectionId}`,
+      headers: { cookie },
+      payload: { display_name: "Renamed tasks" }
+    });
+    expect(renamed.json().collection.display_name).toBe("Renamed tasks");
+    const rotated = await app.inject({
+      method: "POST",
+      url: `/v1/hosted/replicas/${replicaId}/token`,
+      headers: { cookie }
+    });
+    expect(rotated.json().token).toMatch(/^hsr_/);
+    expect(rotated.json().token).not.toBe(enrolled.json().token);
+    expect((await app.inject({
+      method: "DELETE",
+      url: `/v1/hosted/replicas/${replicaId}`,
+      headers: { cookie }
+    })).statusCode).toBe(200);
+    expect((await app.inject({
+      method: "DELETE",
+      url: `/v1/hosted/collections/${collectionId}`,
+      headers: { cookie }
+    })).statusCode).toBe(200);
+    const empty = await app.inject({ method: "GET", url: "/v1/me", headers: { cookie } });
+    expect(empty.json().hosted_collections).toEqual([]);
+  });
 });
 
 function responseCookies(response: { headers: Record<string, string | string[] | undefined> }): string[] {

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -9,6 +9,7 @@ function config(overrides: Partial<Parameters<typeof validateRuntimeConfig>[0]> 
     tailscaleAuth: false,
     githubAuth: null,
     hostedCollections: false,
+    hostedProvider: null,
     trustProxy: false,
     ...overrides
   };
@@ -78,5 +79,40 @@ describe("public runtime configuration", () => {
       publicUrl: "https://connect.example/control",
       tailscaleAuth: true
     }))).toThrow(/must be an origin/);
+  });
+
+  it("requires a canonical TLS provider and a strong internal credential for hosted mode", () => {
+    expect(() => validateRuntimeConfig(config({
+      tailscaleAuth: true,
+      publicUrl: "https://connect.example",
+      hostedCollections: true
+    }))).toThrow(/storage provider/);
+    expect(() => validateRuntimeConfig(config({
+      tailscaleAuth: true,
+      publicUrl: "https://connect.example",
+      hostedCollections: true,
+      hostedProvider: { url: "http://provider.example", internalToken: "x".repeat(40) }
+    }))).toThrow(/HTTPS/);
+    expect(() => validateRuntimeConfig(config({
+      tailscaleAuth: true,
+      publicUrl: "https://connect.example",
+      hostedCollections: true,
+      hostedProvider: { url: "https://provider.example/path", internalToken: "x".repeat(40) }
+    }))).toThrow(/must be an origin/);
+    expect(() => validateRuntimeConfig(config({
+      tailscaleAuth: true,
+      publicUrl: "https://connect.example",
+      hostedCollections: true,
+      hostedProvider: { url: "https://provider.example", internalToken: "short" }
+    }))).toThrow(/32 characters/);
+
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_HOSTED_COLLECTIONS: "1",
+      MDBASE_CONNECT_HOSTED_PROVIDER_URL: "http://127.0.0.1:8790",
+      MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: "x".repeat(40)
+    });
+    expect(value.hostedProvider?.url).toBe("http://127.0.0.1:8790");
   });
 });

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -1,4 +1,5 @@
 import type { GitHubAuthConfig } from "./github-auth.js";
+import type { HostedProviderConfig } from "./hosted-provider.js";
 
 export interface RuntimeConfig {
   host: string;
@@ -7,6 +8,7 @@ export interface RuntimeConfig {
   tailscaleAuth: boolean;
   githubAuth: GitHubAuthConfig | null;
   hostedCollections: boolean;
+  hostedProvider: HostedProviderConfig | null;
   trustProxy: boolean;
 }
 
@@ -40,7 +42,30 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
       }
     }
   }
-  return { ...config, publicUrl: publicUrl.origin };
+  let hostedProvider = config.hostedProvider;
+  if (config.hostedCollections && !hostedProvider) {
+    throw new Error("Hosted collections require a configured hosted storage provider.");
+  }
+  if (hostedProvider) {
+    const providerUrl = new URL(hostedProvider.url);
+    if (
+      providerUrl.username
+      || providerUrl.password
+      || providerUrl.pathname !== "/"
+      || providerUrl.search
+      || providerUrl.hash
+    ) {
+      throw new Error("MDBASE_CONNECT_HOSTED_PROVIDER_URL must be an origin.");
+    }
+    if (providerUrl.protocol !== "https:" && !isLoopback(providerUrl.hostname)) {
+      throw new Error("The hosted storage provider URL must use HTTPS outside loopback development.");
+    }
+    if (hostedProvider.internalToken.length < 32) {
+      throw new Error("The hosted storage provider internal token must contain at least 32 characters.");
+    }
+    hostedProvider = { ...hostedProvider, url: providerUrl.origin };
+  }
+  return { ...config, publicUrl: publicUrl.origin, hostedProvider };
 }
 
 export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
@@ -55,6 +80,10 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   const githubConfigured = Boolean(clientId || clientSecret || allowedUserIds.size);
   const port = Number(env.PORT ?? 8787);
   const host = env.HOST ?? "127.0.0.1";
+  const hostedProviderUrl = env.MDBASE_CONNECT_HOSTED_PROVIDER_URL?.trim() ?? "";
+  const hostedProviderInternalToken =
+    env.MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN?.trim() ?? "";
+  const hostedProviderConfigured = Boolean(hostedProviderUrl || hostedProviderInternalToken);
   return validateRuntimeConfig({
     host,
     publicUrl: env.PUBLIC_URL ?? `http://${host}:${port}`,
@@ -62,6 +91,9 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
     tailscaleAuth: env.MDBASE_CONNECT_TAILSCALE_AUTH === "1",
     githubAuth: githubConfigured ? { clientId, clientSecret, allowedUserIds } : null,
     hostedCollections: env.MDBASE_CONNECT_HOSTED_COLLECTIONS === "1",
+    hostedProvider: hostedProviderConfigured
+      ? { url: hostedProviderUrl, internalToken: hostedProviderInternalToken }
+      : null,
     trustProxy: env.MDBASE_CONNECT_TRUST_PROXY === "1"
   });
 }


### PR DESCRIPTION
## What changed

- add the Rust/PostgreSQL hosted collection authority with encrypted records
  and paths, durable idempotency, quotas, leases, retention, and horizontally
  safe writes
- add hosted collection lifecycle, grant-bound direct SDK access, portal
  management, and versioned Rust/TypeScript protocol support
- add receive-only and writable Markdown mirrors with stable identities,
  first-sync import, conditional writes, explicit conflicts, and symlink-safe
  filesystem boundaries
- add production Docker images, Render infrastructure, CI gates, operational
  documentation, and Node 24 LTS / pnpm 11 dependency upgrades

## Why

Users need to make mdbase's hosted service the source of truth while optionally
materializing an ordinary local Markdown replica. The existing sync vertical
slice did not provide a durable production authority, lifecycle, writable
mirror semantics, recovery proof, or deployment hardening.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:sync`
- `pnpm e2e:provider`
- `pnpm e2e:provider:stress` with 10,003 records
- logical PostgreSQL dump/restore and restored-provider snapshot verification
- publishable package audit and desktop packaging verification
- production server and provider Docker builds plus real PostgreSQL runtime smoke
- linked mdbase-editor: typecheck, 35 unit tests, build, and 11 Chromium E2E tests
- dependency audits: no known vulnerabilities

10k provider profile: mutation p95 35.94 ms, full snapshot 1.15 s,
change-page p95 21.17 ms, warm-read p95 13.21 ms, and warm-query p95 2.83 ms.

The Render blueprint validates against the current official schema. A live
private Render smoke/restore drill remains for the unreleased environment after
merge.
