### PR TITLE
Verify hosted collection picker end to end

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: callumalpass/mdbase-rs
-          ref: 73372a1f786e20d213be6e9821eb0649ecfcc050
+          ref: 600a23236a9ad49e2ad8c416d36fe8e06c797d50
           path: mdbase-rs
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -67,6 +67,9 @@ jobs:
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build
       - run: cp deploy/docker/Cargo.lock.hosted-provider Cargo.lock
-      - run: cargo test --locked -p mdbase-connect-hosted-provider
+      # Compile and test every Rust crate against the exact SDK revision used
+      # by the production provider image. This keeps path-only developer
+      # dependencies from making a clean checkout unreproducible.
+      - run: cargo test --locked --workspace
       - run: cargo build --locked -p mdbase-connect-hosted-provider
       - run: node scripts/hosted-provider-e2e.mjs

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,19 +6,23 @@ product
 
 ## Users
 
-People who keep durable personal or professional data in local mdbase-backed
-Markdown collections and want to use independent web or native applications
-without moving those collections into an application vendor's database. Users
-may be comfortable with files and Obsidian, but should not need to understand
-relays, OAuth, or networking to control access.
+People who keep durable personal or professional data in mdbase-backed Markdown
+collections and want to use independent web or native applications without
+moving those collections into an application vendor's database. A collection
+may be authoritative on their own computer or hosted by mdbase with an optional
+local mirror. Users may be comfortable with files and Obsidian, but should not
+need to understand relays, OAuth, or networking to control access.
 
 ## Product Purpose
 
-mdbase connect makes a user's local collections safely available to applications
-they choose. The local desktop client is the primary control surface for
-collections, applications, permissions, connection state, and activity. The
-hosted service supplies identity, short-lived authorization, routing, and an
-outbound-only relay. Success means connecting an app feels deliberate and
+mdbase connect makes a user's local and hosted collections safely available to
+applications they choose. The local desktop client controls computer-owned
+collections; the account portal controls mdbase-hosted collections and shared
+application access. The hosted service supplies identity, short-lived
+authorization, routing, an outbound-only relay for local authorities, and a
+durable authority for hosted collections. Hosted collections are always mdbase
+collections—application contracts such as TaskNotes are optional consumers,
+never the storage model. Success means connecting an app feels deliberate and
 understandable, while revoking it is immediate and unambiguous.
 
 ## Brand Personality

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # mdbase connect
 
 mdbase connect lets user-authorized websites and native applications operate
-on a user's local [mdbase](https://mdbase.dev) collections without exposing
-collection folders directly to the internet.
+on a user's local or mdbase-hosted [mdbase](https://mdbase.dev) collections.
+Local collection folders are never exposed directly to the internet; hosted
+collections keep their authoritative Markdown on mdbase with optional mirrors.
 
 This is a functional private-beta foundation. The tested path covers creating a local
 collection, pairing an outbound-only connector, discovering an independent web
@@ -13,6 +14,9 @@ their declared contracts, renewing browser authorization, receiving filesystem
 changes, rejecting stale revisions, pausing access, and immediately enforcing
 revocation. Browser-to-connector operation payloads use grant-bound end-to-end
 encryption; the relay sees routing metadata and ciphertext.
+
+Hosted collections are generic mdbase collections. TaskNotes is one reference
+application and contract adapter—not a collection kind or platform default.
 
 ## What is here
 

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -64,7 +64,7 @@ export interface HostedReplica {
 export interface HostedCollection {
   id: string;
   display_name: string;
-  template: "tasknotes";
+  template: "mdbase" | "tasknotes";
   provider_url: string;
   spec_version: string;
   contracts: ContractRequirement[];

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -215,7 +215,7 @@ function HostedCollections({ collections, onChanged, onError }: {
   onError(value: string): void;
 }) {
   const [creating, setCreating] = useState(false);
-  const [name, setName] = useState("My tasks");
+  const [name, setName] = useState("My collection");
   const [busy, setBusy] = useState(false);
 
   async function create(event: React.FormEvent) {
@@ -225,10 +225,10 @@ function HostedCollections({ collections, onChanged, onError }: {
     try {
       await api("/v1/hosted/collections", {
         method: "POST",
-        body: JSON.stringify({ display_name: name.trim(), template: "tasknotes" })
+        body: JSON.stringify({ display_name: name.trim(), template: "mdbase" })
       });
       setCreating(false);
-      setName("My tasks");
+      setName("My collection");
       await onChanged();
     } catch (reason) {
       onError(message(reason));
@@ -244,13 +244,13 @@ function HostedCollections({ collections, onChanged, onError }: {
       count={collections.length}
     />
     {collections.length === 0 && !creating
-      ? <Empty title="No hosted collections" text="Create a TaskNotes collection whose source of truth stays available without a connected computer." />
+      ? <Empty title="No hosted collections" text="Create an mdbase collection whose source of truth stays available without a connected computer." />
       : <div className="hosted-list">{collections.map((collection) => (
           <HostedCollectionRow key={collection.id} collection={collection} onChanged={onChanged} onError={onError} />
         ))}</div>}
     {creating ? <form className="inline-create" onSubmit={(event) => void create(event)}>
       <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
-      <p>Starts with the TaskNotes schema. You can receive an exact Markdown mirror on any computer afterward.</p>
+      <p>Starts as a clean mdbase 0.3 collection. Add Markdown through compatible apps, with an optional exact local mirror.</p>
       <div><button type="button" className="quiet-action" disabled={busy} onClick={() => setCreating(false)}>Cancel</button><button className="button primary" disabled={busy || !name.trim()}>{busy ? "Creating…" : "Create collection"}</button></div>
     </form> : <button className="button secondary" onClick={() => setCreating(true)}>Create hosted collection</button>}
   </>;
@@ -296,7 +296,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
         sync_url: string;
       }>(`/v1/hosted/collections/${collection.id}/replicas`, {
         method: "POST",
-        body: JSON.stringify({ name: mirrorName.trim(), mode: mirrorMode, allowed_types: ["task"] })
+        body: JSON.stringify({ name: mirrorName.trim(), mode: mirrorMode, allowed_types: [] })
       });
       setSecret({ replicaId: enrollment.replica.id, token: enrollment.token, syncUrl: enrollment.sync_url, mode: mirrorMode });
       await onChanged();
@@ -337,7 +337,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
 
   return <article className="hosted-row">
     <div className="hosted-summary">
-      <div><strong>{collection.display_name}</strong><small>TaskNotes · authoritative on mdbase · created {relativeTime(collection.created_at)}</small></div>
+      <div><strong>{collection.display_name}</strong><small>mdbase · authoritative on mdbase · created {relativeTime(collection.created_at)}</small></div>
       <span className="availability online"><i />Hosted</span>
       <span className="replica-count">{activeReplicas.length} {activeReplicas.length === 1 ? "mirror" : "mirrors"}</span>
       <div className="computer-actions"><button className="quiet-action" disabled={busy} onClick={() => { setSecret(null); setPanel(panel === "mirror" ? null : "mirror"); }}>Add mirror</button><button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button><button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button></div>
@@ -366,7 +366,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
 }
 
 function MirrorSetup({ collectionId, secret }: { collectionId: string; secret: ReplicaSecret }) {
-  const command = `mdbase-mirror init ./tasks --server ${secret.syncUrl} --collection ${collectionId} --replica ${secret.replicaId}${secret.mode === "read_write" ? " --writable" : ""}`;
+  const command = `mdbase-mirror init ./collection --server ${secret.syncUrl} --collection ${collectionId} --replica ${secret.replicaId}${secret.mode === "read_write" ? " --writable" : ""}`;
   const [copied, setCopied] = useState<"token" | "command" | null>(null);
   async function copy(value: string, kind: "token" | "command") {
     await navigator.clipboard.writeText(value);

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -579,7 +579,7 @@ function Authorization({ requestId }: { requestId: string }) {
       <section className="decision-panel authorization-panel">
         <RequestIdentity request={authorization} large />
         {status === "pending" ? <>
-          <p>Choose the collection and exact permissions this application may use. The computer holding your files remains the final gate.</p>
+          <p>Choose the collection and exact permissions this application may use. Local collections remain under their connected computer; hosted collections remain under your mdbase account.</p>
           {error && <div className="message error">{error}</div>}
           <ApprovalForm
             request={authorization}
@@ -660,7 +660,7 @@ function ApprovalForm({
       <label className="collection-field" htmlFor={`collection-${request.id}`}>
         <span>Collection</span>
         <select id={`collection-${request.id}`} value={collectionId} onChange={(event) => setCollectionId(event.target.value)} disabled={submitting !== null || collections.length === 0}>
-          {collections.map((collection) => <option value={collection.id} key={collection.id}>{collection.display_name} — {collection.connector_name}</option>)}
+          {collections.map((collection) => <option value={collection.id} key={collection.id}>{collection.display_name} · {collection.connector_name}</option>)}
         </select>
       </label>
       {collections.length === 0 && <p className="field-note error-copy">

--- a/crates/connect-hosted-provider/migrations/0002_collection_display_name.sql
+++ b/crates/connect-hosted-provider/migrations/0002_collection_display_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hosted_provider_collections
+ADD COLUMN IF NOT EXISTS display_name text NOT NULL DEFAULT 'Hosted collection';

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -103,6 +103,12 @@ impl AppState {
 struct CreateCollectionRequest {
     collection_id: Uuid,
     template: String,
+    display_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RenameCollectionRequest {
+    display_name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,7 +147,7 @@ pub fn app(state: AppState) -> Router {
         .route("/internal/v1/collections", post(create_collection))
         .route(
             "/internal/v1/collections/{collection_id}",
-            delete(delete_collection),
+            patch(rename_collection).delete(delete_collection),
         )
         .route(
             "/internal/v1/collections/{collection_id}/replicas",
@@ -269,12 +275,26 @@ async fn create_collection(
     state.authorize_internal(&headers)?;
     let collection = state
         .provider
-        .create_collection(input.collection_id, &input.template)
+        .create_collection(input.collection_id, &input.template, &input.display_name)
         .await?;
     Ok((
         StatusCode::CREATED,
         Json(json!({ "collection": collection })),
     ))
+}
+
+async fn rename_collection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<RenameCollectionRequest>,
+) -> ApiResult<StatusCode> {
+    state.authorize_internal(&headers)?;
+    state
+        .provider
+        .rename_collection(collection_id, &input.display_name)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn delete_collection(

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -80,6 +80,8 @@ pub struct RegisterReplica {
 #[derive(Debug, Clone, Deserialize)]
 pub struct UpdateApplicationReplica {
     pub mode: SyncReplicaMode,
+    #[serde(default)]
+    pub allowed_types: Vec<String>,
     pub allowed_operations: Vec<String>,
 }
 
@@ -94,6 +96,7 @@ pub enum ReplicaPurpose {
 #[derive(Debug, Clone, Serialize)]
 pub struct ProviderCollection {
     pub id: Uuid,
+    pub display_name: String,
     pub spec_version: String,
     pub resource_revision: String,
 }
@@ -202,7 +205,15 @@ impl HostedProvider {
         &self,
         collection_id: Uuid,
         template_name: &str,
+        display_name: &str,
     ) -> ApiResult<ProviderCollection> {
+        let display_name = display_name.trim();
+        if display_name.is_empty() || display_name.chars().count() > 200 {
+            return Err(ApiError::bad_request(
+                "invalid_collection_name",
+                "Hosted collection names must contain between 1 and 200 characters.",
+            ));
+        }
         let (resources, documents) = template::resources(template_name)?;
         let data_key = self.crypto.generate_data_key();
         let wrapped_data_key = self
@@ -214,14 +225,15 @@ impl HostedProvider {
         let mut transaction = self.pool.begin().await?;
         let inserted = sqlx::query(
             r#"INSERT INTO hosted_provider_collections
-                 (id, template, spec_version, resource_revision, wrapped_data_key,
+                 (id, template, display_name, spec_version, resource_revision, wrapped_data_key,
                   resources_ciphertext, max_records, max_content_bytes,
                   max_document_bytes, max_replicas)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
                ON CONFLICT (id) DO NOTHING"#,
         )
         .bind(collection_id)
         .bind(template_name)
+        .bind(display_name)
         .bind(&resources.spec_version)
         .bind(&resources.revision)
         .bind(wrapped_data_key)
@@ -246,20 +258,23 @@ impl HostedProvider {
         .await?;
         if inserted.rows_affected() == 0 {
             let existing = sqlx::query(
-                "SELECT template, spec_version, resource_revision FROM hosted_provider_collections WHERE id = $1",
+                "SELECT template, display_name, spec_version, resource_revision FROM hosted_provider_collections WHERE id = $1",
             )
             .bind(collection_id)
             .fetch_one(&mut *transaction)
             .await?;
             let existing_template: String = existing.get("template");
-            if existing_template != template_name {
+            if existing_template != template_name
+                || existing.get::<String, _>("display_name") != display_name
+            {
                 return Err(ApiError::conflict(
                     "hosted_collection_conflict",
-                    "Hosted collection already exists with a different template.",
+                    "Hosted collection already exists with different metadata.",
                 ));
             }
             let result = ProviderCollection {
                 id: collection_id,
+                display_name: existing.get("display_name"),
                 spec_version: existing.get("spec_version"),
                 resource_revision: existing.get("resource_revision"),
             };
@@ -288,9 +303,38 @@ impl HostedProvider {
         transaction.commit().await?;
         Ok(ProviderCollection {
             id: collection_id,
+            display_name: display_name.to_string(),
             spec_version: resources.spec_version,
             resource_revision: resources.revision,
         })
+    }
+
+    pub async fn rename_collection(
+        &self,
+        collection_id: Uuid,
+        display_name: &str,
+    ) -> ApiResult<()> {
+        let display_name = display_name.trim();
+        if display_name.is_empty() || display_name.chars().count() > 200 {
+            return Err(ApiError::bad_request(
+                "invalid_collection_name",
+                "Hosted collection names must contain between 1 and 200 characters.",
+            ));
+        }
+        let result = sqlx::query(
+            "UPDATE hosted_provider_collections SET display_name = $2, updated_at = now() WHERE id = $1 AND state = 'active'",
+        )
+        .bind(collection_id)
+        .bind(display_name)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            ));
+        }
+        Ok(())
     }
 
     pub async fn delete_collection(&self, collection_id: Uuid) -> ApiResult<()> {
@@ -469,6 +513,8 @@ impl HostedProvider {
         replica_id: Uuid,
         mut input: UpdateApplicationReplica,
     ) -> ApiResult<()> {
+        input.allowed_types.sort();
+        input.allowed_types.dedup();
         input.allowed_operations.sort();
         input.allowed_operations.dedup();
         validate_operations(&input.allowed_operations, input.mode)?;
@@ -481,14 +527,18 @@ impl HostedProvider {
         let result = sqlx::query(
             r#"UPDATE hosted_provider_replicas
                SET scope_epoch = scope_epoch + CASE
-                     WHEN mode IS DISTINCT FROM $2 OR allowed_operations IS DISTINCT FROM $3
+                     WHEN mode IS DISTINCT FROM $2
+                       OR allowed_types IS DISTINCT FROM $3
+                       OR allowed_operations IS DISTINCT FROM $4
                      THEN 1 ELSE 0 END,
                    mode = $2,
-                   allowed_operations = $3
+                   allowed_types = $3,
+                   allowed_operations = $4
                WHERE id = $1 AND purpose = 'application' AND revoked_at IS NULL"#,
         )
         .bind(replica_id)
         .bind(replica_mode(input.mode))
+        .bind(input.allowed_types)
         .bind(input.allowed_operations)
         .execute(&self.pool)
         .await?;
@@ -1403,7 +1453,7 @@ impl HostedProvider {
 
     async fn describe_operation(&self, collection_id: Uuid, replica: &Replica) -> ApiResult<Value> {
         let row = sqlx::query(
-            r#"SELECT head, wrapped_data_key, resources_ciphertext
+            r#"SELECT head, display_name, wrapped_data_key, resources_ciphertext
                FROM hosted_provider_collections WHERE id = $1 AND state = 'active'"#,
         )
         .bind(collection_id)
@@ -1425,7 +1475,7 @@ impl HostedProvider {
         let description = CollectionDescription {
             protocol_version: CONTROL_PROTOCOL_VERSION,
             collection_id,
-            display_name: "Hosted collection".to_string(),
+            display_name: row.get("display_name"),
             spec_version: resources.spec_version,
             operations: replica.allowed_operations.clone(),
             change_cursor: number(row.get::<i64, _>("head"), "collection head")?,

--- a/crates/connect-hosted-provider/src/template.rs
+++ b/crates/connect-hosted-provider/src/template.rs
@@ -15,12 +15,31 @@ pub struct ResourceDocument {
 
 pub fn resources(template: &str) -> ApiResult<(SyncCollectionResources, Vec<ResourceDocument>)> {
     match template {
+        "mdbase" => Ok(mdbase()),
         "tasknotes" => Ok(tasknotes()),
         _ => Err(ApiError::bad_request(
             "unsupported_template",
             "The hosted provider does not support that collection template.",
         )),
     }
+}
+
+fn mdbase() -> (SyncCollectionResources, Vec<ResourceDocument>) {
+    (
+        SyncCollectionResources {
+            revision: "mdbase-template:1".to_string(),
+            spec_version: "0.3.0".to_string(),
+            types: Vec::new(),
+            contracts: Vec::new(),
+            documents: Vec::new(),
+        },
+        vec![ResourceDocument {
+            path: "mdbase.yaml",
+            kind: "configuration",
+            revision: "mdbase-config:1",
+            document: "spec_version: 0.3.0\nsettings:\n  types_folder: _types\n  default_validation: error\n",
+        }],
+    )
 }
 
 fn tasknotes() -> (SyncCollectionResources, Vec<ResourceDocument>) {
@@ -103,4 +122,20 @@ x-tasknotes:
         },
     ];
     (resources, documents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_mdbase_template_has_no_application_contracts() {
+        let (resources, documents) = resources("mdbase").unwrap();
+        assert_eq!(resources.revision, "mdbase-template:1");
+        assert!(resources.types.is_empty());
+        assert!(resources.contracts.is_empty());
+        assert_eq!(documents.len(), 1);
+        assert_eq!(documents[0].path, "mdbase.yaml");
+        assert!(!documents[0].document.contains("TaskNotes"));
+    }
 }

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1526,6 +1526,7 @@ dependencies = [
  "fancy-regex 0.14.0",
  "glob",
  "jsonschema",
+ "notify",
  "rand 0.8.7",
  "regex",
  "rusqlite",

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -1,7 +1,7 @@
 FROM rust:1.94.0-bookworm AS build
 
 ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
-ARG MDBASE_RS_REVISION=73372a1f786e20d213be6e9821eb0649ecfcc050
+ARG MDBASE_RS_REVISION=600a23236a9ad49e2ad8c416d36fe8e06c797d50
 
 RUN git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
  && git -C /build/mdbase-rs checkout --detach "$MDBASE_RS_REVISION"

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -66,7 +66,7 @@ collection-scoped replica credential.
 Before any invitation:
 
 1. Confirm `/health` and `/ready` on both services.
-2. Sign in through GitHub and create a hosted TaskNotes collection.
+2. Sign in through GitHub and create a hosted mdbase collection.
 3. Authorize the current `mdbase-editor` build and perform create, read, query,
    update, rename, and delete operations.
 4. Add one receive-only and one writable mirror. Verify config, type resources,

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -326,29 +326,13 @@ try {
   });
   void hostedSdk.authorize(["describe", "changes", "read", "query", "create", "update"]);
   await waitFor(() => authorizationUrl, "SDK did not start hosted authorization");
-  const authorize = await fetch(authorizationUrl, { headers: { cookie }, redirect: "manual" });
-  assert.equal(authorize.status, 302);
-  const authorizationId = authorize.headers.get("location")?.split("/").at(-1);
-  assert.ok(authorizationId);
-  await controlRequest(
-    controlUrl,
-    `/v1/authorization-requests/${authorizationId}/approve`,
+  const callbackUrl = await authorizeHostedApplication(
+    authorizationUrl,
     cookie,
-    {
-      method: "POST",
-      body: {
-        collection_id: collectionId,
-        operations: ["describe", "changes", "read", "query", "create", "update"]
-      }
-    }
+    collectionId,
+    manifest.origin
   );
-  const authorizationStatus = await controlRequest(
-    controlUrl,
-    `/v1/authorization-requests/${authorizationId}/status`,
-    cookie
-  );
-  assert.equal(authorizationStatus.status, "approved");
-  await hostedSdk.completeAuthorization(authorizationStatus.redirect_uri);
+  await hostedSdk.completeAuthorization(callbackUrl);
   const storedHostedToken = storage.token();
   assert.equal(storedHostedToken.hosted.providerUrl, provider.url);
   assert.equal(storedHostedToken.encryption, undefined);
@@ -1024,6 +1008,33 @@ async function portalLifecycleE2E(controlUrl) {
     page.once("dialog", (dialog) => dialog.accept());
     await renamedRow.getByRole("button", { name: "Delete" }).click();
     await expect(page.getByText("Browser renamed tasks", { exact: true })).toHaveCount(0);
+  } finally {
+    await browser.close();
+  }
+}
+
+async function authorizeHostedApplication(authorizationUrl, cookie, collectionId, callbackOrigin) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const separator = cookie.indexOf("=");
+    assert.ok(separator > 0, "Development session cookie is malformed");
+    const context = await browser.newContext();
+    await context.addCookies([{
+      name: cookie.slice(0, separator),
+      value: cookie.slice(separator + 1),
+      url: new URL(authorizationUrl).origin
+    }]);
+    const page = await context.newPage();
+    await page.goto(authorizationUrl);
+    await expect(page.getByRole("heading", { name: "Hosted SDK E2E" })).toBeVisible();
+    await expect(page.getByText(/Local collections remain under their connected computer/)).toBeVisible();
+    const collection = page.getByLabel("Collection");
+    await expect(collection.locator("option")).toHaveCount(2);
+    await collection.selectOption(collectionId);
+    await expect(collection.locator("option:checked")).toHaveText("Hosted tasks · Hosted by mdbase");
+    await page.getByRole("button", { name: "Allow access" }).click();
+    await page.waitForURL((url) => url.origin === callbackOrigin && url.searchParams.has("code"));
+    return page.url();
   } finally {
     await browser.close();
   }

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -30,7 +30,7 @@ let manifestServer;
 const { HttpSyncTransport, MemoryReplicaStore, OfflineReplica, SyncError } =
   await import("../packages/sync/dist/index.js");
 const { DirectoryMirror, MirrorDivergenceError } = await import("../packages/sync/dist/node.js");
-const { resolveTasknotesSyncContract, TasknotesCollection, TasknotesOfflineCollection } =
+const { resolveTasknotesSyncContract, TasknotesOfflineCollection } =
   await import("../packages/tasknotes/dist/index.js");
 const { MdbaseConnect, MemoryGrantKeyStore } = await import("../packages/client/dist/index.js");
 const { buildApp } = await import("../services/server/dist/app.js");
@@ -88,11 +88,11 @@ try {
   const quotaToken = `quota-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(quotaProvider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: quotaCollectionId, template: "tasknotes" }
+    body: { collection_id: quotaCollectionId, template: "tasknotes", display_name: "Quota tasks" }
   });
   await internalRequest(quotaProvider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: quotaCollectionId, template: "tasknotes" }
+    body: { collection_id: quotaCollectionId, template: "tasknotes", display_name: "Quota tasks" }
   });
   await internalRequest(
     quotaProvider.url,
@@ -193,7 +193,7 @@ try {
   const maintenanceToken = `maintenance-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(maintenanceProvider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: maintenanceCollectionId, template: "tasknotes" }
+    body: { collection_id: maintenanceCollectionId, template: "tasknotes", display_name: "Maintenance tasks" }
   });
   await internalRequest(
     maintenanceProvider.url,
@@ -249,15 +249,15 @@ try {
   assert.ok(cookie);
   const created = await controlRequest(controlUrl, "/v1/hosted/collections", cookie, {
     method: "POST",
-    body: { display_name: "Hosted tasks", template: "tasknotes" }
+    body: { display_name: "Task app data", template: "tasknotes" }
   });
   const collectionId = created.collection.id;
   assert.equal(created.collection.sync_url, provider.url);
   const other = await controlRequest(controlUrl, "/v1/hosted/collections", cookie, {
     method: "POST",
-    body: { display_name: "Other hosted tasks", template: "tasknotes" }
+    body: { display_name: "Hosted writing", template: "mdbase" }
   });
-  const otherCollectionId = other.collection.id;
+  const genericCollectionId = other.collection.id;
   const writer = await registerReplica(controlUrl, cookie, collectionId, "Writer", "read_write", ["task"]);
   const reader = await registerReplica(controlUrl, cookie, collectionId, "Reader", "read_write", ["task"]);
   const mirror = await registerReplica(controlUrl, cookie, collectionId, "Mirror", "read_only", ["task"]);
@@ -324,12 +324,12 @@ try {
     storage,
     keyStore: new MemoryGrantKeyStore()
   });
-  void hostedSdk.authorize(["describe", "changes", "read", "query", "create", "update"]);
+  void hostedSdk.authorize(["describe", "changes", "read", "query", "create", "update", "delete", "rename"]);
   await waitFor(() => authorizationUrl, "SDK did not start hosted authorization");
   const callbackUrl = await authorizeHostedApplication(
     authorizationUrl,
     cookie,
-    collectionId,
+    genericCollectionId,
     manifest.origin
   );
   await hostedSdk.completeAuthorization(callbackUrl);
@@ -338,19 +338,19 @@ try {
   assert.equal(storedHostedToken.encryption, undefined);
   const appToken = storedHostedToken.hosted.accessToken;
   const appReplicaId = storedHostedToken.hosted.replicaId;
-  const appSync = await rawRequest(provider.url, syncPath(collectionId, "sessions"), {
+  const appSync = await rawRequest(provider.url, syncPath(genericCollectionId, "sessions"), {
     method: "POST",
     token: appToken
   });
   assert.equal(appSync.status, 401);
   const wrongOrigin = await rawRequest(
     provider.url,
-    `/v1/hosted/collections/${collectionId}/operations/query`,
+    `/v1/hosted/collections/${genericCollectionId}/operations/query`,
     {
       method: "POST",
       token: appToken,
       headers: { origin: "https://evil.example" },
-      body: { types: ["task"] }
+      body: {}
     }
   );
   assert.equal(wrongOrigin.status, 403);
@@ -364,24 +364,45 @@ try {
     return originalFetch(input, { ...init, headers });
   };
   const description = await hostedSdk.describe();
-  assert.equal(description.contracts[0].id, "tasknotes.task");
-  const hostedTasknotes = new TasknotesCollection(hostedSdk);
-  const sdkCreated = await hostedTasknotes.create({ title: "Created through hosted SDK" });
-  assert.ok(sdkCreated.revision);
-  assert.equal((await hostedTasknotes.list()).some((task) => task.title === "Created through hosted SDK"), true);
-  await hostedTasknotes.setCompleted(sdkCreated.path, true);
-  assert.equal(
-    (await hostedTasknotes.list()).find((task) => task.title === "Created through hosted SDK").completed,
-    true
-  );
+  assert.equal(description.display_name, "Hosted writing");
+  assert.deepEqual(description.contracts, []);
+  const sdkCreated = await hostedSdk.create({
+    path: "Draft.md",
+    frontmatter: { title: "Created through hosted SDK" },
+    body: "Generic mdbase Markdown."
+  });
+  assert.equal(sdkCreated.valid, true);
+  const sdkUpdated = await hostedSdk.update({
+    path: "Draft.md",
+    fields: { title: "Updated through hosted SDK" },
+    if_revision: sdkCreated.result.revision
+  });
+  assert.equal(sdkUpdated.valid, true);
+  const sdkRenamed = await hostedSdk.rename({
+    from: "Draft.md",
+    to: "Writing/Draft.md",
+    if_revision: sdkUpdated.result.revision
+  });
+  assert.equal(sdkRenamed.valid, true);
+  assert.equal((await hostedSdk.query()).result.results[0].path, "Writing/Draft.md");
+  assert.equal((await hostedSdk.delete({
+    path: "Writing/Draft.md",
+    if_revision: sdkRenamed.result.revision
+  })).valid, true);
   globalThis.fetch = originalFetch;
   const dashboardWithApp = await controlRequest(controlUrl, "/v1/me", cookie);
-  const hostedGrant = dashboardWithApp.grants.find((grant) => grant.collection_id === collectionId);
+  const hostedGrant = dashboardWithApp.grants.find((grant) => grant.collection_id === genericCollectionId);
   assert.ok(hostedGrant);
   assert.equal(hostedGrant.collection_kind, "hosted");
   assert.equal(
     dashboardWithApp.hosted_collections
       .find((collection) => collection.id === collectionId)
+      .replicas.some((replica) => replica.id === appReplicaId),
+    false
+  );
+  assert.equal(
+    dashboardWithApp.hosted_collections
+      .find((collection) => collection.id === genericCollectionId)
       .replicas.some((replica) => replica.id === appReplicaId),
     false
   );
@@ -391,14 +412,14 @@ try {
   });
   const deniedWrite = await rawRequest(
     provider.url,
-    `/v1/hosted/collections/${collectionId}/operations/create`,
+    `/v1/hosted/collections/${genericCollectionId}/operations/create`,
     {
       method: "POST",
       token: appToken,
       headers: { origin: manifest.origin },
       body: {
-        path: "tasks/permission-expansion.md",
-        frontmatter: { type: "task", title: "Must not exist" }
+        path: "permission-expansion.md",
+        frontmatter: { title: "Must not exist" }
       }
     }
   );
@@ -407,13 +428,13 @@ try {
   await controlRequest(controlUrl, `/v1/grants/${hostedGrant.id}`, cookie, { method: "DELETE" });
   const revokedApp = await rawRequest(
     provider.url,
-    `/v1/hosted/collections/${collectionId}/operations/query`,
+    `/v1/hosted/collections/${genericCollectionId}/operations/query`,
     { method: "POST", token: appToken, headers: { origin: manifest.origin }, body: {} }
   );
   assert.equal(revokedApp.status, 401);
   assert.equal(
     (
-      await rawRequest(provider.url, syncPath(otherCollectionId, "sessions"), {
+      await rawRequest(provider.url, syncPath(genericCollectionId, "sessions"), {
         method: "POST",
         token: writer.token
       })
@@ -977,10 +998,13 @@ async function portalLifecycleE2E(controlUrl) {
     await expect(page.getByRole("heading", { name: "Your connections." })).toBeVisible();
 
     await page.getByRole("button", { name: "Create hosted collection" }).click();
-    await page.getByLabel("Collection name").fill("Browser E2E tasks");
+    await expect(page.getByText(/Starts as a clean mdbase 0\.3 collection/)).toBeVisible();
+    await expect(page.getByText(/TaskNotes/)).toHaveCount(0);
+    await page.getByLabel("Collection name").fill("Browser E2E collection");
     await page.getByRole("button", { name: "Create collection" }).click();
-    const row = page.locator("article.hosted-row").filter({ hasText: "Browser E2E tasks" });
+    const row = page.locator("article.hosted-row").filter({ hasText: "Browser E2E collection" });
     await expect(row).toBeVisible();
+    await expect(row).toContainText("mdbase · authoritative on mdbase");
 
     await row.getByRole("button", { name: "Add mirror" }).click();
     await row.getByLabel("Mirror name").fill("Browser writable mirror");
@@ -1001,13 +1025,13 @@ async function portalLifecycleE2E(controlUrl) {
     await expect(row).not.toContainText("Browser writable mirror");
 
     await row.getByRole("button", { name: "Rename" }).click();
-    await row.getByLabel("Collection name").fill("Browser renamed tasks");
+    await row.getByLabel("Collection name").fill("Browser renamed collection");
     await row.getByRole("button", { name: "Save" }).click();
-    const renamedRow = page.locator("article.hosted-row").filter({ hasText: "Browser renamed tasks" });
+    const renamedRow = page.locator("article.hosted-row").filter({ hasText: "Browser renamed collection" });
     await expect(renamedRow).toBeVisible();
     page.once("dialog", (dialog) => dialog.accept());
     await renamedRow.getByRole("button", { name: "Delete" }).click();
-    await expect(page.getByText("Browser renamed tasks", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Browser renamed collection", { exact: true })).toHaveCount(0);
   } finally {
     await browser.close();
   }
@@ -1031,7 +1055,7 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     const collection = page.getByLabel("Collection");
     await expect(collection.locator("option")).toHaveCount(2);
     await collection.selectOption(collectionId);
-    await expect(collection.locator("option:checked")).toHaveText("Hosted tasks · Hosted by mdbase");
+    await expect(collection.locator("option:checked")).toHaveText("Hosted writing · Hosted by mdbase");
     await page.getByRole("button", { name: "Allow access" }).click();
     await page.waitForURL((url) => url.origin === callbackOrigin && url.searchParams.has("code"));
     return page.url();
@@ -1311,7 +1335,7 @@ async function openManifestServer() {
       name: "Hosted SDK E2E",
       homepage: origin,
       redirect_uris: [`${origin}/auth/mdbase/callback`],
-      requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] }
+      requirements: { contracts: [] }
     }));
   });
   await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -26,7 +26,13 @@ import type { DatabasePool, DatabaseQueryable } from "./db.js";
 import { fetchManifest } from "./manifest.js";
 import { ConnectorOperationError, RelayHub, RelayUnavailableError } from "./relay.js";
 import { pkceChallenge, randomToken, safeEqual, tokenHash } from "./security.js";
-import { asSyncMutation, HostedAuthorityRegistry, tasknotesContracts } from "./hosted.js";
+import {
+  asSyncMutation,
+  hostedContracts,
+  HostedAuthorityRegistry,
+  hostedTypesForContracts,
+  type HostedTemplate
+} from "./hosted.js";
 import {
   HostedProviderClient,
   HostedProviderResponseError,
@@ -552,7 +558,7 @@ export async function buildApp(options: BuildOptions) {
         ...collection,
         provider_url: collection.provider_url ?? publicUrl,
         spec_version: "0.3.0",
-        contracts: tasknotesContracts(),
+        contracts: hostedContracts(collection.template),
         replicas: hostedReplicas.rows.filter((replica) => replica.collection_id === collection.id)
       })),
       grants: grants.rows,
@@ -848,14 +854,14 @@ export async function buildApp(options: BuildOptions) {
     if (!user) return;
     const input = z.object({
       display_name: z.string().trim().min(1).max(200),
-      template: z.literal("tasknotes").default("tasknotes")
+      template: z.enum(["mdbase", "tasknotes"]).default("mdbase")
     }).strict().parse(request.body);
     const collectionId = randomUUID();
     try {
       if (options.hostedProvider) {
-        await options.hostedProvider.createCollection(collectionId, input.template);
+        await options.hostedProvider.createCollection(collectionId, input.template, input.display_name);
       } else {
-        await hostedReference!.create(collectionId);
+        await hostedReference!.create(collectionId, input.template);
       }
       await options.db.query(
         `INSERT INTO hosted_collections (id, user_id, display_name, template, provider_url)
@@ -891,7 +897,7 @@ export async function buildApp(options: BuildOptions) {
     const input = z.object({
       name: z.string().trim().min(1).max(200),
       mode: z.enum(["read_only", "read_write"]),
-      allowed_types: z.array(z.string().min(1).max(100)).max(100).default(["task"])
+      allowed_types: z.array(z.string().min(1).max(100)).max(100).default([])
     }).strict().parse(request.body);
     if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
@@ -954,6 +960,12 @@ export async function buildApp(options: BuildOptions) {
     if (!user) return;
     const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
     const input = z.object({ display_name: z.string().trim().min(1).max(200) }).strict().parse(request.body);
+    if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
+      return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
+    }
+    if (options.hostedProvider) {
+      await options.hostedProvider.renameCollection(collectionId, input.display_name);
+    }
     const renamed = await options.db.query<{ id: string; display_name: string }>(
       `UPDATE hosted_collections SET display_name = $3
        WHERE id = $1 AND user_id = $2 RETURNING id, display_name`,
@@ -1164,9 +1176,14 @@ export async function buildApp(options: BuildOptions) {
       hosted_replica_id: string | null;
       operations: string[];
       encryption: GrantEncryption | null;
+      scope: GrantScope;
+      template: string | null;
     }>(
-      `SELECT g.id, g.operations, g.encryption, col.connector_id, g.hosted_replica_id
-       FROM grants g LEFT JOIN collections col ON col.id = g.collection_id
+      `SELECT g.id, g.operations, g.encryption, g.scope, col.connector_id,
+              g.hosted_replica_id, hosted.template
+       FROM grants g
+       LEFT JOIN collections col ON col.id = g.collection_id
+       LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
        WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL`,
       [grantId, user.id]
     );
@@ -1186,6 +1203,7 @@ export async function buildApp(options: BuildOptions) {
       const write = operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
       await options.hostedProvider.updateApplicationReplica(current.hosted_replica_id, {
         mode: write ? "read_write" : "read_only",
+        allowedTypes: hostedTypesForContracts(current.template!, current.scope.contracts),
         allowedOperations: operations
       });
     }
@@ -1317,9 +1335,9 @@ export async function buildApp(options: BuildOptions) {
           id: string;
           display_name: string;
           spec_version?: string;
-          contracts?: ContractRequirement[];
+          template: HostedTemplate;
         }>(
-          `SELECT id, display_name FROM hosted_collections
+          `SELECT id, display_name, template FROM hosted_collections
            WHERE user_id = $1 ORDER BY display_name`,
           [user.id]
         )
@@ -1333,7 +1351,7 @@ export async function buildApp(options: BuildOptions) {
           kind: "hosted",
           connector_name: "Hosted by mdbase",
           spec_version: "0.3.0",
-          contracts: tasknotesContracts()
+          contracts: hostedContracts(collection.template)
         }))
       ]
     };
@@ -1397,8 +1415,8 @@ export async function buildApp(options: BuildOptions) {
         source: "portal"
       });
     } else {
-      const hosted = await options.db.query<{ id: string; template: string }>(
-        "SELECT id, template FROM hosted_collections WHERE id = $1 AND user_id = $2",
+      const hosted = await options.db.query<{ id: string; template: string; display_name: string }>(
+        "SELECT id, template, display_name FROM hosted_collections WHERE id = $1 AND user_id = $2",
         [input.collection_id, user.id]
       );
       if (!hosted.rows[0] || !options.hostedProvider) {
@@ -1409,7 +1427,8 @@ export async function buildApp(options: BuildOptions) {
         userId: user.id,
         collectionId: input.collection_id,
         operations: input.operations,
-        template: hosted.rows[0].template
+        template: hosted.rows[0].template,
+        displayName: hosted.rows[0].display_name
       });
     }
     if (!approved) return reply.code(404).send(apiError("authorization_not_found", "Authorization request expired or was not found."));
@@ -1707,8 +1726,8 @@ async function reconcileApplicationGrants(
   );
   const changedConnectors = new Set<string>();
   for (const grant of grants.rows) {
-    const availableContracts = grant.template === "tasknotes"
-      ? tasknotesContracts()
+    const availableContracts = grant.template
+      ? hostedContracts(grant.template)
       : grant.contracts ?? [];
     const collectionCompatible = contractsSatisfy(availableContracts, desiredScope.contracts);
     if (scopesEqual(grant.scope, desiredScope) && collectionCompatible) continue;
@@ -1721,6 +1740,7 @@ async function reconcileApplicationGrants(
         const write = grant.operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
         await hostedProvider.updateApplicationReplica(grant.hosted_replica_id, {
           mode: write ? "read_write" : "read_only",
+          allowedTypes: hostedTypesForContracts(grant.template!, desiredScope.contracts),
           allowedOperations: grant.operations
         });
       }
@@ -1871,6 +1891,7 @@ async function approveHostedAuthorization(
     collectionId: string;
     operations: string[];
     template: string;
+    displayName: string;
   }
 ): Promise<boolean> {
   const connection = await db.connect();
@@ -1902,15 +1923,15 @@ async function approveHostedAuthorization(
     if (input.operations.some((operation) => !pending.requested_operations.includes(operation))) {
       throw new RequestValidationError("Approved operations must be requested by the application.");
     }
-    if (input.template !== "tasknotes") {
-      throw new RequestValidationError("The hosted collection template is unavailable.");
-    }
     const scope = scopeForRequirements(pending.requirements);
-    if (!contractsSatisfy(tasknotesContracts(), scope.contracts)) {
+    const availableContracts = hostedContracts(input.template);
+    if (!contractsSatisfy(availableContracts, scope.contracts)) {
       throw new RequestValidationError(
         "This hosted collection does not provide the contracts required by the application."
       );
     }
+    const allowedTypes = hostedTypesForContracts(input.template, scope.contracts);
+    await provider.renameCollection(input.collectionId, input.displayName);
     const operations = [...new Set(input.operations)];
     const write = operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
     const applicationUrl = new URL(pending.application_homepage);
@@ -1924,7 +1945,7 @@ async function approveHostedAuthorization(
       name: `${pending.application_name} application access`,
       purpose: "application",
       mode: write ? "read_write" : "read_only",
-      allowedTypes: ["task"],
+      allowedTypes,
       allowedOperations: operations,
       allowedOrigin,
       token: bootstrapToken,
@@ -1940,7 +1961,7 @@ async function approveHostedAuthorization(
         input.collectionId,
         `${pending.application_name} application access`,
         write ? "read_write" : "read_only",
-        JSON.stringify(["task"])
+        JSON.stringify(allowedTypes)
       ]
     );
     await connection.query(

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -69,6 +69,7 @@ describe("hosted provider control client", () => {
     });
     await provider.updateApplicationReplica("replica", {
       mode: "read_only",
+      allowedTypes: ["task"],
       allowedOperations: ["read", "query"]
     });
     await provider.rotateReplicaToken("replica", "new-token", 3600);
@@ -76,7 +77,11 @@ describe("hosted provider control client", () => {
       [
         "https://provider.example/internal/v1/replicas/replica/policy",
         "PATCH",
-        JSON.stringify({ mode: "read_only", allowed_operations: ["read", "query"] })
+        JSON.stringify({
+          mode: "read_only",
+          allowed_types: ["task"],
+          allowed_operations: ["read", "query"]
+        })
       ],
       [
         "https://provider.example/internal/v1/replicas/replica/token",
@@ -94,8 +99,26 @@ describe("hosted provider control client", () => {
       url: "https://provider.example",
       internalToken: "internal-secret"
     });
-    await provider.createCollection("collection", "tasknotes");
+    await provider.createCollection("collection", "tasknotes", "Tasks");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(fetchMock.mock.calls[1]?.[1]?.body);
+  });
+
+  it("propagates collection identity changes to the authority", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(undefined, { status: 204 })
+    );
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    await provider.renameCollection("collection", "Research notes");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://provider.example/internal/v1/collections/collection",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ display_name: "Research notes" })
+      })
+    );
   });
 });

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -28,11 +28,20 @@ export class HostedProviderClient {
     await this.request("GET", "/ready", undefined, false);
   }
 
-  async createCollection(collectionId: string, template: string): Promise<void> {
+  async createCollection(collectionId: string, template: string, displayName: string): Promise<void> {
     await this.request("POST", "/internal/v1/collections", {
       collection_id: collectionId,
-      template
+      template,
+      display_name: displayName
     });
+  }
+
+  async renameCollection(collectionId: string, displayName: string): Promise<void> {
+    await this.request(
+      "PATCH",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}`,
+      { display_name: displayName }
+    );
   }
 
   async deleteCollection(collectionId: string): Promise<void> {
@@ -67,12 +76,20 @@ export class HostedProviderClient {
 
   async updateApplicationReplica(
     replicaId: string,
-    policy: { mode: "read_only" | "read_write"; allowedOperations: string[] }
+    policy: {
+      mode: "read_only" | "read_write";
+      allowedTypes: string[];
+      allowedOperations: string[];
+    }
   ): Promise<void> {
     await this.request(
       "PATCH",
       `/internal/v1/replicas/${encodeURIComponent(replicaId)}/policy`,
-      { mode: policy.mode, allowed_operations: policy.allowedOperations }
+      {
+        mode: policy.mode,
+        allowed_types: policy.allowedTypes,
+        allowed_operations: policy.allowedOperations
+      }
     );
   }
 

--- a/services/server/src/hosted.test.ts
+++ b/services/server/src/hosted.test.ts
@@ -1,10 +1,26 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
 import { createDatabase, type DatabasePool } from "./db.js";
-import { HostedAuthorityRegistry } from "./hosted.js";
+import {
+  hostedContracts,
+  HostedAuthorityRegistry,
+  hostedTypesForContracts
+} from "./hosted.js";
 
 let database: DatabasePool | undefined;
 afterEach(async () => database?.end());
+
+describe("hosted collection profiles", () => {
+  it("keeps generic mdbase collections independent of application contracts", () => {
+    expect(hostedContracts("mdbase")).toEqual([]);
+    expect(hostedTypesForContracts("mdbase", [])).toEqual([]);
+    expect(hostedContracts("tasknotes")).toEqual([{ id: "tasknotes.task", version: 1 }]);
+    expect(hostedTypesForContracts(
+      "tasknotes",
+      [{ id: "tasknotes.task", version: 1 }]
+    )).toEqual(["task"]);
+  });
+});
 
 describe("persisted hosted authority", () => {
   it("survives registry restart, preserves idempotency, and serializes stale writers", async () => {
@@ -18,7 +34,7 @@ describe("persisted hosted authority", () => {
       [collectionId, userId, "Tasks", "tasknotes"]
     );
     const first = new HostedAuthorityRegistry(database);
-    await first.create(collectionId);
+    await first.create(collectionId, "tasknotes");
     await first.registerReplica(collectionId, {
       id: replicaId,
       name: "Client",
@@ -67,7 +83,7 @@ describe("persisted hosted authority", () => {
       [collectionId, userId, "Tasks", "tasknotes"]
     );
     const first = new HostedAuthorityRegistry(database);
-    await first.create(collectionId);
+    await first.create(collectionId, "tasknotes");
     await first.registerReplica(collectionId, {
       id: replicaId, name: "Client", mode: "read_write", allowedTypes: ["task"]
     });
@@ -111,7 +127,7 @@ describe("persisted hosted authority", () => {
       [collectionId, userId, "Tasks", "tasknotes"]
     );
     const writerRegistry = new HostedAuthorityRegistry(database);
-    await writerRegistry.create(collectionId);
+    await writerRegistry.create(collectionId, "tasknotes");
     await writerRegistry.registerReplica(collectionId, {
       id: replicaId, name: "Client", mode: "read_write", allowedTypes: ["task"]
     });

--- a/services/server/src/hosted.ts
+++ b/services/server/src/hosted.ts
@@ -1,4 +1,9 @@
-import type { JsonObject, SyncCollectionResources, SyncMutation } from "@mdbase/connect-protocol";
+import type {
+  ContractRequirement,
+  JsonObject,
+  SyncCollectionResources,
+  SyncMutation
+} from "@mdbase/connect-protocol";
 import {
   MemoryHostedAuthority,
   SyncError,
@@ -12,6 +17,8 @@ interface CachedAuthority {
   authority: MemoryHostedAuthority;
   version: number;
 }
+
+export type HostedTemplate = "mdbase" | "tasknotes";
 
 /**
  * Transactional persistence boundary for the sync reference authority.
@@ -36,13 +43,9 @@ export class HostedAuthorityRegistry {
     `);
   }
 
-  async create(collectionId: string): Promise<void> {
+  async create(collectionId: string, template: HostedTemplate = "mdbase"): Promise<void> {
     await this.schemaReady;
-    const authority = new MemoryHostedAuthority({
-      id: collectionId,
-      validate: validateTasknotes,
-      resources: tasknotesResources()
-    });
+    const authority = new MemoryHostedAuthority({ id: collectionId, ...authorityOptions(hostedResources(template)) });
     await this.db.query(
       `INSERT INTO hosted_authority_states (collection_id, state, version)
        VALUES ($1, $2::jsonb, 1)`,
@@ -109,7 +112,7 @@ export class HostedAuthorityRegistry {
         const cached = await this.load(collectionId, true);
         const working = MemoryHostedAuthority.restore(
           cached.authority.serialize(),
-          authorityOptions(),
+          authorityOptions(cached.authority.serialize().resources ?? mdbaseResources()),
           cached.authority
         );
         const result = await operation(working);
@@ -159,7 +162,11 @@ export class HostedAuthorityRegistry {
     const version = Number(row.version);
     if (present?.version === version) return present;
     const cached = {
-      authority: MemoryHostedAuthority.restore(row.state, authorityOptions(), present?.authority),
+      authority: MemoryHostedAuthority.restore(
+        row.state,
+        authorityOptions(row.state.resources ?? mdbaseResources()),
+        present?.authority
+      ),
       version
     };
     this.cache.set(collectionId, cached);
@@ -167,10 +174,11 @@ export class HostedAuthorityRegistry {
   }
 }
 
-function authorityOptions() {
+function authorityOptions(resources: SyncCollectionResources) {
+  const tasknotes = resources.contracts.some((contract) => contract.id === "tasknotes.task");
   return {
-    validate: validateTasknotes,
-    resources: tasknotesResources()
+    ...(tasknotes ? { validate: validateTasknotes } : {}),
+    resources
   };
 }
 
@@ -183,6 +191,42 @@ function validateTasknotes(record: { types: string[]; frontmatter: JsonObject })
 
 export function asSyncMutation(value: unknown): SyncMutation {
   return value as SyncMutation;
+}
+
+export function hostedResources(template: string): SyncCollectionResources {
+  if (template === "mdbase") return mdbaseResources();
+  if (template === "tasknotes") return tasknotesResources();
+  throw new SyncError("unsupported_template", "The hosted collection template is unavailable.");
+}
+
+export function hostedContracts(template: string): ContractRequirement[] {
+  return hostedResources(template).contracts.map(({ id, version }) => ({ id, version }));
+}
+
+export function hostedTypesForContracts(
+  template: string,
+  contracts: ContractRequirement[]
+): string[] {
+  if (contracts.length === 0) return [];
+  const requested = new Set(contracts.map(({ id, version }) => `${id}@${version}`));
+  return [...new Set(hostedResources(template).contracts
+    .filter(({ id, version }) => requested.has(`${id}@${version}`))
+    .map(({ type_name }) => type_name))];
+}
+
+export function mdbaseResources(): SyncCollectionResources {
+  return {
+    revision: "mdbase-template:1",
+    spec_version: "0.3.0",
+    types: [],
+    contracts: [],
+    documents: [{
+      path: "mdbase.yaml",
+      kind: "configuration",
+      revision: "mdbase-config:1",
+      document: "spec_version: 0.3.0\nsettings:\n  types_folder: _types\n  default_validation: error\n"
+    }]
+  };
 }
 
 export function tasknotesResources(): SyncCollectionResources {
@@ -254,8 +298,4 @@ x-tasknotes:
 `
     }]
   };
-}
-
-export function tasknotesContracts(): Array<{ id: string; version: number }> {
-  return tasknotesResources().contracts.map(({ id, version }) => ({ id, version }));
 }

--- a/services/server/src/production-auth.test.ts
+++ b/services/server/src/production-auth.test.ts
@@ -200,7 +200,7 @@ describe("production GitHub authentication", () => {
       method: "POST",
       url: "/v1/hosted/collections",
       headers: { cookie },
-      payload: { display_name: "Tasks", template: "tasknotes" }
+      payload: { display_name: "Writing" }
     });
     expect(created.statusCode).toBe(201);
     const collectionId = created.json().collection.id as string;
@@ -211,7 +211,7 @@ describe("production GitHub authentication", () => {
       payload: {
         name: "Laptop mirror",
         mode: "read_only",
-        allowed_types: ["task"]
+        allowed_types: []
       }
     });
     expect(enrolled.statusCode).toBe(201);
@@ -221,8 +221,9 @@ describe("production GitHub authentication", () => {
     expect(dashboard.json().hosted_collections).toEqual([
       expect.objectContaining({
         id: collectionId,
-        display_name: "Tasks",
-        contracts: [{ id: "tasknotes.task", version: 1 }],
+        display_name: "Writing",
+        template: "mdbase",
+        contracts: [],
         replicas: [expect.objectContaining({ id: replicaId, mode: "read_only" })]
       })
     ]);
@@ -230,9 +231,9 @@ describe("production GitHub authentication", () => {
       method: "PATCH",
       url: `/v1/hosted/collections/${collectionId}`,
       headers: { cookie },
-      payload: { display_name: "Renamed tasks" }
+      payload: { display_name: "Renamed collection" }
     });
-    expect(renamed.json().collection.display_name).toBe("Renamed tasks");
+    expect(renamed.json().collection.display_name).toBe("Renamed collection");
     const rotated = await app.inject({
       method: "POST",
       url: `/v1/hosted/replicas/${replicaId}/token`,


### PR DESCRIPTION
Makes hosted collections generic mdbase collections by default, with TaskNotes retained only as an explicit reference application contract. The portal creates clean mdbase 0.3 collections, the provider persists their real display names, app capability reconciliation narrows both operations and record types, and hosted collections remain selectable in the browser authorization flow.

Also drives hosted SDK authorization through the real browser picker, updates production and CI to the merged serialized-runtime SDK revision, and tests the complete Rust workspace against that exact revision.

Validated locally with cargo fmt, all Rust workspace tests, workspace build/typecheck/unit tests, local connector E2E, reference sync E2E, real Chromium portal and authorization flows, a 10,000-record PostgreSQL provider stress/backup/recovery run, package consumability/audit, and a locked production provider image build.