### PR TITLE
Keep provider creation compatible during rolling deploys

### DIFF
--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -103,7 +103,8 @@ impl AppState {
 struct CreateCollectionRequest {
     collection_id: Uuid,
     template: String,
-    display_name: String,
+    #[serde(default)]
+    display_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -275,7 +276,11 @@ async fn create_collection(
     state.authorize_internal(&headers)?;
     let collection = state
         .provider
-        .create_collection(input.collection_id, &input.template, &input.display_name)
+        .create_collection(
+            input.collection_id,
+            &input.template,
+            input.display_name.as_deref().unwrap_or("Hosted collection"),
+        )
         .await?;
     Ok((
         StatusCode::CREATED,
@@ -500,6 +505,16 @@ mod tests {
         assert!(bool::from(hash.ct_eq(&hash)));
         let other: [u8; 32] = Sha256::digest(b"another-long-test-token-that-is-different").into();
         assert!(!bool::from(hash.ct_eq(&other)));
+    }
+
+    #[test]
+    fn collection_creation_remains_compatible_with_pre_identity_clients() {
+        let input: CreateCollectionRequest = serde_json::from_value(serde_json::json!({
+            "collection_id": Uuid::new_v4(),
+            "template": "tasknotes"
+        }))
+        .unwrap();
+        assert_eq!(input.display_name, None);
     }
 
     #[test]

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -88,11 +88,12 @@ try {
   const quotaToken = `quota-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(quotaProvider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: quotaCollectionId, template: "tasknotes", display_name: "Quota tasks" }
+    // Exercise the pre-display-name control-plane document during rolling upgrades.
+    body: { collection_id: quotaCollectionId, template: "tasknotes" }
   });
   await internalRequest(quotaProvider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: quotaCollectionId, template: "tasknotes", display_name: "Quota tasks" }
+    body: { collection_id: quotaCollectionId, template: "tasknotes" }
   });
   await internalRequest(
     quotaProvider.url,


### PR DESCRIPTION
Makes the newly added hosted collection display name optional at the Rust provider boundary, preserving the previous control-plane create document during provider-first rolling deployments. Missing names receive the legacy placeholder and are backfilled by the current control service on authorization or rename.

The compatibility shape is covered by a Rust unit test and is exercised through the real HTTP/PostgreSQL/browser provider E2E. Full Rust workspace tests, Node build/typecheck/unit suites, local connector E2E, and hosted provider E2E pass locally.