### PR TITLE
Add type management across connector and SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror",
  "ulid",
  "uuid",

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -10,7 +10,7 @@ import "./styles.css";
 
 type Route = "overview" | "collections" | "access" | "activity" | "settings";
 
-const allOperations = ["read", "query", "create", "update", "rename", "delete", "validate"];
+const allOperations = ["read", "query", "create", "update", "rename", "delete", "validate", "read_type", "create_type", "update_type"];
 const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }> = {
   overview: {
     eyebrow: "This computer",
@@ -636,7 +636,7 @@ function StatusDot({ state }: { state: "connected" | "paused" | "danger" | "idle
 }
 
 function operationDescription(operation: string) {
-  return ({ read: "Open individual records", query: "Find and filter records", create: "Add records", update: "Change records", rename: "Move or rename records", delete: "Delete records", validate: "Check collection validity" } as Record<string, string>)[operation] ?? operation;
+  return ({ read: "Open individual records", query: "Find and filter records", create: "Add records", update: "Change records", rename: "Move or rename records", delete: "Delete records", validate: "Check collection validity", read_type: "Inspect type definitions", create_type: "Add definitions that shape records", update_type: "Change definitions and compatibility" } as Record<string, string>)[operation] ?? operation;
 }
 
 function compatibleCollections(

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -17,7 +17,7 @@ import {
 } from "./api";
 import "./styles.css";
 
-const allOperations = ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename"];
+const allOperations = ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"];
 
 function Portal() {
   const pairingId = location.pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
@@ -692,7 +692,14 @@ function Loading({ error = "" }: { error?: string }) { return <main className="l
 function initials(value: string) { return value.split(/\s+/).map((part) => part[0]).join("").slice(0, 2).toUpperCase(); }
 function message(value: unknown) { return value instanceof Error ? value.message : String(value); }
 function host(value: string) { try { return new URL(value).host; } catch { return value; } }
-function operationLabel(operation: string) { return operation === "query" ? "Search and query" : `${operation[0]?.toUpperCase() ?? ""}${operation.slice(1)}`; }
+function operationLabel(operation: string) {
+  return ({
+    query: "Search and query",
+    read_type: "Inspect type definitions",
+    create_type: "Create type definitions",
+    update_type: "Change type definitions"
+  } as Record<string, string>)[operation] ?? `${operation[0]?.toUpperCase() ?? ""}${operation.slice(1)}`;
+}
 function compatibleCollections<T extends { contracts: ContractRequirement[] }>(
   request: PendingAuthorization,
   collections: T[]

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -549,7 +549,10 @@ impl AgentState {
 }
 
 fn is_mutation(operation: &str) -> bool {
-    matches!(operation, "create" | "update" | "delete" | "rename")
+    matches!(
+        operation,
+        "create" | "update" | "delete" | "rename" | "create_type" | "update_type"
+    )
 }
 
 async fn handle_stream<S>(stream: S, state: Arc<AgentState>) -> io::Result<()>

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -661,6 +661,10 @@ impl CollectionRegistry {
                 "Collection-wide validation is unavailable to a contract-scoped application."
                     .to_string(),
             )),
+            "read_type" | "create_type" | "update_type" => Err(ConnectError::AccessDenied(
+                "Type definitions can only be managed by an application with full collection access."
+                    .to_string(),
+            )),
             other => Err(ConnectError::UnsupportedOperation(other.to_string())),
         }
     }
@@ -1600,6 +1604,9 @@ fn execute_loaded(
             "update" => operations.update(input),
             "delete" => operations.delete(input),
             "rename" => operations.rename(input),
+            "read_type" => operations.read_type(input),
+            "create_type" => operations.create_type(input),
+            "update_type" => operations.update_type(input),
             other => return Err(ConnectError::UnsupportedOperation(other.to_string())),
         };
         return serde_json::to_value(result).map_err(ConnectError::from);
@@ -1618,7 +1625,18 @@ fn execute_loaded(
 
 fn supported_operations() -> &'static [&'static str] {
     &[
-        "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
+        "describe",
+        "changes",
+        "read",
+        "query",
+        "validate",
+        "create",
+        "update",
+        "delete",
+        "rename",
+        "read_type",
+        "create_type",
+        "update_type",
     ]
 }
 
@@ -1738,6 +1756,69 @@ mod tests {
             .unwrap();
         assert_eq!(read["valid"], true);
         assert_eq!(read["result"]["frontmatter"]["title"], "Hello");
+    }
+
+    #[test]
+    fn type_operations_are_revision_safe_and_require_full_collection_scope() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("typed");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let collection = registry.create(&root, Some("Typed")).unwrap();
+        let document = r#"---
+kind: mdbase.type
+name: project
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    properties:
+      title: { type: string }
+---
+"#;
+
+        let created = registry
+            .operation(collection.id, "create_type", &json!({"document": document}))
+            .unwrap();
+        assert_eq!(created["valid"], true, "{created}");
+        assert_eq!(created["result"]["path"], "_types/project.md");
+        let revision = created["result"]["revision"].as_str().unwrap();
+
+        let read = registry
+            .operation(collection.id, "read_type", &json!({"name": "project"}))
+            .unwrap();
+        assert_eq!(read["result"]["revision"], revision);
+
+        let updated = registry
+            .operation(
+                collection.id,
+                "update_type",
+                &json!({
+                    "name": "project",
+                    "if_revision": revision,
+                    "document": document.replace("version: 1", "version: 2")
+                }),
+            )
+            .unwrap();
+        assert_eq!(updated["valid"], true, "{updated}");
+        assert_ne!(updated["result"]["revision"], revision);
+
+        let contract_scope = GrantScope {
+            contracts: vec![ContractRequirement {
+                id: "some.app".to_string(),
+                version: 1,
+            }],
+        };
+        assert!(matches!(
+            registry.scoped_operation(
+                collection.id,
+                "read_type",
+                &json!({"name": "project"}),
+                &contract_scope
+            ),
+            Err(ConnectError::AccessDenied(_))
+        ));
     }
 
     #[test]

--- a/crates/connect-hosted-provider/migrations/0002_type_resource_changes.sql
+++ b/crates/connect-hosted-provider/migrations/0002_type_resource_changes.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS hosted_provider_resource_changes (
+  collection_id uuid NOT NULL REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  sequence bigint NOT NULL CHECK (sequence > 0),
+  type_name text NOT NULL,
+  path text NOT NULL,
+  revision text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (collection_id, sequence)
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_resource_changes_type_idx
+  ON hosted_provider_resource_changes (collection_id, type_name, sequence);

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -600,6 +600,13 @@ impl HostedProvider {
         .bind(to_i64(through, "compaction cursor")?)
         .execute(&mut *transaction)
         .await?;
+        sqlx::query(
+            "DELETE FROM hosted_provider_resource_changes WHERE collection_id = $1 AND sequence <= $2",
+        )
+        .bind(collection_id)
+        .bind(to_i64(through, "compaction cursor")?)
+        .execute(&mut *transaction)
+        .await?;
         let through_i64 = to_i64(through, "compaction cursor")?;
         let oldest_live_snapshot: Option<i64> = sqlx::query_scalar(
             r#"SELECT min(cursor) FROM hosted_provider_snapshot_leases
@@ -861,6 +868,27 @@ impl HostedProvider {
                 "invalid_cursor",
                 "Change cursor is ahead of the collection authority.",
             ));
+        }
+        let resource_changed = sqlx::query_scalar::<_, bool>(
+            r#"SELECT EXISTS(
+                 SELECT 1 FROM hosted_provider_resource_changes
+                 WHERE collection_id = $1 AND sequence > $2
+               )"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(after, "change cursor")?)
+        .fetch_one(&self.pool)
+        .await?;
+        if resource_changed {
+            return Ok(SyncChangesPage {
+                protocol_version: SYNC_PROTOCOL_VERSION,
+                scope_epoch: replica.scope_epoch,
+                events: Vec::new(),
+                cursor: after,
+                head,
+                has_more: false,
+                reset_required: true,
+            });
         }
         let raw_limit = i64::from(limit.clamp(1, 500));
         let rows = sqlx::query(
@@ -1422,13 +1450,21 @@ impl HostedProvider {
             .authenticate_for(collection_id, token, ReplicaPurpose::Application)
             .await?;
         authorize_application_operation(&replica, operation, request_origin)?;
+        if matches!(operation, "read_type" | "create_type" | "update_type")
+            && !replica.allowed_types.is_empty()
+        {
+            return Err(ApiError::forbidden(
+                "scope_denied",
+                "Type definitions can only be managed with full collection access.",
+            ));
+        }
         match operation {
             "describe" => self.describe_operation(collection_id, &replica).await,
             "changes" => {
                 self.changes_operation(collection_id, &replica, &input)
                     .await
             }
-            "read" | "query" | "validate" => {
+            "read" | "query" | "validate" | "read_type" => {
                 let scoped_input = scope_read_input(operation, input, &replica.allowed_types)?;
                 let result = self
                     .execute_read_operation(collection_id, operation, &scoped_input)
@@ -1442,6 +1478,10 @@ impl HostedProvider {
             }
             "create" | "update" | "delete" | "rename" => {
                 self.write_operation(collection_id, token, &replica, operation, input)
+                    .await
+            }
+            "create_type" | "update_type" => {
+                self.write_type_operation(collection_id, &replica, operation, input)
                     .await
             }
             _ => Err(ApiError::bad_request(
@@ -1545,7 +1585,7 @@ impl HostedProvider {
             .and_then(Value::as_u64)
             .unwrap_or(100)
             .clamp(1, 500);
-        let rows = sqlx::query(
+        let record_rows = sqlx::query(
             r#"SELECT sequence, before_ciphertext, after_ciphertext, created_at::text AS occurred_at
                FROM hosted_provider_changes
                WHERE collection_id = $1 AND sequence > $2
@@ -1559,10 +1599,24 @@ impl HostedProvider {
         .bind(to_i64(limit + 1, "change page limit")?)
         .fetch_all(&self.pool)
         .await?;
-        let has_more = rows.len() > limit as usize;
+        let resource_rows = sqlx::query(
+            r#"SELECT sequence, type_name, path, revision, created_at::text AS occurred_at
+               FROM hosted_provider_resource_changes
+               WHERE collection_id = $1 AND sequence > $2
+                 AND (cardinality($3::text[]) = 0 OR type_name = ANY($3::text[]))
+               ORDER BY sequence LIMIT $4"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(after, "change cursor")?)
+        .bind(&replica.allowed_types)
+        .bind(to_i64(limit + 1, "change page limit")?)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut has_more =
+            record_rows.len() > limit as usize || resource_rows.len() > limit as usize;
         let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
         let mut events = Vec::new();
-        for row in rows.into_iter().take(limit as usize) {
+        for row in record_rows {
             let sequence = number(row.get::<i64, _>("sequence"), "change sequence")?;
             let before = optional_encrypted_record(
                 &self.crypto,
@@ -1592,6 +1646,23 @@ impl HostedProvider {
                 occurred_at: row.get("occurred_at"),
                 payload,
             });
+        }
+        for row in resource_rows {
+            events.push(CollectionChange {
+                cursor: number(row.get::<i64, _>("sequence"), "resource change sequence")?,
+                event_type: "mdbase.type.changed".to_string(),
+                occurred_at: row.get("occurred_at"),
+                payload: json!({
+                    "name": row.get::<String, _>("type_name"),
+                    "path": row.get::<String, _>("path"),
+                    "revision": row.get::<String, _>("revision"),
+                }),
+            });
+        }
+        events.sort_by_key(|event| event.cursor);
+        if events.len() > limit as usize {
+            events.truncate(limit as usize);
+            has_more = true;
         }
         let cursor = events.last().map(|event| event.cursor).unwrap_or_else(|| {
             if has_more {
@@ -1864,6 +1935,228 @@ impl HostedProvider {
             ),
         };
         serde_json::to_value(result).map_err(|error| {
+            ApiError::internal(format!("Hosted operation could not serialize: {error}"))
+        })
+    }
+
+    async fn write_type_operation(
+        &self,
+        collection_id: Uuid,
+        replica: &Replica,
+        operation: &str,
+        input: Value,
+    ) -> ApiResult<Value> {
+        if !replica.allowed_types.is_empty() {
+            return Err(ApiError::forbidden(
+                "scope_denied",
+                "Type definitions can only be managed with full collection access.",
+            ));
+        }
+        let mut transaction = self.pool.begin().await?;
+        let collection = sqlx::query(
+            r#"SELECT head, wrapped_data_key, resources_ciphertext, max_document_bytes
+               FROM hosted_provider_collections
+               WHERE id = $1 AND state = 'active' FOR UPDATE"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let mut head = number(collection.get::<i64, _>("head"), "collection head")?;
+        let max_document_bytes = number(
+            collection.get::<i64, _>("max_document_bytes"),
+            "maximum document size",
+        )?;
+        if input
+            .get("document")
+            .and_then(Value::as_str)
+            .is_some_and(|document| document.len() as u64 > max_document_bytes)
+        {
+            return Err(ApiError::bad_request(
+                "document_quota_exceeded",
+                "The type definition exceeds the hosted document size limit.",
+            ));
+        }
+        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let working_set = self.working_set(collection_id).await;
+        let mut cached = working_set.lock().await;
+        if cached
+            .as_ref()
+            .is_none_or(|working_set| working_set.head != Some(head))
+        {
+            let resources =
+                load_resource_documents(&mut transaction, &self.crypto, &data_key, collection_id)
+                    .await?;
+            let records =
+                load_records(&mut transaction, &self.crypto, &data_key, collection_id).await?;
+            let workspace = WorkingSet::materialize(
+                resources,
+                records.values().map(|record| StoredDocument {
+                    record_id: record.record.record_id,
+                    path: record.record.path.clone(),
+                    document: record.document.clone(),
+                }),
+            )?;
+            *cached = Some(CachedCollection {
+                head: Some(head),
+                workspace,
+                records,
+                query_cache: HashMap::new(),
+                query_order: VecDeque::new(),
+            });
+        }
+        let cached = cached
+            .as_mut()
+            .expect("hosted working set was initialized above");
+        let envelope = cached.workspace.type_operation(operation, &input)?;
+        if !envelope.valid {
+            transaction.commit().await?;
+            return serde_json::to_value(envelope).map_err(|error| {
+                ApiError::internal(format!("Hosted operation could not serialize: {error}"))
+            });
+        }
+        // The workspace has already changed. Keep the cache invalid until the
+        // matching database transaction commits so a failed persistence step
+        // cannot leave a stale in-memory collection serving future requests.
+        cached.head = None;
+        let path = result_string(&envelope.result, "path")?.to_string();
+        let type_name = result_string(&envelope.result, "name")?.to_string();
+        let revision = result_string(&envelope.result, "revision")?.to_string();
+        let document = cached.workspace.resource_document(&path)?;
+        let (types, contracts) = cached.workspace.type_resources()?;
+        let record_inputs = cached
+            .records
+            .iter()
+            .map(|(id, persisted)| {
+                (
+                    *id,
+                    persisted.record.path.clone(),
+                    persisted.record.frontmatter.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let classifications = cached.workspace.classify_records(&record_inputs)?;
+
+        head = head
+            .checked_add(1)
+            .ok_or_else(|| ApiError::internal("The hosted collection sequence is exhausted."))?;
+        let resource_revision = format!("hosted:1:{head}:resources");
+        let mut resources: SyncCollectionResources = self.crypto.decrypt_json(
+            &data_key,
+            collection.get("resources_ciphertext"),
+            &resources_aad(collection_id),
+        )?;
+        resources.revision = resource_revision.clone();
+        resources.types = types;
+        resources.contracts = contracts;
+        let resources_ciphertext =
+            self.crypto
+                .encrypt_json(&data_key, &resources, &resources_aad(collection_id))?;
+        let document_ciphertext = self.crypto.encrypt_bytes(
+            &data_key,
+            document.as_bytes(),
+            &resource_document_aad(collection_id, &path),
+        )?;
+        sqlx::query(
+            r#"INSERT INTO hosted_provider_resources
+                 (collection_id, path, kind, revision, document_ciphertext)
+               VALUES ($1, $2, 'type', $3, $4)
+               ON CONFLICT (collection_id, path) DO UPDATE SET
+                 revision = EXCLUDED.revision,
+                 document_ciphertext = EXCLUDED.document_ciphertext,
+                 updated_at = now()"#,
+        )
+        .bind(collection_id)
+        .bind(&path)
+        .bind(&revision)
+        .bind(document_ciphertext)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"INSERT INTO hosted_provider_resource_changes
+                 (collection_id, sequence, type_name, path, revision)
+               VALUES ($1, $2, $3, $4, $5)"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(head, "resource change sequence")?)
+        .bind(&type_name)
+        .bind(&path)
+        .bind(&revision)
+        .execute(&mut *transaction)
+        .await?;
+
+        for (record_id, next_types) in classifications {
+            let Some(persisted) = cached.records.get_mut(&record_id) else {
+                continue;
+            };
+            if persisted.record.types == next_types {
+                continue;
+            }
+            persisted.record.types = next_types;
+            let sequence: i64 = sqlx::query_scalar(
+                "SELECT sequence FROM hosted_provider_records WHERE collection_id = $1 AND record_id = $2",
+            )
+            .bind(collection_id)
+            .bind(record_id)
+            .fetch_one(&mut *transaction)
+            .await?;
+            let sequence_u64 = number(sequence, "record sequence")?;
+            let current_ciphertext = self.crypto.encrypt_json(
+                &data_key,
+                persisted,
+                &current_record_aad(collection_id, record_id, sequence_u64),
+            )?;
+            let version_ciphertext = self.crypto.encrypt_json(
+                &data_key,
+                persisted,
+                &record_version_aad(collection_id, record_id, sequence_u64),
+            )?;
+            sqlx::query(
+                r#"UPDATE hosted_provider_records
+                   SET types = $3, payload_ciphertext = $4, updated_at = now()
+                   WHERE collection_id = $1 AND record_id = $2"#,
+            )
+            .bind(collection_id)
+            .bind(record_id)
+            .bind(&persisted.record.types)
+            .bind(current_ciphertext)
+            .execute(&mut *transaction)
+            .await?;
+            sqlx::query(
+                r#"UPDATE hosted_provider_record_versions
+                   SET types = $4, payload_ciphertext = $5
+                   WHERE collection_id = $1 AND record_id = $2 AND sequence = $3"#,
+            )
+            .bind(collection_id)
+            .bind(record_id)
+            .bind(sequence)
+            .bind(&persisted.record.types)
+            .bind(version_ciphertext)
+            .execute(&mut *transaction)
+            .await?;
+        }
+
+        sqlx::query(
+            r#"UPDATE hosted_provider_collections
+               SET head = $2, resource_revision = $3, resources_ciphertext = $4, updated_at = now()
+               WHERE id = $1"#,
+        )
+        .bind(collection_id)
+        .bind(to_i64(head, "collection head")?)
+        .bind(resource_revision)
+        .bind(resources_ciphertext)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        cached.head = Some(head);
+        cached.query_cache.clear();
+        cached.query_order.clear();
+        serde_json::to_value(envelope).map_err(|error| {
             ApiError::internal(format!("Hosted operation could not serialize: {error}"))
         })
     }
@@ -2246,6 +2539,14 @@ fn authorize_application_operation(
     Ok(())
 }
 
+fn result_string<'a>(value: &'a Value, field: &str) -> ApiResult<&'a str> {
+    value.get(field).and_then(Value::as_str).ok_or_else(|| {
+        ApiError::internal(format!(
+            "The hosted collection operation omitted its {field} result."
+        ))
+    })
+}
+
 fn scope_read_input(operation: &str, input: Value, allowed_types: &[String]) -> ApiResult<Value> {
     if operation != "query" || allowed_types.is_empty() {
         return Ok(input);
@@ -2541,9 +2842,27 @@ fn validate_replica_capability(input: &RegisterReplica) -> ApiResult<()> {
 
 fn validate_operations(operations: &[String], mode: SyncReplicaMode) -> ApiResult<()> {
     const OPERATIONS: &[&str] = &[
-        "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
+        "describe",
+        "changes",
+        "read",
+        "query",
+        "validate",
+        "create",
+        "update",
+        "delete",
+        "rename",
+        "read_type",
+        "create_type",
+        "update_type",
     ];
-    const WRITES: &[&str] = &["create", "update", "delete", "rename"];
+    const WRITES: &[&str] = &[
+        "create",
+        "update",
+        "delete",
+        "rename",
+        "create_type",
+        "update_type",
+    ];
     if operations
         .iter()
         .any(|operation| !OPERATIONS.contains(&operation.as_str()))

--- a/crates/connect-hosted-provider/src/workspace.rs
+++ b/crates/connect-hosted-provider/src/workspace.rs
@@ -169,6 +169,7 @@ impl WorkingSet {
         })?;
         match operation {
             "read" => Ok(operations.read(input)),
+            "read_type" => Ok(operations.read_type(input)),
             // Query execution remains entirely in mdbase-rs. Its v0.3 query
             // facade is newer than the minimum path dependency supported by
             // the hosted build, so only the common legacy envelope is adapted
@@ -180,6 +181,129 @@ impl WorkingSet {
                 "The hosted provider does not support that read operation.",
             )),
         }
+    }
+
+    pub fn type_operation(&self, operation: &str, input: &Value) -> ApiResult<OperationResult> {
+        let collection = Collection::open(self.directory.path()).map_err(|error| {
+            ApiError::internal(format!(
+                "The hosted collection working set is invalid: {error}"
+            ))
+        })?;
+        let operations = collection.v03_operations().map_err(|diagnostic| {
+            ApiError::internal(format!(
+                "The hosted collection could not open: {}",
+                diagnostic.message
+            ))
+        })?;
+        match operation {
+            "create_type" => Ok(operations.create_type(input)),
+            "update_type" => Ok(operations.update_type(input)),
+            _ => Err(ApiError::bad_request(
+                "unsupported_operation",
+                "The hosted provider does not support that type operation.",
+            )),
+        }
+    }
+
+    pub fn resource_document(&self, path: &str) -> ApiResult<String> {
+        fs::read_to_string(safe_path(self.directory.path(), path)?).map_err(Into::into)
+    }
+
+    pub fn type_resources(
+        &self,
+    ) -> ApiResult<(
+        Vec<mdbase_connect_protocol::CollectionTypeDescriptor>,
+        Vec<mdbase_connect_protocol::CollectionContractDescriptor>,
+    )> {
+        let report = mdbase::v03::inspect_collection(self.directory.path());
+        if !report.valid {
+            return Err(ApiError::internal(
+                report
+                    .diagnostics
+                    .first()
+                    .map(|diagnostic| diagnostic.message.clone())
+                    .unwrap_or_else(|| "The hosted type registry is invalid.".to_string()),
+            ));
+        }
+        let mut types = Vec::new();
+        let mut contracts = Vec::new();
+        for type_file in report.types {
+            let description = type_file
+                .frontmatter
+                .get("description")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let collection = type_file.frontmatter.get("collection").cloned();
+            let lifecycle = type_file.frontmatter.get("lifecycle").cloned();
+            let extensions = type_file
+                .frontmatter
+                .as_object()
+                .into_iter()
+                .flatten()
+                .filter(|(key, _)| key.starts_with("x-"))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<Map<_, _>>();
+            for (extension, configuration) in &extensions {
+                let Some(id) = configuration.get("contract").and_then(Value::as_str) else {
+                    continue;
+                };
+                contracts.push(mdbase_connect_protocol::CollectionContractDescriptor {
+                    id: id.to_string(),
+                    version: configuration
+                        .get("version")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(1),
+                    type_name: type_file.name.clone(),
+                    extension: extension.clone(),
+                    configuration: configuration.clone(),
+                });
+            }
+            types.push(mdbase_connect_protocol::CollectionTypeDescriptor {
+                name: type_file.name,
+                version: type_file.version,
+                description,
+                path: Some(type_file.path),
+                definition: type_file
+                    .frontmatter
+                    .as_object()
+                    .cloned()
+                    .map(Value::Object),
+                schema: type_file.schema,
+                collection,
+                lifecycle,
+                extensions,
+            });
+        }
+        types.sort_by(|left, right| left.name.cmp(&right.name));
+        contracts.sort_by(|left, right| {
+            (&left.id, left.version, &left.type_name).cmp(&(
+                &right.id,
+                right.version,
+                &right.type_name,
+            ))
+        });
+        Ok((types, contracts))
+    }
+
+    pub fn classify_records(
+        &self,
+        records: &[(Uuid, String, Map<String, Value>)],
+    ) -> ApiResult<BTreeMap<Uuid, Vec<String>>> {
+        let collection = Collection::open(self.directory.path()).map_err(|error| {
+            ApiError::internal(format!(
+                "The hosted collection working set is invalid: {error}"
+            ))
+        })?;
+        Ok(records
+            .iter()
+            .map(|(id, path, frontmatter)| {
+                (
+                    *id,
+                    collection
+                        .determine_types_for_path(&Value::Object(frontmatter.clone()), Some(path)),
+                )
+            })
+            .collect())
     }
 }
 
@@ -478,5 +602,41 @@ mod tests {
         };
         let error = workspace.execute(&mutation).unwrap_err();
         assert_eq!(error.code, "invalid_path");
+    }
+
+    #[test]
+    fn reads_creates_and_updates_type_resources() {
+        let workspace = WorkingSet::materialize(resources(), []).unwrap();
+        let task = workspace
+            .read_operation("read_type", &json!({"name": "task"}))
+            .unwrap();
+        assert!(task.valid);
+        let task_revision = task.result["revision"].as_str().unwrap();
+        let updated = workspace
+            .type_operation(
+                "update_type",
+                &json!({
+                    "name": "task",
+                    "if_revision": task_revision,
+                    "document": task.result["document"].as_str().unwrap().replace(
+                        "A TaskNotes-compatible task.",
+                        "An updated task."
+                    )
+                }),
+            )
+            .unwrap();
+        assert!(updated.valid, "{:?}", updated.diagnostics);
+
+        let created = workspace
+            .type_operation(
+                "create_type",
+                &json!({
+                    "document": "---\nkind: mdbase.type\nname: project\nversion: 1\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\n    properties:\n      title: { type: string }\n---\n"
+                }),
+            )
+            .unwrap();
+        assert!(created.valid, "{:?}", created.diagnostics);
+        let (types, _) = workspace.type_resources().unwrap();
+        assert!(types.iter().any(|definition| definition.name == "project"));
     }
 }

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -26,6 +26,35 @@ for await (const change of connect.watch()) {
 }
 ```
 
+Applications with full collection access can also register and maintain type
+definitions. Type source is returned with a revision token so updates cannot
+silently overwrite a definition changed by another application:
+
+```ts
+const created = await connect.createType({
+  document: `---
+kind: mdbase.type
+name: workout
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+---
+`
+});
+
+const current = await connect.readType({ name: "workout" });
+await connect.updateType({
+  path: current.result.path,
+  document: current.result.document.replace("version: 1", "version: 2"),
+  if_revision: current.result.revision
+});
+```
+
+Request `read_type`, `create_type`, and `update_type` during authorization.
+Contract-scoped applications cannot manage collection-wide type definitions.
+
 Application identity is derived from the manifest's exact origin. No developer
 account or manually issued client secret is required.
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -32,6 +32,28 @@ describe("provider-neutral collection client", () => {
     }]);
   });
 
+  it("exposes revision-safe type document operations", async () => {
+    const calls: Array<{ operation: string; input: unknown }> = [];
+    const client = new MdbaseCollectionClient({
+      async operation<Result>(operation: string, input: unknown) {
+        calls.push({ operation, input });
+        return { valid: true, result: {}, diagnostics: [] } as Result;
+      }
+    });
+    await client.readType({ name: "task" });
+    await client.createType({ document: "---\nkind: mdbase.type\n---\n" });
+    await client.updateType({
+      path: "_types/task.md",
+      document: "---\nkind: mdbase.type\n---\n",
+      if_revision: "sha256:one"
+    });
+    expect(calls.map(({ operation }) => operation)).toEqual([
+      "read_type",
+      "create_type",
+      "update_type"
+    ]);
+  });
+
   it("surfaces cursor resets from any transport", async () => {
     const client = new MdbaseCollectionClient({
       async operation<Result>() {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,6 +4,7 @@ import type {
   CollectionDescription,
   CollectionFileMetadata,
   CollectionOperation,
+  CollectionTypeDocument,
   EncryptedRelayOperationResponse,
   GrantEncryption,
   GrantScope,
@@ -36,6 +37,7 @@ export type {
   CollectionFileMetadata,
   CollectionOperation as MdbaseOperation,
   CollectionTypeDescriptor,
+  CollectionTypeDocument,
   ContractRequirement,
   GrantScope,
   JsonObject,
@@ -131,6 +133,21 @@ export interface RenameResult extends RecordResult {
   references_updated?: JsonObject[];
 }
 
+export interface ReadTypeInput {
+  name?: string;
+  path?: string;
+}
+
+export interface CreateTypeInput {
+  document: string;
+  path?: string;
+}
+
+export interface UpdateTypeInput extends ReadTypeInput {
+  document: string;
+  if_revision: string;
+}
+
 export interface ChangesInput {
   after?: number;
   limit?: number;
@@ -194,6 +211,18 @@ export class MdbaseCollectionClient<Frontmatter extends JsonObject = JsonObject>
 
   validate(input: JsonObject = {}): Promise<MdbaseOperationEnvelope> {
     return this.operation("validate", input);
+  }
+
+  readType(input: ReadTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
+    return this.operation("read_type", input);
+  }
+
+  createType(input: CreateTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
+    return this.operation("create_type", input);
+  }
+
+  updateType(input: UpdateTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
+    return this.operation("update_type", input);
   }
 
   async *watch(options: WatchOptions = {}): AsyncGenerator<CollectionChange> {
@@ -428,6 +457,18 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
 
   validate(input: JsonObject = {}): Promise<MdbaseOperationEnvelope> {
     return this.collectionClient.validate(input);
+  }
+
+  readType(input: ReadTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
+    return this.collectionClient.readType(input);
+  }
+
+  createType(input: CreateTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
+    return this.collectionClient.createType(input);
+  }
+
+  updateType(input: UpdateTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
+    return this.collectionClient.updateType(input);
   }
 
   async *watch(options: WatchOptions = {}): AsyncGenerator<CollectionChange> {

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -428,7 +428,7 @@ function sandboxDescription(value: Partial<CollectionDescription> = {}): Collect
     collection_id: value.collection_id ?? "01900000-0000-7000-8000-000000000001",
     display_name: value.display_name ?? "Developer sandbox",
     spec_version: value.spec_version ?? "0.3.0",
-    operations: value.operations ?? ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename"],
+    operations: value.operations ?? ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"],
     change_cursor: value.change_cursor ?? 0,
     types: clone(value.types ?? []),
     contracts: clone(value.contracts ?? [])

--- a/packages/protocol/schemas/connect-protocol.v2.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v2.schema.json
@@ -14,7 +14,7 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
     "operation": {
-      "enum": ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename"]
+      "enum": ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"]
     },
     "contractRequirement": {
       "type": "object",

--- a/packages/protocol/schemas/encrypted-relay.v3.schema.json
+++ b/packages/protocol/schemas/encrypted-relay.v3.schema.json
@@ -14,7 +14,7 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
     "operation": {
-      "enum": ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename"]
+      "enum": ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"]
     },
     "envelope": {
       "type": "object",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -20,7 +20,10 @@ export type CollectionOperation =
   | "create"
   | "update"
   | "delete"
-  | "rename";
+  | "rename"
+  | "read_type"
+  | "create_type"
+  | "update_type";
 
 export interface MdbaseAppManifest {
   manifest_version: 1;
@@ -268,6 +271,13 @@ export interface CollectionTypeDescriptor {
   collection?: JsonObject;
   lifecycle?: JsonObject;
   extensions: Record<string, unknown>;
+}
+
+export interface CollectionTypeDocument {
+  name: string;
+  path: string;
+  revision: string;
+  document: string;
 }
 
 export interface CollectionContractDescriptor {

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -45,7 +45,7 @@ import {
   type GitHubAuthConfig
 } from "./github-auth.js";
 
-const OPERATIONS = ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename"] as const;
+const OPERATIONS = ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"] as const;
 const operationSchema = z.enum(OPERATIONS);
 const contractRequirementSchema = z.object({
   id: z.string().trim().min(1).max(100),
@@ -1200,7 +1200,7 @@ export async function buildApp(options: BuildOptions) {
       if (!options.hostedProvider) {
         return reply.code(503).send(apiError("hosted_provider_unavailable", "Hosted application access is temporarily unavailable."));
       }
-      const write = operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
+      const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
       await options.hostedProvider.updateApplicationReplica(current.hosted_replica_id, {
         mode: write ? "read_write" : "read_only",
         allowedTypes: hostedTypesForContracts(current.template!, current.scope.contracts),
@@ -1745,7 +1745,7 @@ async function reconcileApplicationGrants(
     if ((scopeMatches || mayNarrow) && collectionCompatible) {
       if (grant.hosted_replica_id) {
         if (!hostedProvider) throw new Error("Hosted provider unavailable during grant reconciliation.");
-        const write = grant.operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
+        const write = grant.operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
         await hostedProvider.updateApplicationReplica(grant.hosted_replica_id, {
           mode: write ? "read_write" : "read_only",
           allowedTypes: desiredAllowedTypes,
@@ -1956,7 +1956,7 @@ async function approveHostedAuthorization(
     const allowedTypes = hostedTypesForContracts(input.template, scope.contracts);
     await provider.renameCollection(input.collectionId, input.displayName);
     const operations = [...new Set(input.operations)];
-    const write = operations.some((operation) => ["create", "update", "delete", "rename"].includes(operation));
+    const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
     const applicationUrl = new URL(pending.application_homepage);
     const allowedOrigin = ["http:", "https:"].includes(applicationUrl.protocol)
       ? applicationUrl.origin


### PR DESCRIPTION
## What changed

- add `read_type`, `create_type`, and `update_type` to the protocol and browser SDK
- route type operations through local connectors and hosted collections
- keep updates revision-safe and publish `mdbase.type.changed` events
- refresh hosted resources and record type classification after definition changes
- restrict collection-wide type management to full-collection grants
- surface the new permissions in portal, desktop, and devkit defaults

## Why

Applications need a supported way to register types, while users and hosted collections need consistent authorization, persistence, and change-feed behavior.

## Checks

- package builds followed by `pnpm typecheck`
- `cargo test -p mdbase-connect-core -p mdbase-connect-hosted-provider`
- `git diff --check`
