### PR TITLE
Make new local mirrors two-way by default

### DIFF
--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -264,7 +264,6 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
   const [panel, setPanel] = useState<"mirror" | "rename" | null>(null);
   const [name, setName] = useState(collection.display_name);
   const [mirrorName, setMirrorName] = useState("Local mirror");
-  const [mirrorMode, setMirrorMode] = useState<"read_only" | "read_write">("read_only");
   const [busy, setBusy] = useState(false);
   const [secret, setSecret] = useState<ReplicaSecret | null>(null);
   const activeReplicas = collection.replicas.filter((replica) => !replica.revoked_at);
@@ -296,9 +295,9 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
         sync_url: string;
       }>(`/v1/hosted/collections/${collection.id}/replicas`, {
         method: "POST",
-        body: JSON.stringify({ name: mirrorName.trim(), mode: mirrorMode, allowed_types: [] })
+        body: JSON.stringify({ name: mirrorName.trim(), mode: "read_write", allowed_types: [] })
       });
-      setSecret({ replicaId: enrollment.replica.id, token: enrollment.token, syncUrl: enrollment.sync_url, mode: mirrorMode });
+      setSecret({ replicaId: enrollment.replica.id, token: enrollment.token, syncUrl: enrollment.sync_url, mode: "read_write" });
       await onChanged();
     } catch (reason) { onError(message(reason)); }
     finally { setBusy(false); }
@@ -349,8 +348,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
     {panel === "mirror" && <div className="hosted-detail">
       {!secret ? <form className="mirror-form" onSubmit={(event) => void addMirror(event)}>
         <label><span>Mirror name</span><input autoFocus maxLength={200} value={mirrorName} onChange={(event) => setMirrorName(event.target.value)} /></label>
-        <label><span>Local edits</span><select value={mirrorMode} onChange={(event) => setMirrorMode(event.target.value as "read_only" | "read_write")}><option value="read_only">Receive only</option><option value="read_write">Sync to hosted</option></select></label>
-        <p>{mirrorMode === "read_only" ? "Local edits never overwrite the hosted source of truth." : "Local edits sync conditionally. Concurrent edits stop for an explicit choice—never last-write-wins."}</p>
+        <p>Edits sync in both directions. Concurrent edits stop for an explicit choice; mdbase never uses last-write-wins.</p>
         <button className="button primary" disabled={busy || !mirrorName.trim()}>{busy ? "Preparing…" : "Prepare mirror"}</button>
       </form> : <MirrorSetup collectionId={collection.id} secret={secret} />}
     </div>}

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -199,7 +199,7 @@ h1 {
 }
 
 .mirror-form {
-  grid-template-columns: minmax(12rem, 0.8fr) minmax(11rem, 0.7fr) minmax(16rem, 1.2fr) auto;
+  grid-template-columns: minmax(12rem, 0.8fr) minmax(20rem, 1.5fr) auto;
 }
 
 .hosted-rename {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1010,8 +1010,9 @@ async function portalLifecycleE2E(controlUrl) {
 
     await row.getByRole("button", { name: "Add mirror" }).click();
     await row.getByLabel("Mirror name").fill("Browser writable mirror");
-    await row.getByLabel("Local edits").selectOption("read_write");
-    await expect(row).toContainText("never last-write-wins");
+    await expect(row.getByLabel("Local edits")).toHaveCount(0);
+    await expect(row).not.toContainText("Receive only");
+    await expect(row).toContainText("Edits sync in both directions");
     await row.getByRole("button", { name: "Prepare mirror" }).click();
     await expect(row.locator("code").filter({ hasText: "mdbase-mirror init" })).toContainText("--writable");
     await expect(row).toContainText("Save this token now");


### PR DESCRIPTION
## What changed

- remove the receive-only selector from the portal's Add mirror flow
- enroll every new portal-created mirror with a read-write capability
- explain the two-way conflict behavior directly in the form
- keep existing receive-only replicas visible and token-compatible
- update the real-browser provider E2E to prove the option is absent and the resulting mirror is writable

## Why

A local Markdown directory implies that users can edit it. Offering receive-only as the default created a surprising path where normal local edits stopped mirroring because of divergence.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:sync`
- `pnpm e2e:provider`
