### PR TITLE
Add connector-controlled type provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ on a user's local or mdbase-hosted [mdbase](https://mdbase.dev) collections.
 Local collection folders are never exposed directly to the internet; hosted
 collections keep their authoritative Markdown on mdbase with optional mirrors.
 
+Applications can declare portable type provisions in their manifest.
+When a selected collection is missing a required contract, its local or hosted
+authority installs the declared type during approval, verifies the resulting
+contract scope, and creates the grant afterward. Setup does not grant the
+application general type-management access.
+
 This is a functional private-beta foundation. The tested path covers creating a local
 collection, pairing an outbound-only connector, discovering an independent web
 app, approving exact operations locally or from the authenticated account

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -24,6 +24,17 @@ interface ApplicationRequirements {
   contracts: ContractRequirement[];
 }
 
+interface TypeProvision {
+  name: string;
+  path?: string;
+  document: string;
+  provides: ContractRequirement[];
+}
+
+interface ApplicationProvisions {
+  types: TypeProvision[];
+}
+
 interface GrantScope {
   contracts: ContractRequirement[];
 }
@@ -51,6 +62,7 @@ interface ApplicationSummary {
   homepage: string;
   icon?: string;
   requirements: ApplicationRequirements;
+  provisions?: ApplicationProvisions;
 }
 
 interface GrantSummary {
@@ -74,7 +86,9 @@ interface PendingAuthorization {
   application_icon?: string;
   requested_operations: string[];
   requirements: ApplicationRequirements;
+  provisions: ApplicationProvisions;
   compatible_collection_ids: string[];
+  provisionable_collection_ids: string[];
   expires_at: string;
 }
 

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -407,24 +407,32 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
 }) {
-  const compatible = useMemo(
-    () => collections.filter((collection) => request.compatible_collection_ids.includes(collection.id)),
-    [collections, request.compatible_collection_ids]
+  const available = useMemo(
+    () => collections.filter((collection) =>
+      request.compatible_collection_ids.includes(collection.id)
+      || request.provisionable_collection_ids.includes(collection.id)
+    ),
+    [collections, request.compatible_collection_ids, request.provisionable_collection_ids]
   );
-  const [collectionId, setCollectionId] = useState(compatible[0]?.id ?? "");
+  const [collectionId, setCollectionId] = useState(available[0]?.id ?? "");
   const [operations, setOperations] = useState(request.requested_operations);
+  const selected = available.find((collection) => collection.id === collectionId);
+  const setup = selected && request.provisionable_collection_ids.includes(selected.id)
+    ? neededProvisions(request.requirements, request.provisions, selected)
+    : [];
   useEffect(() => {
-    if (!compatible.some((collection) => collection.id === collectionId)) {
-      setCollectionId(compatible[0]?.id ?? "");
+    if (!available.some((collection) => collection.id === collectionId)) {
+      setCollectionId(available[0]?.id ?? "");
     }
-  }, [collectionId, compatible]);
+  }, [collectionId, available]);
   return (
     <article className="request-panel">
       <div className="identity-mark">{initials(request.application_name)}</div>
       <div className="request-identity"><p className="eyebrow">Access request</p><h3>{request.application_name}</h3><code>{host(request.application_homepage)}</code><small>Expires {relativeTime(request.expires_at)}</small>{request.requirements.contracts.length > 0 && <small>{scopeDescription(request.requirements.contracts)}</small>}</div>
       <div className="request-fields">
-        <label><span>Collection</span><select value={collectionId} disabled={compatible.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{compatible.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}</option>)}</select></label>
-        {compatible.length === 0 && <small>No registered collection provides the required contracts.</small>}
+        <label><span>Collection</span><select value={collectionId} disabled={available.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}{request.provisionable_collection_ids.includes(collection.id) ? " · setup required" : ""}</option>)}</select></label>
+        {available.length === 0 && <small>No registered collection provides the required contracts and the app cannot install them.</small>}
+        {setup.length > 0 && <small>Allowing access will add {provisionNames(setup)} to this collection.</small>}
         <fieldset><legend>Requested operations</legend><OperationChoices allowed={request.requested_operations} selected={operations} onChange={setOperations} /></fieldset>
       </div>
       <div className="decision-actions">
@@ -462,9 +470,13 @@ function ManualApplication({ collections, busy, onAct, onNotice }: { collections
   const [collectionId, setCollectionId] = useState(collections[0]?.id ?? "");
   const [operations, setOperations] = useState(["read", "query"]);
   const compatible = useMemo(
-    () => application ? compatibleCollections(application.requirements, collections) : collections,
+    () => application ? availableCollections(application.requirements, application.provisions, collections) : collections,
     [application, collections]
   );
+  const selected = compatible.find((collection) => collection.id === collectionId);
+  const setup = application && selected
+    ? neededProvisions(application.requirements, application.provisions, selected)
+    : [];
   useEffect(() => {
     if (!compatible.some((collection) => collection.id === collectionId)) {
       setCollectionId(compatible[0]?.id ?? "");
@@ -483,8 +495,9 @@ function ManualApplication({ collections, busy, onAct, onNotice }: { collections
           ) : (
             <div className="manual-grant">
               <div><p className="eyebrow">Application found</p><h3>{application.name}</h3><code>{host(application.homepage)}</code>{application.requirements.contracts.length > 0 && <small>{scopeDescription(application.requirements.contracts)}</small>}</div>
-              <label><span>Collection</span><select value={collectionId} disabled={compatible.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{compatible.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}</option>)}</select></label>
-              {compatible.length === 0 && <small>No registered collection provides the required contracts.</small>}
+              <label><span>Collection</span><select value={collectionId} disabled={compatible.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{compatible.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}{neededProvisions(application.requirements, application.provisions, collection).length ? " · setup required" : ""}</option>)}</select></label>
+              {compatible.length === 0 && <small>No registered collection provides the required contracts and the app cannot install them.</small>}
+              {setup.length > 0 && <small>Connecting will add {provisionNames(setup)} to this collection.</small>}
               <fieldset><legend>Allow</legend><OperationChoices allowed={allOperations} selected={operations} onChange={setOperations} compact /></fieldset>
               <button className="button primary" disabled={busy || !collectionId || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.createGrant({ applicationId: application.id, collectionId, operations }); onNotice(`${application.name} is connected.`); setApplication(null); setManifestUrl(""); setExpanded(false); })}>Connect app</button>
             </div>
@@ -693,17 +706,32 @@ function operationDescription(operation: string) {
   return ({ read: "Open individual records", query: "Find and filter records", create: "Add records", update: "Change records", rename: "Move or rename records", delete: "Delete records", validate: "Check collection validity", read_type: "Inspect type definitions", create_type: "Add definitions that shape records", update_type: "Change definitions and compatibility" } as Record<string, string>)[operation] ?? operation;
 }
 
-function compatibleCollections(
+function availableCollections(
   requirements: ApplicationRequirements,
+  provisions: ApplicationProvisions | undefined,
   collections: CollectionSummary[]
 ): CollectionSummary[] {
   if (requirements.contracts.length === 0) return collections;
   return collections.filter((collection) => requirements.contracts.every((requirement) =>
-    collection.contracts.some((contract) =>
-      contract.id === requirement.id && contract.version === requirement.version
-    )
+    hasContract(collection.contracts, requirement)
+    || (provisions?.types ?? []).some((provision) => provision.provides.some((provided) => sameContract(provided, requirement)))
   ));
 }
+
+function neededProvisions(
+  requirements: ApplicationRequirements,
+  provisions: ApplicationProvisions | undefined,
+  collection: CollectionSummary
+): TypeProvision[] {
+  const missing = requirements.contracts.filter((requirement) => !hasContract(collection.contracts, requirement));
+  return (provisions?.types ?? []).filter((provision) =>
+    provision.provides.some((provided) => missing.some((requirement) => sameContract(provided, requirement)))
+  );
+}
+
+function hasContract(contracts: ContractRequirement[], required: ContractRequirement) { return contracts.some((contract) => sameContract(contract, required)); }
+function sameContract(left: ContractRequirement, right: ContractRequirement) { return left.id === right.id && left.version === right.version; }
+function provisionNames(provisions: TypeProvision[]) { return provisions.map((provision) => provision.name).join(" and "); }
 
 function scopeDescription(contracts: ContractRequirement[]): string {
   const names = contracts.map((contract) => `${contract.id} v${contract.version}`);

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -84,6 +84,7 @@ export interface PendingAuthorization {
   homepage: string;
   icon: string | null;
   requirements: ApplicationRequirements;
+  provisions: ApplicationProvisions;
 }
 
 export interface AvailableCollection {
@@ -102,6 +103,17 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+}
+
+export interface TypeProvision {
+  name: string;
+  path?: string;
+  document: string;
+  provides: ContractRequirement[];
+}
+
+export interface ApplicationProvisions {
+  types: TypeProvision[];
 }
 
 export interface GrantScope {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -13,7 +13,8 @@ import {
   type ContractRequirement,
   type DashboardData,
   type HostedCollection,
-  type PendingAuthorization
+  type PendingAuthorization,
+  type TypeProvision
 } from "./api";
 import "./styles.css";
 
@@ -753,6 +754,8 @@ function ApprovalForm({
   const [operations, setOperations] = useState(() => new Set(request.requested_operations));
   const [submitting, setSubmitting] = useState<"approved" | "denied" | null>(null);
   const [error, setError] = useState("");
+  const selected = collections.find((collection) => collection.id === collectionId);
+  const setup = selected ? neededProvisions(request, selected) : [];
 
   useEffect(() => {
     if (!collections.some((collection) => collection.id === collectionId)) {
@@ -791,12 +794,13 @@ function ApprovalForm({
       <label className="collection-field" htmlFor={`collection-${request.id}`}>
         <span>Collection</span>
         <select id={`collection-${request.id}`} value={collectionId} onChange={(event) => setCollectionId(event.target.value)} disabled={submitting !== null || collections.length === 0}>
-          {collections.map((collection) => <option value={collection.id} key={collection.id}>{collection.display_name} · {collection.connector_name}</option>)}
+          {collections.map((collection) => <option value={collection.id} key={collection.id}>{collection.display_name} · {collection.connector_name}{neededProvisions(request, collection).length ? " · setup required" : ""}</option>)}
         </select>
       </label>
       {collections.length === 0 && <p className="field-note error-copy">
-        No enabled collection provides the contracts required by this application.
+        No collection is ready. Open mdbase connect on the collection's computer to add the required types.
       </p>}
+      {setup.length > 0 && <p className="field-note">Allowing access will add {provisionNames(setup)} to this hosted collection.</p>}
       <fieldset className="permission-field">
         <legend>Permissions</legend>
         <div className="permission-options">{request.requested_operations.map((operation) => (
@@ -833,16 +837,31 @@ function operationLabel(operation: string) {
 }
 function compatibleCollections<T extends { contracts: ContractRequirement[] }>(
   request: PendingAuthorization,
-  collections: T[]
+  collections: Array<T & { kind?: "local" | "hosted" }>
 ): T[] {
   const required = request.requirements.contracts;
   if (required.length === 0) return collections;
   return collections.filter((collection) => required.every((requirement) =>
-    collection.contracts.some((contract) =>
-      contract.id === requirement.id && contract.version === requirement.version
-    )
+    hasContract(collection.contracts, requirement)
+    || (collection.kind === "hosted" && request.provisions.types.some((provision) =>
+      provision.provides.some((provided) => sameContract(provided, requirement))
+    ))
   ));
 }
+
+function neededProvisions(
+  request: Pick<PendingAuthorization, "requirements" | "provisions">,
+  collection: Pick<AvailableCollection, "contracts">
+): TypeProvision[] {
+  const missing = request.requirements.contracts.filter((requirement) => !hasContract(collection.contracts, requirement));
+  return request.provisions.types.filter((provision) =>
+    provision.provides.some((provided) => missing.some((requirement) => sameContract(provided, requirement)))
+  );
+}
+
+function hasContract(contracts: ContractRequirement[], required: ContractRequirement) { return contracts.some((contract) => sameContract(contract, required)); }
+function sameContract(left: ContractRequirement, right: ContractRequirement) { return left.id === right.id && left.version === right.version; }
+function provisionNames(provisions: TypeProvision[]) { return provisions.map((provision) => provision.name).join(" and "); }
 function scopeDescription(contracts: ContractRequirement[]) {
   const names = contracts.map((contract) => `${contract.id} v${contract.version}`);
   return `Access is limited to records matching ${names.join(" and ")}.`;

--- a/apps/tasknotes/scripts/write-manifest.mjs
+++ b/apps/tasknotes/scripts/write-manifest.mjs
@@ -3,6 +3,31 @@ import { resolve } from "node:path";
 
 const origin = (process.env.TASKNOTES_APP_ORIGIN ?? "http://localhost:5179").replace(/\/$/, "");
 const target = resolve(import.meta.dirname, "..", "public", ".well-known", "mdbase-app.json");
+const taskTypeDocument = `---
+kind: mdbase.type
+name: task
+version: 1
+description: A TaskNotes-compatible task.
+collection:
+  path:
+    folder: tasks
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    required: [type, title]
+    additionalProperties: true
+    properties:
+      type: { const: task }
+      title: { type: string, minLength: 1 }
+      status: { enum: [open, done] }
+x-tasknotes:
+  contract: tasknotes.task
+  version: 1
+  field_roles: { title: title, status: status }
+  status: { completed_values: [done], default: open }
+---
+`;
 await mkdir(resolve(target, ".."), { recursive: true });
 await writeFile(target, JSON.stringify({
   manifest_version: 1,
@@ -11,5 +36,13 @@ await writeFile(target, JSON.stringify({
   redirect_uris: [`${origin}/`],
   requirements: {
     contracts: [{ id: "tasknotes.task", version: 1 }]
+  },
+  provisions: {
+    types: [{
+      name: "task",
+      path: "_types/task.md",
+      document: taskTypeDocument,
+      provides: [{ id: "tasknotes.task", version: 1 }]
+    }]
   }
 }, null, 2));

--- a/crates/connect-agent/src/cloud.rs
+++ b/crates/connect-agent/src/cloud.rs
@@ -1,7 +1,8 @@
 use mdbase_connect_core::ConnectError;
 use mdbase_connect_protocol::{
-    AccessSnapshot, ApplicationDiscoverParams, AuthorizationApproveParams, AuthorizationIdParams,
-    ComputerNameParams, GrantCreateParams, GrantIdParams, GrantUpdateParams,
+    AccessSnapshot, ApplicationDiscoverParams, ApplicationSummary, AuthorizationApproveParams,
+    AuthorizationIdParams, CollectionSummary, ComputerNameParams, GrantCreateParams, GrantIdParams,
+    GrantUpdateParams,
 };
 use reqwest::{Client, Method, Response};
 use serde::de::DeserializeOwned;
@@ -51,11 +52,56 @@ impl CloudControlClient {
         .await
     }
 
-    pub async fn create_grant(&self, params: &GrantCreateParams) -> Result<Value, ConnectError> {
+    pub async fn application(
+        &self,
+        application_id: uuid::Uuid,
+    ) -> Result<ApplicationSummary, ConnectError> {
+        let value: Value = self
+            .json(
+                Method::GET,
+                &format!("/v1/connectors/apps/{application_id}"),
+                None,
+            )
+            .await?;
+        serde_json::from_value(value["application"].clone()).map_err(ConnectError::from)
+    }
+
+    pub async fn sync_collection(
+        &self,
+        collection: &CollectionSummary,
+    ) -> Result<(), ConnectError> {
+        let _: Value = self
+            .json(
+                Method::POST,
+                "/v1/connectors/sync",
+                Some(serde_json::json!({
+                    "collections": [{
+                        "id": collection.id,
+                        "display_name": collection.display_name,
+                        "spec_version": collection.spec_version,
+                        "enabled": collection.enabled,
+                        "contracts": collection.contracts,
+                    }]
+                })),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn create_grant(
+        &self,
+        params: &GrantCreateParams,
+        contracts: &[mdbase_connect_protocol::ContractRequirement],
+    ) -> Result<Value, ConnectError> {
         self.json(
             Method::POST,
             "/v1/connectors/grants",
-            Some(serde_json::to_value(params)?),
+            Some(serde_json::json!({
+                "application_id": params.application_id,
+                "collection_id": params.collection_id,
+                "operations": params.operations,
+                "contracts": contracts,
+            })),
         )
         .await
     }
@@ -81,6 +127,7 @@ impl CloudControlClient {
     pub async fn approve_authorization(
         &self,
         params: &AuthorizationApproveParams,
+        contracts: &[mdbase_connect_protocol::ContractRequirement],
     ) -> Result<Value, ConnectError> {
         self.json(
             Method::POST,
@@ -91,6 +138,7 @@ impl CloudControlClient {
             Some(serde_json::json!({
                 "collection_id": params.collection_id,
                 "operations": params.operations,
+                "contracts": contracts,
             })),
         )
         .await

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -433,10 +433,7 @@ impl AgentState {
                 Ok(cloud) => cloud.discover(&params).await,
                 Err(error) => Err(error),
             },
-            ControlCommand::GrantCreate(params) => match self.cloud() {
-                Ok(cloud) => cloud.create_grant(&params).await,
-                Err(error) => Err(error),
-            },
+            ControlCommand::GrantCreate(params) => self.create_grant(&params).await,
             ControlCommand::GrantUpdate(params) => match self.cloud() {
                 Ok(cloud) => cloud.update_grant(&params).await,
                 Err(error) => Err(error),
@@ -491,16 +488,55 @@ impl AgentState {
             .ok_or_else(|| {
                 ConnectError::Cloud("The authorization request is no longer available.".to_string())
             })?;
-        if !self
-            .registry
-            .is_compatible(params.collection_id, &pending.requirements)?
-        {
+        let contracts = self
+            .ensure_application_types(
+                cloud,
+                params.collection_id,
+                &pending.requirements,
+                &pending.provisions,
+            )
+            .await?;
+        cloud.approve_authorization(params, &contracts).await
+    }
+
+    async fn create_grant(
+        &self,
+        params: &mdbase_connect_protocol::GrantCreateParams,
+    ) -> Result<serde_json::Value, ConnectError> {
+        let cloud = self.cloud()?;
+        let application = cloud.application(params.application_id).await?;
+        let contracts = self
+            .ensure_application_types(
+                cloud,
+                params.collection_id,
+                &application.requirements,
+                &application.provisions,
+            )
+            .await?;
+        cloud.create_grant(params, &contracts).await
+    }
+
+    async fn ensure_application_types(
+        &self,
+        cloud: &CloudControlClient,
+        collection_id: uuid::Uuid,
+        requirements: &mdbase_connect_protocol::ApplicationRequirements,
+        provisions: &mdbase_connect_protocol::ApplicationProvisions,
+    ) -> Result<Vec<mdbase_connect_protocol::ContractRequirement>, ConnectError> {
+        let registered = self.registry.get(collection_id)?;
+        if !registered.enabled {
             return Err(ConnectError::AccessDenied(
-                "This collection does not provide the contracts required by the application."
-                    .to_string(),
+                "This collection is disabled on its computer.".to_string(),
             ));
         }
-        cloud.approve_authorization(params).await
+        let contracts =
+            self.registry
+                .provision_types(collection_id, requirements, &provisions.types)?;
+        self.watcher.rescan(collection_id);
+        let mut collection = self.registry.get(collection_id)?;
+        collection.contracts = contracts;
+        cloud.sync_collection(&collection).await?;
+        Ok(collection.contracts)
     }
 
     async fn access_snapshot(&self) -> Result<serde_json::Value, ConnectError> {
@@ -543,9 +579,36 @@ impl AgentState {
                         .map(|_| collection.id)
                 })
                 .collect();
+            pending.provisionable_collection_ids = collections
+                .iter()
+                .filter(|collection| collection.enabled)
+                .filter(|collection| !pending.compatible_collection_ids.contains(&collection.id))
+                .filter(|collection| {
+                    requirements_can_be_provisioned(
+                        &pending.requirements,
+                        &pending.provisions,
+                        &collection.contracts,
+                    )
+                })
+                .map(|collection| collection.id)
+                .collect();
         }
         serde_json::to_value(snapshot).map_err(ConnectError::from)
     }
+}
+
+fn requirements_can_be_provisioned(
+    requirements: &mdbase_connect_protocol::ApplicationRequirements,
+    provisions: &mdbase_connect_protocol::ApplicationProvisions,
+    available: &[mdbase_connect_protocol::ContractRequirement],
+) -> bool {
+    requirements.contracts.iter().all(|required| {
+        available.contains(required)
+            || provisions
+                .types
+                .iter()
+                .any(|provision| provision.provides.contains(required))
+    })
 }
 
 fn is_mutation(operation: &str) -> bool {

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -5,7 +5,7 @@ use mdbase_connect_protocol::{
     ActivityEntry, ApplicationRequirements, CollectionChange, CollectionChangesPage,
     CollectionContractDescriptor, CollectionDescription, CollectionSummary,
     CollectionTypeDescriptor, ContractRequirement, GrantPolicy, GrantScope, GrantSummary,
-    CONTROL_PROTOCOL_VERSION,
+    TypeProvision, CONTROL_PROTOCOL_VERSION,
 };
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde_json::{json, Value};
@@ -521,6 +521,79 @@ impl CollectionRegistry {
                 available.id == required.id && available.version == required.version
             })
         }))
+    }
+
+    pub fn provision_types(
+        &self,
+        id: Uuid,
+        requirements: &ApplicationRequirements,
+        provisions: &[TypeProvision],
+    ) -> Result<Vec<ContractRequirement>, ConnectError> {
+        let mut available = self.describe(id)?.contracts;
+        let missing = requirements
+            .contracts
+            .iter()
+            .filter(|required| !has_contract(&available, required))
+            .cloned()
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            return Ok(contract_requirements(&available));
+        }
+        if missing.iter().any(|required| {
+            !provisions
+                .iter()
+                .any(|provision| provision.provides.contains(required))
+        }) {
+            return Err(ConnectError::AccessDenied(
+                "This collection is missing a required contract that the application cannot install."
+                    .to_string(),
+            ));
+        }
+
+        for provision in provisions {
+            if !provision
+                .provides
+                .iter()
+                .any(|provided| missing.contains(provided) && !has_contract(&available, provided))
+            {
+                continue;
+            }
+            let mut input = json!({ "document": provision.document });
+            if let Some(path) = &provision.path {
+                input["path"] = json!(path);
+            }
+            let result = self.operation(id, "create_type", &input)?;
+            if result.get("valid").and_then(Value::as_bool) != Some(true) {
+                return Err(ConnectError::AccessDenied(format!(
+                    "The {} type could not be installed: {}",
+                    provision.name,
+                    error_message(&result, "the type definition was rejected")
+                )));
+            }
+            if result
+                .pointer("/result/name")
+                .and_then(Value::as_str)
+                .is_none_or(|name| !name.eq_ignore_ascii_case(&provision.name))
+            {
+                return Err(ConnectError::AccessDenied(format!(
+                    "The installed type did not match the declared {} type.",
+                    provision.name
+                )));
+            }
+            available = self.describe(id)?.contracts;
+        }
+
+        if requirements
+            .contracts
+            .iter()
+            .any(|required| !has_contract(&available, required))
+        {
+            return Err(ConnectError::AccessDenied(
+                "The installed type definitions did not provide every required contract."
+                    .to_string(),
+            ));
+        }
+        Ok(contract_requirements(&available))
     }
 
     pub fn scoped_operation(
@@ -1629,10 +1702,30 @@ fn normalized_optional(value: Option<String>) -> Option<String> {
 fn error_message(value: &Value, fallback: &str) -> String {
     value
         .pointer("/error/message")
+        .or_else(|| value.pointer("/diagnostics/0/message"))
         .or_else(|| value.get("message"))
         .and_then(Value::as_str)
         .unwrap_or(fallback)
         .to_string()
+}
+
+fn has_contract(
+    available: &[CollectionContractDescriptor],
+    required: &ContractRequirement,
+) -> bool {
+    available
+        .iter()
+        .any(|contract| contract.id == required.id && contract.version == required.version)
+}
+
+fn contract_requirements(contracts: &[CollectionContractDescriptor]) -> Vec<ContractRequirement> {
+    contracts
+        .iter()
+        .map(|contract| ContractRequirement {
+            id: contract.id.clone(),
+            version: contract.version,
+        })
+        .collect()
 }
 
 fn execute_loaded(
@@ -1867,6 +1960,55 @@ schema:
             ),
             Err(ConnectError::AccessDenied(_))
         ));
+    }
+
+    #[test]
+    fn provisions_required_type_contracts_idempotently() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("provisioned");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let collection = registry.create(&root, Some("Provisioned")).unwrap();
+        let requirements = ApplicationRequirements {
+            contracts: vec![ContractRequirement {
+                id: "workout.record".to_string(),
+                version: 1,
+            }],
+        };
+        let provision = TypeProvision {
+            name: "Workout".to_string(),
+            path: None,
+            document: r#"---
+kind: mdbase.type
+name: workout
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    properties:
+      type: { const: workout }
+x-workout:
+  contract: workout.record
+  version: 1
+---
+"#
+            .to_string(),
+            provides: requirements.contracts.clone(),
+        };
+
+        let contracts = registry
+            .provision_types(
+                collection.id,
+                &requirements,
+                std::slice::from_ref(&provision),
+            )
+            .unwrap();
+        assert!(contracts.contains(&requirements.contracts[0]));
+        assert!(root.join("_types/workout.md").is_file());
+        registry
+            .provision_types(collection.id, &requirements, &[provision])
+            .unwrap();
     }
 
     #[test]

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -11,6 +11,7 @@ use axum::{
 };
 use mdbase_connect_protocol::{
     SyncChangesPage, SyncMutation, SyncMutationReceipt, SyncSession, SyncSnapshotPage,
+    TypeProvision,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -124,6 +125,11 @@ struct CompactRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct ProvisionTypesRequest {
+    types: Vec<TypeProvision>,
+}
+
+#[derive(Debug, Deserialize)]
 struct SnapshotQuery {
     snapshot_id: Uuid,
     page: Option<String>,
@@ -157,6 +163,10 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/internal/v1/collections/{collection_id}/compact",
             post(compact_collection),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/types/provision",
+            post(provision_types),
         )
         .route(
             "/internal/v1/replicas/{replica_id}/token",
@@ -438,6 +448,24 @@ async fn mutate(
             .mutate(collection_id, token, mutation)
             .await?,
     ))
+}
+
+async fn provision_types(
+    State(state): State<AppState>,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<ProvisionTypesRequest>,
+) -> ApiResult<Json<Value>> {
+    if input.types.len() > 20 {
+        return Err(ApiError::bad_request(
+            "too_many_type_provisions",
+            "An application may provision at most 20 type definitions.",
+        ));
+    }
+    let contracts = state
+        .provider
+        .provision_types(collection_id, input.types)
+        .await?;
+    Ok(Json(json!({ "contracts": contracts })))
 }
 
 async fn operation(

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -7,10 +7,11 @@ use chrono::Utc;
 use hmac::{Hmac, Mac};
 use mdbase::v03::{Diagnostic, OperationResult};
 use mdbase_connect_protocol::{
-    CollectionChange, CollectionChangesPage, CollectionDescription, SyncChange, SyncChangesPage,
-    SyncCollectionResources, SyncConflict, SyncMutation, SyncMutationError, SyncMutationOperation,
-    SyncMutationReceipt, SyncRecord, SyncReplicaMode, SyncResourceDocument, SyncSession,
-    SyncSnapshotPage, CONTROL_PROTOCOL_VERSION, SYNC_PROTOCOL_VERSION,
+    CollectionChange, CollectionChangesPage, CollectionContractDescriptor, CollectionDescription,
+    SyncChange, SyncChangesPage, SyncCollectionResources, SyncConflict, SyncMutation,
+    SyncMutationError, SyncMutationOperation, SyncMutationReceipt, SyncRecord, SyncReplicaMode,
+    SyncResourceDocument, SyncSession, SyncSnapshotPage, TypeProvision, CONTROL_PROTOCOL_VERSION,
+    SYNC_PROTOCOL_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -1481,7 +1482,7 @@ impl HostedProvider {
                     .await
             }
             "create_type" | "update_type" => {
-                self.write_type_operation(collection_id, &replica, operation, input)
+                self.write_type_operation(collection_id, operation, input)
                     .await
             }
             _ => Err(ApiError::bad_request(
@@ -1489,6 +1490,97 @@ impl HostedProvider {
                 "The hosted provider does not support that collection operation.",
             )),
         }
+    }
+
+    pub async fn provision_types(
+        &self,
+        collection_id: Uuid,
+        provisions: Vec<TypeProvision>,
+    ) -> ApiResult<Vec<CollectionContractDescriptor>> {
+        let mut contracts = self.collection_contracts(collection_id).await?;
+        for provision in provisions {
+            if provision.provides.iter().all(|provided| {
+                contracts.iter().any(|available| {
+                    available.id == provided.id && available.version == provided.version
+                })
+            }) {
+                continue;
+            }
+            let mut input = json!({ "document": provision.document });
+            if let Some(path) = provision.path {
+                input["path"] = json!(path);
+            }
+            let result = self
+                .write_type_operation(collection_id, "create_type", input)
+                .await?;
+            if result.get("valid").and_then(Value::as_bool) != Some(true) {
+                let detail = result
+                    .pointer("/diagnostics/0/message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("the type definition was rejected");
+                return Err(ApiError::bad_request(
+                    "type_provision_failed",
+                    format!(
+                        "The {} type could not be installed: {detail}",
+                        provision.name
+                    ),
+                ));
+            }
+            if result
+                .pointer("/result/name")
+                .and_then(Value::as_str)
+                .is_none_or(|name| !name.eq_ignore_ascii_case(&provision.name))
+            {
+                return Err(ApiError::bad_request(
+                    "type_provision_failed",
+                    format!(
+                        "The installed type did not match the declared {} type.",
+                        provision.name
+                    ),
+                ));
+            }
+            contracts = self.collection_contracts(collection_id).await?;
+            if provision.provides.iter().any(|provided| {
+                !contracts.iter().any(|available| {
+                    available.id == provided.id && available.version == provided.version
+                })
+            }) {
+                return Err(ApiError::bad_request(
+                    "type_provision_failed",
+                    format!(
+                        "The {} type did not provide every contract declared by the application.",
+                        provision.name
+                    ),
+                ));
+            }
+        }
+        Ok(contracts)
+    }
+
+    async fn collection_contracts(
+        &self,
+        collection_id: Uuid,
+    ) -> ApiResult<Vec<CollectionContractDescriptor>> {
+        let row = sqlx::query(
+            r#"SELECT wrapped_data_key, resources_ciphertext
+               FROM hosted_provider_collections WHERE id = $1 AND state = 'active'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let resources: SyncCollectionResources = self.crypto.decrypt_json(
+            &data_key,
+            row.get("resources_ciphertext"),
+            &resources_aad(collection_id),
+        )?;
+        Ok(resources.contracts)
     }
 
     async fn describe_operation(&self, collection_id: Uuid, replica: &Replica) -> ApiResult<Value> {
@@ -1942,16 +2034,9 @@ impl HostedProvider {
     async fn write_type_operation(
         &self,
         collection_id: Uuid,
-        replica: &Replica,
         operation: &str,
         input: Value,
     ) -> ApiResult<Value> {
-        if !replica.allowed_types.is_empty() {
-            return Err(ApiError::forbidden(
-                "scope_denied",
-                "Type definitions can only be managed with full collection access.",
-            ));
-        }
         let mut transaction = self.pool.begin().await?;
         let collection = sqlx::query(
             r#"SELECT head, wrapped_data_key, resources_ciphertext, max_document_bytes

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -461,6 +461,8 @@ pub struct ApplicationSummary {
     pub icon: Option<String>,
     #[serde(default)]
     pub requirements: ApplicationRequirements,
+    #[serde(default)]
+    pub provisions: ApplicationProvisions,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -473,6 +475,22 @@ pub struct ContractRequirement {
 pub struct ApplicationRequirements {
     #[serde(default)]
     pub contracts: Vec<ContractRequirement>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApplicationProvisions {
+    #[serde(default)]
+    pub types: Vec<TypeProvision>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TypeProvision {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub document: String,
+    #[serde(default)]
+    pub provides: Vec<ContractRequirement>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -511,7 +529,11 @@ pub struct PendingAuthorization {
     #[serde(default)]
     pub requirements: ApplicationRequirements,
     #[serde(default)]
+    pub provisions: ApplicationProvisions,
+    #[serde(default)]
     pub compatible_collection_ids: Vec<Uuid>,
+    #[serde(default)]
+    pub provisionable_collection_ids: Vec<Uuid>,
     pub expires_at: String,
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,16 @@ are unavailable to a contract-scoped grant. Scoped queries reject link
 traversal into other records until the query engine can carry the grant scope
 through link resolution.
 
+An application manifest may pair required contracts with portable type provisions.
+A collection is then either ready, provisionable, or incompatible. During
+approval, the authority that owns the collection installs only provisions
+needed for missing contracts, reopens the collection, and verifies the exact
+contract identities and versions before a grant is created. This setup action
+does not give the application continuing `create_type` or `update_type`
+permission. Local collection paths and record payloads remain outside the
+control plane; only the declared type documents and resulting contract metadata
+participate in authorization.
+
 `describe` returns the collection's spec version, supported operations, JSON
 Schemas, collection-relative type paths, complete portable type definitions,
 canonical collection settings, `x-*` type extensions, discovered contract

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -59,7 +59,9 @@ Application identity is derived from the manifest's exact origin. No developer
 account or manually issued client secret is required.
 
 Applications declare required domain contracts in their manifest. Connect only
-offers compatible collections and derives the record scope from this declaration:
+offers collections that are compatible or can be configured safely, then derives
+the record scope from this declaration. The manifest may include portable
+type definitions for the connector to install during approval:
 
 ```json
 {
@@ -69,9 +71,21 @@ offers compatible collections and derives the record scope from this declaration
   "redirect_uris": ["https://tasks.example/auth/mdbase/callback"],
   "requirements": {
     "contracts": [{ "id": "tasknotes.task", "version": 1 }]
+  },
+  "provisions": {
+    "types": [{
+      "name": "Task",
+      "document": "---\nkind: mdbase.type\nname: task\nversion: 1\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\nx-tasknotes:\n  contract: tasknotes.task\n  version: 1\n---\n",
+      "provides": [{ "id": "tasknotes.task", "version": 1 }]
+    }]
   }
 }
 ```
+
+Provisioning is part of the approval flow. The connector validates and
+installs only the missing type definitions, verifies that they expose the
+declared contracts, and creates the scoped grant afterward. The application is
+not granted collection-wide `create_type` access.
 
 The SDK returns the mdbase operation envelope, carries revision tokens in typed
 record results, and accepts `if_revision` on mutations. `describe()` exposes

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -30,6 +30,8 @@ export {
 } from "./crypto.js";
 
 export type {
+  ApplicationProvisions,
+  ApplicationRequirements,
   CollectionChange,
   CollectionChangesPage,
   CollectionContractDescriptor,
@@ -41,10 +43,12 @@ export type {
   ContractRequirement,
   GrantScope,
   JsonObject,
+  MdbaseAppManifest,
   MdbaseDiagnostic,
   MdbaseOperationEnvelope,
   RecordResult,
-  RecordSummary
+  RecordSummary,
+  TypeProvision
 } from "@mdbase/connect-protocol";
 
 export interface MdbaseConnectOptions {

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -29,3 +29,8 @@ mdbase-connect-dev validate-manifest public/.well-known/mdbase-app.json
 mdbase-connect-dev validate-manifest public/.well-known/mdbase-app.json --allow-local
 mdbase-connect-dev validate-contract tasknotes-contract.json
 ```
+
+Application manifests support connector-controlled type provisioning. Put the
+complete portable type document in `provisions.types`, declare the contracts it
+provides, and list the same contracts under `requirements.contracts`. The
+validator rejects provisions for contracts the application does not require.

--- a/packages/devkit/src/index.test.ts
+++ b/packages/devkit/src/index.test.ts
@@ -55,6 +55,34 @@ describe("canonical developer validation", () => {
       homepage: "https://tasks.example/",
       redirect_uris: ["https://attacker.example/callback"]
     }).valid).toBe(false);
+    expect(validateAppManifest({
+      manifest_version: 1,
+      name: "Tasks",
+      homepage: "https://tasks.example/",
+      redirect_uris: ["https://tasks.example/callback"],
+      requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+      provisions: {
+        types: [{
+          name: "Task",
+          document: "---\nkind: mdbase.type\nname: task\n---\n",
+          provides: [{ id: "tasknotes.task", version: 1 }]
+        }]
+      }
+    }).valid).toBe(true);
+    expect(validateAppManifest({
+      manifest_version: 1,
+      name: "Tasks",
+      homepage: "https://tasks.example/",
+      redirect_uris: ["https://tasks.example/callback"],
+      requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+      provisions: {
+        types: [{
+          name: "Unrelated",
+          document: "---\nkind: mdbase.type\nname: unrelated\n---\n",
+          provides: [{ id: "other.contract", version: 1 }]
+        }]
+      }
+    }).valid).toBe(false);
   });
 
   it("defines extension contracts without erasing application-specific fields", () => {

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -52,7 +52,9 @@ export function validateAppManifest(
   const candidate = options.allowLocal ? localManifestSchemaCandidate(value) : value;
   const schemaResult = validationResult(appManifestValidator, candidate);
   if (!schemaResult.valid) return schemaResult;
-  return validateManifestOrigins(value, options.allowLocal === true);
+  const originResult = validateManifestOrigins(value, options.allowLocal === true);
+  if (!originResult.valid) return originResult;
+  return validateProvisionRequirements(value);
 }
 
 export function validateContractExtension(value: unknown): ValidationResult {
@@ -380,6 +382,31 @@ function validateManifestOrigins(value: unknown, allowLocal: boolean): Validatio
   } catch {
     return semanticIssue("/", "contains an invalid URL");
   }
+}
+
+function validateProvisionRequirements(value: unknown): ValidationResult {
+  const manifest = asObject(value);
+  const requirements = asObject(manifest.requirements);
+  const requiredContracts = Array.isArray(requirements.contracts) ? requirements.contracts : [];
+  const required = new Set(requiredContracts.map((contract) => {
+    const value = asObject(contract);
+    return `${value.id}@${value.version}`;
+  }));
+  const provisions = asObject(manifest.provisions);
+  const types = Array.isArray(provisions.types) ? provisions.types : [];
+  for (const [typeIndex, provisionValue] of types.entries()) {
+    const provision = asObject(provisionValue);
+    for (const providedValue of provision.provides as unknown[]) {
+      const provided = asObject(providedValue);
+      if (!required.has(`${provided.id}@${provided.version}`)) {
+        return semanticIssue(
+          `/provisions/types/${typeIndex}/provides`,
+          "may only contain contracts required by the application"
+        );
+      }
+    }
+  }
+  return { valid: true, issues: [] };
 }
 
 function localManifestSchemaCandidate(value: unknown): unknown {

--- a/packages/protocol/schemas/mdbase-app.schema.json
+++ b/packages/protocol/schemas/mdbase-app.schema.json
@@ -13,8 +13,38 @@
     "redirect_uris": {
       "type": "array",
       "minItems": 1,
+      "maxItems": 10,
       "uniqueItems": true,
       "items": { "type": "string", "format": "uri", "pattern": "^https://" }
+    },
+    "requirements": { "$ref": "#/$defs/requirements" },
+    "provisions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["types"],
+      "properties": {
+        "types": {
+          "type": "array",
+          "maxItems": 20,
+          "items": { "$ref": "#/$defs/typeProvision" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+        },
+        "version": { "type": "integer", "minimum": 1 }
+      }
     },
     "requirements": {
       "type": "object",
@@ -25,20 +55,24 @@
           "type": "array",
           "maxItems": 20,
           "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["id", "version"],
-            "properties": {
-              "id": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 100,
-                "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
-              },
-              "version": { "type": "integer", "minimum": 1 }
-            }
-          }
+          "items": { "$ref": "#/$defs/contract" }
+        }
+      }
+    },
+    "typeProvision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "document", "provides"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "path": { "type": "string", "minLength": 1, "maxLength": 240 },
+        "document": { "type": "string", "minLength": 1, "maxLength": 131072 },
+        "provides": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/contract" }
         }
       }
     }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,6 +32,7 @@ export interface MdbaseAppManifest {
   icon?: string;
   redirect_uris: string[];
   requirements?: ApplicationRequirements;
+  provisions?: ApplicationProvisions;
 }
 
 export interface ContractRequirement {
@@ -41,6 +42,21 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+}
+
+export interface TypeProvision {
+  /** Type name shown during approval and verified after installation. */
+  name: string;
+  /** Optional collection-relative destination. The collection validates the final path. */
+  path?: string;
+  /** Complete portable mdbase type document. */
+  document: string;
+  /** Contracts expected to be exposed after this type is installed. */
+  provides: ContractRequirement[];
+}
+
+export interface ApplicationProvisions {
+  types: TypeProvision[];
 }
 
 export interface GrantScope {

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -34,6 +34,27 @@ test("all canonical schemas compile as strict JSON Schema 2020-12", () => {
   assert.ok(validator(syncSchema.$id));
 });
 
+test("application manifests declare connector-controlled type provisioning", () => {
+  const validate = validator(manifestSchema.$id);
+  const manifest = {
+    manifest_version: 1,
+    name: "Tasks",
+    homepage: "https://tasks.example/",
+    redirect_uris: ["https://tasks.example/callback"],
+    requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+    provisions: {
+      types: [{
+        name: "Task",
+        document: "---\nkind: mdbase.type\nname: task\n---\n",
+        provides: [{ id: "tasknotes.task", version: 1 }]
+      }]
+    }
+  };
+  assert.equal(validate(manifest), true, JSON.stringify(validate.errors));
+  assert.equal(validate({ ...manifest, manifest_version: 2 }), false);
+  assert.equal(validate({ ...manifest, provisions: { types: [{ ...manifest.provisions.types[0], provides: [] }] } }), false);
+});
+
 test("sync wire objects are independently addressable", () => {
   const validateWireObject = validator(syncSchema.$id);
   const validateMutation = validator(`${syncSchema.$id}#/$defs/mutation`);

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -76,6 +76,36 @@ try {
   });
   assert.equal(publicPreflight.headers.get("access-control-allow-origin"), "*");
 
+  phase("provisioning a portable application type through the internal authority");
+  const provisionCollectionId = crypto.randomUUID();
+  await internalRequest(provider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: { collection_id: provisionCollectionId, template: "mdbase", display_name: "Provision probe" }
+  });
+  const typeProvision = {
+    name: "Workout",
+    document: "---\nkind: mdbase.type\nname: workout\nversion: 1\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\nx-workout:\n  contract: workout.record\n  version: 1\n---\n",
+    provides: [{ id: "workout.record", version: 1 }]
+  };
+  const provisionedTypes = await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${provisionCollectionId}/types/provision`,
+    { method: "POST", body: { types: [typeProvision] } }
+  );
+  assert.deepEqual(
+    provisionedTypes.contracts.map(({ id, version, type_name }) => ({ id, version, type_name })),
+    [{ id: "workout.record", version: 1, type_name: "workout" }]
+  );
+  const repeatedProvision = await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${provisionCollectionId}/types/provision`,
+    { method: "POST", body: { types: [typeProvision] } }
+  );
+  assert.equal(repeatedProvision.contracts.length, 1);
+  await internalRequest(provider.url, `/internal/v1/collections/${provisionCollectionId}`, {
+    method: "DELETE"
+  });
+
   phase("enforcing durable collection, document, and replica quotas");
   const quotaProvider = await startProvider(databaseUrl, 0, masterKey, {
     MDBASE_CONNECT_HOSTED_MAX_RECORDS_PER_COLLECTION: "1",

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -481,6 +481,106 @@ describe("mdbase connect server", () => {
     expect(reconciled.rows[0].allowed_types).toEqual([]);
   });
 
+  it("provisions missing hosted types before creating a contract-scoped grant", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const contract = {
+      id: "workout.record",
+      version: 1,
+      type_name: "workout",
+      extension: "x-workout",
+      configuration: { contract: "workout.record", version: 1 }
+    };
+    const hostedProvider = {
+      url: "https://sync.example",
+      ready: vi.fn(),
+      createCollection: vi.fn(),
+      renameCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      provisionTypes: vi.fn().mockResolvedValue([contract]),
+      registerReplica: vi.fn(),
+      updateApplicationReplica: vi.fn(),
+      revokeReplica: vi.fn(),
+      rotateReplicaToken: vi.fn(),
+      compactThrough: vi.fn()
+    } as unknown as HostedProviderClient;
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedProvider,
+      publicUrl: "http://connect.test",
+      allowInsecureManifests: true
+    });
+    resources.push(() => app.close());
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Athlete", email: "athlete@example.com" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const collection = await app.inject({
+      method: "POST",
+      url: "/v1/hosted/collections",
+      headers: { cookie },
+      payload: { display_name: "Training", template: "mdbase" }
+    });
+    const collectionId = collection.json().collection.id as string;
+    const typeDocument = "---\nkind: mdbase.type\nname: workout\nversion: 1\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\nx-workout:\n  contract: workout.record\n  version: 1\n---\n";
+    const manifestServer = await startManifestServer(
+      { contracts: [{ id: "workout.record", version: 1 }] },
+      "Workout Tracker",
+      { types: [{
+        name: "Workout",
+        document: typeDocument,
+        provides: [{ id: "workout.record", version: 1 }]
+      }] }
+    );
+    resources.push(manifestServer.close);
+    const discovered = await app.inject({
+      method: "POST",
+      url: "/v1/apps/discover",
+      payload: { manifest_url: manifestServer.manifestUrl }
+    });
+    const applicationId = discovered.json().application.id as string;
+    expect(discovered.json().application.provisions.types[0].name).toBe("Workout");
+    const authorization = await app.inject({
+      method: "GET",
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge("hosted-provision-verifier-that-is-long-enough-0001")}&code_challenge_method=S256&operations=read,query,create`,
+      headers: { cookie }
+    });
+    const requestId = authorization.headers.location!.split("/").at(-1)!;
+    const pending = await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${requestId}`,
+      headers: { cookie }
+    });
+    expect(pending.json().authorization.provisions.types[0].provides).toEqual([
+      { id: "workout.record", version: 1 }
+    ]);
+    const approved = await app.inject({
+      method: "POST",
+      url: `/v1/authorization-requests/${requestId}/approve`,
+      headers: { cookie },
+      payload: { collection_id: collectionId, operations: ["read", "query", "create"] }
+    });
+    expect(approved.statusCode).toBe(200);
+    expect(hostedProvider.provisionTypes).toHaveBeenCalledWith(
+      collectionId,
+      [expect.objectContaining({ name: "Workout", document: typeDocument })]
+    );
+    expect(hostedProvider.registerReplica).toHaveBeenCalledWith(
+      collectionId,
+      expect.objectContaining({ allowedTypes: ["workout"] })
+    );
+    const stored = await db.query<{ contracts: unknown[] }>(
+      "SELECT contracts FROM hosted_collections WHERE id = $1",
+      [collectionId]
+    );
+    expect(stored.rows[0].contracts).toEqual([contract]);
+  });
+
   it("uses a trusted Tailscale identity instead of a development session", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());
@@ -529,7 +629,15 @@ describe("mdbase connect server", () => {
 
 async function startManifestServer(
   requirements = { contracts: [{ id: "workout.record", version: 1 }] },
-  name = "Workout Tracker"
+  name = "Workout Tracker",
+  provisions?: {
+    types: Array<{
+      name: string;
+      path?: string;
+      document: string;
+      provides: Array<{ id: string; version: number }>;
+    }>;
+  }
 ): Promise<{
   manifestUrl: string;
   redirectUri: string;
@@ -545,7 +653,8 @@ async function startManifestServer(
       name,
       homepage: origin,
       redirect_uris: [`${origin}/auth/mdbase/callback`],
-      requirements
+      requirements,
+      ...(provisions ? { provisions } : {})
     }));
   });
   await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -10,11 +10,14 @@ import websocket from "@fastify/websocket";
 import helmet from "@fastify/helmet";
 import rateLimit from "@fastify/rate-limit";
 import type {
+  ApplicationProvisions,
   ApplicationRequirements,
+  CollectionContractDescriptor,
   ContractRequirement,
   EncryptedRelayOperationRequest,
   GrantEncryption,
-  GrantScope
+  GrantScope,
+  TypeProvision
 } from "@mdbase/connect-protocol";
 import {
   ENCRYPTED_RELAY_PROTOCOL_VERSION,
@@ -28,9 +31,11 @@ import { ConnectorOperationError, RelayHub, RelayUnavailableError } from "./rela
 import { pkceChallenge, randomToken, safeEqual, tokenHash } from "./security.js";
 import {
   asSyncMutation,
-  hostedContracts,
+  contractRequirements,
+  effectiveHostedContractDescriptors,
+  hostedContractDescriptors,
   HostedAuthorityRegistry,
-  hostedTypesForContracts,
+  typesForContracts,
   type HostedTemplate
 } from "./hosted.js";
 import {
@@ -596,10 +601,11 @@ export async function buildApp(options: BuildOptions) {
           id: string;
           display_name: string;
           template: string;
+          contracts: CollectionContractDescriptor[];
           provider_url: string | null;
           created_at: string;
         }>(
-          `SELECT id, display_name, template, provider_url, created_at
+          `SELECT id, display_name, template, provider_url, contracts, created_at
            FROM hosted_collections WHERE user_id = $1 ORDER BY display_name`,
           [user.id]
         )
@@ -637,7 +643,7 @@ export async function buildApp(options: BuildOptions) {
     const pendingAuthorizations = await options.db.query(
       `SELECT ar.id, ar.requested_operations, ar.expires_at,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
-              a.requirements
+              a.requirements, a.provisions
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
@@ -657,7 +663,7 @@ export async function buildApp(options: BuildOptions) {
         ...collection,
         provider_url: collection.provider_url ?? publicUrl,
         spec_version: "0.3.0",
-        contracts: hostedContracts(collection.template),
+        contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template)),
         replicas: hostedReplicas.rows.filter((replica) => replica.collection_id === collection.id)
       })),
       grants: grants.rows,
@@ -800,7 +806,7 @@ export async function buildApp(options: BuildOptions) {
     const pendingAuthorizations = await options.db.query(
       `SELECT ar.id, ar.application_id, a.name AS application_name,
               a.homepage AS application_homepage, a.icon AS application_icon,
-              ar.requested_operations, ar.expires_at, a.requirements
+              ar.requested_operations, ar.expires_at, a.requirements, a.provisions
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
@@ -830,14 +836,37 @@ export async function buildApp(options: BuildOptions) {
     return { application };
   });
 
+  app.get("/v1/connectors/apps/:applicationId", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { applicationId } = z.object({ applicationId: z.uuid() }).parse(request.params);
+    const application = await options.db.query(
+      `SELECT id, name, homepage, icon, requirements, provisions
+       FROM applications WHERE id = $1`,
+      [applicationId]
+    );
+    if (!application.rows[0]) {
+      return reply.code(404).send(apiError("application_not_found", "Application not found."));
+    }
+    return { application: application.rows[0] };
+  });
+
   app.post("/v1/connectors/grants", async (request, reply) => {
     const connector = await requireConnector(request, reply, options.db);
     if (!connector) return;
     const input = z.object({
       application_id: z.uuid(),
       collection_id: z.uuid(),
-      operations: z.array(operationSchema).min(1)
+      operations: z.array(operationSchema).min(1),
+      contracts: z.array(contractRequirementSchema).max(100).optional()
     }).parse(request.body);
+    if (input.contracts) {
+      await options.db.query(
+        `UPDATE collections SET contracts = $3::jsonb, last_seen_at = now()
+         WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
+        [connector.id, input.collection_id, JSON.stringify(input.contracts)]
+      );
+    }
     const collection = await options.db.query<{ id: string; contracts: ContractRequirement[] }>(
       `SELECT id, contracts FROM collections WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
       [connector.id, input.collection_id]
@@ -914,8 +943,16 @@ export async function buildApp(options: BuildOptions) {
     const { requestId } = z.object({ requestId: z.uuid() }).parse(request.params);
     const input = z.object({
       collection_id: z.uuid(),
-      operations: z.array(operationSchema).min(1)
+      operations: z.array(operationSchema).min(1),
+      contracts: z.array(contractRequirementSchema).max(100).optional()
     }).parse(request.body);
+    if (input.contracts) {
+      await options.db.query(
+        `UPDATE collections SET contracts = $3::jsonb, last_seen_at = now()
+         WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
+        [connector.id, input.collection_id, JSON.stringify(input.contracts)]
+      );
+    }
     const collection = await options.db.query<{ id: string }>(
       `SELECT id FROM collections
        WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
@@ -963,9 +1000,16 @@ export async function buildApp(options: BuildOptions) {
         await hostedReference!.create(collectionId, input.template);
       }
       await options.db.query(
-        `INSERT INTO hosted_collections (id, user_id, display_name, template, provider_url)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [collectionId, user.id, input.display_name, input.template, options.hostedProvider?.url ?? null]
+        `INSERT INTO hosted_collections (id, user_id, display_name, template, provider_url, contracts)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+        [
+          collectionId,
+          user.id,
+          input.display_name,
+          input.template,
+          options.hostedProvider?.url ?? null,
+          JSON.stringify(hostedContractDescriptors(input.template))
+        ]
       );
     } catch (error) {
       if (options.hostedProvider) {
@@ -1277,9 +1321,10 @@ export async function buildApp(options: BuildOptions) {
       encryption: GrantEncryption | null;
       scope: GrantScope;
       template: string | null;
+      hosted_contracts: CollectionContractDescriptor[] | null;
     }>(
       `SELECT g.id, g.operations, g.encryption, g.scope, col.connector_id,
-              g.hosted_replica_id, hosted.template
+              g.hosted_replica_id, hosted.template, hosted.contracts AS hosted_contracts
        FROM grants g
        LEFT JOIN collections col ON col.id = g.collection_id
        LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
@@ -1302,7 +1347,10 @@ export async function buildApp(options: BuildOptions) {
       const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
       await options.hostedProvider.updateApplicationReplica(current.hosted_replica_id, {
         mode: write ? "read_write" : "read_only",
-        allowedTypes: hostedTypesForContracts(current.template!, current.scope.contracts),
+        allowedTypes: typesForContracts(
+          effectiveHostedContractDescriptors(current.hosted_contracts, current.template!),
+          current.scope.contracts
+        ),
         allowedOperations: operations
       });
     }
@@ -1416,7 +1464,7 @@ export async function buildApp(options: BuildOptions) {
     const authorization = await options.db.query(
       `SELECT ar.id, ar.requested_operations, ar.expires_at,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
-              a.requirements
+              a.requirements, a.provisions
        FROM authorization_requests ar JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.expires_at > now()`,
       [requestId, user.id]
@@ -1435,8 +1483,9 @@ export async function buildApp(options: BuildOptions) {
           display_name: string;
           spec_version?: string;
           template: HostedTemplate;
+          contracts: CollectionContractDescriptor[];
         }>(
-          `SELECT id, display_name, template FROM hosted_collections
+          `SELECT id, display_name, template, contracts FROM hosted_collections
            WHERE user_id = $1 ORDER BY display_name`,
           [user.id]
         )
@@ -1450,7 +1499,7 @@ export async function buildApp(options: BuildOptions) {
           kind: "hosted",
           connector_name: "Hosted by mdbase",
           spec_version: "0.3.0",
-          contracts: hostedContracts(collection.template)
+          contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template))
         }))
       ]
     };
@@ -1514,8 +1563,8 @@ export async function buildApp(options: BuildOptions) {
         source: "portal"
       });
     } else {
-      const hosted = await options.db.query<{ id: string; template: string; display_name: string }>(
-        "SELECT id, template, display_name FROM hosted_collections WHERE id = $1 AND user_id = $2",
+      const hosted = await options.db.query<{ id: string; template: string; display_name: string; contracts: CollectionContractDescriptor[] }>(
+        "SELECT id, template, display_name, contracts FROM hosted_collections WHERE id = $1 AND user_id = $2",
         [input.collection_id, user.id]
       );
       if (!hosted.rows[0] || !options.hostedProvider) {
@@ -1527,7 +1576,8 @@ export async function buildApp(options: BuildOptions) {
         collectionId: input.collection_id,
         operations: input.operations,
         template: hosted.rows[0].template,
-        displayName: hosted.rows[0].display_name
+        displayName: hosted.rows[0].display_name,
+        contracts: effectiveHostedContractDescriptors(hosted.rows[0].contracts, hosted.rows[0].template)
       });
     }
     if (!approved) return reply.code(404).send(apiError("authorization_not_found", "Authorization request expired or was not found."));
@@ -1724,6 +1774,7 @@ async function upsertApplication(
   redirect_uris: string[];
   canonical_identity: string;
   requirements: ApplicationRequirements;
+  provisions: ApplicationProvisions;
 }> {
   const application = await db.query<{
     id: string;
@@ -1733,10 +1784,11 @@ async function upsertApplication(
     redirect_uris: string[];
     canonical_identity: string;
     requirements: ApplicationRequirements;
+    provisions: ApplicationProvisions;
   }>(
     `INSERT INTO applications
-       (id, canonical_identity, manifest_url, name, homepage, icon, redirect_uris, requirements)
-     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb)
+       (id, canonical_identity, manifest_url, name, homepage, icon, redirect_uris, requirements, provisions)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb)
      ON CONFLICT(canonical_identity) DO UPDATE SET
        manifest_url = excluded.manifest_url,
        name = excluded.name,
@@ -1744,8 +1796,9 @@ async function upsertApplication(
        icon = excluded.icon,
        redirect_uris = excluded.redirect_uris,
        requirements = excluded.requirements,
+       provisions = excluded.provisions,
        updated_at = now()
-     RETURNING id, name, homepage, icon, redirect_uris, canonical_identity, requirements`,
+     RETURNING id, name, homepage, icon, redirect_uris, canonical_identity, requirements, provisions`,
     [
       randomUUID(),
       discovered.canonicalIdentity,
@@ -1754,7 +1807,8 @@ async function upsertApplication(
       discovered.manifest.homepage,
       discovered.manifest.icon ?? null,
       JSON.stringify(discovered.manifest.redirect_uris),
-      JSON.stringify(discovered.manifest.requirements)
+      JSON.stringify(discovered.manifest.requirements),
+      JSON.stringify(discovered.manifest.provisions)
     ]
   );
   return application.rows[0];
@@ -1811,13 +1865,16 @@ async function reconcileApplicationGrants(
     connector_id: string | null;
     hosted_replica_id: string | null;
     operations: string[];
-    contracts: ContractRequirement[] | null;
+    local_contracts: ContractRequirement[] | null;
+    hosted_contracts: CollectionContractDescriptor[] | null;
     template: string | null;
     allowed_types: string[] | null;
     scope: GrantScope;
   }>(
     `SELECT g.id, g.user_id, col.connector_id, g.hosted_replica_id,
-            g.operations, col.contracts, hosted.template, replica.allowed_types, g.scope
+            g.operations, col.contracts AS local_contracts,
+            hosted.contracts AS hosted_contracts, hosted.template,
+            replica.allowed_types, g.scope
      FROM grants g
      LEFT JOIN collections col ON col.id = g.collection_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
@@ -1827,13 +1884,16 @@ async function reconcileApplicationGrants(
   );
   const changedConnectors = new Set<string>();
   for (const grant of grants.rows) {
+    const hostedDescriptors = grant.template
+      ? effectiveHostedContractDescriptors(grant.hosted_contracts, grant.template)
+      : [];
     const availableContracts = grant.template
-      ? hostedContracts(grant.template)
-      : grant.contracts ?? [];
+      ? contractRequirements(hostedDescriptors)
+      : grant.local_contracts ?? [];
     const collectionCompatible = contractsSatisfy(availableContracts, desiredScope.contracts);
     const scopeMatches = scopesEqual(grant.scope, desiredScope);
     const desiredAllowedTypes = grant.template
-      ? hostedTypesForContracts(grant.template, desiredScope.contracts)
+      ? typesForContracts(hostedDescriptors, desiredScope.contracts)
       : [];
     const replicaScopeMatches = !grant.hosted_replica_id
       || sameStrings(grant.allowed_types ?? [], desiredAllowedTypes);
@@ -2014,6 +2074,7 @@ async function approveHostedAuthorization(
     operations: string[];
     template: string;
     displayName: string;
+    contracts: CollectionContractDescriptor[];
   }
 ): Promise<boolean> {
   const connection = await db.connect();
@@ -2026,10 +2087,11 @@ async function approveHostedAuthorization(
       application_homepage: string;
       requested_operations: string[];
       requirements: ApplicationRequirements;
+      provisions: ApplicationProvisions;
     }>(
       `SELECT ar.application_id, a.name AS application_name, a.homepage AS application_homepage,
               ar.requested_operations,
-              a.requirements
+              a.requirements, a.provisions
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
@@ -2046,13 +2108,28 @@ async function approveHostedAuthorization(
       throw new RequestValidationError("Approved operations must be requested by the application.");
     }
     const scope = scopeForRequirements(pending.requirements);
-    const availableContracts = hostedContracts(input.template);
+    let availableDescriptors = input.contracts;
+    let availableContracts = contractRequirements(availableDescriptors);
+    if (!contractsSatisfy(availableContracts, scope.contracts)) {
+      const provisions = requiredTypeProvisions(pending.requirements, pending.provisions, availableContracts);
+      if (!provisions) {
+        throw new RequestValidationError(
+          "This hosted collection does not provide the contracts required by the application."
+        );
+      }
+      availableDescriptors = await provider.provisionTypes(input.collectionId, provisions);
+      availableContracts = contractRequirements(availableDescriptors);
+      await connection.query(
+        "UPDATE hosted_collections SET contracts = $2::jsonb WHERE id = $1",
+        [input.collectionId, JSON.stringify(availableDescriptors)]
+      );
+    }
     if (!contractsSatisfy(availableContracts, scope.contracts)) {
       throw new RequestValidationError(
         "This hosted collection does not provide the contracts required by the application."
       );
     }
-    const allowedTypes = hostedTypesForContracts(input.template, scope.contracts);
+    const allowedTypes = typesForContracts(availableDescriptors, scope.contracts);
     await provider.renameCollection(input.collectionId, input.displayName);
     const operations = [...new Set(input.operations)];
     const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
@@ -2348,6 +2425,22 @@ function contractsSatisfy(
 ): boolean {
   const present = new Set((available ?? []).map((contract) => `${contract.id}@${contract.version}`));
   return required.every((contract) => present.has(`${contract.id}@${contract.version}`));
+}
+
+function requiredTypeProvisions(
+  requirements: ApplicationRequirements,
+  provisions: ApplicationProvisions,
+  available: ContractRequirement[]
+): TypeProvision[] | null {
+  const missing = requirements.contracts.filter((required) =>
+    !available.some((present) => present.id === required.id && present.version === required.version)
+  );
+  if (missing.some((required) => !provisions.types.some((provision) =>
+    provision.provides.some((provided) => provided.id === required.id && provided.version === required.version)
+  ))) return null;
+  return provisions.types.filter((provision) => provision.provides.some((provided) =>
+    missing.some((required) => required.id === provided.id && required.version === provided.version)
+  ));
 }
 
 class RequestValidationError extends Error {}

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -100,6 +100,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       display_name text NOT NULL,
       template text NOT NULL,
       provider_url text,
+      contracts jsonb NOT NULL DEFAULT '[]'::jsonb,
       created_at timestamptz NOT NULL DEFAULT now()
     );
     CREATE TABLE IF NOT EXISTS hosted_replicas (
@@ -122,6 +123,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       icon text,
       redirect_uris jsonb NOT NULL,
       requirements jsonb NOT NULL DEFAULT '{"contracts":[]}'::jsonb,
+      provisions jsonb NOT NULL DEFAULT '{"types":[]}'::jsonb,
       first_seen_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     );
@@ -219,6 +221,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   await ensureColumn(
     db,
     "applications",
+    "provisions",
+    "ALTER TABLE applications ADD COLUMN provisions jsonb NOT NULL DEFAULT '{\"types\":[]}'::jsonb"
+  );
+  await ensureColumn(
+    db,
+    "applications",
     "requirements",
     "ALTER TABLE applications ADD COLUMN requirements jsonb NOT NULL DEFAULT '{\"contracts\":[]}'::jsonb"
   );
@@ -233,6 +241,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
   await ensureColumn(db, "hosted_collections", "provider_url", "ALTER TABLE hosted_collections ADD COLUMN provider_url text");
+  await ensureColumn(
+    db,
+    "hosted_collections",
+    "contracts",
+    "ALTER TABLE hosted_collections ADD COLUMN contracts jsonb NOT NULL DEFAULT '[]'::jsonb"
+  );
   await ensureColumn(
     db,
     "external_identities",

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -121,4 +121,37 @@ describe("hosted provider control client", () => {
       })
     );
   });
+
+  it("sends bounded type provisions and returns authoritative contract metadata", async () => {
+    const contract = {
+      id: "workout.record",
+      version: 1,
+      type_name: "workout",
+      extension: "x-workout",
+      configuration: { contract: "workout.record", version: 1 }
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ contracts: [contract] }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    const provision = {
+      name: "Workout",
+      document: "---\nkind: mdbase.type\nname: workout\n---\n",
+      provides: [{ id: "workout.record", version: 1 }]
+    };
+    await expect(provider.provisionTypes("collection", [provision])).resolves.toEqual([contract]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://provider.example/internal/v1/collections/collection/types/provision",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ types: [provision] })
+      })
+    );
+  });
 });

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -1,3 +1,5 @@
+import type { CollectionContractDescriptor, TypeProvision } from "@mdbase/connect-protocol";
+
 export interface HostedProviderConfig {
   url: string;
   internalToken: string;
@@ -46,6 +48,18 @@ export class HostedProviderClient {
 
   async deleteCollection(collectionId: string): Promise<void> {
     await this.request("DELETE", `/internal/v1/collections/${encodeURIComponent(collectionId)}`);
+  }
+
+  async provisionTypes(
+    collectionId: string,
+    provisions: TypeProvision[]
+  ): Promise<CollectionContractDescriptor[]> {
+    const result = await this.request(
+      "POST",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/types/provision`,
+      { types: provisions }
+    ) as { contracts?: CollectionContractDescriptor[] } | undefined;
+    return result?.contracts ?? [];
   }
 
   async registerReplica(collectionId: string, replica: HostedReplicaEnrollment): Promise<void> {

--- a/services/server/src/hosted.ts
+++ b/services/server/src/hosted.ts
@@ -1,4 +1,5 @@
 import type {
+  CollectionContractDescriptor,
   ContractRequirement,
   JsonObject,
   SyncCollectionResources,
@@ -203,15 +204,37 @@ export function hostedContracts(template: string): ContractRequirement[] {
   return hostedResources(template).contracts.map(({ id, version }) => ({ id, version }));
 }
 
+export function hostedContractDescriptors(template: string): CollectionContractDescriptor[] {
+  return hostedResources(template).contracts;
+}
+
+export function effectiveHostedContractDescriptors(
+  contracts: CollectionContractDescriptor[] | null | undefined,
+  template: string
+): CollectionContractDescriptor[] {
+  return contracts?.length ? contracts : hostedContractDescriptors(template);
+}
+
+export function contractRequirements(contracts: CollectionContractDescriptor[]): ContractRequirement[] {
+  return contracts.map(({ id, version }) => ({ id, version }));
+}
+
+export function typesForContracts(
+  available: CollectionContractDescriptor[],
+  required: ContractRequirement[]
+): string[] {
+  if (required.length === 0) return [];
+  const requested = new Set(required.map(({ id, version }) => `${id}@${version}`));
+  return [...new Set(available
+    .filter(({ id, version }) => requested.has(`${id}@${version}`))
+    .map(({ type_name }) => type_name))];
+}
+
 export function hostedTypesForContracts(
   template: string,
   contracts: ContractRequirement[]
 ): string[] {
-  if (contracts.length === 0) return [];
-  const requested = new Set(contracts.map(({ id, version }) => `${id}@${version}`));
-  return [...new Set(hostedResources(template).contracts
-    .filter(({ id, version }) => requested.has(`${id}@${version}`))
-    .map(({ type_name }) => type_name))];
+  return typesForContracts(hostedContractDescriptors(template), contracts);
 }
 
 export function mdbaseResources(): SyncCollectionResources {

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -1,25 +1,56 @@
 import { isIP } from "node:net";
 import { lookup } from "node:dns/promises";
+import type { ApplicationProvisions, ApplicationRequirements } from "@mdbase/connect-protocol";
 import { z } from "zod";
 
+const contractSchema = z.object({
+  id: z.string().trim().min(1).max(100).regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/),
+  version: z.number().int().positive()
+}).strict();
+const contractsSchema = z.array(contractSchema).max(20).refine(
+  (contracts) => new Set(contracts.map((contract) => `${contract.id}@${contract.version}`)).size === contracts.length,
+  "Contracts must be unique."
+);
+const requirementsSchema = z.object({ contracts: contractsSchema }).strict().default({ contracts: [] });
 const manifestSchema = z.object({
   manifest_version: z.literal(1),
   name: z.string().trim().min(1).max(100),
   homepage: z.url(),
   icon: z.url().optional(),
   redirect_uris: z.array(z.url()).min(1).max(10),
-  requirements: z.object({
-    contracts: z.array(z.object({
-      id: z.string().trim().min(1).max(100).regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/),
-      version: z.number().int().positive()
-    }).strict()).max(20).refine(
-      (contracts) => new Set(contracts.map((contract) => `${contract.id}@${contract.version}`)).size === contracts.length,
-      "Contract requirements must be unique."
-    )
-  }).strict().default({ contracts: [] })
-}).strict();
+  requirements: requirementsSchema,
+  provisions: z.object({
+    types: z.array(z.object({
+      name: z.string().trim().min(1).max(100),
+      path: z.string().trim().min(1).max(240).optional(),
+      document: z.string().min(1).max(131_072),
+      provides: contractsSchema.refine((contracts) => contracts.length > 0, "A provision must provide at least one contract.")
+    }).strict()).max(20)
+  }).strict().default({ types: [] })
+}).strict().superRefine((manifest, context) => {
+  const required = new Set(manifest.requirements.contracts.map((contract) => `${contract.id}@${contract.version}`));
+  for (const [typeIndex, provision] of manifest.provisions.types.entries()) {
+    for (const provided of provision.provides) {
+      if (!required.has(`${provided.id}@${provided.version}`)) {
+        context.addIssue({
+          code: "custom",
+          path: ["provisions", "types", typeIndex, "provides"],
+          message: "Type provisions may only provide contracts required by the application."
+        });
+      }
+    }
+  }
+});
 
-export type AppManifest = z.infer<typeof manifestSchema>;
+export interface AppManifest {
+  manifest_version: 1;
+  name: string;
+  homepage: string;
+  icon?: string;
+  redirect_uris: string[];
+  requirements: ApplicationRequirements;
+  provisions: ApplicationProvisions;
+}
 
 export async function fetchManifest(source: string, allowInsecure = false): Promise<{
   manifest: AppManifest;
@@ -43,10 +74,10 @@ export async function fetchManifest(source: string, allowInsecure = false): Prom
     });
     if (!response.ok) throw new Error(`Manifest returned HTTP ${response.status}.`);
     const length = Number(response.headers.get("content-length") ?? "0");
-    if (length > 65_536) throw new Error("Application manifest is too large.");
+    if (length > 524_288) throw new Error("Application manifest is too large.");
     const sourceText = await response.text();
-    if (sourceText.length > 65_536) throw new Error("Application manifest is too large.");
-    const manifest = manifestSchema.parse(JSON.parse(sourceText));
+    if (sourceText.length > 524_288) throw new Error("Application manifest is too large.");
+    const manifest: AppManifest = manifestSchema.parse(JSON.parse(sourceText));
     validateManifestOrigins(url, manifest, developmentOrigin);
     return {
       manifest,


### PR DESCRIPTION
## Summary

- allow app manifests to declare portable type provisions alongside required contracts
- let local and hosted collection authorities install only missing types during approval, then verify exact contracts before granting access
- surface provisionable collections in desktop and portal approval flows
- expose provisioning declarations through the SDK and devkit using the single `manifest_version: 1` format

This lets an app connect to a compatible collection even when its required types have not been installed yet, without granting ongoing collection-wide type-management access.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:provider`
