### PR TITLE
Build full direct local collection access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ MDBASE_CONNECT_HOSTED_COLLECTIONS=0
 
 # Enable only behind a trusted reverse proxy such as Render.
 MDBASE_CONNECT_TRUST_PROXY=0
+
+# Local agent only: fixed browser loopback port. The SDK default is 28485.
+# MDBASE_CONNECT_LOOPBACK_PORT=28485

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: callumalpass/mdbase-rs
-          ref: b47eecfbb6f6f82f9a92b461f5eba10265e7abd2
+          ref: 66089ba5499aa351ca396b903a6f1c54d2df768f
           path: mdbase-rs
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -351,30 +351,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-tz"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
-dependencies = [
- "chrono",
- "phf",
-]
-
-[[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -394,14 +385,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -452,6 +443,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -515,12 +512,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -530,14 +526,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -582,7 +580,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -752,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -902,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -952,13 +950,18 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "group"
@@ -1119,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1336,11 +1339,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1439,9 +1442,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -1526,15 +1529,14 @@ name = "mdbase"
 version = "0.3.0-rc.1"
 dependencies = [
  "chrono",
- "chrono-tz",
  "clap",
  "fancy-regex 0.14.0",
+ "glob",
  "jsonschema",
  "notify",
  "rand 0.8.7",
  "regex",
  "rusqlite",
- "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1562,6 +1564,7 @@ dependencies = [
 name = "mdbase-connect-agent"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "axum",
  "clap",
  "futures-util",
  "mdbase",
@@ -1572,6 +1575,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "tower",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1809,12 +1814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,24 +1882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,13 +1905,12 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -2405,12 +2385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,14 +2411,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2573,12 +2547,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2847,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2906,7 +2874,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2920,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2940,9 +2908,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2975,9 +2943,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3235,12 +3203,12 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -3710,18 +3678,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"
 
 [workspace.dependencies]
-aes-gcm = "0.10"
+aes-gcm = "0.11"
 axum = "0.8.9"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -68,6 +68,9 @@ label.
   led. No dark fills or shadows. All include hover, focus, disabled, and busy
   states.
 - Status: pair a colored dot with a text label. Never show a dot alone.
+- Direct access: explain the browser's local-network prompt beside one quiet,
+  user-initiated action. Afterward, show only `Connected directly` or
+  `Connected through mdbase`; do not ask users to choose a transport.
 - Permission scopes: plain checkboxes with concrete action descriptions.
 - Lists: stable four-column rhythm for identity, target, state, and actions.
 - Empty states teach the first useful action without decorative illustration.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -25,6 +25,11 @@ collections—application contracts such as TaskNotes are optional consumers,
 never the storage model. Success means connecting an app feels deliberate and
 understandable, while revoking it is immediate and unambiguous.
 
+For a local-authority collection, the browser SDK should use the connector's
+same-computer loopback service when the user has allowed local-network access,
+then fall back to the encrypted relay when direct access is unavailable. This
+is an automatic route choice, not another storage mode or onboarding decision.
+
 ## Brand Personality
 
 Quiet, trustworthy, capable. The product should feel like a well-made operating

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ application general type-management access.
 This is a functional private-beta foundation. The tested path covers creating a local
 collection, pairing an outbound-only connector, discovering an independent web
 app, approving exact operations locally or from the authenticated account
-portal, reading and writing records through the relay, discovering schemas and
+portal, reading and writing records directly on the same computer or through
+the encrypted relay, discovering schemas and
 TaskNotes contract metadata, limiting applications to records belonging to
 their declared contracts, renewing browser authorization, receiving filesystem
 changes, rejecting stale revisions, pausing access, and immediately enforcing
@@ -27,7 +28,8 @@ application and contract adapter—not a collection kind or platform default.
 ## What is here
 
 - `crates/connect-agent`: Rust background connector, local policy enforcement,
-  filesystem watching, and outbound WebSocket relay.
+  a hardened browser loopback API, filesystem watching, and outbound WebSocket
+  relay.
 - `crates/connect-cli`: local administration and operation CLI.
 - `apps/desktop`: Electron controller for collection registration, application
   metadata and availability, application access, browser pairing, local
@@ -73,13 +75,16 @@ pnpm e2e:provider
 
 `pnpm e2e` launches an ephemeral control plane, a real connector agent, a test
 web application, and a real mdbase collection. It completes OAuth/PKCE,
-approves access through the local control API, discovers a real JSON Schema and
+approves access through the local control API, performs a 1,000-record query
+through the browser SDK's direct route, discovers a real JSON Schema and
 TaskNotes contract, proves that private records outside the contract cannot be
 read or queried, rotates authorization credentials, relays create/read/update
 operations, verifies change delivery and revision conflicts, exercises the
 local pause switch, revokes the grant, and confirms that access and renewal are
 rejected. It also crosses the JavaScript/Rust encryption boundary and verifies
-tamper, replay, and plaintext-downgrade rejection.
+tamper and plaintext-downgrade rejection. It also proves that an identical
+direct-to-relay retry returns a durable encrypted receipt without executing a
+mutation twice.
 
 `pnpm e2e:sync` exercises the hosted TaskNotes vertical slice through the real
 HTTP server, including offline writes, two-client convergence, idempotency,
@@ -136,6 +141,11 @@ tokens are stored encrypted by Electron, and cloud tokens are hashed at rest.
 New SDK authorizations require encrypted relay protocol 3 by default. Operation
 inputs and results remain ciphertext at the control plane; identifiers,
 operation names, timing, and sizes remain visible.
+
+The same envelopes protect direct loopback operations. The connector requires
+the grant's exact browser origin, an exact loopback `Host`, non-simple JSON, and
+application-key proof on every operation; its desktop administration socket is
+not exposed to browsers.
 
 The private Render deployment can use GitHub OAuth and Google Identity Services
 with allowlists of immutable provider subjects. The server refuses development

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -3,6 +3,8 @@ interface AgentStatus {
   state: "local_only" | "connecting" | "connected" | "offline";
   registered_collections: number;
   paused: boolean;
+  direct_access_available: boolean;
+  loopback_port?: number;
 }
 
 interface CollectionSummary {
@@ -70,6 +72,7 @@ interface GrantSummary {
   application_id: string;
   application_name: string;
   application_homepage: string;
+  application_origin: string;
   application_icon?: string;
   collection_id: string;
   collection_name: string;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -15,7 +15,7 @@ const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }>
   overview: {
     eyebrow: "This computer",
     title: "Your local connection.",
-    lede: "Collections, application access, and relay status in one place."
+    lede: "Collections, application access, and connection status in one place."
   },
   collections: {
     eyebrow: "Local collections",
@@ -266,12 +266,12 @@ function Overview({ status, cloud, access, collections, busy, onNavigate, onPair
         <div className="readiness-copy">
           <p className="eyebrow">Connection state</p>
           <h2>{status?.paused ? "Access is paused." : access.online ? "This computer is ready." : "Working from the local cache."}</h2>
-          <p>{status?.paused ? "Apps remain connected, but every remote operation is being denied locally." : access.online ? "Approved applications can reach available collections while this connector is running." : "Existing local settings remain visible. Cloud changes will resume when the relay reconnects."}</p>
+          <p>{status?.paused ? "Apps remain connected, but every collection operation is being denied locally." : access.online ? "Approved applications can reach available collections directly or through mdbase while this connector is running." : "Direct access keeps working from cached local policy. Cloud changes resume when the portal reconnects."}</p>
         </div>
         <SettingSwitch
           className="pause-control"
-          label="Remote access"
-          description="Pause without disconnecting applications"
+          label="Application access"
+          description="Pause direct and relayed operations without disconnecting apps"
           checked={status ? !status.paused : false}
           disabled={busy || status === null}
           stateLabel={status ? status.paused ? "Paused" : "Available" : "Checking"}
@@ -538,6 +538,7 @@ function Settings({ startup, cloud, access, status, busy, onAct, onNotice, onPai
             <ComputerNameSetting account={access.account} online={access.online} busy={busy} onAct={onAct} onNotice={onNotice} />
             <SettingRow label="Server" value={cloud.serverUrl ?? "Configured"} detail={access.online ? "Control service reachable" : "Using cached local policy"} mono />
             <SettingRow label="Connection" value={status?.state === "connected" ? "Connected" : "Offline"} detail="The relay connection is always outbound from this computer" />
+            <SettingRow label="Direct access" value={status?.direct_access_available ? "Available" : "Unavailable"} detail="Approved apps on this computer can bypass the relay" />
           </div>
           <button className="button secondary danger-text disconnect-button" disabled={busy} onClick={() => { if (window.confirm("Disconnect this computer from its portal? Existing local collection files are unaffected.")) void onAct(async () => { await window.mdbaseConnect.clearCloudConfig(); }); }}>Disconnect computer</button>
         </section>
@@ -559,19 +560,19 @@ function Settings({ startup, cloud, access, status, busy, onAct, onNotice, onPai
           />
           <SettingSwitch
             className="setting-toggle"
-            label="Remote access"
-            description="Pause all applications while keeping the relay connected"
+            label="Application access"
+            description="Pause direct and relayed operations while keeping grants connected"
             checked={status ? !status.paused : false}
             disabled={busy || status === null}
             stateLabel={status ? status.paused ? "Paused" : "Available" : "Checking"}
             onChange={(checked) => void onAct(async () => {
               await window.mdbaseConnect.setAccessPaused(!checked);
-              onNotice(checked ? "Remote access is available." : "Remote access is paused.");
+              onNotice(checked ? "Application access is available." : "Application access is paused.");
             })}
           />
         </div>
       </section>
-      <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Local paths are never synchronized.</strong><p>The portal receives collection names, versions, stable identifiers, and grant metadata. Record payloads pass through the relay only while an operation is active.</p></div></section>
+      <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Local paths are never synchronized.</strong><p>The portal receives collection names, versions, stable identifiers, and grant metadata. Same-computer apps connect directly when allowed; remote operations remain end-to-end encrypted through the relay.</p></div></section>
     </div>
   );
 }

--- a/apps/tasknotes/src/main.tsx
+++ b/apps/tasknotes/src/main.tsx
@@ -10,13 +10,16 @@ const requestedOperations = ["describe", "changes", "read", "query", "create", "
 function App() {
   const connect = useMemo(() => new MdbaseConnect<TaskFrontmatter>({ serverUrl }), []);
   const tasknotes = useMemo(() => new TasknotesCollection(connect), [connect]);
-  const [connected, setConnected] = useState(() => connect.connection() !== null);
+  const [connection, setConnection] = useState(() => connect.connection());
+  const connected = connection !== null;
   const [tasks, setTasks] = useState<TaskSummary[]>([]);
   const [title, setTitle] = useState("");
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
   const loadGeneration = useRef(0);
+
+  useEffect(() => connect.onConnectionChange(setConnection), [connect]);
 
   const load = useCallback(async () => {
     const generation = ++loadGeneration.current;
@@ -40,13 +43,14 @@ function App() {
     connect.completeAuthorization()
       .then(() => {
         history.replaceState({}, "", callback.pathname);
-        setConnected(true);
+        setConnection(connect.connection());
       })
       .catch((caught) => setError(message(caught)));
   }, [connect]);
 
   useEffect(() => {
     if (!connected) return;
+    void connect.checkDirectAccess();
     void load();
     const controller = new AbortController();
     void (async () => {
@@ -110,11 +114,19 @@ function App() {
     <header>
       <div>
         <p className="wordmark">TaskNotes</p>
-        <p className="connection">Connected through mdbase</p>
+        <p className="connection">{connection?.route === "direct" ? "Connected directly" : "Connected through mdbase"}</p>
+        {connection?.directAccess === "permission_required" && (
+          <div className="direct-option">
+            <button className="direct-access" aria-describedby="direct-access-hint" onClick={() => void connect.requestDirectAccess()}>
+              Connect directly
+            </button>
+            <span id="direct-access-hint">Let TaskNotes reach mdbase on this computer.</span>
+          </div>
+        )}
       </div>
       <button className="quiet" onClick={() => {
         connect.disconnect();
-        setConnected(false);
+        setConnection(null);
         setTasks([]);
       }}>Disconnect</button>
     </header>

--- a/apps/tasknotes/src/styles.css
+++ b/apps/tasknotes/src/styles.css
@@ -42,6 +42,9 @@ button:disabled { cursor: default; opacity: 0.48; }
 header { display: flex; align-items: flex-start; justify-content: space-between; min-height: 120px; }
 header .wordmark { margin: 0 0 5px; }
 .connection { margin: 0; font-size: 12px; color: oklch(0.55 0.02 225); }
+.direct-access { min-height: 28px; margin-top: 8px; padding-inline: 9px; font-size: 12px; background: transparent; }
+.direct-option { display: flex; align-items: baseline; gap: 9px; }
+.direct-option span { font-size: 11px; color: oklch(0.59 0.018 225); }
 section h1 { margin: 0 0 22px; font-size: 25px; line-height: 1.2; letter-spacing: -0.025em; }
 
 .quick-add { display: flex; gap: 8px; padding-bottom: 24px; border-bottom: 1px solid oklch(0.9 0.007 225); }
@@ -78,6 +81,7 @@ section h1 { margin: 0 0 22px; font-size: 25px; line-height: 1.2; letter-spacing
   .welcome h1 { font-size: 34px; }
   .shell { width: min(100% - 28px, 720px); padding-top: 20px; }
   header { min-height: 104px; }
+  .direct-option span { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/crates/connect-agent/Cargo.toml
+++ b/crates/connect-agent/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+axum.workspace = true
 clap.workspace = true
 futures-util.workspace = true
 mdbase.workspace = true
@@ -18,5 +19,9 @@ tokio.workspace = true
 tokio-tungstenite.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tower-http.workspace = true
 uuid.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/crates/connect-agent/src/loopback.rs
+++ b/crates/connect-agent/src/loopback.rs
@@ -1,0 +1,837 @@
+use crate::server::AgentState;
+use axum::body::Body;
+use axum::extract::{DefaultBodyLimit, State};
+use axum::http::{header, HeaderMap, HeaderValue, Method, Request, Response, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use mdbase_connect_protocol::{
+    RelayMessage, ENCRYPTED_RELAY_PROTOCOL_VERSION, LOOPBACK_PROTOCOL_VERSION,
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::io;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+
+const MAX_REQUEST_BYTES: usize = 3 * 1024 * 1024;
+const MAX_CONCURRENT_OPERATIONS: usize = 32;
+const MAX_REQUESTS_PER_MINUTE_PER_ORIGIN: u32 = 600;
+
+#[derive(Clone)]
+struct LoopbackState {
+    agent: Arc<AgentState>,
+    port: u16,
+    operations: Arc<Semaphore>,
+    rates: Arc<Mutex<HashMap<String, (Instant, u32)>>>,
+}
+
+pub struct LoopbackServer {
+    port: u16,
+    tasks: Vec<JoinHandle<io::Result<()>>>,
+}
+
+impl LoopbackServer {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn stop(self) {
+        for task in self.tasks {
+            task.abort();
+        }
+    }
+}
+
+pub async fn start(port: u16, agent: Arc<AgentState>) -> io::Result<LoopbackServer> {
+    let ipv4 = TcpListener::bind(("127.0.0.1", port)).await?;
+    let actual_port = ipv4.local_addr()?.port();
+    let app = router(agent, actual_port);
+    let mut tasks = vec![tokio::spawn(serve(ipv4, app.clone()))];
+
+    match TcpListener::bind(("::1", actual_port)).await {
+        Ok(ipv6) => tasks.push(tokio::spawn(serve(ipv6, app))),
+        Err(error) => {
+            tracing::debug!(%error, "IPv6 loopback is unavailable; continuing on IPv4 loopback")
+        }
+    }
+    tracing::info!(
+        port = actual_port,
+        "direct collection access listening on loopback"
+    );
+    Ok(LoopbackServer {
+        port: actual_port,
+        tasks,
+    })
+}
+
+async fn serve(listener: TcpListener, app: Router) -> io::Result<()> {
+    axum::serve(listener, app).await.map_err(io::Error::other)
+}
+
+fn router(agent: Arc<AgentState>, port: u16) -> Router {
+    let state = LoopbackState {
+        agent,
+        port,
+        operations: Arc::new(Semaphore::new(MAX_CONCURRENT_OPERATIONS)),
+        rates: Arc::new(Mutex::new(HashMap::new())),
+    };
+    Router::new()
+        .route("/v1/ready", get(ready).options(preflight))
+        .route("/v1/operations", post(operation).options(preflight))
+        .fallback(not_found)
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
+        .with_state(state)
+}
+
+async fn ready(State(state): State<LoopbackState>, request: Request<Body>) -> Response<Body> {
+    let Ok(origin) = authorize_browser_request(&state, &request, false) else {
+        return denied();
+    };
+    cors_response(
+        Json(json!({
+            "service": "mdbase-connect",
+            "loopback_protocol_version": LOOPBACK_PROTOCOL_VERSION,
+            "encrypted_protocol_version": ENCRYPTED_RELAY_PROTOCOL_VERSION,
+        }))
+        .into_response(),
+        &origin,
+    )
+}
+
+async fn preflight(State(state): State<LoopbackState>, request: Request<Body>) -> Response<Body> {
+    let Ok(origin) = authorize_browser_request(&state, &request, true) else {
+        return denied();
+    };
+    let requested_method = request
+        .headers()
+        .get(header::ACCESS_CONTROL_REQUEST_METHOD)
+        .and_then(|value| value.to_str().ok());
+    if !matches!(requested_method, Some("GET" | "POST")) {
+        return denied();
+    }
+    let requested_headers = request
+        .headers()
+        .get(header::ACCESS_CONTROL_REQUEST_HEADERS)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if requested_headers
+        .split(',')
+        .map(|value| value.trim().to_ascii_lowercase())
+        .any(|value| !value.is_empty() && value != "content-type")
+    {
+        return denied();
+    }
+    let mut response = cors_response(StatusCode::NO_CONTENT.into_response(), &origin);
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_METHODS,
+        HeaderValue::from_static("GET, POST, OPTIONS"),
+    );
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderValue::from_static("Content-Type"),
+    );
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_MAX_AGE,
+        HeaderValue::from_static("600"),
+    );
+    if request
+        .headers()
+        .get("access-control-request-private-network")
+        .is_some_and(|value| value == "true")
+    {
+        response.headers_mut().insert(
+            "access-control-allow-private-network",
+            HeaderValue::from_static("true"),
+        );
+    }
+    response
+}
+
+async fn operation(
+    State(state): State<LoopbackState>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Response<Body> {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/operations")
+        .body(Body::empty())
+        .expect("static direct request");
+    let (mut parts, _) = request.into_parts();
+    parts.headers = headers;
+    let request = Request::from_parts(parts, Body::empty());
+    let Ok(origin) = authorize_browser_request(&state, &request, false) else {
+        return denied();
+    };
+    if request
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        != Some("application/mdbase-connect+json")
+    {
+        return cors_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "unsupported_media_type",
+            "Direct operations require application/mdbase-connect+json.",
+            &origin,
+        );
+    }
+    let Ok(RelayMessage::EncryptedOperationRequest { envelope }) =
+        serde_json::from_value::<RelayMessage>(body)
+    else {
+        return cors_error(
+            StatusCode::UPGRADE_REQUIRED,
+            "encryption_required",
+            "Direct operations require encrypted protocol 3.",
+            &origin,
+        );
+    };
+    let permit = match tokio::time::timeout(
+        Duration::from_secs(5),
+        state.operations.clone().acquire_owned(),
+    )
+    .await
+    {
+        Ok(Ok(permit)) => permit,
+        _ => {
+            return cors_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "connector_busy",
+                "The local connector is busy.",
+                &origin,
+            )
+        }
+    };
+    let agent = state.agent.clone();
+    let operation_origin = origin.clone();
+    let execution = tokio::task::spawn_blocking(move || {
+        // Keep the concurrency slot until the filesystem operation and its durable receipt
+        // have both completed, even when the HTTP request times out and disconnects.
+        let _permit = permit;
+        agent.handle_direct_encrypted_operation(&operation_origin, envelope)
+    });
+    let response = tokio::time::timeout(Duration::from_secs(30), execution).await;
+    match response {
+        Ok(Ok(RelayMessage::EncryptedOperationResponse { envelope })) => cors_response(
+            Json(json!({
+                "ok": true,
+                "envelope": RelayMessage::EncryptedOperationResponse { envelope }
+            }))
+            .into_response(),
+            &origin,
+        ),
+        Ok(Ok(_)) => cors_error(
+            StatusCode::FORBIDDEN,
+            "direct_operation_rejected",
+            "The local connector rejected this operation.",
+            &origin,
+        ),
+        Ok(Err(_)) => cors_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "connector_failed",
+            "The local connector could not complete this operation.",
+            &origin,
+        ),
+        Err(_) => cors_error(
+            StatusCode::GATEWAY_TIMEOUT,
+            "connector_timeout",
+            "The local connector did not complete this operation in time.",
+            &origin,
+        ),
+    }
+}
+
+async fn not_found() -> Response<Body> {
+    StatusCode::NOT_FOUND.into_response()
+}
+
+fn authorize_browser_request(
+    state: &LoopbackState,
+    request: &Request<Body>,
+    preflight: bool,
+) -> Result<String, ()> {
+    let expected_host_v4 = format!("127.0.0.1:{}", state.port);
+    let expected_host_v6 = format!("[::1]:{}", state.port);
+    let host = request
+        .headers()
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(())?;
+    if host != expected_host_v4 && host != expected_host_v6 {
+        return Err(());
+    }
+    if preflight && request.method() != Method::OPTIONS {
+        return Err(());
+    }
+    let origin = request
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(())?;
+    let parsed = url::Url::parse(origin).map_err(|_| ())?;
+    if parsed.origin().ascii_serialization() != origin
+        || !matches!(parsed.scheme(), "http" | "https")
+    {
+        return Err(());
+    }
+    if !state.agent.origin_allowed(origin) || !within_rate_limit(state, origin) {
+        return Err(());
+    }
+    Ok(origin.to_string())
+}
+
+fn within_rate_limit(state: &LoopbackState, origin: &str) -> bool {
+    let now = Instant::now();
+    let mut rates = state.rates.lock().expect("loopback rate lock poisoned");
+    rates.retain(|_, (window, _)| now.duration_since(*window) < Duration::from_secs(120));
+    let entry = rates.entry(origin.to_string()).or_insert((now, 0));
+    if now.duration_since(entry.0) >= Duration::from_secs(60) {
+        *entry = (now, 0);
+    }
+    if entry.1 >= MAX_REQUESTS_PER_MINUTE_PER_ORIGIN {
+        return false;
+    }
+    entry.1 += 1;
+    true
+}
+
+fn denied() -> Response<Body> {
+    StatusCode::FORBIDDEN.into_response()
+}
+
+fn cors_error(status: StatusCode, code: &str, message: &str, origin: &str) -> Response<Body> {
+    cors_response(
+        (
+            status,
+            Json(json!({ "error": { "code": code, "message": message } })),
+        )
+            .into_response(),
+        origin,
+    )
+}
+
+fn cors_response(mut response: Response<Body>, origin: &str) -> Response<Body> {
+    if let Ok(value) = HeaderValue::from_str(origin) {
+        response
+            .headers_mut()
+            .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, value);
+    }
+    response.headers_mut().insert(
+        header::VARY,
+        HeaderValue::from_static(
+            "Origin, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Request-Private-Network",
+        ),
+    );
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response.headers_mut().insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_TYPE, HOST, ORIGIN};
+    use mdbase_connect_core::CollectionRegistry;
+    use mdbase_connect_protocol::crypto::{
+        RelayBinding, RelayDirection, RelayIdentity, RelayMetadata,
+    };
+    use mdbase_connect_protocol::{
+        EncryptedRelayEnvelope, GrantEncryption, GrantPolicy, GrantScope, RELAY_ENCRYPTION_SUITE,
+    };
+    use std::fs;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn exact_origin_host_and_protocol_three_are_enforced() {
+        let fixture = fixture();
+        let app = router(fixture.agent.clone(), 28_485);
+
+        let hostile = app
+            .clone()
+            .oneshot(request(
+                Method::GET,
+                "/v1/ready",
+                "https://evil.example",
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(hostile.status(), StatusCode::FORBIDDEN);
+        assert!(hostile.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).is_none());
+
+        let rebound = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/v1/ready")
+                    .header(HOST, "connector.evil.example:28485")
+                    .header(ORIGIN, &fixture.origin)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rebound.status(), StatusCode::FORBIDDEN);
+
+        let ready = app
+            .clone()
+            .oneshot(request(Method::GET, "/v1/ready", &fixture.origin, None))
+            .await
+            .unwrap();
+        assert_eq!(ready.status(), StatusCode::OK);
+        assert_eq!(
+            ready.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+            fixture.origin.as_str()
+        );
+
+        let plaintext = app
+            .oneshot(request(
+                Method::POST,
+                "/v1/operations",
+                &fixture.origin,
+                Some(r#"{"type":"operation_request"}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(plaintext.status(), StatusCode::UPGRADE_REQUIRED);
+
+        fs::remove_dir_all(fixture.root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn every_grantable_operation_runs_directly_and_duplicate_writes_cross_transports_once() {
+        let fixture = fixture();
+        let app = router(fixture.agent.clone(), 28_485);
+
+        let described = fixture.direct(&app, "describe", json!({}), 1).await;
+        assert_eq!(described["ok"], true);
+        assert_eq!(described["result"]["display_name"], "Direct notes");
+        let cursor = described["result"]["change_cursor"].as_u64().unwrap();
+
+        let created = fixture
+            .direct(
+                &app,
+                "create",
+                json!({
+                    "path": "notes/one.md",
+                    "frontmatter": { "title": "One" },
+                    "body": "Direct body"
+                }),
+                2,
+            )
+            .await;
+        assert_eq!(created["result"]["valid"], true);
+        let revision = created["result"]["result"]["revision"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let read = fixture
+            .direct(&app, "read", json!({ "path": "notes/one.md" }), 3)
+            .await;
+        assert_eq!(read["result"]["result"]["body"], "Direct body\n");
+
+        let updated = fixture
+            .direct(
+                &app,
+                "update",
+                json!({
+                    "path": "notes/one.md",
+                    "patch": { "title": "Updated" },
+                    "if_revision": revision
+                }),
+                4,
+            )
+            .await;
+        assert_eq!(updated["result"]["valid"], true);
+
+        let renamed = fixture
+            .direct(
+                &app,
+                "rename",
+                json!({ "from": "notes/one.md", "to": "notes/renamed.md" }),
+                5,
+            )
+            .await;
+        assert_eq!(renamed["result"]["valid"], true);
+
+        let queried = fixture
+            .direct(&app, "query", json!({ "include_body": true }), 6)
+            .await;
+        assert_eq!(
+            queried["result"]["result"]["results"][0]["path"],
+            "notes/renamed.md"
+        );
+
+        let validated = fixture.direct(&app, "validate", json!({}), 7).await;
+        assert_eq!(validated["result"]["valid"], true);
+
+        let type_document = "---\nkind: mdbase.type\nname: browsernote\nversion: 1\ndescription: Browser note\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\n    properties:\n      title: { type: string }\n---\n";
+        let created_type = fixture
+            .direct(&app, "create_type", json!({ "document": type_document }), 8)
+            .await;
+        assert_eq!(created_type["result"]["valid"], true);
+        assert_eq!(
+            created_type["result"]["result"]["path"],
+            "_types/browsernote.md"
+        );
+
+        let read_type = fixture
+            .direct(&app, "read_type", json!({ "name": "browsernote" }), 9)
+            .await;
+        assert_eq!(read_type["result"]["valid"], true);
+        let type_revision = read_type["result"]["result"]["revision"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let updated_type = fixture
+            .direct(
+                &app,
+                "update_type",
+                json!({
+                    "name": "browsernote",
+                    "document": type_document.replace("Browser note", "Updated browser note"),
+                    "if_revision": type_revision
+                }),
+                10,
+            )
+            .await;
+        assert_eq!(updated_type["result"]["valid"], true);
+
+        let changes = fixture
+            .direct(&app, "changes", json!({ "after": cursor }), 11)
+            .await;
+        assert!(!changes["result"]["events"].as_array().unwrap().is_empty());
+
+        let deleted = fixture
+            .direct(&app, "delete", json!({ "path": "notes/renamed.md" }), 12)
+            .await;
+        assert_eq!(deleted["result"]["valid"], true);
+
+        let duplicate = fixture.encrypted_request(
+            "create",
+            json!({ "path": "only-once.md", "frontmatter": { "title": "Once" } }),
+            13,
+        );
+        let direct_response = fixture.send(&app, duplicate.clone()).await;
+        let relay_response = fixture
+            .agent
+            .handle_relay_message(duplicate)
+            .expect("relay response");
+        let RelayMessage::EncryptedOperationResponse {
+            envelope: relay_envelope,
+        } = relay_response
+        else {
+            panic!("expected encrypted relay receipt")
+        };
+        assert_eq!(direct_response, relay_envelope);
+
+        let final_query = fixture.direct(&app, "query", json!({}), 14).await;
+        let only_once = final_query["result"]["result"]["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|record| record["path"] == "only-once.md")
+            .count();
+        assert_eq!(only_once, 1);
+
+        fs::remove_dir_all(fixture.root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn preflight_pause_tampering_and_revocation_fail_closed() {
+        let fixture = fixture();
+        let app = router(fixture.agent.clone(), 28_485);
+        let preflight = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/v1/operations")
+                    .header(HOST, "127.0.0.1:28485")
+                    .header(ORIGIN, &fixture.origin)
+                    .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                    .header(header::ACCESS_CONTROL_REQUEST_HEADERS, "content-type")
+                    .header("access-control-request-private-network", "true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(preflight.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            preflight
+                .headers()
+                .get("access-control-allow-private-network")
+                .unwrap(),
+            "true"
+        );
+
+        fixture.registry.set_paused(true).unwrap();
+        let paused = fixture.direct(&app, "query", json!({}), 1).await;
+        assert_eq!(paused["ok"], false);
+        assert_eq!(paused["error"]["code"], "access_paused");
+        fixture.registry.set_paused(false).unwrap();
+
+        let mut tampered = fixture.encrypted_request("query", json!({}), 2);
+        let RelayMessage::EncryptedOperationRequest { envelope } = &mut tampered else {
+            unreachable!()
+        };
+        envelope.ciphertext.replace_range(
+            ..1,
+            if envelope.ciphertext.starts_with('A') {
+                "B"
+            } else {
+                "A"
+            },
+        );
+        let tampered_response = app
+            .clone()
+            .oneshot(request(
+                Method::POST,
+                "/v1/operations",
+                &fixture.origin,
+                Some(&serde_json::to_string(&tampered).unwrap()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(tampered_response.status(), StatusCode::FORBIDDEN);
+
+        fixture.registry.replace_grants(&[]).unwrap();
+        let revoked = app
+            .oneshot(request(
+                Method::POST,
+                "/v1/operations",
+                &fixture.origin,
+                Some(
+                    &serde_json::to_string(&fixture.encrypted_request("query", json!({}), 3))
+                        .unwrap(),
+                ),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(revoked.status(), StatusCode::FORBIDDEN);
+        assert!(revoked.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).is_none());
+
+        fs::remove_dir_all(fixture.root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_direct_requests_allow_authenticated_counter_reordering() {
+        let fixture = fixture();
+        let app = router(fixture.agent.clone(), 28_485);
+        let created = fixture
+            .direct(
+                &app,
+                "create",
+                json!({ "path": "load.md", "frontmatter": { "title": "Load" } }),
+                1,
+            )
+            .await;
+        assert_eq!(created["result"]["valid"], true);
+
+        let mut requests = (2..130)
+            .map(|counter| fixture.encrypted_request("query", json!({}), counter))
+            .collect::<Vec<_>>();
+        requests.reverse();
+        let responses = futures_util::future::join_all(
+            requests
+                .into_iter()
+                .map(|request| fixture.send(&app, request)),
+        )
+        .await;
+        assert_eq!(responses.len(), 128);
+        assert!(responses
+            .iter()
+            .all(|response| response.operation == "query" && !response.ciphertext.is_empty()));
+
+        fs::remove_dir_all(fixture.root).unwrap();
+    }
+
+    struct Fixture {
+        root: std::path::PathBuf,
+        registry: CollectionRegistry,
+        agent: Arc<AgentState>,
+        origin: String,
+        application: RelayIdentity,
+        application_id: Uuid,
+        grant_id: Uuid,
+        encryption: GrantEncryption,
+    }
+
+    impl Fixture {
+        fn encrypted_request(
+            &self,
+            operation: &str,
+            input: serde_json::Value,
+            counter: u64,
+        ) -> RelayMessage {
+            let binding =
+                RelayBinding::from_grant(self.grant_id, self.application_id, &self.encryption);
+            let keys = self
+                .application
+                .derive(&self.encryption.connector_public_key, &binding)
+                .unwrap();
+            let counter = counter.to_string();
+            let metadata = RelayMetadata {
+                binding: &binding,
+                request_id: Uuid::new_v4(),
+                operation,
+                counter: &counter,
+            };
+            RelayMessage::EncryptedOperationRequest {
+                envelope: metadata.envelope(
+                    keys.encrypt_json(RelayDirection::Request, metadata, &input)
+                        .unwrap(),
+                ),
+            }
+        }
+
+        async fn send(&self, app: &Router, message: RelayMessage) -> EncryptedRelayEnvelope {
+            let response = app
+                .clone()
+                .oneshot(request(
+                    Method::POST,
+                    "/v1/operations",
+                    &self.origin,
+                    Some(&serde_json::to_string(&message).unwrap()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = to_bytes(response.into_body(), MAX_REQUEST_BYTES)
+                .await
+                .unwrap();
+            serde_json::from_value::<EncryptedRelayEnvelope>(
+                serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["envelope"].clone(),
+            )
+            .unwrap()
+        }
+
+        async fn direct(
+            &self,
+            app: &Router,
+            operation: &str,
+            input: serde_json::Value,
+            counter: u64,
+        ) -> serde_json::Value {
+            let request = self.encrypted_request(operation, input, counter);
+            let RelayMessage::EncryptedOperationRequest {
+                envelope: request_envelope,
+            } = request.clone()
+            else {
+                unreachable!()
+            };
+            let response = self.send(app, request).await;
+            let binding =
+                RelayBinding::from_grant(self.grant_id, self.application_id, &self.encryption);
+            let keys = self
+                .application
+                .derive(&self.encryption.connector_public_key, &binding)
+                .unwrap();
+            let metadata = RelayMetadata {
+                binding: &binding,
+                request_id: request_envelope.request_id,
+                operation,
+                counter: &request_envelope.counter,
+            };
+            keys.decrypt_json(RelayDirection::Response, metadata, &response.ciphertext)
+                .unwrap()
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let root = std::env::temp_dir().join(format!("mdbase-loopback-{}", Uuid::new_v4()));
+        let registry = CollectionRegistry::open(root.join("state")).unwrap();
+        let collection = registry
+            .create(root.join("collection"), Some("Direct notes"))
+            .unwrap();
+        let connector = RelayIdentity::generate();
+        let application = RelayIdentity::generate();
+        let application_id = Uuid::new_v4();
+        let grant_id = Uuid::new_v4();
+        let origin = "https://tasks.example".to_string();
+        let encryption = GrantEncryption {
+            protocol_version: ENCRYPTED_RELAY_PROTOCOL_VERSION,
+            suite: RELAY_ENCRYPTION_SUITE.to_string(),
+            key_id: "direct-key".to_string(),
+            scope_epoch: 1,
+            connector_id: Uuid::new_v4(),
+            collection_id: collection.id,
+            application_public_key: application.public_key(),
+            connector_public_key: connector.public_key(),
+        };
+        registry
+            .replace_grants(&[GrantPolicy {
+                id: grant_id,
+                application_id,
+                collection_id: collection.id,
+                operations: [
+                    "describe",
+                    "changes",
+                    "read",
+                    "query",
+                    "validate",
+                    "create",
+                    "update",
+                    "delete",
+                    "rename",
+                    "read_type",
+                    "create_type",
+                    "update_type",
+                ]
+                .map(str::to_string)
+                .to_vec(),
+                scope: GrantScope::default(),
+                application_name: "Tasks".to_string(),
+                application_homepage: origin.clone(),
+                application_origin: origin.clone(),
+                application_icon: None,
+                collection_name: "Direct notes".to_string(),
+                created_at: "2026-07-22T00:00:00Z".to_string(),
+                encryption: Some(encryption.clone()),
+            }])
+            .unwrap();
+        let watcher = crate::watcher::CollectionWatchService::start(registry.clone());
+        watcher.refresh(&registry.list().unwrap());
+        Fixture {
+            root,
+            registry: registry.clone(),
+            agent: Arc::new(AgentState::with_identity(
+                registry, watcher, None, connector,
+            )),
+            origin,
+            application,
+            application_id,
+            grant_id,
+            encryption,
+        }
+    }
+
+    fn request(method: Method, path: &str, origin: &str, body: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(path)
+            .header(HOST, "127.0.0.1:28485")
+            .header(ORIGIN, origin);
+        if body.is_some() {
+            builder = builder.header(CONTENT_TYPE, "application/mdbase-connect+json");
+        }
+        builder
+            .body(Body::from(body.unwrap_or_default().to_string()))
+            .unwrap()
+    }
+}

--- a/crates/connect-agent/src/main.rs
+++ b/crates/connect-agent/src/main.rs
@@ -1,4 +1,5 @@
 mod cloud;
+mod loopback;
 mod relay;
 mod server;
 mod watcher;
@@ -7,6 +8,7 @@ use clap::Parser;
 use cloud::CloudControlClient;
 use mdbase_connect_core::{default_control_endpoint, default_state_dir, CollectionRegistry};
 use mdbase_connect_protocol::crypto::RelayIdentity;
+use mdbase_connect_protocol::DEFAULT_LOOPBACK_PORT;
 use server::AgentState;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,6 +34,10 @@ struct Args {
     /// One-time connector credential created in the user portal.
     #[arg(long, env = "MDBASE_CONNECT_CONNECTOR_TOKEN")]
     connector_token: Option<String>,
+
+    /// Browser-facing direct collection API port, bound only to loopback.
+    #[arg(long, env = "MDBASE_CONNECT_LOOPBACK_PORT", default_value_t = DEFAULT_LOOPBACK_PORT)]
+    loopback_port: u16,
 }
 
 #[tokio::main]
@@ -77,7 +83,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let initialization_state = state.clone();
     let relay_state = state.clone();
     tracing::info!(%endpoint, state_dir = %state_dir.display(), "starting local connector agent");
-    server::serve(&endpoint, state, move || {
+    let loopback = loopback::start(args.loopback_port, state.clone()).await?;
+    state.set_loopback_port(loopback.port());
+    let result = server::serve(&endpoint, state, move || {
         let (initialized, initialization_complete) = tokio::sync::oneshot::channel();
         tokio::task::spawn_blocking(move || {
             match registry.list() {
@@ -94,6 +102,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             });
         }
     })
-    .await?;
+    .await;
+    loopback.stop();
+    result?;
     Ok(())
 }

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -1,6 +1,8 @@
 use crate::cloud::CloudControlClient;
 use crate::watcher::CollectionWatchService;
-use mdbase_connect_core::{CollectionRegistry, ConnectError};
+use mdbase_connect_core::{
+    encrypted_request_fingerprint, CollectionRegistry, ConnectError, EncryptedRequestClaim,
+};
 use mdbase_connect_protocol::crypto::{
     parse_counter, validate_envelope, RelayBinding, RelayDirection, RelayIdentity, RelayMetadata,
 };
@@ -17,6 +19,7 @@ pub struct AgentState {
     watcher: CollectionWatchService,
     connection_state: std::sync::RwLock<AgentConnectionState>,
     initialized: std::sync::atomic::AtomicBool,
+    loopback_port: std::sync::atomic::AtomicU16,
     cloud: Option<CloudControlClient>,
     relay_identity: RelayIdentity,
 }
@@ -42,6 +45,7 @@ impl AgentState {
             watcher,
             connection_state: std::sync::RwLock::new(AgentConnectionState::LocalOnly),
             initialized: std::sync::atomic::AtomicBool::new(false),
+            loopback_port: std::sync::atomic::AtomicU16::new(0),
             cloud,
             relay_identity,
         }
@@ -54,6 +58,11 @@ impl AgentState {
     pub fn mark_initialized(&self) {
         self.initialized
             .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    pub fn set_loopback_port(&self, port: u16) {
+        self.loopback_port
+            .store(port, std::sync::atomic::Ordering::Release);
     }
 
     fn initialized(&self) -> bool {
@@ -78,6 +87,32 @@ impl AgentState {
         &self,
     ) -> Result<Vec<mdbase_connect_protocol::CollectionSummary>, ConnectError> {
         self.registry.list()
+    }
+
+    pub fn origin_allowed(&self, origin: &str) -> bool {
+        !origin.is_empty()
+            && self.registry.list_grants().is_ok_and(|grants| {
+                grants
+                    .iter()
+                    .any(|grant| grant.application_origin == origin && grant.encryption.is_some())
+            })
+    }
+
+    pub fn handle_direct_encrypted_operation(
+        &self,
+        origin: &str,
+        envelope: mdbase_connect_protocol::EncryptedRelayEnvelope,
+    ) -> RelayMessage {
+        let origin_matches = self
+            .registry
+            .grant_context(envelope.grant_id)
+            .ok()
+            .flatten()
+            .is_some_and(|grant| grant.application_origin == origin);
+        if !origin_matches {
+            return encrypted_rejection(envelope.request_id);
+        }
+        self.handle_encrypted_operation(envelope)
     }
 
     pub fn handle_relay_message(&self, message: RelayMessage) -> Option<RelayMessage> {
@@ -231,15 +266,7 @@ impl AgentState {
         &self,
         envelope: mdbase_connect_protocol::EncryptedRelayEnvelope,
     ) -> RelayMessage {
-        let rejected = || RelayMessage::EncryptedOperationRejected {
-            protocol_version: ENCRYPTED_RELAY_PROTOCOL_VERSION,
-            request_id: envelope.request_id,
-            error: ControlError {
-                code: "encrypted_relay_rejected".to_string(),
-                message: "Encrypted relay request was rejected.".to_string(),
-                details: None,
-            },
-        };
+        let rejected = || encrypted_rejection(envelope.request_id);
         let Some(context) = self
             .registry
             .grant_context(envelope.grant_id)
@@ -284,16 +311,49 @@ impl AgentState {
         let Ok(counter) = parse_counter(&envelope.counter) else {
             return rejected();
         };
-        if self
-            .registry
-            .accept_encrypted_request(context.id, &encryption.key_id, counter, envelope.request_id)
-            .is_err()
-        {
-            return rejected();
-        }
         let Ok(input) = serde_json::from_slice::<serde_json::Value>(&plaintext) else {
             return rejected();
         };
+        let Ok(fingerprint) = encrypted_request_fingerprint(&envelope) else {
+            return rejected();
+        };
+        match self.registry.claim_encrypted_request(
+            context.id,
+            &encryption.key_id,
+            counter,
+            envelope.request_id,
+            &fingerprint,
+        ) {
+            Ok(EncryptedRequestClaim::Fresh) => {}
+            Ok(EncryptedRequestClaim::Completed(response)) => {
+                return serde_json::from_str(&response).map_or_else(
+                    |_| rejected(),
+                    |envelope| RelayMessage::EncryptedOperationResponse { envelope },
+                );
+            }
+            Ok(EncryptedRequestClaim::InProgress) => {
+                for _ in 0..1_000 {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                    match self.registry.encrypted_request_response(
+                        context.id,
+                        &encryption.key_id,
+                        envelope.request_id,
+                        &fingerprint,
+                    ) {
+                        Ok(Some(response)) => {
+                            return serde_json::from_str(&response).map_or_else(
+                                |_| rejected(),
+                                |envelope| RelayMessage::EncryptedOperationResponse { envelope },
+                            );
+                        }
+                        Ok(None) => {}
+                        Err(_) => return rejected(),
+                    }
+                }
+                return rejected();
+            }
+            Err(_) => return rejected(),
+        }
 
         let paused = self.registry.paused().unwrap_or(true);
         let result = if paused {
@@ -338,8 +398,25 @@ impl AgentState {
         let Ok(ciphertext) = keys.encrypt_json(RelayDirection::Response, metadata, &body) else {
             return rejected();
         };
+        let response_envelope = metadata.envelope(ciphertext);
+        let Ok(serialized_response) = serde_json::to_string(&response_envelope) else {
+            return rejected();
+        };
+        if self
+            .registry
+            .complete_encrypted_request(
+                context.id,
+                &encryption.key_id,
+                envelope.request_id,
+                &fingerprint,
+                &serialized_response,
+            )
+            .is_err()
+        {
+            return rejected();
+        }
         RelayMessage::EncryptedOperationResponse {
-            envelope: metadata.envelope(ciphertext),
+            envelope: response_envelope,
         }
     }
 
@@ -360,6 +437,17 @@ impl AgentState {
                         .clone(),
                     registered_collections,
                     paused: self.registry.paused().unwrap_or(true),
+                    direct_access_available: self
+                        .loopback_port
+                        .load(std::sync::atomic::Ordering::Acquire)
+                        != 0,
+                    loopback_port: match self
+                        .loopback_port
+                        .load(std::sync::atomic::Ordering::Acquire)
+                    {
+                        0 => None,
+                        port => Some(port),
+                    },
                 })
                 .expect("agent status must serialize")
             }),
@@ -618,6 +706,18 @@ fn is_mutation(operation: &str) -> bool {
     )
 }
 
+fn encrypted_rejection(request_id: uuid::Uuid) -> RelayMessage {
+    RelayMessage::EncryptedOperationRejected {
+        protocol_version: ENCRYPTED_RELAY_PROTOCOL_VERSION,
+        request_id,
+        error: ControlError {
+            code: "encrypted_relay_rejected".to_string(),
+            message: "Encrypted relay request was rejected.".to_string(),
+            details: None,
+        },
+    }
+}
+
 async fn handle_stream<S>(stream: S, state: Arc<AgentState>) -> io::Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -743,7 +843,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_operations_round_trip_and_replays_fail_closed() {
+    fn encrypted_operations_round_trip_and_replays_return_the_durable_receipt() {
         let test_root = std::env::temp_dir().join(format!(
             "mdbase-connect-encryption-test-{}",
             uuid::Uuid::new_v4()
@@ -779,6 +879,7 @@ mod tests {
                 scope: GrantScope::default(),
                 application_name: "Encrypted application".to_string(),
                 application_homepage: "https://example.test".to_string(),
+                application_origin: "https://example.test".to_string(),
                 application_icon: None,
                 collection_name: "Encrypted notes".to_string(),
                 created_at: "2026-07-21T00:00:00Z".to_string(),
@@ -812,10 +913,14 @@ mod tests {
         assert_eq!(body["ok"], true);
         assert_eq!(body["result"]["display_name"], "Encrypted notes");
 
-        assert!(matches!(
-            state.handle_relay_message(request),
-            Some(RelayMessage::EncryptedOperationRejected { .. })
-        ));
+        let replay = state.handle_relay_message(request).unwrap();
+        let RelayMessage::EncryptedOperationResponse {
+            envelope: replay_envelope,
+        } = replay
+        else {
+            panic!("expected cached encrypted response")
+        };
+        assert_eq!(replay_envelope, envelope);
         fs::remove_dir_all(test_root).unwrap();
     }
 }

--- a/crates/connect-core/src/lib.rs
+++ b/crates/connect-core/src/lib.rs
@@ -1,3 +1,6 @@
 mod registry;
 
-pub use registry::{default_control_endpoint, default_state_dir, CollectionRegistry, ConnectError};
+pub use registry::{
+    default_control_endpoint, default_state_dir, encrypted_request_fingerprint, CollectionRegistry,
+    ConnectError, EncryptedRequestClaim,
+};

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -4,12 +4,11 @@ use mdbase::{Collection, SpecProfile};
 use mdbase_connect_protocol::{
     ActivityEntry, ApplicationRequirements, CollectionChange, CollectionChangesPage,
     CollectionContractDescriptor, CollectionDescription, CollectionSummary,
-    CollectionTypeDescriptor, ContractRequirement, GrantPolicy, GrantScope, GrantSummary,
-    TypeProvision, CONTROL_PROTOCOL_VERSION,
+    CollectionTypeDescriptor, ContractRequirement, EncryptedRelayEnvelope, GrantPolicy, GrantScope,
+    GrantSummary, TypeProvision, CONTROL_PROTOCOL_VERSION,
 };
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use serde_json::{json, Value};
-#[cfg(windows)]
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::env;
@@ -114,6 +113,20 @@ pub struct CollectionRegistry {
     providers: Arc<Mutex<HashMap<Uuid, Arc<FilesystemProvider>>>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncryptedRequestClaim {
+    Fresh,
+    Completed(String),
+    InProgress,
+}
+
+pub fn encrypted_request_fingerprint(
+    envelope: &EncryptedRelayEnvelope,
+) -> Result<String, ConnectError> {
+    let digest = Sha256::digest(serde_json::to_vec(envelope)?);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
 impl CollectionRegistry {
     pub fn open(state_dir: impl AsRef<Path>) -> Result<Self, ConnectError> {
         fs::create_dir_all(state_dir.as_ref())?;
@@ -154,6 +167,7 @@ impl CollectionRegistry {
                 scope TEXT NOT NULL DEFAULT '{\"contracts\":[]}',
                 application_name TEXT NOT NULL DEFAULT 'Application',
                 application_homepage TEXT NOT NULL DEFAULT '',
+                application_origin TEXT NOT NULL DEFAULT '',
                 application_icon TEXT,
                 collection_name TEXT NOT NULL DEFAULT 'Collection',
                 encryption TEXT,
@@ -196,7 +210,9 @@ impl CollectionRegistry {
                 grant_id TEXT NOT NULL,
                 key_id TEXT NOT NULL,
                 request_id TEXT NOT NULL,
-                counter TEXT,
+                request_counter TEXT NOT NULL DEFAULT '',
+                request_fingerprint TEXT NOT NULL DEFAULT '',
+                response_envelope TEXT,
                 received_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (grant_id, key_id, request_id)
             );
@@ -207,6 +223,7 @@ impl CollectionRegistry {
         for migration in [
             "ALTER TABLE grants ADD COLUMN application_name TEXT NOT NULL DEFAULT 'Application'",
             "ALTER TABLE grants ADD COLUMN application_homepage TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE grants ADD COLUMN application_origin TEXT NOT NULL DEFAULT ''",
             "ALTER TABLE grants ADD COLUMN application_icon TEXT",
             "ALTER TABLE grants ADD COLUMN collection_name TEXT NOT NULL DEFAULT 'Collection'",
             "ALTER TABLE grants ADD COLUMN created_at TEXT NOT NULL DEFAULT ''",
@@ -215,6 +232,9 @@ impl CollectionRegistry {
             "ALTER TABLE collections ADD COLUMN description TEXT",
             "ALTER TABLE grant_crypto_state ADD COLUMN reorder_floor TEXT",
             "ALTER TABLE grant_crypto_requests ADD COLUMN counter TEXT",
+            "ALTER TABLE grant_crypto_requests ADD COLUMN request_counter TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE grant_crypto_requests ADD COLUMN request_fingerprint TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE grant_crypto_requests ADD COLUMN response_envelope TEXT",
         ] {
             if let Err(error) = connection.execute(migration, []) {
                 if !error.to_string().contains("duplicate column name") {
@@ -232,9 +252,14 @@ impl CollectionRegistry {
             [],
         )?;
         connection.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS grant_crypto_requests_counter
-             ON grant_crypto_requests (grant_id, key_id, counter)
-             WHERE counter IS NOT NULL",
+            "UPDATE grant_crypto_requests SET request_counter = counter
+             WHERE request_counter = '' AND counter IS NOT NULL",
+            [],
+        )?;
+        connection.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS grant_crypto_requests_request_counter
+             ON grant_crypto_requests (grant_id, key_id, request_counter)
+             WHERE request_counter <> ''",
             [],
         )?;
         Ok(())
@@ -696,7 +721,11 @@ impl CollectionRegistry {
                     .and_then(Value::as_object)
                     .cloned()
                     .unwrap_or_default();
-                if let Some(fields) = input.get("fields").and_then(Value::as_object) {
+                if let Some(fields) = input
+                    .get("patch")
+                    .or_else(|| input.get("fields"))
+                    .and_then(Value::as_object)
+                {
                     for (field, value) in fields {
                         if value.is_null() {
                             prospective.remove(field);
@@ -1075,8 +1104,9 @@ impl CollectionRegistry {
             let mut statement = transaction.prepare(
                 "INSERT INTO grants
                    (id, application_id, collection_id, operations, scope, application_name,
-                    application_homepage, application_icon, collection_name, created_at, encryption)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    application_homepage, application_origin, application_icon, collection_name,
+                    created_at, encryption)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             )?;
             for grant in grants {
                 statement.execute(params![
@@ -1087,6 +1117,7 @@ impl CollectionRegistry {
                     serde_json::to_string(&grant.scope)?,
                     grant.application_name,
                     grant.application_homepage,
+                    grant.application_origin,
                     grant.application_icon,
                     grant.collection_name,
                     grant.created_at,
@@ -1147,6 +1178,7 @@ impl CollectionRegistry {
                     scope: grant.scope.clone(),
                     application_name: grant.application_name.clone(),
                     application_homepage: grant.application_homepage.clone(),
+                    application_origin: grant.application_origin.clone(),
                     application_icon: grant.application_icon.clone(),
                     collection_name: grant.collection_name.clone(),
                     created_at: grant.created_at.clone(),
@@ -1160,8 +1192,8 @@ impl CollectionRegistry {
         let connection = self.connection()?;
         let mut statement = connection.prepare(
             "SELECT id, application_id, application_name, application_homepage,
-                    application_icon, collection_id, collection_name, operations, scope, created_at,
-                    encryption
+                    application_origin, application_icon, collection_id, collection_name,
+                    operations, scope, created_at, encryption
              FROM grants ORDER BY application_name COLLATE NOCASE, collection_name COLLATE NOCASE",
         )?;
         let rows = statement.query_map([], |row| {
@@ -1170,13 +1202,14 @@ impl CollectionRegistry {
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
-                row.get::<_, Option<String>>(4)?,
-                row.get::<_, String>(5)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
                 row.get::<_, String>(6)?,
                 row.get::<_, String>(7)?,
                 row.get::<_, String>(8)?,
                 row.get::<_, String>(9)?,
-                row.get::<_, Option<String>>(10)?,
+                row.get::<_, String>(10)?,
+                row.get::<_, Option<String>>(11)?,
             ))
         })?;
         rows.map(|row| {
@@ -1185,6 +1218,7 @@ impl CollectionRegistry {
                 application_id,
                 application_name,
                 application_homepage,
+                application_origin,
                 application_icon,
                 collection_id,
                 collection_name,
@@ -1198,6 +1232,7 @@ impl CollectionRegistry {
                 application_id: parse_registry_uuid(&application_id)?,
                 application_name,
                 application_homepage,
+                application_origin,
                 application_icon,
                 collection_id: parse_registry_uuid(&collection_id)?,
                 collection_name,
@@ -1318,18 +1353,19 @@ impl CollectionRegistry {
             .find(|grant| grant.id == grant_id))
     }
 
-    /// Atomically accepts a fresh encrypted request counter and request ID.
+    /// Atomically claims a fresh encrypted request or returns its durable response receipt.
     ///
     /// Authentication must happen before this call so unauthenticated traffic cannot advance the
     /// durable replay window. The immediate transaction makes concurrent duplicate deliveries
     /// deterministic across relay sessions and process threads.
-    pub fn accept_encrypted_request(
+    pub fn claim_encrypted_request(
         &self,
         grant_id: Uuid,
         key_id: &str,
         counter: u64,
         request_id: Uuid,
-    ) -> Result<(), ConnectError> {
+        request_fingerprint: &str,
+    ) -> Result<EncryptedRequestClaim, ConnectError> {
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let state = transaction
@@ -1347,26 +1383,35 @@ impl CollectionRegistry {
             )
             .transpose()
             .map_err(|_| ConnectError::EncryptedRelayRejected)?;
-        let duplicate_id = transaction
+        let existing = transaction
             .query_row(
-                "SELECT 1 FROM grant_crypto_requests
+                "SELECT request_fingerprint, response_envelope FROM grant_crypto_requests
                  WHERE grant_id = ?1 AND key_id = ?2 AND request_id = ?3",
                 params![grant_id.to_string(), key_id, request_id.to_string()],
-                |_| Ok(()),
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
             )
-            .optional()?
-            .is_some();
+            .optional()?;
+        if let Some((fingerprint, response)) = existing {
+            if fingerprint != request_fingerprint {
+                return Err(ConnectError::EncryptedRelayRejected);
+            }
+            transaction.commit()?;
+            return Ok(match response {
+                Some(response) => EncryptedRequestClaim::Completed(response),
+                None => EncryptedRequestClaim::InProgress,
+            });
+        }
         let duplicate_counter = transaction
             .query_row(
                 "SELECT 1 FROM grant_crypto_requests
-                 WHERE grant_id = ?1 AND key_id = ?2 AND counter = ?3",
+                 WHERE grant_id = ?1 AND key_id = ?2 AND request_counter = ?3",
                 params![grant_id.to_string(), key_id, counter.to_string()],
                 |_| Ok(()),
             )
             .optional()?
             .is_some();
         let reorder_floor = state.map_or(0, |(_, floor)| floor);
-        if duplicate_id || duplicate_counter || counter <= reorder_floor {
+        if duplicate_counter || counter <= reorder_floor {
             return Err(ConnectError::EncryptedRelayRejected);
         }
         let last = state.map_or(counter, |(last, _)| last.max(counter));
@@ -1386,26 +1431,80 @@ impl CollectionRegistry {
             ],
         )?;
         transaction.execute(
-            "INSERT INTO grant_crypto_requests (grant_id, key_id, request_id, counter)
-             VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO grant_crypto_requests
+               (grant_id, key_id, request_id, request_counter, request_fingerprint)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
                 grant_id.to_string(),
                 key_id,
                 request_id.to_string(),
-                counter.to_string()
+                counter.to_string(),
+                request_fingerprint
             ],
         )?;
         transaction.execute(
             "DELETE FROM grant_crypto_requests
-             WHERE grant_id = ?1 AND key_id = ?2 AND rowid NOT IN (
+             WHERE grant_id = ?1 AND key_id = ?2 AND response_envelope IS NOT NULL
+               AND rowid NOT IN (
                SELECT rowid FROM grant_crypto_requests
                WHERE grant_id = ?1 AND key_id = ?2
+                 AND response_envelope IS NOT NULL
                ORDER BY rowid DESC LIMIT 1024
              )",
             params![grant_id.to_string(), key_id],
         )?;
         transaction.commit()?;
+        Ok(EncryptedRequestClaim::Fresh)
+    }
+
+    pub fn complete_encrypted_request(
+        &self,
+        grant_id: Uuid,
+        key_id: &str,
+        request_id: Uuid,
+        request_fingerprint: &str,
+        response_envelope: &str,
+    ) -> Result<(), ConnectError> {
+        let updated = self.connection()?.execute(
+            "UPDATE grant_crypto_requests SET response_envelope = ?5
+             WHERE grant_id = ?1 AND key_id = ?2 AND request_id = ?3
+               AND request_fingerprint = ?4 AND response_envelope IS NULL",
+            params![
+                grant_id.to_string(),
+                key_id,
+                request_id.to_string(),
+                request_fingerprint,
+                response_envelope
+            ],
+        )?;
+        if updated != 1 {
+            return Err(ConnectError::EncryptedRelayRejected);
+        }
         Ok(())
+    }
+
+    pub fn encrypted_request_response(
+        &self,
+        grant_id: Uuid,
+        key_id: &str,
+        request_id: Uuid,
+        request_fingerprint: &str,
+    ) -> Result<Option<String>, ConnectError> {
+        self.connection()?
+            .query_row(
+                "SELECT response_envelope FROM grant_crypto_requests
+                 WHERE grant_id = ?1 AND key_id = ?2 AND request_id = ?3
+                   AND request_fingerprint = ?4",
+                params![
+                    grant_id.to_string(),
+                    key_id,
+                    request_id.to_string(),
+                    request_fingerprint
+                ],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(ConnectError::from)
     }
 
     pub fn authorizes(
@@ -2321,7 +2420,7 @@ schema:
             registry.scoped_operation(
                 collection.id,
                 "update",
-                &json!({ "path": "tasks/one.md", "fields": { "type": "private" } }),
+                &json!({ "path": "tasks/one.md", "patch": { "type": "private" } }),
                 &scope
             ),
             Err(ConnectError::AccessDenied(_))
@@ -2427,6 +2526,7 @@ schema:
             scope: GrantScope::default(),
             application_name: "Workout Tracker".to_string(),
             application_homepage: "https://workouts.example".to_string(),
+            application_origin: "https://workouts.example".to_string(),
             application_icon: None,
             collection_name: "Workouts".to_string(),
             created_at: "2026-07-19T00:00:00Z".to_string(),
@@ -2454,31 +2554,60 @@ schema:
     }
 
     #[test]
-    fn encrypted_replay_window_survives_restart_and_allows_reordered_delivery() {
+    fn encrypted_replay_window_survives_restart_allows_reordering_and_serializes_duplicates() {
         let state = tempdir().unwrap();
         let grant_id = Uuid::new_v4();
         let first_request = Uuid::new_v4();
         let registry = CollectionRegistry::open(state.path()).unwrap();
+        assert_eq!(
+            registry
+                .claim_encrypted_request(grant_id, "key-1", 40, first_request, "fingerprint-1")
+                .unwrap(),
+            EncryptedRequestClaim::Fresh
+        );
         registry
-            .accept_encrypted_request(grant_id, "key-1", 40, first_request)
+            .complete_encrypted_request(
+                grant_id,
+                "key-1",
+                first_request,
+                "fingerprint-1",
+                r#"{"ciphertext":"response"}"#,
+            )
             .unwrap();
         drop(registry);
 
         let registry = CollectionRegistry::open(state.path()).unwrap();
         assert!(matches!(
-            registry.accept_encrypted_request(grant_id, "key-1", 40, Uuid::new_v4()),
+            registry.claim_encrypted_request(
+                grant_id,
+                "key-1",
+                40,
+                Uuid::new_v4(),
+                "fingerprint-2"
+            ),
             Err(ConnectError::EncryptedRelayRejected)
         ));
-        assert!(matches!(
-            registry.accept_encrypted_request(grant_id, "key-1", 41, first_request),
-            Err(ConnectError::EncryptedRelayRejected)
-        ));
-        registry
-            .accept_encrypted_request(grant_id, "key-1", 42, Uuid::new_v4())
-            .unwrap();
-        registry
-            .accept_encrypted_request(grant_id, "key-1", 41, Uuid::new_v4())
-            .unwrap();
+        assert_eq!(
+            registry
+                .claim_encrypted_request(grant_id, "key-1", 40, first_request, "fingerprint-1")
+                .unwrap(),
+            EncryptedRequestClaim::Completed(r#"{"ciphertext":"response"}"#.to_string())
+        );
+        assert!(registry
+            .claim_encrypted_request(grant_id, "key-1", 41, first_request, "tampered")
+            .is_err());
+        assert_eq!(
+            registry
+                .claim_encrypted_request(grant_id, "key-1", 42, Uuid::new_v4(), "fingerprint-42")
+                .unwrap(),
+            EncryptedRequestClaim::Fresh
+        );
+        assert_eq!(
+            registry
+                .claim_encrypted_request(grant_id, "key-1", 41, Uuid::new_v4(), "fingerprint-41")
+                .unwrap(),
+            EncryptedRequestClaim::Fresh
+        );
 
         let shared = Arc::new(registry);
         let request_id = Uuid::new_v4();
@@ -2486,16 +2615,110 @@ schema:
             .map(|_| {
                 let registry = shared.clone();
                 std::thread::spawn(move || {
-                    registry.accept_encrypted_request(grant_id, "key-1", 43, request_id)
+                    registry.claim_encrypted_request(
+                        grant_id,
+                        "key-1",
+                        43,
+                        request_id,
+                        "fingerprint-43",
+                    )
                 })
             })
             .collect::<Vec<_>>();
         let accepted = threads
             .into_iter()
             .map(|thread| thread.join().unwrap())
-            .filter(Result::is_ok)
+            .filter(|result| matches!(result, Ok(EncryptedRequestClaim::Fresh)))
             .count();
         assert_eq!(accepted, 1);
+        assert_eq!(
+            shared
+                .claim_encrypted_request(
+                    grant_id,
+                    "key-1",
+                    2_000,
+                    Uuid::new_v4(),
+                    "fingerprint-2000"
+                )
+                .unwrap(),
+            EncryptedRequestClaim::Fresh
+        );
+        assert!(shared
+            .claim_encrypted_request(grant_id, "key-1", 975, Uuid::new_v4(), "fingerprint-stale")
+            .is_err());
+    }
+
+    #[test]
+    fn development_registry_upgrade_adds_origin_receipts_and_a_safe_reorder_floor() {
+        let state = tempdir().unwrap();
+        let path = state.path().join("connector.sqlite");
+        let legacy = Connection::open(&path).unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE grants (
+                    id TEXT PRIMARY KEY,
+                    application_id TEXT NOT NULL,
+                    collection_id TEXT NOT NULL,
+                    operations TEXT NOT NULL
+                 );
+                 CREATE TABLE grant_crypto_state (
+                    grant_id TEXT NOT NULL,
+                    key_id TEXT NOT NULL,
+                    last_request_counter TEXT NOT NULL,
+                    PRIMARY KEY (grant_id, key_id)
+                 );
+                 CREATE TABLE grant_crypto_requests (
+                    grant_id TEXT NOT NULL,
+                    key_id TEXT NOT NULL,
+                    request_id TEXT NOT NULL,
+                    received_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (grant_id, key_id, request_id)
+                 );",
+            )
+            .unwrap();
+        let grant_id = Uuid::new_v4();
+        legacy
+            .execute(
+                "INSERT INTO grant_crypto_state (grant_id, key_id, last_request_counter)
+                 VALUES (?1, 'legacy-key', '40')",
+                [grant_id.to_string()],
+            )
+            .unwrap();
+        drop(legacy);
+
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let connection = registry.connection().unwrap();
+        let origin: String = connection
+            .query_row(
+                "SELECT dflt_value FROM pragma_table_info('grants')
+                 WHERE name = 'application_origin'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(origin, "''");
+        let floor: String = connection
+            .query_row(
+                "SELECT reorder_floor FROM grant_crypto_state
+                 WHERE grant_id = ?1 AND key_id = 'legacy-key'",
+                [grant_id.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(floor, "40");
+        drop(connection);
+        assert_eq!(
+            registry
+                .claim_encrypted_request(
+                    grant_id,
+                    "legacy-key",
+                    41,
+                    Uuid::new_v4(),
+                    "upgraded-fingerprint"
+                )
+                .unwrap(),
+            EncryptedRequestClaim::Fresh
+        );
     }
 
     #[test]
@@ -2510,6 +2733,7 @@ schema:
             scope: GrantScope::default(),
             application_name: "Encrypted app".to_string(),
             application_homepage: "https://app.example".to_string(),
+            application_origin: "https://app.example".to_string(),
             application_icon: None,
             collection_name: "Collection".to_string(),
             created_at: "2026-07-21T00:00:00Z".to_string(),
@@ -2528,7 +2752,7 @@ schema:
             .replace_grants(std::slice::from_ref(&grant))
             .unwrap();
         registry
-            .accept_encrypted_request(grant.id, "key-1", 7, Uuid::new_v4())
+            .claim_encrypted_request(grant.id, "key-1", 7, Uuid::new_v4(), "fingerprint")
             .unwrap();
 
         registry

--- a/crates/connect-hosted-provider/src/crypto.rs
+++ b/crates/connect-hosted-provider/src/crypto.rs
@@ -111,9 +111,10 @@ fn encrypt(key: &[u8; KEY_BYTES], plaintext: &[u8], aad: &[u8]) -> ApiResult<Vec
         .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
     let mut nonce = [0_u8; NONCE_BYTES];
     OsRng.fill_bytes(&mut nonce);
+    let nonce = Nonce::from(nonce);
     let ciphertext = cipher
         .encrypt(
-            Nonce::from_slice(&nonce),
+            &nonce,
             Payload {
                 msg: plaintext,
                 aad,
@@ -135,9 +136,13 @@ fn decrypt(key: &[u8; KEY_BYTES], envelope: &[u8], aad: &[u8]) -> ApiResult<Vec<
     }
     let cipher = Aes256Gcm::new_from_slice(key)
         .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
+    let nonce_bytes: [u8; NONCE_BYTES] = envelope[1..1 + NONCE_BYTES]
+        .try_into()
+        .map_err(|_| ApiError::internal("The hosted ciphertext envelope is invalid."))?;
+    let nonce = Nonce::from(nonce_bytes);
     cipher
         .decrypt(
-            Nonce::from_slice(&envelope[1..1 + NONCE_BYTES]),
+            &nonce,
             Payload {
                 msg: &envelope[1 + NONCE_BYTES..],
                 aad,

--- a/crates/connect-protocol/src/crypto.rs
+++ b/crates/connect-protocol/src/crypto.rs
@@ -65,7 +65,7 @@ impl RelayIdentity {
             Ok(bytes) => Self::decode_identity(&bytes),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let identity = Self::generate();
-                match write_identity_file(&path, identity.secret.to_bytes().as_slice()) {
+                match write_identity_file(&path, &identity.secret.to_bytes()) {
                     Ok(()) => Ok(identity),
                     Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                         Self::decode_identity(&fs::read(path)?)
@@ -101,7 +101,7 @@ impl RelayIdentity {
         let peer = PublicKey::from_sec1_bytes(&peer_bytes)
             .map_err(|_| RelayCryptoError::InvalidPublicKey)?;
         let shared = diffie_hellman(self.secret.to_nonzero_scalar(), peer.as_affine());
-        RelayKeys::derive(shared.raw_secret_bytes().as_slice(), binding)
+        RelayKeys::derive(shared.raw_secret_bytes(), binding)
     }
 
     #[cfg(test)]
@@ -218,9 +218,10 @@ impl RelayKeys {
         let cipher = Aes256Gcm::new_from_slice(self.key(direction))
             .map_err(|_| RelayCryptoError::InvalidBinding)?;
         let nonce_bytes = nonce(counter);
+        let nonce = Nonce::from(nonce_bytes);
         let ciphertext = cipher
             .encrypt(
-                Nonce::from_slice(&nonce_bytes),
+                &nonce,
                 Payload {
                     msg: plaintext,
                     aad: metadata.aad(direction).as_bytes(),
@@ -243,9 +244,10 @@ impl RelayKeys {
         let cipher = Aes256Gcm::new_from_slice(self.key(direction))
             .map_err(|_| RelayCryptoError::InvalidBinding)?;
         let nonce_bytes = nonce(counter);
+        let nonce = Nonce::from(nonce_bytes);
         cipher
             .decrypt(
-                Nonce::from_slice(&nonce_bytes),
+                &nonce,
                 Payload {
                     msg: &ciphertext,
                     aad: metadata.aad(direction).as_bytes(),

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -6,6 +6,8 @@ pub mod crypto;
 
 pub const CONTROL_PROTOCOL_VERSION: u32 = 2;
 pub const ENCRYPTED_RELAY_PROTOCOL_VERSION: u32 = 3;
+pub const LOOPBACK_PROTOCOL_VERSION: u32 = 1;
+pub const DEFAULT_LOOPBACK_PORT: u16 = 28_485;
 pub const SYNC_PROTOCOL_VERSION: u32 = 1;
 pub const RELAY_ENCRYPTION_SUITE: &str = "P256-HKDF-SHA256-AES256GCM";
 
@@ -218,6 +220,10 @@ pub struct AgentStatus {
     pub state: AgentConnectionState,
     pub registered_collections: usize,
     pub paused: bool,
+    #[serde(default)]
+    pub direct_access_available: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loopback_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -505,6 +511,9 @@ pub struct GrantSummary {
     pub application_id: Uuid,
     pub application_name: String,
     pub application_homepage: String,
+    /// Exact browser origin authorized to use this grant over loopback.
+    #[serde(default)]
+    pub application_origin: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub application_icon: Option<String>,
     pub collection_id: Uuid,
@@ -581,6 +590,9 @@ pub struct GrantPolicy {
     pub application_name: String,
     #[serde(default)]
     pub application_homepage: String,
+    /// Exact browser origin authorized to use this grant over loopback.
+    #[serde(default)]
+    pub application_origin: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub application_icon: Option<String>,
     #[serde(default = "default_collection_name")]
@@ -795,6 +807,7 @@ mod tests {
                     scope: GrantScope::default(),
                     application_name: "Tasks".to_string(),
                     application_homepage: "https://tasks.example".to_string(),
+                    application_origin: "https://tasks.example".to_string(),
                     application_icon: None,
                     collection_name: "My tasks".to_string(),
                     created_at: "2026-07-21T00:00:00Z".to_string(),

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.6",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
@@ -352,19 +352,20 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.6",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -384,14 +385,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -442,6 +443,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -510,7 +517,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -520,14 +526,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -942,19 +950,18 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "group"
@@ -1332,11 +1339,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1435,9 +1442,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -1557,6 +1564,7 @@ dependencies = [
 name = "mdbase-connect-agent"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "axum",
  "clap",
  "futures-util",
  "mdbase",
@@ -1567,6 +1575,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "tower",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1804,12 +1814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,13 +1905,12 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -3200,12 +3203,12 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.6",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -1,7 +1,7 @@
 FROM rust:1.94.0-bookworm AS build
 
 ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
-ARG MDBASE_RS_REVISION=b47eecfbb6f6f82f9a92b461f5eba10265e7abd2
+ARG MDBASE_RS_REVISION=66089ba5499aa351ca396b903a6f1c54d2df768f
 
 RUN git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
  && git -C /build/mdbase-rs checkout --detach "$MDBASE_RS_REVISION"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,8 @@ Four trust zones make up the local-hosted path:
 
 1. An independently hosted frontend application.
 2. A hosted or self-hosted Connect control plane and transient relay.
-3. A user-owned connector agent with outbound network connections.
+3. A user-owned connector agent with a browser-only loopback service and
+   outbound network connections.
 4. User-owned mdbase collections on the local filesystem.
 
 The connector is the authority for local data and policy. The server routes a
@@ -24,7 +25,8 @@ checks its local policy copy again before it opens a collection.
 - `mdbase-rs` owns collection loading, validation, querying, mutation,
   revisions, and normalized filesystem events.
 - `connect-agent` owns collection registration, local policy enforcement, the
-  local change journal, activity, and outbound relay connectivity.
+  local change journal, activity, browser loopback access, and outbound relay
+  connectivity.
 - `connect-cli` and the Electron controller use the agent's versioned local
   control socket.
 - `connect-server` owns accounts, pairing, app discovery, grants, token
@@ -150,6 +152,34 @@ design is in
 The Electron controller is the primary collection and permission surface. The
 portal handles sign-in, pairing, account state, remote approval on trusted
 private deployments, and emergency computer revocation.
+
+## Direct local transport
+
+Local-authority grants synchronize the application's exact approved origin to
+the connector. The browser SDK can then send the existing protocol-3 envelope
+to `http://127.0.0.1:28485/v1/operations`. The fixed endpoint reveals only
+generic protocol readiness. It is separate from the Unix socket or Windows
+pipe used for desktop administration and exposes all grantable collection
+operations through the same connector handler as the relay.
+
+The loopback listener binds only IPv4 and IPv6 loopback, validates the exact
+`Host` and grant origin, returns exact-origin CORS headers, omits ambient
+credentials, requires `application/mdbase-connect+json`, and bounds request
+size, concurrency, execution time, and per-origin rate. Protocol-3 key proof
+remains the operation authority; CORS is an additional browser boundary.
+
+Chrome's Local Network Access permission is requested from an explicit app
+action. Once granted, routing is automatic and the UI may quietly report
+`Connected directly`. Unsupported, denied, absent, or incompatible local
+access falls back to the encrypted relay without changing application record
+code. Hosted authorities continue to use their provider directly.
+
+Every authenticated request is claimed in the connector's durable replay
+window. The completed encrypted response is stored as a receipt. If a direct
+response is lost, the SDK retries the exact envelope through the relay and the
+connector returns that receipt instead of executing the operation again.
+Authenticated counters may arrive out of order within a bounded 1,024-message
+window so concurrent browser requests remain safe and usable.
 
 ## Data authority and hosted replication
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -169,8 +169,10 @@ authenticated associated data binds at least:
 
 The encrypted body contains the canonical operation input or response. A unique
 nonce is derived or generated according to the selected audited construction.
-Authentication failure, duplicate request IDs, reused counters, wrong
-direction, and stale keys are rejected before decoding the payload.
+Authentication failure, reused counters under another request, wrong direction,
+and stale keys are rejected before decoding the payload. Authenticated counters
+may arrive out of order within a bounded window. An identical request ID and
+envelope returns its completed encrypted response receipt.
 
 Server-generated authorization and routing errors remain visible protocol
 errors. Connector-generated mdbase results and diagnostics stay inside the
@@ -203,6 +205,21 @@ authorization codes, and cryptographic error details from ordinary logs.
 Payloads remain in memory only for request routing. Queueing, retry, and
 backpressure use request IDs and sizes. The service does not persist encrypted
 payloads as an incidental message archive.
+
+### Direct loopback delivery
+
+The same protocol-3 request and response envelopes are used on the connector's
+browser-only loopback service. This preserves grant binding, key proof, replay
+handling, and response authentication while avoiding control-plane payload
+delivery for same-computer applications. Exact-origin CORS, loopback `Host`
+validation, non-simple content types, no cookies, and bounded resources harden
+the HTTP boundary; none replace cryptographic authorization.
+
+The connector persists completed encrypted response receipts locally, keyed by
+grant key, request ID, counter, and request fingerprint. If a direct response
+is lost, relay fallback presents the exact same request and receives the same
+ciphertext without repeating the collection operation. Receipts contain
+ciphertext rather than plaintext and are pruned with the bounded replay window.
 
 ## Standard hosted encryption
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -55,6 +55,28 @@ await connect.updateType({
 Request `read_type`, `create_type`, and `update_type` during authorization.
 Contract-scoped applications cannot manage collection-wide type definitions.
 
+For a local collection, ask for same-computer access from a user gesture:
+
+```ts
+const status = await connect.checkDirectAccess();
+if (status === "permission_required") {
+  directButton.onclick = () => connect.requestDirectAccess();
+}
+
+connect.onConnectionChange((connection) => {
+  console.log(connection?.route); // "direct", "relay", or "hosted"
+});
+```
+
+After permission is granted, all grantable operations prefer the fixed
+loopback connector automatically. If it is absent or unavailable, the SDK
+retries the exact encrypted envelope through the relay. Durable connector
+receipts prevent an ambiguous direct write from running twice. The SDK retains
+one unresolved encrypted mutation locally and requires that exact write to be
+retried before a later mutation can overtake it. Set
+`directAccess: "disabled"` only when an embedding environment cannot use
+loopback requests.
+
 Application identity is derived from the manifest's exact origin. No developer
 account or manually issued client secret is required.
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -3,8 +3,10 @@ import {
   createPkce,
   MdbaseCollectionClient,
   MdbaseConnect,
-  MdbaseConnectError
+  MdbaseConnectError,
+  MemoryGrantKeyStore
 } from "./index.js";
+import type { GrantEncryption } from "@mdbase/connect-protocol";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -215,6 +217,265 @@ describe("authorization renewal", () => {
       .toEqual(expect.objectContaining({ refreshToken: "ref_from_other_tab" }));
   });
 });
+
+describe("direct loopback routing", () => {
+  it("retries the exact encrypted envelope through the relay after an ambiguous direct failure", async () => {
+    const fixture = await encryptedConnection();
+    const requests: Array<{ url: string; body: string }> = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async (input, init) => {
+        requests.push({ url: String(input), body: String(init?.body) });
+        throw new TypeError("loopback response was lost");
+      })
+      .mockImplementationOnce(async (input, init) => {
+        requests.push({ url: String(input), body: String(init?.body) });
+        return new Response(JSON.stringify({
+          error: { code: "connector_offline", message: "Connector offline." }
+        }), { status: 503, headers: { "content-type": "application/json" } });
+      });
+
+    await expect(fixture.connect.create({
+      path: "one.md",
+      frontmatter: { title: "Only once" }
+    })).rejects.toEqual(expect.objectContaining({ code: "direct_outcome_unknown" }));
+
+    expect(requests.map(({ url }) => url)).toEqual([
+      "http://127.0.0.1:28485/v1/operations",
+      `${fixture.serverUrl}/v1/collections/${fixture.collectionId}/operations/create`
+    ]);
+    expect(requests[0].body).toBe(requests[1].body);
+    expect(JSON.parse(requests[0].body)).toEqual(expect.objectContaining({
+      type: "encrypted_operation_request",
+      operation: "create",
+      counter: "1"
+    }));
+
+    await expect(fixture.connect.createType({
+      document: `---
+kind: mdbase.type
+name: different
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+---
+`
+    })).rejects.toEqual(expect.objectContaining({ code: "pending_mutation_unresolved" }));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    fetchMock
+      .mockImplementationOnce(async (input, init) => {
+        requests.push({ url: String(input), body: String(init?.body) });
+        return new Response(JSON.stringify({
+          error: { code: "upgrade_required", message: "Use the relay." }
+        }), { status: 426, headers: { "content-type": "application/json" } });
+      })
+      .mockImplementationOnce(async (input, init) => {
+        requests.push({ url: String(input), body: String(init?.body) });
+        return new Response(JSON.stringify({
+          error: { code: "connector_offline", message: "Connector offline." }
+        }), { status: 503, headers: { "content-type": "application/json" } });
+      });
+    await expect(fixture.connect.create({
+      frontmatter: { title: "Only once" },
+      path: "one.md"
+    })).rejects.toEqual(expect.objectContaining({ code: "connector_offline" }));
+    expect(requests[2].body).toBe(requests[0].body);
+    expect(requests[3].body).toBe(requests[0].body);
+  });
+
+  it("does not bypass an explicit rejection from the local authorization boundary", async () => {
+    const fixture = await encryptedConnection();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: { code: "direct_operation_rejected", message: "Rejected locally." }
+    }), { status: 403, headers: { "content-type": "application/json" } }));
+
+    await expect(fixture.connect.query()).rejects.toEqual(expect.objectContaining({
+      code: "direct_operation_rejected"
+    }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe("http://127.0.0.1:28485/v1/operations");
+  });
+
+  it("backs off an unavailable loopback route while keeping relay operations usable", async () => {
+    const fixture = await encryptedConnection();
+    const urls: string[] = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async (input) => {
+        urls.push(String(input));
+        throw new TypeError("connector absent");
+      })
+      .mockImplementation(async (input) => {
+        urls.push(String(input));
+        return new Response(JSON.stringify({
+          error: { code: "connector_offline", message: "Connector offline." }
+        }), { status: 503, headers: { "content-type": "application/json" } });
+      });
+
+    await expect(fixture.connect.query()).rejects.toEqual(expect.objectContaining({
+      code: "connector_offline"
+    }));
+    await expect(fixture.connect.query()).rejects.toEqual(expect.objectContaining({
+      code: "connector_offline"
+    }));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(urls).toEqual([
+      "http://127.0.0.1:28485/v1/operations",
+      `${fixture.serverUrl}/v1/collections/${fixture.collectionId}/operations/query`,
+      `${fixture.serverUrl}/v1/collections/${fixture.collectionId}/operations/query`
+    ]);
+  });
+
+  it("renews a stale binding after an uncertain direct read without reporting an unknown write", async () => {
+    const fixture = await encryptedConnection();
+    const token = JSON.parse(fixture.storage.getItem(
+      `mdbase-connect:token:${fixture.serverUrl}:${fixture.manifestUrl}`
+    )!);
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("loopback response was lost"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: { code: "encryption_binding_stale", message: "Refresh authorization." }
+      }), { status: 409, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        access_token: "mdb_refreshed",
+        refresh_token: "ref_refreshed",
+        expires_in: 3_600,
+        refresh_expires_in: 7_200,
+        collection_id: token.collectionId,
+        operations: token.operations,
+        scope: token.scope,
+        grant_id: token.grantId,
+        encryption: token.encryption,
+        application_origin: token.applicationOrigin
+      }), { status: 200, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: { code: "connector_offline", message: "Connector offline." }
+      }), { status: 503, headers: { "content-type": "application/json" } }));
+
+    await expect(fixture.connect.query()).rejects.toEqual(expect.objectContaining({
+      code: "connector_offline"
+    }));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("checks generic readiness from a user gesture without sending ambient credentials", async () => {
+    const fixture = await encryptedConnection();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      service: "mdbase-connect",
+      loopback_protocol_version: 1,
+      encrypted_protocol_version: 3
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const changes: string[] = [];
+    fixture.connect.onConnectionChange((connection) => {
+      if (connection) changes.push(connection.directAccess);
+    });
+
+    await expect(fixture.connect.requestDirectAccess()).resolves.toBe("available");
+    const init = fetchMock.mock.calls[0][1] as RequestInit & { targetAddressSpace?: string };
+    expect(init.credentials).toBe("omit");
+    expect(init.targetAddressSpace).toBe("loopback");
+    expect(changes).toContain("checking");
+    expect(changes.at(-1)).toBe("available");
+  });
+
+  it("lets a user re-enable direct access after disabling it", async () => {
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    expect(fixture.connect.connection()?.directAccess).toBe("disabled");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      service: "mdbase-connect",
+      loopback_protocol_version: 1,
+      encrypted_protocol_version: 3
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+
+    await expect(fixture.connect.requestDirectAccess()).resolves.toBe("available");
+    expect(fixture.connect.connection()?.directAccess).toBe("available");
+  });
+
+  it("keeps direct grant proof usable after every cloud credential expires", async () => {
+    const fixture = await encryptedConnection();
+    const tokenKey = `mdbase-connect:token:${fixture.serverUrl}:${fixture.manifestUrl}`;
+    const token = JSON.parse(fixture.storage.getItem(tokenKey)!);
+    fixture.storage.setItem(tokenKey, JSON.stringify({
+      ...token,
+      expiresAt: Date.now() - 60_000,
+      refreshExpiresAt: Date.now() - 30_000
+    }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: { code: "direct_operation_rejected", message: "Reached the connector." }
+    }), { status: 403, headers: { "content-type": "application/json" } }));
+
+    await expect(fixture.connect.query()).rejects.toEqual(expect.objectContaining({
+      code: "direct_operation_rejected"
+    }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe("http://127.0.0.1:28485/v1/operations");
+    expect(fixture.storage.getItem(tokenKey)).not.toBeNull();
+  });
+
+  it("rejects loopback overrides that could escape the local machine", () => {
+    expect(() => new MdbaseConnect({
+      serverUrl: "https://connect.example",
+      manifestUrl: "https://tasks.example/manifest.json",
+      redirectUri: "https://tasks.example/callback",
+      storage: new MemoryStorage(),
+      loopbackUrl: "http://connector.evil.example:28485"
+    })).toThrow(expect.objectContaining({ code: "invalid_loopback_url" }));
+  });
+});
+
+async function encryptedConnection() {
+  const storage = new MemoryStorage();
+  const keyStore = new MemoryGrantKeyStore();
+  const connectorKeys = new MemoryGrantKeyStore();
+  const application = await keyStore.create("grant-key");
+  const connector = await connectorKeys.create("connector-key");
+  const serverUrl = "https://connect.example";
+  const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
+  const collectionId = "01944444-4444-7444-8444-444444444444";
+  const encryption: GrantEncryption = {
+    protocol_version: 3,
+    suite: "P256-HKDF-SHA256-AES256GCM",
+    key_id: "enc_direct",
+    scope_epoch: 1,
+    connector_id: "01933333-3333-7333-8333-333333333333",
+    collection_id: collectionId,
+    application_public_key: application.publicKey,
+    connector_public_key: connector.publicKey
+  };
+  storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    accessToken: "mdb_current",
+    refreshToken: "ref_current",
+    clientId: "01922222-2222-7222-8222-222222222222",
+    collectionId,
+    operations: [
+      "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
+      "read_type", "create_type", "update_type"
+    ],
+    scope: { contracts: [] },
+    expiresAt: Date.now() + 60_000,
+    refreshExpiresAt: Date.now() + 120_000,
+    grantId: "01911111-1111-7111-8111-111111111111",
+    encryption,
+    applicationOrigin: "https://tasks.example",
+    keyHandle: "grant-key"
+  }));
+  storage.setItem("mdbase-connect:direct:https://tasks.example", "enabled");
+  return {
+    serverUrl,
+    manifestUrl,
+    collectionId,
+    storage,
+    connect: new MdbaseConnect({
+      serverUrl,
+      manifestUrl,
+      redirectUri: "https://tasks.example/callback",
+      storage,
+      keyStore
+    })
+  };
+}
 
 class MemoryStorage implements Storage {
   private readonly values = new Map<string, string>();

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,6 +5,7 @@ import type {
   CollectionFileMetadata,
   CollectionOperation,
   CollectionTypeDocument,
+  EncryptedRelayOperationRequest,
   EncryptedRelayOperationResponse,
   GrantEncryption,
   GrantScope,
@@ -13,6 +14,7 @@ import type {
   RecordSummary,
   RecordResult
 } from "@mdbase/connect-protocol";
+import { DEFAULT_LOOPBACK_PORT } from "@mdbase/connect-protocol";
 import {
   decryptRelayResponse,
   encryptRelayRequest,
@@ -59,6 +61,27 @@ export interface MdbaseConnectOptions {
   /** Encrypted relay is required by default for newly authorized grants. */
   relayEncryption?: "required" | "disabled";
   keyStore?: GrantKeyStore;
+  /** Prefer same-computer connector access when the browser permits it. */
+  directAccess?: "auto" | "disabled";
+  /** Loopback origin override for development and automated testing. */
+  loopbackUrl?: string;
+}
+
+export type MdbaseConnectionRoute = "hosted" | "direct" | "relay";
+export type DirectAccessStatus =
+  | "disabled"
+  | "permission_required"
+  | "checking"
+  | "available"
+  | "unavailable"
+  | "denied";
+
+export interface MdbaseConnection {
+  collectionId: string;
+  operations: CollectionOperation[];
+  scope: GrantScope;
+  route: MdbaseConnectionRoute;
+  directAccess: DirectAccessStatus;
 }
 
 export interface ReadInput {
@@ -275,12 +298,22 @@ interface StoredToken {
   refreshExpiresAt?: number;
   grantId?: string;
   encryption?: GrantEncryption;
+  applicationOrigin?: string;
   keyHandle?: string;
   hosted?: {
     providerUrl: string;
     replicaId: string;
     accessToken: string;
   };
+}
+
+interface PendingDirectMutation {
+  grantId: string;
+  keyId: string;
+  operation: CollectionOperation;
+  inputFingerprint: string;
+  envelope: EncryptedRelayOperationRequest;
+  createdAt: number;
 }
 
 const DEFAULT_OPERATIONS: CollectionOperation[] = ["describe", "changes", "read", "query"];
@@ -292,9 +325,16 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   private readonly storage: Storage;
   private readonly relayEncryption: "required" | "disabled";
   private readonly keyStore: GrantKeyStore;
+  private readonly directAccessMode: "auto" | "disabled";
+  private readonly loopbackUrl: string;
   private application: Application | null = null;
   private refreshPromise: Promise<StoredToken> | null = null;
   private readonly collectionClient: MdbaseCollectionClient<Frontmatter>;
+  private directStatus: DirectAccessStatus;
+  private route: MdbaseConnectionRoute = "relay";
+  private directFailures = 0;
+  private directRetryAt = 0;
+  private readonly connectionListeners = new Set<(connection: MdbaseConnection | null) => void>();
 
   constructor(options: MdbaseConnectOptions) {
     this.serverUrl = stripTrailingSlash(options.serverUrl);
@@ -303,6 +343,11 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     this.storage = options.storage ?? defaultStorage();
     this.relayEncryption = options.relayEncryption ?? "required";
     this.keyStore = options.keyStore ?? new IndexedDbGrantKeyStore();
+    this.directAccessMode = options.directAccess ?? "auto";
+    this.loopbackUrl = canonicalLoopbackUrl(
+      options.loopbackUrl ?? `http://127.0.0.1:${DEFAULT_LOOPBACK_PORT}`
+    );
+    this.directStatus = this.directAccessMode === "disabled" ? "disabled" : "unavailable";
     this.collectionClient = new MdbaseCollectionClient({
       operation: (operation, input) => this.performOperation(operation, input)
     });
@@ -331,6 +376,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     const replaced = parseStored<StoredAuthorization>(this.storage.getItem(this.pendingKey()));
     if (replaced?.keyHandle) await this.keyStore.delete(replaced.keyHandle);
     this.storage.removeItem(this.pendingKey());
+    this.clearPendingMutation();
     const application = await this.discover();
     const { verifier, challenge } = await createPkce();
     const state = randomBase64Url(24);
@@ -410,11 +456,50 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     return { collectionId: token.collectionId, operations: token.operations, scope: token.scope };
   }
 
-  connection(): { collectionId: string; operations: CollectionOperation[]; scope: GrantScope } | null {
+  connection(): MdbaseConnection | null {
     const token = this.currentToken();
     return token
-      ? { collectionId: token.collectionId, operations: token.operations, scope: token.scope }
+      ? {
+          collectionId: token.collectionId,
+          operations: token.operations,
+          scope: token.scope,
+          route: token.hosted ? "hosted" : this.route,
+          directAccess: token.hosted ? "disabled" : this.directStatus
+        }
       : null;
+  }
+
+  onConnectionChange(listener: (connection: MdbaseConnection | null) => void): () => void {
+    this.connectionListeners.add(listener);
+    listener(this.connection());
+    return () => this.connectionListeners.delete(listener);
+  }
+
+  async checkDirectAccess(): Promise<DirectAccessStatus> {
+    const token = this.currentToken();
+    if (!this.directEligible(token)) return this.setDirectStatus("disabled");
+    const permission = await localNetworkPermission();
+    if (permission === "denied") return this.setDirectStatus("denied");
+    if ((permission === "prompt" || permission === null)
+        && this.storage.getItem(this.directPreferenceKey()) !== "enabled") {
+      return this.setDirectStatus("permission_required");
+    }
+    return this.probeDirectAccess();
+  }
+
+  /** Call from a user gesture to request browser permission for direct local access. */
+  async requestDirectAccess(): Promise<DirectAccessStatus> {
+    const token = this.currentToken();
+    if (!this.directCapable(token)) return this.setDirectStatus("disabled");
+    this.storage.setItem(this.directPreferenceKey(), "enabled");
+    this.directRetryAt = 0;
+    return this.probeDirectAccess();
+  }
+
+  disableDirectAccess(): void {
+    this.storage.setItem(this.directPreferenceKey(), "disabled");
+    this.setDirectStatus("disabled");
+    this.setRoute("relay");
   }
 
   disconnect(): void {
@@ -425,6 +510,9 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     for (const handle of handles) void this.keyStore.delete(handle);
     this.storage.removeItem(this.tokenKey());
     this.storage.removeItem(this.pendingKey());
+    this.clearPendingMutation();
+    this.setRoute("relay");
+    this.emitConnection();
   }
 
   describe(): Promise<CollectionDescription> {
@@ -484,22 +572,46 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   }
 
   private async performOperation<Result>(operation: CollectionOperation, input: unknown): Promise<Result> {
-    let token = await this.authorizedToken();
+    let token = this.currentToken();
     if (!token) throw new MdbaseConnectError("not_authorized", "Connect this application before accessing a collection.");
     if (!token.operations.includes(operation)) {
       throw new MdbaseConnectError("insufficient_access", `This connection does not allow ${operation}.`);
     }
-    let attempt = await this.sendOperation<Result>(token, operation, input);
+    let tryDirect = isMutation(operation) && this.storage.getItem(this.pendingMutationKey()) !== null
+      ? true
+      : await this.shouldAttemptDirect(token);
+    if (!tryDirect) {
+      token = await this.authorizedToken();
+      if (!token) throw new MdbaseConnectError("not_authorized", "Reconnect this application to continue.");
+    }
+    let attempt = await this.sendOperation<Result>(token, operation, input, tryDirect);
     let response = attempt.response;
     const staleBinding = response.status === 409
       && (await response.clone().json().catch(() => null))?.error?.code === "encryption_binding_stale";
     if ((response.status === 401 || staleBinding) && token.refreshToken) {
+      if (attempt.pendingMutation && attempt.directDeliveryUncertain) {
+        throw new MdbaseConnectError(
+          "direct_outcome_unknown",
+          "The direct operation may have completed, but its encrypted grant changed before the response could be recovered. Refresh before making another change."
+        );
+      }
+      if (attempt.pendingMutation) this.clearPendingMutation();
       token = await this.refreshAuthorization();
-      attempt = await this.sendOperation<Result>(token, operation, input);
+      tryDirect = await this.shouldAttemptDirect(token);
+      attempt = await this.sendOperation<Result>(token, operation, input, tryDirect);
       response = attempt.response;
     }
     const body = await response.json();
-    if (!response.ok) throw apiError(body, "operation_failed", "Collection operation failed.");
+    if (!response.ok) {
+      const error = apiError(body, "operation_failed", "Collection operation failed.");
+      if (attempt.pendingMutation && attempt.directDeliveryUncertain) {
+        throw uncertainDirectMutation(error);
+      }
+      if (attempt.pendingMutation && !attempt.directDeliveryUncertain) {
+        this.clearPendingMutation();
+      }
+      throw error;
+    }
     if (attempt.encryptedRequest) {
       const encryptedResponse = body?.envelope as EncryptedRelayOperationResponse | undefined;
       if (!encryptedResponse || !token.encryption || !token.grantId || !token.keyHandle) {
@@ -516,6 +628,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
           attempt.encryptedRequest,
           encryptedResponse
         );
+        if (attempt.pendingMutation) this.clearPendingMutation();
         if (!decrypted.ok) throw new MdbaseConnectError(decrypted.error.code, decrypted.error.message);
         return decrypted.result;
       } catch (error) {
@@ -530,46 +643,223 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   private async sendOperation<Result>(
     token: StoredToken,
     operation: CollectionOperation,
-    input: unknown
+    input: unknown,
+    tryDirect: boolean
   ): Promise<{
     response: Response;
     encryptedRequest?: Awaited<ReturnType<typeof encryptRelayRequest>>;
+    directDeliveryUncertain?: boolean;
+    pendingMutation?: boolean;
   }> {
     let body: unknown = input ?? {};
     let encryptedRequest: Awaited<ReturnType<typeof encryptRelayRequest>> | undefined;
+    let pendingMutation = false;
     if (token.encryption && !token.hosted) {
       if (!token.grantId || !token.keyHandle) {
         throw new MdbaseConnectError("missing_grant_key", "Reconnect this application to restore encrypted access.");
       }
       try {
-        encryptedRequest = await encryptRelayRequest(
-          this.keyStore,
-          token.keyHandle,
-          { grantId: token.grantId, applicationId: token.clientId, encryption: token.encryption },
-          operation,
-          input
-        );
+        if (tryDirect && isMutation(operation)) {
+          const inputFingerprint = await operationFingerprint(operation, input);
+          const pending = parseStored<PendingDirectMutation>(
+            this.storage.getItem(this.pendingMutationKey())
+          );
+          if (pending) {
+            if (pending.grantId !== token.grantId
+                || pending.keyId !== token.encryption.key_id
+                || pending.operation !== operation
+                || pending.inputFingerprint !== inputFingerprint) {
+              throw new MdbaseConnectError(
+                "pending_mutation_unresolved",
+                "A previous direct write still has an unknown outcome. Retry that same write before making another change."
+              );
+            }
+            encryptedRequest = pending.envelope;
+          } else {
+            encryptedRequest = await encryptRelayRequest(
+              this.keyStore,
+              token.keyHandle,
+              { grantId: token.grantId, applicationId: token.clientId, encryption: token.encryption },
+              operation,
+              input
+            );
+            this.storage.setItem(this.pendingMutationKey(), JSON.stringify({
+              grantId: token.grantId,
+              keyId: token.encryption.key_id,
+              operation,
+              inputFingerprint,
+              envelope: encryptedRequest,
+              createdAt: Date.now()
+            } satisfies PendingDirectMutation));
+          }
+          pendingMutation = true;
+        } else {
+          encryptedRequest = await encryptRelayRequest(
+            this.keyStore,
+            token.keyHandle,
+            { grantId: token.grantId, applicationId: token.clientId, encryption: token.encryption },
+            operation,
+            input
+          );
+        }
       } catch (error) {
         if (error instanceof RelayCryptoError) throw new MdbaseConnectError(error.code, error.message);
         throw error;
       }
       body = encryptedRequest;
     }
+    if (tryDirect && encryptedRequest && !token.hosted) {
+      let directDeliveryUncertain = false;
+      try {
+        const response = await fetch(`${this.loopbackUrl}/v1/operations`, loopbackRequest({
+          method: "POST",
+          headers: { "content-type": "application/mdbase-connect+json" },
+          body: JSON.stringify(encryptedRequest)
+        }));
+        if (!directFallbackStatus(response.status)) {
+          if (response.ok) {
+            this.markDirectAvailable();
+            this.setRoute("direct");
+          }
+          return { response, encryptedRequest, pendingMutation };
+        }
+        directDeliveryUncertain = response.status >= 500;
+        this.markDirectUnavailable();
+      } catch {
+        directDeliveryUncertain = true;
+        if ((await localNetworkPermission()) === "denied") this.setDirectStatus("denied");
+        else this.markDirectUnavailable();
+      }
+      let relayToken: StoredToken;
+      try {
+        relayToken = token.expiresAt > Date.now() + 30_000
+          ? token
+          : await this.refreshAuthorization();
+      } catch (error) {
+        if (pendingMutation && directDeliveryUncertain) throw uncertainDirectMutation(error);
+        throw error;
+      }
+      let response: Response;
+      try {
+        response = await fetch(
+          `${this.serverUrl}/v1/collections/${encodeURIComponent(relayToken.collectionId)}/operations/${operation}`,
+          {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${relayToken.accessToken}`,
+            "content-type": "application/json"
+          },
+          body: JSON.stringify(encryptedRequest)
+          }
+        );
+      } catch (error) {
+        if (pendingMutation && directDeliveryUncertain) throw uncertainDirectMutation(error);
+        throw error;
+      }
+      if (response.ok) this.setRoute("relay");
+      return { response, encryptedRequest, directDeliveryUncertain, pendingMutation };
+    }
     const operationUrl = token.hosted
       ? `${stripTrailingSlash(token.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`
       : `${this.serverUrl}/v1/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`;
-    const response = await fetch(
-      operationUrl,
-      {
+    const response = await fetch(operationUrl, {
         method: "POST",
         headers: {
           authorization: `Bearer ${token.hosted?.accessToken ?? token.accessToken}`,
           "content-type": "application/json"
         },
         body: JSON.stringify(body)
-      }
-    );
+      });
+    if (response.ok) this.setRoute(token.hosted ? "hosted" : "relay");
     return { response, encryptedRequest };
+  }
+
+  private directCapable(token: StoredToken | null): boolean {
+    if (!token || token.hosted || !token.encryption || !token.grantId || !token.keyHandle) return false;
+    if (this.directAccessMode === "disabled") return false;
+    if (typeof location !== "undefined"
+        && token.applicationOrigin
+        && token.applicationOrigin !== location.origin) return false;
+    return true;
+  }
+
+  private directEligible(token: StoredToken | null): token is StoredToken {
+    return token !== null
+      && this.directCapable(token)
+      && this.storage.getItem(this.directPreferenceKey()) !== "disabled";
+  }
+
+  private async shouldAttemptDirect(token: StoredToken): Promise<boolean> {
+    if (!this.directEligible(token)) return false;
+    if (this.directStatus === "available") return true;
+    if (this.directStatus === "unavailable" && Date.now() < this.directRetryAt) return false;
+    const permission = await localNetworkPermission();
+    if (permission === "denied") {
+      this.setDirectStatus("denied");
+      return false;
+    }
+    if ((permission === "prompt" || permission === null)
+        && this.storage.getItem(this.directPreferenceKey()) !== "enabled") {
+      this.setDirectStatus("permission_required");
+      return false;
+    }
+    this.setDirectStatus("checking");
+    return true;
+  }
+
+  private async probeDirectAccess(): Promise<DirectAccessStatus> {
+    this.setDirectStatus("checking");
+    try {
+      const response = await fetch(`${this.loopbackUrl}/v1/ready`, loopbackRequest({
+        method: "GET",
+        cache: "no-store"
+      }));
+      const body = await response.json().catch(() => null);
+      if (response.ok
+          && body?.service === "mdbase-connect"
+          && body?.loopback_protocol_version === 1
+          && body?.encrypted_protocol_version === 3) {
+        this.markDirectAvailable();
+        return "available";
+      }
+    } catch {
+      // Permission denial, unsupported mixed content, and an absent connector all reject fetch.
+    }
+    if ((await localNetworkPermission()) === "denied") return this.setDirectStatus("denied");
+    this.markDirectUnavailable();
+    return "unavailable";
+  }
+
+  private markDirectAvailable(): void {
+    this.directFailures = 0;
+    this.directRetryAt = 0;
+    this.setDirectStatus("available");
+  }
+
+  private markDirectUnavailable(): void {
+    this.directFailures += 1;
+    this.directRetryAt = Date.now() + Math.min(60_000, 1_000 * 2 ** (this.directFailures - 1));
+    this.setDirectStatus("unavailable");
+  }
+
+  private setDirectStatus(status: DirectAccessStatus): DirectAccessStatus {
+    if (this.directStatus !== status) {
+      this.directStatus = status;
+      this.emitConnection();
+    }
+    return status;
+  }
+
+  private setRoute(route: MdbaseConnectionRoute): void {
+    if (this.route !== route) {
+      this.route = route;
+      this.emitConnection();
+    }
+  }
+
+  private emitConnection(): void {
+    const connection = this.connection();
+    for (const listener of this.connectionListeners) listener(connection);
   }
 
   private currentToken(): StoredToken | null {
@@ -578,6 +868,10 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     token.scope ??= { contracts: [] };
     if (token.expiresAt <= Date.now()
         && (!token.refreshToken || (token.refreshExpiresAt ?? 0) <= Date.now())) {
+      // The cloud bearer and the local grant proof have separate lifetimes. Keep an
+      // encrypted local grant usable while the connector still recognizes it; relay
+      // use will require reauthorization, and revocation remains enforced locally.
+      if (this.directCapable(token)) return token;
       if (token.keyHandle) void this.keyStore.delete(token.keyHandle);
       this.storage.removeItem(this.tokenKey());
       return null;
@@ -589,7 +883,13 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     const token = this.currentToken();
     if (!token) return null;
     if (token.expiresAt > Date.now() + 30_000) return token;
-    if (!token.refreshToken) {
+    if (!token.refreshToken || (token.refreshExpiresAt ?? 0) <= Date.now()) {
+      if (this.directCapable(token)) {
+        throw new MdbaseConnectError(
+          "relay_authorization_expired",
+          "Direct access is still available on this computer, but using the relay requires reconnecting this application."
+        );
+      }
       if (token.keyHandle) void this.keyStore.delete(token.keyHandle);
       this.storage.removeItem(this.tokenKey());
       return null;
@@ -610,6 +910,12 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     if (!current?.refreshToken) {
       throw new MdbaseConnectError("not_authorized", "Reconnect this application to continue.");
     }
+    if ((current.refreshExpiresAt ?? 0) <= Date.now()) {
+      throw new MdbaseConnectError(
+        "relay_authorization_expired",
+        "Direct access is still available on this computer, but using the relay requires reconnecting this application."
+      );
+    }
     const attemptedRefreshToken = current.refreshToken;
     const response = await fetch(`${this.serverUrl}/oauth/token`, {
       method: "POST",
@@ -626,8 +932,10 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       if (latest?.refreshToken && latest.refreshToken !== attemptedRefreshToken) {
         return latest;
       }
-      if (current.keyHandle) void this.keyStore.delete(current.keyHandle);
-      this.storage.removeItem(this.tokenKey());
+      if (!this.directCapable(current)) {
+        if (current.keyHandle) void this.keyStore.delete(current.keyHandle);
+        this.storage.removeItem(this.tokenKey());
+      }
       throw apiError(body, "authorization_expired", "Reconnect this application to continue.");
     }
     return this.storeTokenResponse(body, current.clientId, current.keyHandle);
@@ -647,6 +955,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
         : undefined,
       grantId: body.grant_id,
       encryption: body.encryption ?? undefined,
+      applicationOrigin: body.application_origin ?? new URL(this.manifestUrl).origin,
       keyHandle,
       hosted: body.hosted ? {
         providerUrl: body.hosted.provider_url,
@@ -655,17 +964,116 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       } : undefined
     };
     this.storage.setItem(this.tokenKey(), JSON.stringify(token));
+    this.route = token.hosted ? "hosted" : "relay";
+    this.directStatus = token.hosted || this.directAccessMode === "disabled"
+      ? "disabled"
+      : "unavailable";
+    this.emitConnection();
     return token;
   }
 
   private pendingKey() { return `mdbase-connect:pending:${this.serverUrl}:${this.manifestUrl}`; }
   private tokenKey() { return `mdbase-connect:token:${this.serverUrl}:${this.manifestUrl}`; }
+  private pendingMutationKey() {
+    return `mdbase-connect:pending-mutation:${this.serverUrl}:${this.manifestUrl}`;
+  }
+  private clearPendingMutation(): void {
+    this.storage.removeItem(this.pendingMutationKey());
+  }
+  private directPreferenceKey() {
+    return `mdbase-connect:direct:${new URL(this.manifestUrl).origin}`;
+  }
 }
 
 export class MdbaseConnectError extends Error {
   constructor(public readonly code: string, message: string) {
     super(message);
   }
+}
+
+type LoopbackRequestInit = RequestInit & {
+  targetAddressSpace?: "loopback";
+};
+
+function loopbackRequest(init: RequestInit): LoopbackRequestInit {
+  return { ...init, credentials: "omit", targetAddressSpace: "loopback" };
+}
+
+async function localNetworkPermission(): Promise<PermissionState | null> {
+  if (typeof navigator === "undefined" || !navigator.permissions?.query) return null;
+  try {
+    const status = await navigator.permissions.query({
+      name: "local-network-access" as PermissionName
+    });
+    return status.state;
+  } catch {
+    return null;
+  }
+}
+
+function directFallbackStatus(status: number): boolean {
+  return status === 404 || status === 405 || status === 426 || status >= 500;
+}
+
+function isMutation(operation: CollectionOperation): boolean {
+  return operation === "create"
+    || operation === "update"
+    || operation === "delete"
+    || operation === "rename"
+    || operation === "create_type"
+    || operation === "update_type";
+}
+
+async function operationFingerprint(
+  operation: CollectionOperation,
+  input: unknown
+): Promise<string> {
+  const encoded = new TextEncoder().encode(`${operation}\0${canonicalJson(input ?? {})}`);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return bytesToBase64Url(new Uint8Array(digest));
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => sortJson(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, item]) => item !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, sortJson(item)])
+    );
+  }
+  return value;
+}
+
+function uncertainDirectMutation(cause: unknown): MdbaseConnectError {
+  const error = new MdbaseConnectError(
+    "direct_outcome_unknown",
+    "The direct write may have completed, and mdbase could not recover its receipt through the relay. Retry the exact same write to recover safely."
+  );
+  Object.defineProperty(error, "cause", { value: cause, configurable: true });
+  return error;
+}
+
+function canonicalLoopbackUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== "http:"
+      || !["127.0.0.1", "[::1]"].includes(url.hostname)
+      || url.username
+      || url.password
+      || url.pathname !== "/"
+      || url.search
+      || url.hash) {
+    throw new MdbaseConnectError(
+      "invalid_loopback_url",
+      "loopbackUrl must be an HTTP origin on 127.0.0.1 or ::1."
+    );
+  }
+  return url.origin;
 }
 
 export async function createPkce(): Promise<{ verifier: string; challenge: string }> {

--- a/packages/protocol/schemas/connect-protocol.v2.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v2.schema.json
@@ -125,6 +125,7 @@
         "scope": { "$ref": "#/$defs/grantScope" },
         "application_name": { "type": "string", "minLength": 1 },
         "application_homepage": { "type": "string" },
+        "application_origin": { "type": "string", "format": "uri" },
         "application_icon": { "type": "string" },
         "collection_name": { "type": "string", "minLength": 1 },
         "created_at": { "type": "string", "format": "date-time" },

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,7 @@
 export const CONTROL_PROTOCOL_VERSION = 2 as const;
 export const ENCRYPTED_RELAY_PROTOCOL_VERSION = 3 as const;
+export const LOOPBACK_PROTOCOL_VERSION = 1 as const;
+export const DEFAULT_LOOPBACK_PORT = 28_485 as const;
 export const RELAY_ENCRYPTION_SUITE = "P256-HKDF-SHA256-AES256GCM" as const;
 export const SYNC_PROTOCOL_VERSION = 1 as const;
 
@@ -94,6 +96,8 @@ export interface GrantPolicy {
   scope: GrantScope;
   application_name: string;
   application_homepage: string;
+  /** Exact browser origin authorized to use this grant over loopback. */
+  application_origin?: string;
   application_icon?: string;
   collection_name: string;
   created_at: string;

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -1,16 +1,18 @@
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { execFile } from "node:child_process";
+import { chromium } from "@playwright/test";
 import {
   decryptRelayResponse,
   encryptRelayRequest,
   MemoryGrantKeyStore
 } from "../packages/client/dist/crypto.js";
+import { MdbaseConnect } from "../packages/client/dist/index.js";
 
 process.env.NODE_ENV = "test";
 const run = promisify(execFile);
@@ -36,8 +38,20 @@ const agentBinary = join(repoRoot, "target", "debug", `mdbase-connect-agent${ext
 const cliBinary = join(repoRoot, "target", "debug", `mdbase-connect${extension}`);
 let agent;
 let manifestServer;
+let browserManifestServer;
+let directOrigin;
 const applicationKeyStore = new MemoryGrantKeyStore();
 let relayContext;
+
+class MemoryStorage {
+  values = new Map();
+  get length() { return this.values.size; }
+  clear() { this.values.clear(); }
+  getItem(key) { return this.values.get(key) ?? null; }
+  key(index) { return [...this.values.keys()][index] ?? null; }
+  removeItem(key) { this.values.delete(key); }
+  setItem(key, value) { this.values.set(key, value); }
+}
 
 try {
   const session = await request("/v1/dev/session", {
@@ -103,6 +117,11 @@ type: private
 secret: connector scope test
 ---
 `);
+  await mkdir(join(collectionPath, "bulk"), { recursive: true });
+  await Promise.all(Array.from({ length: 1_000 }, (_, index) => writeFile(
+    join(collectionPath, "bulk", `${String(index).padStart(4, "0")}.md`),
+    `---\ntype: task\ntitle: Bulk ${index}\nstatus: open\n---\n`
+  )));
   await stopAgent(agent);
   agent = startAgent(["--server-url", serverUrl, "--connector-token", connector.body.token]);
 
@@ -114,6 +133,8 @@ secret: connector scope test
 
   const manifest = await openManifestServer();
   manifestServer = manifest.server;
+  browserManifestServer = manifest.browserServer;
+  directOrigin = manifest.origin;
   const application = await request("/v1/apps/discover", {
     method: "POST",
     body: { manifest_url: manifest.manifestUrl }
@@ -171,6 +192,21 @@ secret: connector scope test
       encryption: token.body.encryption
     }
   };
+  const hostileReady = await fetch("http://127.0.0.1:28485/v1/ready", {
+    headers: { origin: "https://hostile.example" }
+  });
+  if (hostileReady.status !== 403 || hostileReady.headers.has("access-control-allow-origin")) {
+    throw new Error("Hostile origin could read loopback readiness");
+  }
+  const directReady = await fetch("http://127.0.0.1:28485/v1/ready", {
+    headers: { origin: directOrigin }
+  });
+  const directReadyBody = await directReady.json();
+  if (directReady.status !== 200
+      || directReady.headers.get("access-control-allow-origin") !== directOrigin
+      || directReadyBody.loopback_protocol_version !== 1) {
+    throw new Error(`Authorized origin could not discover direct access: ${JSON.stringify(directReadyBody)}`);
+  }
   const refreshed = await request("/oauth/token", {
     method: "POST",
     form: {
@@ -181,6 +217,146 @@ secret: connector scope test
   });
   const accessToken = refreshed.body.access_token;
   relayContext.binding.encryption = refreshed.body.encryption;
+  const sdkStorage = new MemoryStorage();
+  sdkStorage.setItem(`mdbase-connect:token:${serverUrl}:${manifest.manifestUrl}`, JSON.stringify({
+    accessToken,
+    refreshToken: refreshed.body.refresh_token,
+    clientId: appId,
+    collectionId: collection.id,
+    operations: refreshed.body.operations,
+    scope: refreshed.body.scope,
+    // Direct access remains usable while the cloud access token needs renewal.
+    expiresAt: Date.now() - 1,
+    refreshExpiresAt: Date.now() + refreshed.body.refresh_expires_in * 1_000,
+    grantId: refreshed.body.grant_id,
+    encryption: refreshed.body.encryption,
+    applicationOrigin: refreshed.body.application_origin,
+    keyHandle: "e2e-grant"
+  }));
+  const sdk = new MdbaseConnect({
+    serverUrl,
+    manifestUrl: manifest.manifestUrl,
+    redirectUri: manifest.redirectUri,
+    storage: sdkStorage,
+    keyStore: applicationKeyStore
+  });
+  const browserFetch = globalThis.fetch;
+  globalThis.fetch = (input, init = {}) => {
+    if (!String(input).startsWith("http://127.0.0.1:28485/")) return browserFetch(input, init);
+    const headers = new Headers(init.headers);
+    headers.set("origin", directOrigin);
+    return browserFetch(input, { ...init, headers });
+  };
+  try {
+    if (await sdk.requestDirectAccess() !== "available") {
+      throw new Error("Browser SDK did not discover the direct connector");
+    }
+    const sdkQuery = await sdk.query({ limit: 1_100 });
+    if (!sdkQuery.valid
+        || sdkQuery.result.results.length !== 1_000
+        || sdk.connection()?.route !== "direct") {
+      throw new Error("Browser SDK did not complete the 1,000-record query directly");
+    }
+  } finally {
+    globalThis.fetch = browserFetch;
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const browserContext = await browser.newContext();
+    await browserContext.grantPermissions(["local-network-access"], { origin: manifest.browserOrigin });
+    const page = await browserContext.newPage();
+    await page.goto(`${manifest.browserOrigin}/browser-e2e`);
+    await page.waitForFunction(() => Boolean(globalThis.directHarness?.publicKey));
+    const browserPublicKey = await page.evaluate(() => globalThis.directHarness.publicKey);
+    const browserApplication = await request("/v1/apps/discover", {
+      method: "POST",
+      body: { manifest_url: manifest.browserManifestUrl }
+    });
+    const browserAppId = browserApplication.body.application.id;
+    const browserVerifier = "browser-end-to-end-pkce-verifier-forty-three-chars";
+    const browserChallenge = createHash("sha256").update(browserVerifier).digest("base64url");
+    const browserOperations = [
+      "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
+      "read_type", "create_type", "update_type"
+    ];
+    const browserAuthorize = await fetch(
+      `${serverUrl}/oauth/authorize?client_id=${browserAppId}&redirect_uri=${encodeURIComponent(manifest.browserRedirectUri)}&code_challenge=${browserChallenge}&code_challenge_method=S256&state=browser-e2e&operations=${browserOperations.join(",")}&relay_protocol=3&application_public_key=${encodeURIComponent(browserPublicKey)}`,
+      { headers: { cookie }, redirect: "manual" }
+    );
+    if (browserAuthorize.status !== 302) {
+      throw new Error(`Browser authorization start returned HTTP ${browserAuthorize.status}`);
+    }
+    const browserAuthorizationId = browserAuthorize.headers.get("location")?.split("/").at(-1);
+    if (!browserAuthorizationId) throw new Error("Browser authorization request ID missing");
+    await poll(async () => {
+      const snapshot = await cliJson(["access", "snapshot"]);
+      return snapshot.result?.pending_authorizations?.some(
+        (pending) => pending.id === browserAuthorizationId
+      ) ? snapshot : null;
+    }, "browser authorization request did not reach the local connector controls");
+    await cliJson([
+      "access", "approve", browserAuthorizationId, collection.local_id,
+      "--operations", browserOperations.join(",")
+    ]);
+    const browserCompleted = await poll(async () => {
+      const current = await request(
+        `/v1/authorization-requests/${browserAuthorizationId}/status`,
+        { cookie }
+      );
+      return current.body.redirect_uri ? current : null;
+    }, "approved browser authorization did not return to the browser");
+    const browserCallback = new URL(browserCompleted.body.redirect_uri);
+    const browserToken = await request("/oauth/token", {
+      method: "POST",
+      form: {
+        grant_type: "authorization_code",
+        code: browserCallback.searchParams.get("code"),
+        client_id: browserAppId,
+        redirect_uri: manifest.browserRedirectUri,
+        code_verifier: browserVerifier
+      }
+    });
+    const browserResult = await page.evaluate(async (config) => {
+      return globalThis.directHarness.exercise(config);
+    }, {
+      serverUrl,
+      manifestUrl: manifest.browserManifestUrl,
+      redirectUri: manifest.browserRedirectUri,
+      token: {
+        accessToken: browserToken.body.access_token,
+        refreshToken: browserToken.body.refresh_token,
+        clientId: browserAppId,
+        collectionId: browserToken.body.collection_id,
+        operations: browserToken.body.operations,
+        scope: browserToken.body.scope,
+        // Exercise genuine cloud-independent access, not merely deferred renewal.
+        expiresAt: Date.now() - 60_000,
+        refreshExpiresAt: Date.now() - 30_000,
+        grantId: browserToken.body.grant_id,
+        encryption: browserToken.body.encryption,
+        applicationOrigin: browserToken.body.application_origin,
+        keyHandle: "browser-e2e-grant"
+      }
+    });
+    if (browserResult.status !== "available"
+        || browserResult.route !== "direct"
+        || browserResult.records !== 1_002
+        || !browserResult.read
+        || !browserResult.updated
+        || !browserResult.renamed
+        || !browserResult.validated
+        || !browserResult.createdType
+        || !browserResult.readType
+        || !browserResult.updatedType
+        || !browserResult.changed
+        || !browserResult.deleted) {
+      throw new Error(`Real browser direct-operation matrix failed: ${JSON.stringify(browserResult)}`);
+    }
+    await browserContext.close();
+  } finally {
+    await browser.close();
+  }
 
   const descriptionResponse = await rawOperation(collection.id, "describe", accessToken, {});
   const descriptionBody = await descriptionResponse.json();
@@ -250,6 +426,11 @@ secret: connector scope test
       || readBody.result?.result?.frontmatter?.status !== "done") {
     throw new Error(`Unexpected relay read response: ${JSON.stringify(readBody)}`);
   }
+  const bulkQuery = await rawOperation(collection.id, "query", accessToken, { limit: 1_100 });
+  const bulkQueryBody = await bulkQuery.json();
+  if (bulkQuery.status !== 200 || bulkQueryBody.result?.result?.results?.length < 1_001) {
+    throw new Error(`Direct 1,000-record query was incomplete: ${JSON.stringify(bulkQueryBody)}`);
+  }
   const downgrade = await fetch(`${serverUrl}/v1/collections/${collection.id}/operations/read`, {
     method: "POST",
     headers: {
@@ -268,12 +449,18 @@ secret: connector scope test
     "read",
     { path: "sessions/first.md" }
   );
-  const replayFirst = await rawEncryptedEnvelope(collection.id, "read", accessToken, replayEnvelope);
+  const replayFirst = await rawDirectEnvelope(replayEnvelope);
   if (replayFirst.status !== 200) throw new Error(`Fresh encrypted request failed with HTTP ${replayFirst.status}`);
   const replaySecond = await rawEncryptedEnvelope(collection.id, "read", accessToken, replayEnvelope);
-  if (replaySecond.status !== 502
-      || (await replaySecond.json()).error?.code !== "encrypted_relay_rejected") {
-    throw new Error("Connector did not reject an authenticated replay");
+  const replayFirstBody = await replayFirst.json();
+  const replaySecondBody = await replaySecond.json();
+  if (replaySecond.status !== 200
+      || !sameEnvelope(replaySecondBody.envelope, replayFirstBody.envelope)) {
+    throw new Error(`Direct-to-relay retry did not return the durable encrypted receipt: ${JSON.stringify({
+      direct: replayFirstBody,
+      relay: replaySecondBody,
+      relayStatus: replaySecond.status
+    })}`);
   }
   const tampered = {
     ...await encryptRelayRequest(
@@ -315,12 +502,11 @@ secret: connector scope test
   }
   await cliJson(["access", "pause", "false"]);
 
-  const localAccess = await cliJson(["access", "snapshot"]);
-  await cliJson(["access", "revoke", localAccess.result.grants[0].id]);
+  await cliJson(["access", "revoke", token.body.grant_id]);
   const revoked = await rawOperation(collection.id, "read", accessToken, {
     path: "sessions/first.md"
   });
-  if (revoked.status !== 401) throw new Error(`Revoked token returned HTTP ${revoked.status}`);
+  if (revoked.status !== 403) throw new Error(`Revoked direct grant returned HTTP ${revoked.status}`);
   const revokedRefresh = await fetch(`${serverUrl}/oauth/token`, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -336,6 +522,9 @@ secret: connector scope test
   process.stdout.write("mdbase connect end-to-end MVP path passed\n");
 } finally {
   if (agent) await stopAgent(agent);
+  if (browserManifestServer) {
+    await new Promise((resolveClose) => browserManifestServer.close(resolveClose));
+  }
   if (manifestServer) await new Promise((resolveClose) => manifestServer.close(resolveClose));
   await app.close();
   await database.end();
@@ -409,6 +598,18 @@ async function rawEncryptedEnvelope(collectionId, operation, accessToken, envelo
   });
 }
 
+async function rawDirectEnvelope(envelope) {
+  if (!directOrigin) throw new Error("Direct origin is unavailable");
+  return fetch("http://127.0.0.1:28485/v1/operations", {
+    method: "POST",
+    headers: {
+      origin: directOrigin,
+      "content-type": "application/mdbase-connect+json"
+    },
+    body: JSON.stringify(envelope)
+  });
+}
+
 async function rawOperation(collectionId, operation, accessToken, input) {
   if (!relayContext) {
     return rawEncryptedEnvelope(collectionId, operation, accessToken, input);
@@ -420,7 +621,7 @@ async function rawOperation(collectionId, operation, accessToken, input) {
     operation,
     input
   );
-  const response = await rawEncryptedEnvelope(collectionId, operation, accessToken, encryptedRequest);
+  const response = await rawDirectEnvelope(encryptedRequest);
   if (!response.ok) return response;
   const routed = await response.json();
   const decrypted = await decryptRelayResponse(
@@ -445,6 +646,12 @@ function syntheticResponse(status, body) {
   };
 }
 
+function sameEnvelope(left, right) {
+  const keys = Object.keys(left ?? {});
+  return keys.length === Object.keys(right ?? {}).length
+    && keys.every((key) => left[key] === right[key]);
+}
+
 async function poll(action, failureMessage) {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const result = await action();
@@ -455,16 +662,126 @@ async function poll(action, failureMessage) {
 }
 
 async function openManifestServer() {
-  const server = createServer((request, response) => {
+  const primary = await openApplicationServer(
+    "MVP Workout App",
+    [{ id: "tasknotes.task", version: 1 }]
+  );
+  const browser = await openApplicationServer("Browser direct E2E", []);
+  return {
+    server: primary.server,
+    browserServer: browser.server,
+    origin: primary.origin,
+    browserOrigin: browser.origin,
+    manifestUrl: primary.manifestUrl,
+    browserManifestUrl: browser.manifestUrl,
+    redirectUri: primary.redirectUri,
+    browserRedirectUri: browser.redirectUri
+  };
+}
+
+async function openApplicationServer(name, contracts) {
+  const server = createServer(async (request, response) => {
     const address = server.address();
     const origin = `http://localhost:${address.port}`;
+    if (request.url === "/client/index.js" || request.url === "/client/crypto.js") {
+      response.setHeader("content-type", "text/javascript");
+      response.end(await readFile(join(repoRoot, "packages", "client", "dist", request.url.split("/").at(-1))));
+      return;
+    }
+    if (request.url === "/protocol/index.js") {
+      response.setHeader("content-type", "text/javascript");
+      response.end(await readFile(join(repoRoot, "packages", "protocol", "dist", "index.js")));
+      return;
+    }
+    if (request.url === "/browser-e2e") {
+      response.setHeader("content-type", "text/html");
+      response.end(`<!doctype html>
+<meta charset="utf-8">
+<script type="importmap">{"imports":{"@mdbase/connect-protocol":"${origin}/protocol/index.js"}}</script>
+<script type="module">
+  import { MdbaseConnect, MemoryGrantKeyStore } from "${origin}/client/index.js";
+  const keyStore = new MemoryGrantKeyStore();
+  const key = await keyStore.create("browser-e2e-grant");
+  globalThis.directHarness = {
+    publicKey: key.publicKey,
+    async exercise(config) {
+      const tokenKey = \`mdbase-connect:token:\${config.serverUrl}:\${config.manifestUrl}\`;
+      localStorage.setItem(tokenKey, JSON.stringify(config.token));
+      const connect = new MdbaseConnect({
+        serverUrl: config.serverUrl,
+        manifestUrl: config.manifestUrl,
+        redirectUri: config.redirectUri,
+        keyStore
+      });
+      const status = await connect.requestDirectAccess();
+      const description = await connect.describe();
+      const created = await connect.create({
+        path: "browser/direct.md",
+        frontmatter: { type: "task", title: "Real browser direct", status: "open" },
+        body: "Created in Chromium."
+      });
+      const revision = created.result.revision;
+      const read = await connect.read({ path: "browser/direct.md" });
+      const updated = await connect.update({
+        path: "browser/direct.md",
+        patch: { status: "done" },
+        if_revision: revision
+      });
+      const readUpdated = await connect.read({ path: "browser/direct.md" });
+      const renamed = await connect.rename({
+        from: "browser/direct.md",
+        to: "browser/renamed.md"
+      });
+      const query = await connect.query({ limit: 1_100 });
+      const validated = await connect.validate();
+      const typeDocument = \`---
+kind: mdbase.type
+name: browsernote
+version: 1
+description: Browser note
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+    properties:
+      title: { type: string }
+---
+\`;
+      const createdType = await connect.createType({ document: typeDocument });
+      const readType = await connect.readType({ name: "browsernote" });
+      const updatedType = await connect.updateType({
+        name: "browsernote",
+        document: typeDocument.replace("Browser note", "Updated browser note"),
+        if_revision: readType.result.revision
+      });
+      const changed = await connect.changes({ after: description.change_cursor });
+      const deleted = await connect.delete({ path: "browser/renamed.md" });
+      return {
+        status,
+        route: connect.connection()?.route,
+        records: query.result.results.length,
+        read: read.result.body.includes("Created in Chromium"),
+        updated: updated.valid && readUpdated.result.frontmatter.status === "done",
+        renamed: renamed.result.path === "browser/renamed.md",
+        validated: validated.valid,
+        createdType: createdType.valid && createdType.result.path === "_types/browsernote.md",
+        readType: readType.valid && readType.result.document.includes("Browser note"),
+        updatedType: updatedType.valid && updatedType.result.document.includes("Updated browser note"),
+        changed: changed.events.length > 0,
+        deleted: deleted.result.deleted
+      };
+    }
+  };
+</script>`);
+      return;
+    }
     response.setHeader("content-type", "application/json");
     response.end(JSON.stringify({
       manifest_version: 1,
-      name: "MVP Workout App",
+      name,
       homepage: origin,
       redirect_uris: [`${origin}/auth/mdbase/callback`],
-      requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] }
+      requirements: { contracts }
     }));
   });
   await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
@@ -472,6 +789,7 @@ async function openManifestServer() {
   const origin = `http://localhost:${address.port}`;
   return {
     server,
+    origin,
     manifestUrl: `${origin}/.well-known/mdbase-app.json`,
     redirectUri: `${origin}/auth/mdbase/callback`
   };

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -233,6 +233,7 @@ describe("mdbase connect server", () => {
     expect(token.json().collection_id).toBe(collectionId);
     expect(token.json().operations).toEqual(["read", "query"]);
     expect(token.json().scope).toEqual({ contracts: [{ id: "workout.record", version: 1 }] });
+    expect(token.json().application_origin).toBe(new URL(manifestServer.redirectUri).origin);
     expect(token.json().refresh_token).toMatch(/^ref_/);
 
     const refreshed = await app.inject({
@@ -318,7 +319,11 @@ describe("mdbase connect server", () => {
       headers: { authorization: `Bearer ${connector.token}` }
     });
     expect(policyAfterPortalApproval.json().grants).toContainEqual(
-      expect.objectContaining({ collection_id: localCollectionId, operations: ["read"] })
+      expect.objectContaining({
+        collection_id: localCollectionId,
+        operations: ["read"],
+        application_origin: new URL(manifestServer.redirectUri).origin
+      })
     );
     expect(policyAfterPortalApproval.json().pending_authorizations).toHaveLength(0);
 

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -629,6 +629,8 @@ export async function buildApp(options: BuildOptions) {
       : { rows: [] };
     const grants = await options.db.query(
       `SELECT g.id, g.operations, g.scope, g.created_at, g.revoked_at,
+              CASE WHEN g.application_origin = '' THEN a.homepage
+                   ELSE g.application_origin END AS application_origin,
               COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
               COALESCE(col.display_name, hosted.display_name) AS collection_name,
@@ -666,7 +668,10 @@ export async function buildApp(options: BuildOptions) {
         contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template)),
         replicas: hostedReplicas.rows.filter((replica) => replica.collection_id === collection.id)
       })),
-      grants: grants.rows,
+      grants: grants.rows.map((grant) => ({
+        ...grant,
+        application_origin: new URL(grant.application_origin).origin
+      })),
       pending_authorizations: pendingAuthorizations.rows
     };
   });
@@ -793,7 +798,10 @@ export async function buildApp(options: BuildOptions) {
     );
     const grants = await options.db.query(
       `SELECT g.id, g.application_id, a.name AS application_name,
-              a.homepage AS application_homepage, a.icon AS application_icon,
+              a.homepage AS application_homepage,
+              CASE WHEN g.application_origin = '' THEN a.homepage
+                   ELSE g.application_origin END AS application_origin,
+              a.icon AS application_icon,
               col.local_id AS collection_id, col.display_name AS collection_name,
               g.operations, g.scope, g.encryption, g.created_at
        FROM grants g
@@ -818,7 +826,10 @@ export async function buildApp(options: BuildOptions) {
       configured: true,
       online: true,
       account: account.rows[0],
-      grants: grants.rows,
+      grants: grants.rows.map((grant) => ({
+        ...grant,
+        application_origin: new URL(grant.application_origin).origin
+      })),
       pending_authorizations: pendingAuthorizations.rows
     };
   });
@@ -872,8 +883,12 @@ export async function buildApp(options: BuildOptions) {
       [connector.id, input.collection_id]
     );
     if (!collection.rows[0]) return reply.code(404).send(apiError("collection_not_found", "Collection is not synchronized yet."));
-    const application = await options.db.query<{ id: string; requirements: ApplicationRequirements }>(
-      "SELECT id, requirements FROM applications WHERE id = $1",
+    const application = await options.db.query<{
+      id: string;
+      homepage: string;
+      requirements: ApplicationRequirements;
+    }>(
+      "SELECT id, homepage, requirements FROM applications WHERE id = $1",
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
@@ -889,7 +904,8 @@ export async function buildApp(options: BuildOptions) {
       applicationId: input.application_id,
       collectionId: collection.rows[0].id,
       operations: input.operations,
-      scope
+      scope,
+      applicationOrigin: new URL(application.rows[0].homepage).origin
     });
     await relay.pushPolicy(connector.id);
     await audit(options.db, connector.user_id, "grant.created", grant.id, {
@@ -1282,8 +1298,12 @@ export async function buildApp(options: BuildOptions) {
       [input.collection_id, user.id]
     );
     if (!ownership.rows[0]) return reply.code(404).send(apiError("collection_not_found", "Collection not found."));
-    const application = await options.db.query<{ id: string; requirements: ApplicationRequirements }>(
-      "SELECT id, requirements FROM applications WHERE id = $1",
+    const application = await options.db.query<{
+      id: string;
+      homepage: string;
+      requirements: ApplicationRequirements;
+    }>(
+      "SELECT id, homepage, requirements FROM applications WHERE id = $1",
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
@@ -1299,7 +1319,8 @@ export async function buildApp(options: BuildOptions) {
       applicationId: input.application_id,
       collectionId: input.collection_id,
       operations: input.operations,
-      scope
+      scope,
+      applicationOrigin: new URL(application.rows[0].homepage).origin
     });
     await relay.pushPolicy(ownership.rows[0].connector_id);
     await audit(options.db, user.id, "grant.created", grant.id, input);
@@ -1822,6 +1843,7 @@ async function createOrUpdateGrant(
     collectionId: string;
     operations: string[];
     scope: GrantScope;
+    applicationOrigin: string;
   }
 ): Promise<{ id: string; operations: string[]; scope: GrantScope }> {
   const operations = [...new Set(input.operations)];
@@ -1832,20 +1854,29 @@ async function createOrUpdateGrant(
   );
   const grant = existing.rows[0]
     ? await db.query<{ id: string; operations: string[]; scope: GrantScope }>(
-        `UPDATE grants SET operations = $2::jsonb, scope = $3::jsonb
+        `UPDATE grants SET operations = $2::jsonb, scope = $3::jsonb,
+                           application_origin = $4
          WHERE id = $1 RETURNING id, operations, scope`,
-        [existing.rows[0].id, JSON.stringify(operations), JSON.stringify(input.scope)]
+        [
+          existing.rows[0].id,
+          JSON.stringify(operations),
+          JSON.stringify(input.scope),
+          input.applicationOrigin
+        ]
       )
     : await db.query<{ id: string; operations: string[]; scope: GrantScope }>(
-        `INSERT INTO grants (id, user_id, application_id, collection_id, operations, scope)
-         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb) RETURNING id, operations, scope`,
+        `INSERT INTO grants
+           (id, user_id, application_id, collection_id, operations, scope, application_origin)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)
+         RETURNING id, operations, scope`,
         [
           randomUUID(),
           input.userId,
           input.applicationId,
           input.collectionId,
           JSON.stringify(operations),
-          JSON.stringify(input.scope)
+          JSON.stringify(input.scope),
+          input.applicationOrigin
         ]
       );
   if (existing.rows[0]?.encryption) await rotateGrantEncryption(db, existing.rows[0].id);
@@ -1988,9 +2019,10 @@ async function approveAuthorization(
     requirements: ApplicationRequirements;
     relay_protocol: number | null;
     application_public_key: string | null;
+    redirect_uri: string;
   }>(
     `SELECT ar.application_id, ar.requested_operations, a.requirements,
-            ar.relay_protocol, ar.application_public_key
+            ar.relay_protocol, ar.application_public_key, ar.redirect_uri
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id
      WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL AND ar.expires_at > now()`,
@@ -2037,8 +2069,10 @@ async function approveAuthorization(
     };
   }
   await db.query(
-    `INSERT INTO grants (id, user_id, application_id, collection_id, operations, scope, encryption)
-     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb)`,
+    `INSERT INTO grants
+       (id, user_id, application_id, collection_id, operations, scope, encryption,
+        application_origin)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8)`,
     [
       grantId,
       input.userId,
@@ -2046,7 +2080,8 @@ async function approveAuthorization(
       input.collectionId,
       JSON.stringify(input.operations),
       JSON.stringify(scope),
-      encryption ? JSON.stringify(encryption) : null
+      encryption ? JSON.stringify(encryption) : null,
+      new URL(pending.redirect_uri).origin
     ]
   );
   await db.query(
@@ -2085,12 +2120,13 @@ async function approveHostedAuthorization(
       application_id: string;
       application_name: string;
       application_homepage: string;
+      redirect_uri: string;
       requested_operations: string[];
       requirements: ApplicationRequirements;
       provisions: ApplicationProvisions;
     }>(
       `SELECT ar.application_id, a.name AS application_name, a.homepage AS application_homepage,
-              ar.requested_operations,
+              ar.redirect_uri, ar.requested_operations,
               a.requirements, a.provisions
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
@@ -2133,7 +2169,7 @@ async function approveHostedAuthorization(
     await provider.renameCollection(input.collectionId, input.displayName);
     const operations = [...new Set(input.operations)];
     const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
-    const applicationUrl = new URL(pending.application_homepage);
+    const applicationUrl = new URL(pending.redirect_uri);
     const allowedOrigin = ["http:", "https:"].includes(applicationUrl.protocol)
       ? applicationUrl.origin
       : undefined;
@@ -2165,9 +2201,9 @@ async function approveHostedAuthorization(
     );
     await connection.query(
       `INSERT INTO grants
-         (id, user_id, application_id, hosted_collection_id, hosted_replica_id,
-          operations, scope, encryption)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL)`,
+          (id, user_id, application_id, hosted_collection_id, hosted_replica_id,
+          operations, scope, encryption, application_origin)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL, $8)`,
       [
         grantId,
         input.userId,
@@ -2175,7 +2211,8 @@ async function approveHostedAuthorization(
         input.collectionId,
         replicaId,
         JSON.stringify(operations),
-        JSON.stringify(scope)
+        JSON.stringify(scope),
+        applicationUrl.origin
       ]
     );
     await connection.query(
@@ -2270,6 +2307,7 @@ async function issueApplicationTokens(
   scope: GrantScope;
   grant_id: string;
   encryption: GrantEncryption | null;
+  application_origin: string;
   hosted?: {
     provider_url: string;
     replica_id: string;
@@ -2284,11 +2322,15 @@ async function issueApplicationTokens(
     operations: string[];
     scope: GrantScope;
     encryption: GrantEncryption | null;
+    application_origin: string;
   }>(
     `SELECT COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
             g.hosted_collection_id, g.hosted_replica_id, hosted.provider_url,
-            g.operations, g.scope, g.encryption
+            g.operations, g.scope, g.encryption,
+            CASE WHEN g.application_origin = '' THEN app.homepage
+                 ELSE g.application_origin END AS application_origin
      FROM grants g
+     JOIN applications app ON app.id = g.application_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
      WHERE g.id = $1 AND g.revoked_at IS NULL`,
     [grantId]
@@ -2330,6 +2372,7 @@ async function issueApplicationTokens(
     scope: grant.rows[0].scope,
     grant_id: grantId,
     encryption: grant.rows[0].encryption,
+    application_origin: new URL(grant.rows[0].application_origin).origin,
     ...(hosted ? { hosted } : {})
   };
 }

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -137,6 +137,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       operations jsonb NOT NULL,
       scope jsonb NOT NULL DEFAULT '{"contracts":[]}'::jsonb,
       encryption jsonb,
+      application_origin text NOT NULL DEFAULT '',
       created_at timestamptz NOT NULL DEFAULT now(),
       revoked_at timestamptz,
       CHECK ((collection_id IS NULL) <> (hosted_collection_id IS NULL))
@@ -238,6 +239,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   );
   await ensureColumn(db, "connectors", "relay_public_key", "ALTER TABLE connectors ADD COLUMN relay_public_key text");
   await ensureColumn(db, "grants", "encryption", "ALTER TABLE grants ADD COLUMN encryption jsonb");
+  await ensureColumn(
+    db,
+    "grants",
+    "application_origin",
+    "ALTER TABLE grants ADD COLUMN application_origin text NOT NULL DEFAULT ''"
+  );
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
   await ensureColumn(db, "hosted_collections", "provider_url", "ALTER TABLE hosted_collections ADD COLUMN provider_url text");

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -106,6 +106,7 @@ export class RelayHub {
       application_id: string;
       application_name: string;
       application_homepage: string;
+      application_origin: string;
       application_icon: string | null;
       local_id: string;
       collection_name: string;
@@ -115,7 +116,10 @@ export class RelayHub {
       created_at: string;
     }>(
       `SELECT g.id, g.application_id, a.name AS application_name,
-              a.homepage AS application_homepage, a.icon AS application_icon,
+              a.homepage AS application_homepage,
+              CASE WHEN g.application_origin = '' THEN a.homepage
+                   ELSE g.application_origin END AS application_origin,
+              a.icon AS application_icon,
               c.local_id, c.display_name AS collection_name, g.operations, g.scope,
               g.encryption, g.created_at
        FROM grants g
@@ -135,6 +139,7 @@ export class RelayHub {
         scope: grant.scope,
         application_name: grant.application_name,
         application_homepage: grant.application_homepage,
+        application_origin: new URL(grant.application_origin).origin,
         application_icon: grant.application_icon,
         collection_name: grant.collection_name,
         created_at: grant.created_at,


### PR DESCRIPTION
## Summary
- add a hardened browser-only loopback transport for local-authority collections
- route all 12 current record and type operations through the connector exact grant boundary
- add durable encrypted replay receipts, bounded counter reordering, and exact direct-to-relay mutation recovery
- add SDK permission/routing APIs, conservative backoff, cloud-independent local grant use, and unresolved-write serialization
- integrate quiet direct/relay status into TaskNotes and the desktop controller
- pin the canonical mdbase-rs update fix and refresh Rust dependencies, including aes-gcm 0.11

## Validation
- cargo fmt, workspace tests, and warning-free Clippy
- build, typecheck, and all TypeScript tests
- direct Chromium, sync, hosted-provider, and Oracle E2E suites
- package-consumer audit and locked Docker release build
- 10,000-record hosted-provider stress suite

The real Chromium matrix grants Local Network Access and exercises expired-cloud direct access, 1,002 records, every grantable operation, exact-origin enforcement, relay fallback, pause/revocation, and duplicate-write recovery.