### PR TITLE
Expose deployed server revision

### DIFF
--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -13,6 +13,28 @@ afterEach(async () => {
 });
 
 describe("mdbase connect server", () => {
+  it("reports the deployed revision when one is configured", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test",
+      revision: "ae3a8d9"
+    });
+    resources.push(() => app.close());
+
+    const health = await app.inject({ method: "GET", url: "/health" });
+
+    expect(health.statusCode).toBe(200);
+    expect(health.json()).toEqual({
+      ok: true,
+      service: "mdbase-connect",
+      protocol_version: 2,
+      revision: "ae3a8d9"
+    });
+  });
+
   it("runs the discovery, consent, token, and offline operation path", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -91,6 +91,7 @@ const syncMutationSchema = z.object({
 
 interface BuildOptions {
   db: DatabasePool;
+  revision?: string;
   devAuth?: boolean;
   tailscaleAuth?: boolean;
   githubAuth?: GitHubAuthConfig;
@@ -129,6 +130,7 @@ export async function buildApp(options: BuildOptions) {
     requestTimeout: 35_000
   });
   const publicUrl = options.publicUrl ?? "http://127.0.0.1:8787";
+  const revision = options.revision?.trim() || undefined;
   const registration = options.registration ?? "closed";
   const relay = new RelayHub(options.db);
   if (options.hostedProvider && options.hostedReferenceAuthority) {
@@ -243,7 +245,12 @@ export async function buildApp(options: BuildOptions) {
     return reply.code(500).send(apiError("internal_error", "The request could not be completed."));
   });
 
-  app.get("/health", async () => ({ ok: true, service: "mdbase-connect", protocol_version: 2 }));
+  app.get("/health", async () => ({
+    ok: true,
+    service: "mdbase-connect",
+    protocol_version: 2,
+    ...(revision ? { revision } : {})
+  }));
   app.get("/ready", async (_request, reply) => {
     try {
       await options.db.query("SELECT 1");

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -10,6 +10,7 @@ const db = await createDatabase();
 const portalDist = process.env.PORTAL_DIST ?? resolve(import.meta.dirname, "../../../apps/portal/dist");
 const { app } = await buildApp({
   db,
+  revision: process.env.RENDER_GIT_COMMIT,
   publicUrl: runtime.publicUrl,
   portalDist,
   devAuth: runtime.devAuth,


### PR DESCRIPTION
## Summary

- expose Render's deployed Git commit in the control-plane health response
- add coverage for the optional revision field

The production control-plane rollout failed while leaving the previous release active. This gives deployment verification an authoritative revision signal and creates a fresh rollout of the already-tested type-provisioning release.

## Validation

- `pnpm --filter @mdbase/connect-server typecheck`
- `pnpm --filter @mdbase/connect-server test`
- production Docker image startup against an upgraded PostgreSQL 17 schema
- live Workouts manifest discovery against that image
