### PR TITLE
Complete native hosted sync integration

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: callumalpass/mdbase-rs
-          ref: 66089ba5499aa351ca396b903a6f1c54d2df768f
+          ref: 46ea4776af4111db55bd79bf4e3a2b08486ad2bd
           path: mdbase-rs
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,12 +968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,14 +1533,15 @@ name = "mdbase"
 version = "0.3.0-rc.1"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "clap",
  "fancy-regex 0.14.0",
- "glob",
  "jsonschema",
  "notify",
  "rand 0.8.7",
  "regex",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1880,6 +1885,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2385,6 +2408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2576,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -299,6 +299,7 @@ function Dashboard() {
                   ]
                   )}
                   onDecision={refresh}
+                  onCollectionCreated={() => void refresh()}
                 />
               </article>
             ))}</div></>}
@@ -717,6 +718,10 @@ function Authorization({ requestId }: { requestId: string }) {
             request={authorization}
             collections={compatibleCollections(authorization, request.collections)}
             onDecision={(decision) => setStatus(decision)}
+            onCollectionCreated={(collection) => setRequest((current) => current ? {
+              ...current,
+              collections: [...current.collections, collection]
+            } : current)}
           />
           <div className="desktop-alternative"><span>Want to review this on the computer instead?</span><a href={deepLink}>Open mdbase connect</a></div>
         </> : status === "approved" ? <><p className="eyebrow outcome-label">Access approved</p><h2>Returning to the application…</h2><p>Your approved collection and permissions will follow you back.</p></> : <><p className="eyebrow outcome-label">Access denied</p><h2>Returning to the application…</h2><p>The application will show that access was not granted.</p></>}
@@ -744,15 +749,17 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
 function ApprovalForm({
   request,
   collections,
-  onDecision
+  onDecision,
+  onCollectionCreated
 }: {
   request: PendingAuthorization;
   collections: AvailableCollection[];
   onDecision(decision: "approved" | "denied"): void | Promise<void>;
+  onCollectionCreated(collection: AvailableCollection): void;
 }) {
   const [collectionId, setCollectionId] = useState(collections[0]?.id ?? "");
   const [operations, setOperations] = useState(() => new Set(request.requested_operations));
-  const [submitting, setSubmitting] = useState<"approved" | "denied" | null>(null);
+  const [submitting, setSubmitting] = useState<"approved" | "denied" | "creating" | null>(null);
   const [error, setError] = useState("");
   const selected = collections.find((collection) => collection.id === collectionId);
   const setup = selected ? neededProvisions(request, selected) : [];
@@ -789,6 +796,35 @@ function ApprovalForm({
     }
   }
 
+  async function createCloudCollection() {
+    setSubmitting("creating");
+    setError("");
+    try {
+      const tasknotes = request.requirements.contracts.some((contract) => contract.id === "tasknotes.task");
+      const created = await api<{ collection: HostedCollection }>("/v1/hosted/collections", {
+        method: "POST",
+        body: JSON.stringify({
+          display_name: tasknotes ? "My tasks" : "My collection",
+          template: tasknotes ? "tasknotes" : "mdbase"
+        })
+      });
+      const collection: AvailableCollection = {
+        id: created.collection.id,
+        display_name: created.collection.display_name,
+        connector_name: "mdbase cloud",
+        spec_version: created.collection.spec_version ?? "0.3.0",
+        contracts: tasknotes ? [{ id: "tasknotes.task", version: 1 }] : [],
+        kind: "hosted"
+      };
+      onCollectionCreated(collection);
+      setCollectionId(collection.id);
+    } catch (creationError) {
+      setError(message(creationError));
+    } finally {
+      setSubmitting(null);
+    }
+  }
+
   return (
     <div className="approval-form" aria-busy={submitting !== null}>
       <label className="collection-field" htmlFor={`collection-${request.id}`}>
@@ -797,9 +833,15 @@ function ApprovalForm({
           {collections.map((collection) => <option value={collection.id} key={collection.id}>{collection.display_name} · {collection.connector_name}{neededProvisions(request, collection).length ? " · setup required" : ""}</option>)}
         </select>
       </label>
-      {collections.length === 0 && <p className="field-note error-copy">
-        No collection is ready. Open mdbase connect on the collection's computer to add the required types.
-      </p>}
+      {collections.length === 0 && <div className="authorization-empty-collection">
+        <p className="field-note">No compatible collection is ready.</p>
+        <button
+          className="button secondary"
+          type="button"
+          disabled={submitting !== null}
+          onClick={() => void createCloudCollection()}
+        >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>
+      </div>}
       {setup.length > 0 && <p className="field-note">Allowing access will add {provisionNames(setup)} to this hosted collection.</p>}
       <fieldset className="permission-field">
         <legend>Permissions</legend>

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -351,6 +351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,12 +968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,14 +1533,15 @@ name = "mdbase"
 version = "0.3.0-rc.1"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "clap",
  "fancy-regex 0.14.0",
- "glob",
  "jsonschema",
  "notify",
  "rand 0.8.7",
  "regex",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1880,6 +1885,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2385,6 +2408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2576,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -1,7 +1,7 @@
 FROM rust:1.94.0-bookworm AS build
 
 ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
-ARG MDBASE_RS_REVISION=66089ba5499aa351ca396b903a6f1c54d2df768f
+ARG MDBASE_RS_REVISION=46ea4776af4111db55bd79bf4e3a2b08486ad2bd
 
 RUN git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
  && git -C /build/mdbase-rs checkout --detach "$MDBASE_RS_REVISION"

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -118,6 +118,12 @@ Authorization is retained in `localStorage` by default. Access tokens are
 renewed with rotating refresh tokens; passing a custom `Storage` implementation
 allows a host to choose another persistence boundary.
 
+Native shells can pass `navigate` to open the authorization URL in the system
+browser and list a reverse-domain callback such as
+`dev.tasknotes.app://auth/mdbase/callback` in the public manifest. PKCE remains
+mandatory. Call `completeAuthorization(callbackUrl)` when the application
+receives the deep link.
+
 New authorizations require encrypted relay protocol 3 by default. The SDK keeps
 a non-extractable per-authorization P-256 key and atomic message counter in
 IndexedDB, encrypts operation inputs for the connector, and decrypts connector
@@ -130,6 +136,10 @@ hosted Rust data plane, binds browser requests to the manifest origin, and does
 not send record payloads through the Connect control plane. Refresh rotation,
 permission narrowing, and revocation keep the same public SDK behavior across
 local and hosted authorities.
+
+`hostedSync()` exposes a provider-neutral sync transport without exposing the
+provider credential. It refreshes the grant-bound capability as needed and can
+be passed directly to `@mdbase/connect-sync` for an offline application cache.
 
 Record-facing code can depend on `MdbaseCollectionClient` instead of the OAuth
 client. It accepts a small `MdbaseCollectionTransport`, which is the stable seam

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -81,6 +81,31 @@ describe("provider-neutral collection client", () => {
 });
 
 describe("authorization renewal", () => {
+  it("uses injected navigation for native authorization", async () => {
+    const storage = new MemoryStorage();
+    const navigate = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      application: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "TaskNotes",
+        homepage: "https://tasks.example"
+      }
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const connect = new MdbaseConnect({
+      serverUrl: "https://connect.example",
+      manifestUrl: "https://tasks.example/.well-known/mdbase-app.json",
+      redirectUri: "dev.tasknotes.app://auth/mdbase/callback",
+      storage,
+      relayEncryption: "disabled",
+      navigate
+    });
+
+    void connect.authorize(["query"]);
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    expect(new URL(navigate.mock.calls[0][0]).searchParams.get("redirect_uri"))
+      .toBe("dev.tasknotes.app://auth/mdbase/callback");
+  });
+
   it("sends hosted operations directly to the provider with its scoped capability", async () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";
@@ -115,6 +140,59 @@ describe("authorization renewal", () => {
     expect((await connect.query()).valid).toBe(true);
     expect(String(fetchMock.mock.calls[0][0])).toBe(
       `${providerUrl}/v1/hosted/collections/00000000-0000-0000-0000-000000000002/operations/query`
+    );
+    expect((fetchMock.mock.calls[0][1]?.headers as Record<string, string>).authorization)
+      .toBe("Bearer hsa_direct");
+  });
+
+  it("keeps hosted sync credentials private and refreshes them for the offline transport", async () => {
+    const storage = new MemoryStorage();
+    const serverUrl = "https://connect.example";
+    const providerUrl = "https://provider.example";
+    const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
+    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+      accessToken: "mdb_control",
+      refreshToken: "ref_current",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      collectionId: "00000000-0000-0000-0000-000000000002",
+      operations: ["query", "create", "update", "delete"],
+      scope: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+      expiresAt: Date.now() + 60_000,
+      refreshExpiresAt: Date.now() + 120_000,
+      hosted: {
+        providerUrl,
+        replicaId: "00000000-0000-0000-0000-000000000003",
+        accessToken: "hsa_direct"
+      }
+    }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      protocol_version: 1,
+      session_id: "00000000-0000-0000-0000-000000000004",
+      replica_id: "00000000-0000-0000-0000-000000000003",
+      collection_id: "00000000-0000-0000-0000-000000000002",
+      mode: "read_write",
+      scope_epoch: 1,
+      retained_after: 0,
+      head: 0,
+      snapshot_id: "00000000-0000-0000-0000-000000000005",
+      resources: { revision: "one", spec_version: "0.3.0", types: [], contracts: [] }
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const connect = new MdbaseConnect({
+      serverUrl,
+      manifestUrl,
+      redirectUri: "https://tasks.example/callback",
+      storage
+    });
+
+    const hosted = connect.hostedSync();
+    expect(hosted).toEqual(expect.objectContaining({
+      collectionId: "00000000-0000-0000-0000-000000000002",
+      replicaId: "00000000-0000-0000-0000-000000000003"
+    }));
+    expect(JSON.stringify(hosted)).not.toContain("hsa_direct");
+    expect((await hosted!.transport.openSession()).mode).toBe("read_write");
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      `${providerUrl}/v1/hosted/collections/00000000-0000-0000-0000-000000000002/sync/sessions`
     );
     expect((fetchMock.mock.calls[0][1]?.headers as Record<string, string>).authorization)
       .toBe("Bearer hsa_direct");

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,7 +12,12 @@ import type {
   JsonObject,
   MdbaseOperationEnvelope,
   RecordSummary,
-  RecordResult
+  RecordResult,
+  SyncChangesPage,
+  SyncMutation,
+  SyncMutationReceipt,
+  SyncSession,
+  SyncSnapshotPage
 } from "@mdbase/connect-protocol";
 import { DEFAULT_LOOPBACK_PORT } from "@mdbase/connect-protocol";
 import {
@@ -65,6 +70,8 @@ export interface MdbaseConnectOptions {
   directAccess?: "auto" | "disabled";
   /** Loopback origin override for development and automated testing. */
   loopbackUrl?: string;
+  /** Override browser navigation, for example to use a native system browser. */
+  navigate?: (url: string) => void | Promise<void>;
 }
 
 export type MdbaseConnectionRoute = "hosted" | "direct" | "relay";
@@ -82,6 +89,19 @@ export interface MdbaseConnection {
   scope: GrantScope;
   route: MdbaseConnectionRoute;
   directAccess: DirectAccessStatus;
+}
+
+export interface MdbaseHostedSyncTransport<Frontmatter extends JsonObject = JsonObject> {
+  openSession(): Promise<SyncSession>;
+  snapshot(snapshotId: string, page?: string): Promise<SyncSnapshotPage<Frontmatter>>;
+  changes(after: number, limit?: number): Promise<SyncChangesPage<Frontmatter>>;
+  mutate(mutation: SyncMutation): Promise<SyncMutationReceipt<Frontmatter>>;
+}
+
+export interface MdbaseHostedSyncConnection<Frontmatter extends JsonObject = JsonObject> {
+  collectionId: string;
+  replicaId: string;
+  transport: MdbaseHostedSyncTransport<Frontmatter>;
 }
 
 export interface ReadInput {
@@ -327,6 +347,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   private readonly keyStore: GrantKeyStore;
   private readonly directAccessMode: "auto" | "disabled";
   private readonly loopbackUrl: string;
+  private readonly navigate?: (url: string) => void | Promise<void>;
   private application: Application | null = null;
   private refreshPromise: Promise<StoredToken> | null = null;
   private readonly collectionClient: MdbaseCollectionClient<Frontmatter>;
@@ -348,6 +369,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       options.loopbackUrl ?? `http://127.0.0.1:${DEFAULT_LOOPBACK_PORT}`
     );
     this.directStatus = this.directAccessMode === "disabled" ? "disabled" : "unavailable";
+    this.navigate = options.navigate;
     this.collectionClient = new MdbaseCollectionClient({
       operation: (operation, input) => this.performOperation(operation, input)
     });
@@ -367,7 +389,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   }
 
   async authorize(operations: CollectionOperation[] = DEFAULT_OPERATIONS): Promise<never> {
-    if (typeof location === "undefined") {
+    if (typeof location === "undefined" && !this.navigate) {
       throw new MdbaseConnectError(
         "browser_required",
         "Authorization navigation requires a browser environment."
@@ -405,7 +427,8 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       authorize.searchParams.set("relay_protocol", "3");
       authorize.searchParams.set("application_public_key", grantKey.publicKey);
     }
-    location.assign(authorize.href);
+    if (this.navigate) await this.navigate(authorize.href);
+    else location.assign(authorize.href);
     return new Promise<never>(() => undefined);
   }
 
@@ -500,6 +523,43 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     this.storage.setItem(this.directPreferenceKey(), "disabled");
     this.setDirectStatus("disabled");
     this.setRoute("relay");
+  }
+
+  /**
+   * Return an offline-replication transport for an authorized hosted
+   * collection. Provider credentials stay inside the SDK and are refreshed
+   * before requests when necessary.
+   */
+  hostedSync(): MdbaseHostedSyncConnection<Frontmatter> | null {
+    const token = this.currentToken();
+    if (!token?.hosted) return null;
+    const collectionId = token.collectionId;
+    const replicaId = token.hosted.replicaId;
+    return {
+      collectionId,
+      replicaId,
+      transport: {
+        openSession: () => this.performHostedSyncRequest(collectionId, replicaId, "POST", "sessions"),
+        snapshot: (snapshotId, page) => {
+          const query = new URLSearchParams({ snapshot_id: snapshotId });
+          if (page) query.set("page", page);
+          return this.performHostedSyncRequest(collectionId, replicaId, "GET", `snapshot?${query}`);
+        },
+        changes: (after, limit = 200) => this.performHostedSyncRequest(
+          collectionId,
+          replicaId,
+          "GET",
+          `changes?${new URLSearchParams({ after: String(after), limit: String(limit) })}`
+        ),
+        mutate: (mutation) => this.performHostedSyncRequest(
+          collectionId,
+          replicaId,
+          "POST",
+          "mutations",
+          mutation
+        )
+      }
+    };
   }
 
   disconnect(): void {
@@ -638,6 +698,63 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       }
     }
     return body.result as Result;
+  }
+
+  private async performHostedSyncRequest<Result>(
+    collectionId: string,
+    replicaId: string,
+    method: "GET" | "POST",
+    path: string,
+    input?: unknown
+  ): Promise<Result> {
+    let token = await this.authorizedToken();
+    if (!token?.hosted
+        || token.collectionId !== collectionId
+        || token.hosted.replicaId !== replicaId) {
+      throw new MdbaseConnectError(
+        "hosted_authorization_changed",
+        "Reconnect this hosted collection before synchronizing."
+      );
+    }
+    let response = await this.sendHostedSyncRequest(token, collectionId, method, path, input);
+    if (response.status === 401 && token.refreshToken) {
+      token = await this.refreshAuthorization();
+      if (!token.hosted
+          || token.collectionId !== collectionId
+          || token.hosted.replicaId !== replicaId) {
+        throw new MdbaseConnectError(
+          "hosted_authorization_changed",
+          "Reconnect this hosted collection before synchronizing."
+        );
+      }
+      response = await this.sendHostedSyncRequest(token, collectionId, method, path, input);
+    }
+    const body = await response.json();
+    if (!response.ok) throw apiError(body, "sync_failed", "Hosted collection synchronization failed.");
+    return body as Result;
+  }
+
+  private sendHostedSyncRequest(
+    token: StoredToken,
+    collectionId: string,
+    method: "GET" | "POST",
+    path: string,
+    input?: unknown
+  ): Promise<Response> {
+    if (!token.hosted) {
+      throw new MdbaseConnectError("not_hosted", "This authorization is not for a hosted collection.");
+    }
+    return fetch(
+      `${stripTrailingSlash(token.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(collectionId)}/sync/${path}`,
+      {
+        method,
+        headers: {
+          authorization: `Bearer ${token.hosted.accessToken}`,
+          ...(input === undefined ? {} : { "content-type": "application/json" })
+        },
+        ...(input === undefined ? {} : { body: JSON.stringify(input) })
+      }
+    );
   }
 
   private async sendOperation<Result>(

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -34,3 +34,9 @@ Application manifests support connector-controlled type provisioning. Put the
 complete portable type document in `provisions.types`, declare the contracts it
 provides, and list the same contracts under `requirements.contracts`. The
 validator rejects provisions for contracts the application does not require.
+
+Native applications may add a reverse-domain private-use callback scheme that
+is bound to the manifest publisher, such as
+`example.tasks.desktop://auth/mdbase/callback` for a manifest hosted at
+`tasks.example`. Native authorization still uses PKCE and should open the
+authorization URL in the system browser.

--- a/packages/devkit/src/index.test.ts
+++ b/packages/devkit/src/index.test.ts
@@ -59,6 +59,18 @@ describe("canonical developer validation", () => {
       manifest_version: 1,
       name: "Tasks",
       homepage: "https://tasks.example/",
+      redirect_uris: ["example.tasks.desktop://auth/mdbase/callback"]
+    }).valid).toBe(true);
+    expect(validateAppManifest({
+      manifest_version: 1,
+      name: "Tasks",
+      homepage: "https://tasks.example/",
+      redirect_uris: ["com.attacker.desktop://auth/mdbase/callback"]
+    }).valid).toBe(false);
+    expect(validateAppManifest({
+      manifest_version: 1,
+      name: "Tasks",
+      homepage: "https://tasks.example/",
       redirect_uris: ["https://tasks.example/callback"],
       requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] },
       provisions: {

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -13,6 +13,7 @@ import type {
   MdbaseOperationEnvelope,
   RecordResult
 } from "@mdbase/connect-protocol";
+import { isNativeRedirectUri } from "@mdbase/connect-protocol";
 import appManifestSchema from "@mdbase/connect-protocol/schemas/mdbase-app.schema.json" with { type: "json" };
 import contractExtensionSchema from "@mdbase/connect-protocol/schemas/contract-extension.v1.schema.json" with { type: "json" };
 import connectProtocolSchema from "@mdbase/connect-protocol/schemas/connect-protocol.v2.schema.json" with { type: "json" };
@@ -368,11 +369,14 @@ function validateManifestOrigins(value: unknown, allowLocal: boolean): Validatio
     }
     for (const [index, redirect] of (manifest.redirect_uris as unknown[]).entries()) {
       const url = new URL(String(redirect));
-      if (url.origin !== homepage.origin) {
-        return semanticIssue(`/redirect_uris/${index}`, "must use the homepage origin");
-      }
-      if (!secureOrAllowedLocal(url, allowLocal)) {
+      if (url.origin === homepage.origin && !secureOrAllowedLocal(url, allowLocal)) {
         return semanticIssue(`/redirect_uris/${index}`, "must use HTTPS (or loopback HTTP in local mode)");
+      }
+      if (url.origin !== homepage.origin && !isNativeRedirectUri(url, homepage.hostname)) {
+        return semanticIssue(
+          `/redirect_uris/${index}`,
+          "must use the homepage origin or a publisher-bound private-use application scheme"
+        );
       }
     }
     if (manifest.icon !== undefined && new URL(String(manifest.icon)).origin !== homepage.origin) {

--- a/packages/protocol/schemas/mdbase-app.schema.json
+++ b/packages/protocol/schemas/mdbase-app.schema.json
@@ -15,7 +15,11 @@
       "minItems": 1,
       "maxItems": 10,
       "uniqueItems": true,
-      "items": { "type": "string", "format": "uri", "pattern": "^https://" }
+      "items": {
+        "type": "string",
+        "format": "uri",
+        "description": "An HTTPS URI on the manifest origin or a native reverse-domain private-use scheme."
+      }
     },
     "requirements": { "$ref": "#/$defs/requirements" },
     "provisions": {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -5,6 +5,30 @@ export const DEFAULT_LOOPBACK_PORT = 28_485 as const;
 export const RELAY_ENCRYPTION_SUITE = "P256-HKDF-SHA256-AES256GCM" as const;
 export const SYNC_PROTOCOL_VERSION = 1 as const;
 
+/**
+ * Validate a native OAuth callback against the publisher of its web manifest.
+ * Reverse-domain private-use schemes keep native app identity tied to the
+ * manifest origin; PKCE remains mandatory at the authorization boundary.
+ */
+export function isNativeRedirectUri(url: URL, publisherHostname?: string): boolean {
+  const scheme = url.protocol.slice(0, -1);
+  const publisherPrefix = publisherHostname
+    ?.toLowerCase()
+    .split(".")
+    .reverse()
+    .join(".");
+  return scheme.includes(".")
+    && /^[a-z][a-z0-9+.-]*$/.test(scheme)
+    && !["http", "https", "file", "javascript", "data"].includes(scheme)
+    && (!publisherPrefix
+      || scheme === publisherPrefix
+      || scheme.startsWith(`${publisherPrefix}.`))
+    && url.username === ""
+    && url.password === ""
+    && url.hostname.length > 0
+    && url.hash === "";
+}
+
 export const CONNECT_SCHEMA_IDS = {
   appManifest: "https://mdbase.dev/connect/schemas/mdbase-app.v1.json",
   contractExtension: "https://mdbase.dev/connect/schemas/contract-extension.v1.json",

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -6,6 +6,11 @@ scoped ordered changes, conditional idempotent mutations, conflicts, cursor
 reset, revocation, offline queues, and receive-only or writable Markdown
 mirrors.
 
+Application replicas resolve a stale record explicitly with
+`resolveConflict(recordId, "local" | "remote")`. Keeping the local version
+rebases it as a new idempotent mutation; keeping the remote version discards
+only that record's queued mutations.
+
 The in-process reference authority remains useful for deterministic contract
 tests. Production uses `mdbase-connect-hosted-provider`: normalized encrypted
 PostgreSQL storage, durable receipts and snapshot leases, and canonical

--- a/packages/sync/src/index.test.ts
+++ b/packages/sync/src/index.test.ts
@@ -107,6 +107,41 @@ describe("hosted sync vertical slice", () => {
     expect(independent).toMatchObject({ status: "applied", record: { frontmatter: { title: "Independent" } } });
   });
 
+  it("resolves stale offline edits by keeping either the local or hosted version", async () => {
+    const hosted = authority();
+    hosted.seed([{
+      record_id: ids.record,
+      path: "tasks/one.md",
+      frontmatter: { type: "task", title: "Original" },
+      body: "",
+      types: ["task"]
+    }]);
+    hosted.registerReplica({ id: ids.writer, name: "Phone", mode: "read_write", allowedTypes: ["task"] });
+    hosted.registerReplica({ id: ids.reader, name: "Tablet", mode: "read_write", allowedTypes: ["task"] });
+    const phone = new OfflineReplica(hosted.transport(ids.writer), store(ids.writer));
+    const tablet = new OfflineReplica(hosted.transport(ids.reader), store(ids.reader));
+    await Promise.all([phone.initialize(), tablet.initialize()]);
+
+    await phone.queueUpdate({ recordId: ids.record, patch: { title: "Phone edit" } });
+    await phone.sync();
+    await tablet.queueUpdate({ recordId: ids.record, patch: { title: "Tablet edit" } });
+    await tablet.sync();
+    expect(await tablet.conflicts()).toHaveLength(1);
+    await tablet.resolveConflict(ids.record, "local");
+    expect((await tablet.records())[0].frontmatter.title).toBe("Tablet edit");
+    await tablet.sync();
+    await phone.pull();
+    expect((await phone.records())[0].frontmatter.title).toBe("Tablet edit");
+
+    await tablet.queueUpdate({ recordId: ids.record, patch: { title: "Tablet stale again" } });
+    await phone.queueUpdate({ recordId: ids.record, patch: { title: "Phone final" } });
+    await phone.sync();
+    await tablet.sync();
+    await tablet.resolveConflict(ids.record, "remote");
+    expect(await tablet.pending()).toEqual([]);
+    expect((await tablet.records())[0].frontmatter.title).toBe("Phone final");
+  });
+
   it("rebuilds an expired cursor without losing a queued offline mutation", async () => {
     const hosted = authority();
     hosted.registerReplica({ id: ids.writer, name: "Android", mode: "read_write", allowedTypes: ["task"] });

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -537,6 +537,68 @@ export class OfflineReplica<Frontmatter extends JsonObject = JsonObject> {
     return Object.values((await this.store.load()).conflicts);
   }
 
+  async conflictEntries(): Promise<
+    Array<{ recordId: string; receipt: SyncMutationReceipt<Frontmatter> }>
+  > {
+    return Object.entries((await this.store.load()).conflicts).map(
+      ([recordId, receipt]) => ({ recordId, receipt }),
+    );
+  }
+
+  /** Resolve one blocked record without disturbing mutations for other records. */
+  resolveConflict(recordId: string, resolution: "local" | "remote"): Promise<void> {
+    return this.exclusive(async () => {
+      const data = await this.requireInitialized();
+      const receipt = data.conflicts[recordId];
+      if (!receipt) throw new SyncError("conflict_not_found", "The record has no sync issue to resolve.");
+      const current = receipt.status === "conflicted" ? receipt.conflict.current : undefined;
+      if (resolution === "remote") {
+        data.pending = data.pending.filter((mutation) => mutation.record_id !== recordId);
+        if (current) data.records[recordId] = clone(current);
+        else delete data.records[recordId];
+        delete data.conflicts[recordId];
+        await this.store.save(data);
+        return;
+      }
+      if (receipt.status !== "conflicted" || !current) {
+        throw new SyncError(
+          "local_resolution_unavailable",
+          "This sync issue cannot keep the local version; use the hosted version or edit a new record."
+        );
+      }
+      const pending = data.pending.filter((mutation) => mutation.record_id === recordId);
+      if (pending.length === 0) {
+        throw new SyncError("conflict_mutation_missing", "The local change for this sync issue is unavailable.");
+      }
+      const first = pending[0];
+      const replacedMutationId = first.mutation_id;
+      first.mutation_id = crypto.randomUUID();
+      first.created_at = new Date().toISOString();
+      for (const later of pending.slice(1)) {
+        if (later.causal_predecessor === replacedMutationId) {
+          later.causal_predecessor = first.mutation_id;
+        }
+      }
+      if (first.operation === "create") {
+        first.operation = "update";
+        first.base_revision = current.revision;
+        first.input = {
+          patch: clone(first.input.frontmatter ?? {}),
+          body: first.input.body ?? "",
+          types: first.input.types ?? current.types
+        };
+      } else {
+        first.base_revision = current.revision;
+      }
+      delete first.causal_predecessor;
+      delete data.conflicts[recordId];
+      const overlay = applyPendingOverlay<Frontmatter>({ [recordId]: clone(current) }, pending);
+      if (overlay[recordId]) data.records[recordId] = overlay[recordId];
+      else delete data.records[recordId];
+      await this.store.save(data);
+    });
+  }
+
   async collectionResources(): Promise<SyncCollectionResources | null> {
     return clone((await this.store.load()).resources ?? null);
   }

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -334,6 +334,48 @@ try {
   phase("exercising hosted lifecycle and writable enrollment in a real browser");
   await portalLifecycleE2E(controlUrl);
 
+  phase("creating the first compatible hosted collection inside browser authorization");
+  const emptyLogin = await rawRequest(controlUrl, "/v1/dev/session", {
+    method: "POST",
+    body: { name: "Inline E2E", email: "inline-hosted-e2e@example.com" }
+  });
+  assert.equal(emptyLogin.status, 200);
+  const emptyCookie = emptyLogin.headers.get("set-cookie")?.split(";", 1)[0];
+  assert.ok(emptyCookie);
+  const inlineManifest = await openManifestServer({
+    name: "TaskNotes Inline E2E",
+    requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] }
+  });
+  try {
+    const inlineStorage = memoryStorage();
+    let inlineAuthorizationUrl;
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { assign: (value) => { inlineAuthorizationUrl = value; } }
+    });
+    const inlineSdk = new MdbaseConnect({
+      serverUrl: controlUrl,
+      manifestUrl: inlineManifest.manifestUrl,
+      redirectUri: inlineManifest.redirectUri,
+      storage: inlineStorage,
+      keyStore: new MemoryGrantKeyStore()
+    });
+    void inlineSdk.authorize(["describe", "read", "query", "create", "update"]);
+    await waitFor(() => inlineAuthorizationUrl, "SDK did not start inline hosted authorization");
+    const inlineCallback = await authorizeHostedApplicationByCreating(
+      inlineAuthorizationUrl,
+      emptyCookie,
+      inlineManifest.origin
+    );
+    await inlineSdk.completeAuthorization(inlineCallback);
+    const inlineToken = inlineStorage.token();
+    assert.equal(inlineToken.hosted.providerUrl, provider.url);
+    const inlineDescription = await inlineSdk.describe();
+    assert.equal(inlineDescription.contracts[0]?.id, "tasknotes.task");
+  } finally {
+    await new Promise((resolveClose) => inlineManifest.server.close(resolveClose));
+  }
+
   assert.equal(
     (await rawRequest(provider.url, syncPath(collectionId, "sessions"), { method: "POST" })).status,
     401
@@ -1097,6 +1139,33 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
   }
 }
 
+async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, callbackOrigin) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const separator = cookie.indexOf("=");
+    assert.ok(separator > 0, "Development session cookie is malformed");
+    const context = await browser.newContext();
+    await context.addCookies([{
+      name: cookie.slice(0, separator),
+      value: cookie.slice(separator + 1),
+      url: new URL(authorizationUrl).origin
+    }]);
+    const page = await context.newPage();
+    await page.goto(authorizationUrl);
+    await expect(page.getByRole("heading", { name: "TaskNotes Inline E2E" })).toBeVisible();
+    const collection = page.getByLabel("Collection");
+    await expect(collection.locator("option")).toHaveCount(0);
+    await page.getByRole("button", { name: "Create an mdbase cloud collection" }).click();
+    await expect(collection.locator("option")).toHaveCount(1);
+    await expect(collection.locator("option:checked")).toHaveText("My tasks · mdbase cloud");
+    await page.getByRole("button", { name: "Allow access" }).click();
+    await page.waitForURL((url) => url.origin === callbackOrigin && url.searchParams.has("code"));
+    return page.url();
+  } finally {
+    await browser.close();
+  }
+}
+
 async function startPostgres() {
   await execute("docker", [
     "run", "--rm", "--detach", "--name", postgresContainer,
@@ -1357,7 +1426,10 @@ async function waitFor(action, message) {
   throw new Error(message);
 }
 
-async function openManifestServer() {
+async function openManifestServer({
+  name = "Hosted SDK E2E",
+  requirements = { contracts: [] }
+} = {}) {
   const server = createServer((_request, response) => {
     const address = server.address();
     if (!address || typeof address === "string") throw new Error("Manifest server is unavailable");
@@ -1365,10 +1437,10 @@ async function openManifestServer() {
     response.setHeader("content-type", "application/json");
     response.end(JSON.stringify({
       manifest_version: 1,
-      name: "Hosted SDK E2E",
+      name,
       homepage: origin,
       redirect_uris: [`${origin}/auth/mdbase/callback`],
-      requirements: { contracts: [] }
+      requirements
     }));
   });
   await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -258,6 +258,44 @@ describe("mdbase connect server", () => {
     expect(token.json().application_origin).toBe(new URL(manifestServer.redirectUri).origin);
     expect(token.json().refresh_token).toMatch(/^ref_/);
 
+    const nativeVerifier = "native-verifier-that-is-long-enough-for-pkce-00001";
+    const nativeAuthorization = await app.inject({
+      method: "GET",
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.nativeRedirectUri)}&code_challenge=${pkceChallenge(nativeVerifier)}&code_challenge_method=S256&state=native-state&operations=read`,
+      headers: { cookie }
+    });
+    expect(nativeAuthorization.statusCode).toBe(302);
+    const nativeRequestId = nativeAuthorization.headers.location!.split("/").at(-1)!;
+    const nativeApproved = await app.inject({
+      method: "POST",
+      url: `/v1/connectors/authorization-requests/${nativeRequestId}/approve`,
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: { collection_id: localCollectionId, operations: ["read"] }
+    });
+    expect(nativeApproved.statusCode).toBe(200);
+    const nativeStatus = await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${nativeRequestId}/status`,
+      headers: { cookie }
+    });
+    const nativeRedirect = new URL(nativeStatus.json().redirect_uri);
+    expect(nativeRedirect.protocol).toBe("localhost.workout:");
+    expect(nativeRedirect.searchParams.get("state")).toBe("native-state");
+    const nativeToken = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: nativeRedirect.searchParams.get("code")!,
+        client_id: applicationId,
+        redirect_uri: manifestServer.nativeRedirectUri,
+        code_verifier: nativeVerifier
+      }).toString()
+    });
+    expect(nativeToken.statusCode).toBe(200);
+    expect(nativeToken.json().application_origin).toBe(new URL(manifestServer.redirectUri).origin);
+
     const refreshed = await app.inject({
       method: "POST",
       url: "/oauth/token",
@@ -668,18 +706,20 @@ async function startManifestServer(
 ): Promise<{
   manifestUrl: string;
   redirectUri: string;
+  nativeRedirectUri: string;
   close(): Promise<void>;
 }> {
   const server = createServer((request, response) => {
     const address = server.address();
     if (!address || typeof address === "string") throw new Error("Manifest server is not listening.");
     const origin = `http://localhost:${address.port}`;
+    const nativeRedirectUri = "localhost.workout://auth/mdbase/callback";
     response.setHeader("content-type", "application/json");
     response.end(JSON.stringify({
       manifest_version: 1,
       name,
       homepage: origin,
-      redirect_uris: [`${origin}/auth/mdbase/callback`],
+      redirect_uris: [`${origin}/auth/mdbase/callback`, nativeRedirectUri],
       requirements,
       ...(provisions ? { provisions } : {})
     }));
@@ -691,6 +731,7 @@ async function startManifestServer(
   return {
     manifestUrl: `${origin}/.well-known/mdbase-app.json`,
     redirectUri: `${origin}/auth/mdbase/callback`,
+    nativeRedirectUri: "localhost.workout://auth/mdbase/callback",
     close: () => new Promise<void>((resolveClose, reject) => server.close((error) => error ? reject(error) : resolveClose()))
   };
 }

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -2022,13 +2022,15 @@ async function approveAuthorization(
 ): Promise<boolean> {
   const authorization = await db.query<{
     application_id: string;
+    application_homepage: string;
     requested_operations: string[];
     requirements: ApplicationRequirements;
     relay_protocol: number | null;
     application_public_key: string | null;
     redirect_uri: string;
   }>(
-    `SELECT ar.application_id, ar.requested_operations, a.requirements,
+    `SELECT ar.application_id, a.homepage AS application_homepage,
+            ar.requested_operations, a.requirements,
             ar.relay_protocol, ar.application_public_key, ar.redirect_uri
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id
@@ -2088,7 +2090,7 @@ async function approveAuthorization(
       JSON.stringify(input.operations),
       JSON.stringify(scope),
       encryption ? JSON.stringify(encryption) : null,
-      new URL(pending.redirect_uri).origin
+      applicationOriginForRedirect(pending.redirect_uri, pending.application_homepage)
     ]
   );
   await db.query(
@@ -2180,6 +2182,10 @@ async function approveHostedAuthorization(
     const allowedOrigin = ["http:", "https:"].includes(applicationUrl.protocol)
       ? applicationUrl.origin
       : undefined;
+    const applicationOrigin = applicationOriginForRedirect(
+      pending.redirect_uri,
+      pending.application_homepage
+    );
     replicaId = randomUUID();
     const bootstrapToken = randomToken("hsa");
     await provider.registerReplica(input.collectionId, {
@@ -2219,7 +2225,7 @@ async function approveHostedAuthorization(
         replicaId,
         JSON.stringify(operations),
         JSON.stringify(scope),
-        applicationUrl.origin
+        applicationOrigin
       ]
     );
     await connection.query(
@@ -2272,6 +2278,13 @@ function deniedAuthorizationRedirect(input: { redirect_uri: string; state: strin
   redirect.searchParams.set("error", "access_denied");
   if (input.state) redirect.searchParams.set("state", input.state);
   return redirect.href;
+}
+
+function applicationOriginForRedirect(redirectUri: string, homepage: string): string {
+  const redirect = new URL(redirectUri);
+  return ["http:", "https:"].includes(redirect.protocol)
+    ? redirect.origin
+    : new URL(homepage).origin;
 }
 
 async function createAuthorizationRedirect(

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -55,7 +55,7 @@ describe("hosted provider control client", () => {
     await expect(provider.revokeReplica("replica")).rejects.toEqual(
       new HostedProviderResponseError(409, "replica_conflict", "Replica already exists.")
     );
-    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("secret network detail"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("secret network detail"));
     await expect(provider.ready()).rejects.toBeInstanceOf(HostedProviderUnavailableError);
   });
 

--- a/services/server/src/manifest.test.ts
+++ b/services/server/src/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isPrivateAddress } from "./manifest.js";
+import { isNativeRedirectUri, isPrivateAddress } from "./manifest.js";
 
 describe("manifest network boundary", () => {
   it.each([
@@ -23,4 +23,29 @@ describe("manifest network boundary", () => {
     "allows public address %s",
     (address) => expect(isPrivateAddress(address)).toBe(false)
   );
+});
+
+describe("native manifest callbacks", () => {
+  it("accepts a reverse-domain private-use application scheme", () => {
+    expect(isNativeRedirectUri(
+      new URL("dev.tasknotes.app://auth/mdbase/callback"),
+      "tasknotes.dev"
+    )).toBe(true);
+  });
+
+  it("binds the private-use scheme to the manifest publisher", () => {
+    expect(isNativeRedirectUri(
+      new URL("com.example.app://auth/mdbase/callback"),
+      "tasknotes.dev"
+    )).toBe(false);
+  });
+
+  it.each([
+    "tasknotes://auth/callback",
+    "javascript://auth/callback",
+    "dev.tasknotes.app://user:secret@auth/callback",
+    "dev.tasknotes.app://auth/callback#fragment"
+  ])("rejects an unsafe native callback %s", (value) => {
+    expect(isNativeRedirectUri(new URL(value))).toBe(false);
+  });
 });

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -94,16 +94,44 @@ function validateManifestOrigins(source: URL, manifest: AppManifest, development
   if (homepage.origin !== source.origin) throw new Error("Manifest homepage must use the manifest origin.");
   for (const redirect of manifest.redirect_uris) {
     const redirectUrl = new URL(redirect);
-    if (redirectUrl.origin !== source.origin) {
-      throw new Error("Redirect URIs must use the manifest origin.");
+    if (redirectUrl.origin === source.origin) {
+      if (redirectUrl.protocol !== "https:" && !developmentOrigin) {
+        throw new Error("Web redirect URIs must use HTTPS.");
+      }
+      continue;
     }
-    if (redirectUrl.protocol !== "https:" && !developmentOrigin) {
-      throw new Error("Redirect URIs must use HTTPS.");
+    if (!isNativeRedirectUri(redirectUrl, source.hostname)) {
+      throw new Error("Redirect URIs must use the manifest origin or a private-use application scheme.");
     }
   }
   if (manifest.icon && new URL(manifest.icon).origin !== source.origin) {
     throw new Error("Manifest icons must use the manifest origin.");
   }
+}
+
+/**
+ * Native OAuth callbacks use an app-owned reverse-domain scheme. PKCE protects
+ * the authorization code if another installed application claims the same
+ * scheme, while the manifest keeps the callback bound to the web publisher's
+ * identity.
+ */
+export function isNativeRedirectUri(url: URL, publisherHostname?: string): boolean {
+  const scheme = url.protocol.slice(0, -1);
+  const publisherPrefix = publisherHostname
+    ?.toLowerCase()
+    .split(".")
+    .reverse()
+    .join(".");
+  return scheme.includes(".")
+    && /^[a-z][a-z0-9+.-]*$/.test(scheme)
+    && !["http", "https", "file", "javascript", "data"].includes(scheme)
+    && (!publisherPrefix
+      || scheme === publisherPrefix
+      || scheme.startsWith(`${publisherPrefix}.`))
+    && url.username === ""
+    && url.password === ""
+    && url.hostname.length > 0
+    && url.hash === "";
 }
 
 async function assertPublicHost(hostname: string, allowPrivate: boolean): Promise<void> {

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -1,7 +1,10 @@
 import { isIP } from "node:net";
 import { lookup } from "node:dns/promises";
 import type { ApplicationProvisions, ApplicationRequirements } from "@mdbase/connect-protocol";
+import { isNativeRedirectUri } from "@mdbase/connect-protocol";
 import { z } from "zod";
+
+export { isNativeRedirectUri };
 
 const contractSchema = z.object({
   id: z.string().trim().min(1).max(100).regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/),
@@ -107,31 +110,6 @@ function validateManifestOrigins(source: URL, manifest: AppManifest, development
   if (manifest.icon && new URL(manifest.icon).origin !== source.origin) {
     throw new Error("Manifest icons must use the manifest origin.");
   }
-}
-
-/**
- * Native OAuth callbacks use an app-owned reverse-domain scheme. PKCE protects
- * the authorization code if another installed application claims the same
- * scheme, while the manifest keeps the callback bound to the web publisher's
- * identity.
- */
-export function isNativeRedirectUri(url: URL, publisherHostname?: string): boolean {
-  const scheme = url.protocol.slice(0, -1);
-  const publisherPrefix = publisherHostname
-    ?.toLowerCase()
-    .split(".")
-    .reverse()
-    .join(".");
-  return scheme.includes(".")
-    && /^[a-z][a-z0-9+.-]*$/.test(scheme)
-    && !["http", "https", "file", "javascript", "data"].includes(scheme)
-    && (!publisherPrefix
-      || scheme === publisherPrefix
-      || scheme.startsWith(`${publisherPrefix}.`))
-    && url.username === ""
-    && url.password === ""
-    && url.hostname.length > 0
-    && url.hash === "";
 }
 
 async function assertPublicHost(hostname: string, allowPrivate: boolean): Promise<void> {


### PR DESCRIPTION
## Summary
- let applications create their first compatible mdbase-hosted collection directly in authorization
- expose refresh-aware hosted sync transport through the SDK for offline replicas and native mirrors
- support publisher-bound native callback schemes with PKCE and safe web-origin binding
- harden replay/conflict behavior and deterministic provider retry tests
- pin CI and production provider builds to mdbase-rs `46ea4776af4111db55bd79bf4e3a2b08486ad2bd`
- refresh reproducible Rust locks for the newer mdbase runtime foundation

## End-to-end coverage
- zero-compatible-collection browser creation -> OAuth -> SDK describe
- native callback authorization and token exchange
- hosted PostgreSQL provider lifecycle, mirrors, writer races, restart, restore, recovery, rotation, revocation, and tamper checks
- 10,002-record stress run: mutation p95 34.51 ms; snapshot 1.27 s; change-page p95 23.48 ms; warm-read p95 12.86 ms; warm-query p95 3.31 ms

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:sync`
- `pnpm e2e:provider`
- `MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT=10000 node scripts/hosted-provider-e2e.mjs`
- `pnpm e2e:oracle`
- `pnpm package:audit`
- production hosted-provider Docker build against the exact pinned mdbase-rs revision