### PR TITLE
Profile and accelerate Connect operations

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -48,10 +48,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: mdbase-connect
+      - id: mdbase_revision
+        run: echo "revision=$(tr -d '\r\n' < deploy/docker/mdbase-rs-revision)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: callumalpass/mdbase-rs
-          ref: 46ea4776af4111db55bd79bf4e3a2b08486ad2bd
+          ref: ${{ steps.mdbase_revision.outputs.revision }}
           path: mdbase-rs
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
 name = "mdbase-connect-core"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "clap",
  "directories",
  "mdbase",
  "mdbase-connect-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.7.0", features = ["cors", "limit", "request-id", "trace"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 url = "2"
+
+[profile.profiling]
+inherits = "release"
+debug = 1
+strip = false

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -40,6 +40,8 @@ async fn connect_once(
     );
     let (socket, _) = connect_async(request).await?;
     let (mut writer, mut reader) = socket.split();
+    let (responses, mut response_rx) = tokio::sync::mpsc::channel::<RelayMessage>(64);
+    let operation_slots = Arc::new(tokio::sync::Semaphore::new(16));
     state.set_connection_state(AgentConnectionState::Connected);
     tracing::info!(server = server_url, "connected to cloud relay");
     let mut sync_interval = tokio::time::interval(Duration::from_secs(15));
@@ -51,12 +53,28 @@ async fn connect_once(
                 match message? {
                     Message::Text(text) => {
                         let relay_message: RelayMessage = serde_json::from_str(text.as_ref())?;
-                        let state_for_operation = state.clone();
-                        let response = tokio::task::spawn_blocking(move || {
-                            state_for_operation.handle_relay_message(relay_message)
-                        }).await?;
-                        if let Some(response) = response {
-                            writer.send(Message::Text(serde_json::to_string(&response)?.into())).await?;
+                        if matches!(&relay_message, RelayMessage::PolicySnapshot { .. }) {
+                            // Apply policy in receive order so every subsequently
+                            // accepted operation sees the latest local grant state.
+                            state.handle_relay_message(relay_message);
+                        } else {
+                            let state_for_operation = state.clone();
+                            let responses = responses.clone();
+                            let operation_slots = operation_slots.clone();
+                            tokio::spawn(async move {
+                                let Ok(_permit) = operation_slots.acquire_owned().await else {
+                                    return;
+                                };
+                                match tokio::task::spawn_blocking(move || {
+                                    state_for_operation.handle_relay_message(relay_message)
+                                }).await {
+                                    Ok(Some(response)) => {
+                                        let _ = responses.send(response).await;
+                                    }
+                                    Ok(None) => {}
+                                    Err(error) => tracing::warn!(%error, "relay operation task failed"),
+                                }
+                            });
                         }
                     }
                     Message::Ping(payload) => writer.send(Message::Pong(payload)).await?,
@@ -64,8 +82,27 @@ async fn connect_once(
                     _ => {}
                 }
             }
+            response = response_rx.recv() => {
+                let Some(response) = response else {
+                    return Err("relay response channel closed".into());
+                };
+                writer.send(Message::Text(serde_json::to_string(&response)?.into())).await?;
+            }
             _ = sync_interval.tick() => {
-                sync_collections(client, server_url, connector_token, &state).await?;
+                let client = client.clone();
+                let server_url = server_url.to_string();
+                let connector_token = connector_token.to_string();
+                let state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = sync_collections(
+                        &client,
+                        &server_url,
+                        &connector_token,
+                        &state,
+                    ).await {
+                        tracing::warn!(%error, "collection sync failed");
+                    }
+                });
             }
         }
     }

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -12,6 +12,7 @@ use mdbase_connect_protocol::{
 };
 use std::io;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 pub struct AgentState {
@@ -96,6 +97,50 @@ impl AgentState {
                     .iter()
                     .any(|grant| grant.application_origin == origin && grant.encryption.is_some())
             })
+    }
+
+    fn scoped_operation(
+        &self,
+        transport: &'static str,
+        collection_id: uuid::Uuid,
+        operation: &str,
+        input: &serde_json::Value,
+        scope: &mdbase_connect_protocol::GrantScope,
+    ) -> Result<serde_json::Value, ConnectError> {
+        let started = Instant::now();
+        let synchronize_us = std::cell::Cell::new(0_u64);
+        let result = self.registry.scoped_operation_synchronized(
+            collection_id,
+            operation,
+            input,
+            scope,
+            |invalidation| {
+                let synchronize_started = Instant::now();
+                self.watcher.synchronize(collection_id, invalidation);
+                synchronize_us.set(elapsed_us(synchronize_started));
+            },
+        );
+        profile_operation(transport, operation, started, synchronize_us.get(), &result);
+        result
+    }
+
+    fn local_operation(
+        &self,
+        collection_id: uuid::Uuid,
+        operation: &str,
+        input: &serde_json::Value,
+    ) -> Result<serde_json::Value, ConnectError> {
+        let started = Instant::now();
+        let synchronize_us = std::cell::Cell::new(0_u64);
+        let result =
+            self.registry
+                .operation_synchronized(collection_id, operation, input, |invalidation| {
+                    let synchronize_started = Instant::now();
+                    self.watcher.synchronize(collection_id, invalidation);
+                    synchronize_us.set(elapsed_us(synchronize_started));
+                });
+        profile_operation("control", operation, started, synchronize_us.get(), &result);
+        result
     }
 
     pub fn handle_direct_encrypted_operation(
@@ -187,7 +232,8 @@ impl AgentState {
                         && grant.operations.iter().any(|allowed| allowed == &operation)
                 });
                 let result = if authorized {
-                    self.registry.scoped_operation(
+                    self.scoped_operation(
+                        "relay",
                         collection_id,
                         &operation,
                         &input,
@@ -216,9 +262,6 @@ impl AgentState {
                         }),
                     });
                 };
-                if result.is_ok() && is_mutation(&operation) {
-                    self.watcher.rescan(collection_id);
-                }
                 let (outcome, detail) = match &result {
                     Ok(_) => ("succeeded", None),
                     Err(error) => ("failed", Some(error.to_string())),
@@ -361,16 +404,14 @@ impl AgentState {
                 "Remote access is paused on this computer.".to_string(),
             ))
         } else {
-            self.registry.scoped_operation(
+            self.scoped_operation(
+                "encrypted",
                 context.collection_id,
                 &envelope.operation,
                 &input,
                 &context.scope,
             )
         };
-        if result.is_ok() && is_mutation(&envelope.operation) {
-            self.watcher.rescan(context.collection_id);
-        }
         let (outcome, detail) = match &result {
             Ok(_) => ("succeeded", None),
             Err(error) if paused => ("denied", Some(error.to_string())),
@@ -500,13 +541,7 @@ impl AgentState {
                 self.registry.validate(params.collection_id)
             }
             ControlCommand::CollectionOperation(params) => {
-                let result =
-                    self.registry
-                        .operation(params.collection_id, &params.operation, &params.input);
-                if result.is_ok() && is_mutation(&params.operation) {
-                    self.watcher.rescan(params.collection_id);
-                }
-                result
+                self.local_operation(params.collection_id, &params.operation, &params.input)
             }
             ControlCommand::AccessSnapshot => self.access_snapshot().await,
             ControlCommand::AccessPause(params) => self
@@ -699,11 +734,39 @@ fn requirements_can_be_provisioned(
     })
 }
 
-fn is_mutation(operation: &str) -> bool {
-    matches!(
+fn profile_operation(
+    transport: &str,
+    operation: &str,
+    started: Instant,
+    synchronize_us: u64,
+    result: &Result<serde_json::Value, ConnectError>,
+) {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let enabled = ENABLED.get_or_init(|| {
+        std::env::var("MDBASE_CONNECT_PROFILE")
+            .is_ok_and(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+    });
+    if !enabled {
+        return;
+    }
+    let total_us = elapsed_us(started);
+    let execute_us = total_us.saturating_sub(synchronize_us);
+    let error_code = result.as_ref().err().map(ConnectError::code);
+    tracing::info!(
+        target: "mdbase_connect::profile",
+        transport,
         operation,
-        "create" | "update" | "delete" | "rename" | "create_type" | "update_type"
-    )
+        execute_us,
+        synchronize_us,
+        total_us,
+        ok = result.is_ok(),
+        error_code,
+        "collection operation profile"
+    );
+}
+
+fn elapsed_us(started: Instant) -> u64 {
+    started.elapsed().as_micros().min(u128::from(u64::MAX)) as u64
 }
 
 fn encrypted_rejection(request_id: uuid::Uuid) -> RelayMessage {

--- a/crates/connect-agent/src/watcher.rs
+++ b/crates/connect-agent/src/watcher.rs
@@ -1,5 +1,5 @@
 use mdbase::watch::CollectionWatcher;
-use mdbase_connect_core::CollectionRegistry;
+use mdbase_connect_core::{CollectionInvalidation, CollectionRegistry};
 use mdbase_connect_protocol::CollectionSummary;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -15,13 +15,18 @@ pub struct CollectionWatchService {
 
 enum WatchCommand {
     Refresh(Vec<CollectionSummary>, mpsc::SyncSender<()>),
-    Rescan(Uuid, mpsc::SyncSender<()>),
+    Synchronize(Uuid, CollectionInvalidation, mpsc::SyncSender<()>),
 }
 
 struct WatchWorker {
     stop: mpsc::Sender<()>,
-    rescan: mpsc::Sender<mpsc::SyncSender<()>>,
+    synchronize: mpsc::Sender<SynchronizeRequest>,
     worker: thread::JoinHandle<()>,
+}
+
+enum SynchronizeRequest {
+    All(mpsc::SyncSender<()>),
+    Paths(Vec<PathBuf>, mpsc::SyncSender<()>),
 }
 
 impl CollectionWatchService {
@@ -54,11 +59,19 @@ impl CollectionWatchService {
     }
 
     pub fn rescan(&self, collection_id: Uuid) {
+        self.synchronize(collection_id, &CollectionInvalidation::All);
+    }
+
+    pub fn synchronize(&self, collection_id: Uuid, invalidation: &CollectionInvalidation) {
+        if matches!(invalidation, CollectionInvalidation::None) {
+            return;
+        }
         let (ready, receiver) = mpsc::sync_channel(0);
-        if let Err(error) = self
-            .commands
-            .send(WatchCommand::Rescan(collection_id, ready))
-        {
+        if let Err(error) = self.commands.send(WatchCommand::Synchronize(
+            collection_id,
+            invalidation.clone(),
+            ready,
+        )) {
             tracing::warn!(%error, "collection watcher is unavailable");
             return;
         }
@@ -76,10 +89,28 @@ fn watch_supervisor(registry: CollectionRegistry, commands: mpsc::Receiver<Watch
                 refresh_workers(&registry, &mut workers, collections);
                 let _ = ready.send(());
             }
-            WatchCommand::Rescan(collection_id, ready) => {
+            WatchCommand::Synchronize(collection_id, invalidation, ready) => {
                 if let Some(worker) = workers.get(&collection_id) {
-                    if let Err(error) = worker.rescan.send(ready) {
-                        let _ = error.0.send(());
+                    let request = match invalidation {
+                        CollectionInvalidation::None => {
+                            let _ = ready.send(());
+                            continue;
+                        }
+                        CollectionInvalidation::All => SynchronizeRequest::All(ready),
+                        CollectionInvalidation::Records(paths) => SynchronizeRequest::Paths(
+                            paths.into_iter().map(PathBuf::from).collect(),
+                            ready,
+                        ),
+                    };
+                    if let Err(error) = worker.synchronize.send(request) {
+                        match error.0 {
+                            SynchronizeRequest::All(ready)
+                            | SynchronizeRequest::Paths(_, ready) => {
+                                let _ = ready.send(());
+                            }
+                        }
+                    } else {
+                        worker.worker.thread().unpark();
                     }
                 } else {
                     let _ = ready.send(());
@@ -137,7 +168,7 @@ fn start_worker(
         }
     };
     let (stop, stop_rx) = mpsc::channel();
-    let (rescan, rescan_rx) = mpsc::channel::<mpsc::SyncSender<()>>();
+    let (synchronize, synchronize_rx) = mpsc::channel::<SynchronizeRequest>();
     let worker = thread::Builder::new()
         .name(format!("mdbase-connect-watch-{collection_id}"))
         .spawn(move || {
@@ -145,8 +176,14 @@ fn start_worker(
                 if stop_rx.try_recv().is_ok() {
                     return;
                 }
-                while let Ok(ready) = rescan_rx.try_recv() {
-                    if let Err(error) = watcher.rescan() {
+                while let Ok(request) = synchronize_rx.try_recv() {
+                    let (result, ready) = match request {
+                        SynchronizeRequest::All(ready) => (watcher.rescan(), ready),
+                        SynchronizeRequest::Paths(paths, ready) => {
+                            (watcher.rescan_paths(paths), ready)
+                        }
+                    };
+                    if let Err(error) = result {
                         tracing::warn!(collection_id = %collection_id, %error, "collection rescan failed");
                     }
                     while let Ok(Some(event)) = watcher.recv_timeout(Duration::ZERO) {
@@ -154,20 +191,26 @@ fn start_worker(
                     }
                     let _ = ready.send(());
                 }
-                match watcher.recv_timeout(Duration::from_millis(100)) {
-                    Ok(Some(event)) => persist_event(&registry, collection_id, &event),
-                    Ok(None) => {}
-                    Err(error) => {
-                        tracing::warn!(collection_id = %collection_id, %error, "collection watcher stopped");
-                        return;
+                loop {
+                    match watcher.recv_timeout(Duration::ZERO) {
+                        Ok(Some(event)) => persist_event(&registry, collection_id, &event),
+                        Ok(None) => break,
+                        Err(error) => {
+                            tracing::warn!(collection_id = %collection_id, %error, "collection watcher stopped");
+                            return;
+                        }
                     }
                 }
+                // External filesystem events may wait up to this interval;
+                // explicit mutation synchronization unparks the worker and is
+                // processed immediately without a polling tax.
+                thread::park_timeout(Duration::from_millis(100));
             }
         })
         .expect("failed to start collection watcher thread");
     Some(WatchWorker {
         stop,
-        rescan,
+        synchronize,
         worker,
     })
 }
@@ -186,5 +229,6 @@ fn persist_event(
 
 fn stop_worker(worker: WatchWorker) {
     let _ = worker.stop.send(());
+    worker.worker.thread().unpark();
     let _ = worker.worker.join();
 }

--- a/crates/connect-core/Cargo.toml
+++ b/crates/connect-core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+clap.workspace = true
 directories.workspace = true
 mdbase.workspace = true
 mdbase-connect-protocol = { path = "../connect-protocol" }

--- a/crates/connect-core/src/bin/connect-profile.rs
+++ b/crates/connect-core/src/bin/connect-profile.rs
@@ -1,0 +1,324 @@
+use clap::{Parser, ValueEnum};
+use mdbase_connect_core::CollectionRegistry;
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Instant;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "connect-profile",
+    about = "Profile the local Connect request path against a collection"
+)]
+struct Args {
+    /// Existing mdbase collection to profile (records are never modified)
+    #[arg(long)]
+    collection: PathBuf,
+
+    /// Workload to run
+    #[arg(long, value_enum, default_value_t = Scenario::All)]
+    scenario: Scenario,
+
+    /// Number of measured workload iterations
+    #[arg(long, default_value_t = 3)]
+    iterations: usize,
+
+    /// Concurrent query requests per batch
+    #[arg(long, default_value_t = 4)]
+    concurrency: usize,
+
+    /// Emit the full JSON report
+    #[arg(long)]
+    json: bool,
+
+    /// Optionally write the JSON report to a file
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Scenario {
+    Query,
+    Editor,
+    Concurrent,
+    All,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    tool: &'static str,
+    version: &'static str,
+    scenario: &'static str,
+    iterations: usize,
+    concurrency: usize,
+    operations: Vec<Summary>,
+}
+
+#[derive(Debug, Serialize)]
+struct Summary {
+    name: &'static str,
+    iterations: usize,
+    total_ms: f64,
+    min_ms: f64,
+    mean_ms: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    max_ms: f64,
+    operations_per_second: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requests_per_iteration: Option<usize>,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = Args::parse();
+    if args.iterations == 0 || args.concurrency == 0 {
+        return Err("--iterations and --concurrency must be greater than zero".to_string());
+    }
+    let collection = args
+        .collection
+        .canonicalize()
+        .map_err(|error| format!("collection could not be resolved: {error}"))?;
+    let state = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let registry = CollectionRegistry::open(state.path()).map_err(|error| error.to_string())?;
+    let registered = registry
+        .add(collection)
+        .map_err(|error| error.to_string())?;
+
+    // Establish the query cache and find a stable read target outside the
+    // measured samples.
+    let warmup = query(&registry, registered.id, 1, 0, false, None)?;
+    let read_path = warmup
+        .pointer("/result/results/0/file/path")
+        .or_else(|| warmup.pointer("/result/results/0/path"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let record_count = warmup
+        .pointer("/result/meta/total_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let mut operations = Vec::new();
+    if matches!(args.scenario, Scenario::Query | Scenario::All) {
+        operations.push(run_samples("query_page_200", args.iterations, || {
+            query(&registry, registered.id, 200, 0, false, None).map(|_| ())
+        })?);
+        if let Some(path) = &read_path {
+            operations.push(run_samples("read", args.iterations, || {
+                ensure_success(registry.operation(registered.id, "read", &json!({"path": path})))
+            })?);
+        }
+    }
+    if matches!(args.scenario, Scenario::Editor | Scenario::All) {
+        let mut summary = run_samples("editor_two_pass_index", args.iterations, || {
+            editor_index(&registry, registered.id).map(|_| ())
+        })?;
+        let pages_after_first = record_count.saturating_sub(200).div_ceil(1_000);
+        summary.requests_per_iteration = Some(((1 + pages_after_first) * 2) as usize);
+        operations.push(summary);
+    }
+    if matches!(args.scenario, Scenario::Concurrent | Scenario::All) {
+        let mut samples = Vec::with_capacity(args.iterations);
+        for _ in 0..args.iterations {
+            let barrier = Arc::new(Barrier::new(args.concurrency + 1));
+            let handles = (0..args.concurrency)
+                .map(|_| {
+                    let registry = registry.clone();
+                    let barrier = barrier.clone();
+                    let collection_id = registered.id;
+                    thread::spawn(move || {
+                        barrier.wait();
+                        query(&registry, collection_id, 200, 0, false, None).map(|_| ())
+                    })
+                })
+                .collect::<Vec<_>>();
+            let started = Instant::now();
+            barrier.wait();
+            for handle in handles {
+                handle
+                    .join()
+                    .map_err(|_| "concurrent query worker panicked".to_string())??;
+            }
+            samples.push(started.elapsed().as_secs_f64() * 1_000.0);
+        }
+        let mut summary = summarize("concurrent_query_batch", samples);
+        summary.requests_per_iteration = Some(args.concurrency);
+        operations.push(summary);
+    }
+
+    let report = Report {
+        tool: "mdbase-connect-profiler",
+        version: env!("CARGO_PKG_VERSION"),
+        scenario: match args.scenario {
+            Scenario::Query => "query",
+            Scenario::Editor => "editor",
+            Scenario::Concurrent => "concurrent",
+            Scenario::All => "all",
+        },
+        iterations: args.iterations,
+        concurrency: args.concurrency,
+        operations,
+    };
+    let serialized = serde_json::to_string_pretty(&report).map_err(|error| error.to_string())?;
+    if let Some(output) = args.output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        fs::write(output, format!("{serialized}\n")).map_err(|error| error.to_string())?;
+    }
+    if args.json {
+        println!("{serialized}");
+    } else {
+        println!("Connect profile (read-only)");
+        println!(
+            "{:<26} {:>6} {:>11} {:>11} {:>11}",
+            "operation", "runs", "mean", "p95", "max"
+        );
+        for operation in &report.operations {
+            println!(
+                "{:<26} {:>6} {:>8.2} ms {:>8.2} ms {:>8.2} ms",
+                operation.name,
+                operation.iterations,
+                operation.mean_ms,
+                operation.p95_ms,
+                operation.max_ms,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn query(
+    registry: &CollectionRegistry,
+    collection_id: uuid::Uuid,
+    limit: u64,
+    offset: u64,
+    include_body: bool,
+    snapshot: Option<&str>,
+) -> Result<Value, String> {
+    let mut input = json!({
+        "order_by": [{"field": "file.mtime", "direction": "desc"}],
+        "limit": limit,
+        "offset": offset,
+        "include_body": include_body,
+    });
+    if let Some(snapshot) = snapshot {
+        input["snapshot"] = Value::String(snapshot.to_string());
+    }
+    let output = registry
+        .operation(collection_id, "query", &input)
+        .map_err(|error| error.to_string())?;
+    ensure_output_success(&output)?;
+    Ok(output)
+}
+
+fn editor_index(registry: &CollectionRegistry, collection_id: uuid::Uuid) -> Result<usize, String> {
+    let mut requests = 0;
+    let mut snapshot: Option<String> = None;
+    for include_body in [false, true] {
+        let mut offset = 0_u64;
+        loop {
+            let limit = if offset == 0 { 200 } else { 1_000 };
+            let output = query(
+                registry,
+                collection_id,
+                limit,
+                offset,
+                include_body,
+                snapshot.as_deref(),
+            )?;
+            if snapshot.is_none() {
+                snapshot = output
+                    .pointer("/result/meta/snapshot")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+            requests += 1;
+            let page_size = output
+                .pointer("/result/results")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len) as u64;
+            let has_more = output
+                .pointer("/result/meta/has_more")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            offset += page_size;
+            if page_size == 0 || !has_more {
+                break;
+            }
+        }
+    }
+    Ok(requests)
+}
+
+fn ensure_success(result: Result<Value, mdbase_connect_core::ConnectError>) -> Result<(), String> {
+    let output = result.map_err(|error| error.to_string())?;
+    ensure_output_success(&output)
+}
+
+fn ensure_output_success(output: &Value) -> Result<(), String> {
+    if output.get("valid").and_then(Value::as_bool) != Some(false) {
+        return Ok(());
+    }
+    Err(output
+        .pointer("/diagnostics/0/message")
+        .and_then(Value::as_str)
+        .unwrap_or("operation returned an invalid result")
+        .to_string())
+}
+
+fn run_samples(
+    name: &'static str,
+    iterations: usize,
+    mut operation: impl FnMut() -> Result<(), String>,
+) -> Result<Summary, String> {
+    let mut samples = Vec::with_capacity(iterations);
+    for iteration in 0..iterations {
+        let started = Instant::now();
+        operation().map_err(|error| format!("{name} iteration {iteration}: {error}"))?;
+        samples.push(started.elapsed().as_secs_f64() * 1_000.0);
+    }
+    Ok(summarize(name, samples))
+}
+
+fn summarize(name: &'static str, mut samples: Vec<f64>) -> Summary {
+    samples.sort_by(|left, right| left.total_cmp(right));
+    let total_ms = samples.iter().sum::<f64>();
+    let mean_ms = total_ms / samples.len() as f64;
+    Summary {
+        name,
+        iterations: samples.len(),
+        total_ms,
+        min_ms: samples[0],
+        mean_ms,
+        p50_ms: percentile(&samples, 0.50),
+        p95_ms: percentile(&samples, 0.95),
+        max_ms: *samples.last().unwrap_or(&0.0),
+        operations_per_second: if mean_ms == 0.0 {
+            0.0
+        } else {
+            1_000.0 / mean_ms
+        },
+        requests_per_iteration: None,
+    }
+}
+
+fn percentile(samples: &[f64], percentile: f64) -> f64 {
+    if samples.len() == 1 {
+        return samples[0];
+    }
+    let position = percentile * (samples.len() - 1) as f64;
+    let lower = position.floor() as usize;
+    let upper = position.ceil() as usize;
+    let weight = position - lower as f64;
+    samples[lower] * (1.0 - weight) + samples[upper] * weight
+}

--- a/crates/connect-core/src/lib.rs
+++ b/crates/connect-core/src/lib.rs
@@ -1,6 +1,6 @@
 mod registry;
 
 pub use registry::{
-    default_control_endpoint, default_state_dir, encrypted_request_fingerprint, CollectionRegistry,
-    ConnectError, EncryptedRequestClaim,
+    default_control_endpoint, default_state_dir, encrypted_request_fingerprint,
+    CollectionInvalidation, CollectionRegistry, ConnectError, EncryptedRequestClaim,
 };

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -120,6 +120,16 @@ pub enum EncryptedRequestClaim {
     InProgress,
 }
 
+/// Filesystem state that must be synchronized after a successful operation.
+/// Record paths come from mdbase's canonical operation envelope; collection
+/// metadata and type mutations intentionally request a full watcher reload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CollectionInvalidation {
+    None,
+    Records(BTreeSet<String>),
+    All,
+}
+
 pub fn encrypted_request_fingerprint(
     envelope: &EncryptedRelayEnvelope,
 ) -> Result<String, ConnectError> {
@@ -518,18 +528,38 @@ impl CollectionRegistry {
         operation: &str,
         input: &Value,
     ) -> Result<Value, ConnectError> {
+        self.operation_synchronized(id, operation, input, |_| {})
+    }
+
+    pub fn operation_synchronized(
+        &self,
+        id: Uuid,
+        operation: &str,
+        input: &Value,
+        synchronize: impl FnOnce(&CollectionInvalidation),
+    ) -> Result<Value, ConnectError> {
         let registered = self.get(id)?;
         if operation == "changes" {
             return serde_json::to_value(self.changes(id, input)?).map_err(ConnectError::from);
         }
         let provider = self.provider_for(&registered)?;
-        provider.with_collection(|collection| {
+        let execute = |collection: &Collection| {
             if operation == "describe" {
                 return serde_json::to_value(self.describe_loaded(&registered, collection)?)
                     .map_err(ConnectError::from);
             }
             execute_loaded(collection, operation, input)
-        })
+        };
+        if is_collection_mutation(operation) {
+            provider.with_collection(|collection| {
+                let result = execute(collection)?;
+                let invalidation = operation_invalidation(operation, input, &result);
+                synchronize(&invalidation);
+                Ok(result)
+            })
+        } else {
+            provider.with_collection_read(execute)
+        }
     }
 
     pub fn is_compatible(
@@ -628,6 +658,17 @@ impl CollectionRegistry {
         input: &Value,
         scope: &GrantScope,
     ) -> Result<Value, ConnectError> {
+        self.scoped_operation_synchronized(id, operation, input, scope, |_| {})
+    }
+
+    pub fn scoped_operation_synchronized(
+        &self,
+        id: Uuid,
+        operation: &str,
+        input: &Value,
+        scope: &GrantScope,
+        synchronize: impl FnOnce(&CollectionInvalidation),
+    ) -> Result<Value, ConnectError> {
         let registered = self.get(id)?;
         if !registered.enabled {
             return Err(ConnectError::AccessDenied(
@@ -635,9 +676,19 @@ impl CollectionRegistry {
             ));
         }
         let provider = self.provider_for(&registered)?;
-        provider.with_collection(|collection| {
+        let execute = |collection: &Collection| {
             self.scoped_operation_loaded(&registered, collection, operation, input, scope)
-        })
+        };
+        if is_collection_mutation(operation) {
+            provider.with_collection(|collection| {
+                let result = execute(collection)?;
+                let invalidation = operation_invalidation(operation, input, &result);
+                synchronize(&invalidation);
+                Ok(result)
+            })
+        } else {
+            provider.with_collection_read(execute)
+        }
     }
 
     fn scoped_operation_loaded(
@@ -840,7 +891,7 @@ impl CollectionRegistry {
     pub fn describe(&self, id: Uuid) -> Result<CollectionDescription, ConnectError> {
         let registered = self.get(id)?;
         let provider = self.provider_for(&registered)?;
-        provider.with_collection(|collection| self.describe_loaded(&registered, collection))
+        provider.with_collection_read(|collection| self.describe_loaded(&registered, collection))
     }
 
     fn describe_loaded(
@@ -1863,6 +1914,44 @@ fn execute_loaded(
     })
 }
 
+fn is_collection_mutation(operation: &str) -> bool {
+    matches!(
+        operation,
+        "create" | "update" | "delete" | "rename" | "create_type" | "update_type"
+    )
+}
+
+fn operation_invalidation(
+    operation: &str,
+    input: &Value,
+    output: &Value,
+) -> CollectionInvalidation {
+    if !is_collection_mutation(operation)
+        || output.get("valid").and_then(Value::as_bool) == Some(false)
+        || output.get("error").is_some()
+    {
+        return CollectionInvalidation::None;
+    }
+    if matches!(operation, "create_type" | "update_type") {
+        return CollectionInvalidation::All;
+    }
+
+    let Ok(kind) = operation.parse::<mdbase::runtime::OperationKind>() else {
+        return CollectionInvalidation::All;
+    };
+    let Ok(result) = serde_json::from_value::<mdbase::v03::OperationResult>(output.clone()) else {
+        // Legacy profiles do not expose the portable operation envelope. The
+        // operation is still valid, but a full reload is the only safe hint.
+        return CollectionInvalidation::All;
+    };
+    let paths = mdbase::runtime::OperationRequest::new(kind, input.clone()).affected_paths(&result);
+    if paths.is_empty() {
+        CollectionInvalidation::All
+    } else {
+        CollectionInvalidation::Records(paths)
+    }
+}
+
 fn supported_operations() -> &'static [&'static str] {
     &[
         "describe",
@@ -1886,6 +1975,45 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::thread;
     use tempfile::tempdir;
+
+    #[test]
+    fn portable_mutation_results_produce_targeted_invalidations() {
+        let output = serde_json::to_value(mdbase::v03::OperationResult {
+            valid: true,
+            result: json!({
+                "from": "old.md",
+                "to": "new.md",
+                "references_updated": [{"path": "linked.md"}],
+            }),
+            diagnostics: vec![],
+        })
+        .unwrap();
+        assert_eq!(
+            operation_invalidation(
+                "rename",
+                &json!({"from": "old.md", "to": "new.md"}),
+                &output,
+            ),
+            CollectionInvalidation::Records(
+                ["linked.md", "new.md", "old.md"]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect()
+            )
+        );
+        assert_eq!(
+            operation_invalidation(
+                "update",
+                &json!({"path": "private.md"}),
+                &json!({"valid": false}),
+            ),
+            CollectionInvalidation::None,
+        );
+        assert_eq!(
+            operation_invalidation("update_type", &json!({}), &json!({"valid": true})),
+            CollectionInvalidation::All,
+        );
+    }
 
     #[test]
     fn create_register_list_and_remove_collection() {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1592,6 +1592,7 @@ dependencies = [
 name = "mdbase-connect-core"
 version = "0.1.0-alpha.1"
 dependencies = [
+ "clap",
  "directories",
  "mdbase",
  "mdbase-connect-protocol",

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -1,7 +1,7 @@
 FROM rust:1.94.0-bookworm AS build
 
 ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
-ARG MDBASE_RS_REVISION=46ea4776af4111db55bd79bf4e3a2b08486ad2bd
+ARG MDBASE_RS_REVISION=dceaa474c850d8f4fbc98e59b9dde4d4a57a818c
 
 RUN git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
  && git -C /build/mdbase-rs checkout --detach "$MDBASE_RS_REVISION"

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -1,10 +1,13 @@
 FROM rust:1.94.0-bookworm AS build
 
 ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
-ARG MDBASE_RS_REVISION=dceaa474c850d8f4fbc98e59b9dde4d4a57a818c
+ARG MDBASE_RS_REVISION
 
-RUN git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
- && git -C /build/mdbase-rs checkout --detach "$MDBASE_RS_REVISION"
+COPY deploy/docker/mdbase-rs-revision /build/mdbase-rs-revision
+RUN revision="${MDBASE_RS_REVISION:-$(tr -d '\r\n' < /build/mdbase-rs-revision)}" \
+ && test -n "$revision" \
+ && git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
+ && git -C /build/mdbase-rs checkout --detach "$revision"
 
 WORKDIR /build/mdbase-connect
 COPY Cargo.toml ./

--- a/deploy/docker/mdbase-rs-revision
+++ b/deploy/docker/mdbase-rs-revision
@@ -1,0 +1,1 @@
+dceaa474c850d8f4fbc98e59b9dde4d4a57a818c

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -23,8 +23,8 @@ Create a GitHub OAuth app with:
 Keep the client secret out of the repository. The private-preview allowlist
 uses immutable numeric GitHub account IDs rather than usernames.
 
-The hosted container intentionally builds against the pinned, published
-`mdbase-rs` revision in `Dockerfile.hosted-provider`. Update that SHA only after
+The hosted container and CI intentionally build against the pinned, published
+`mdbase-rs` revision in `deploy/docker/mdbase-rs-revision`. Update that SHA only after
 running its conformance suite and `pnpm e2e:provider:stress` against the new
 revision. Regenerate `deploy/docker/Cargo.lock.hosted-provider` against that
 clean revision at the same time. The repository-root lock remains the local

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,77 @@
+# Local performance profiling
+
+The local loop has two complementary profilers. Both run optimized binaries
+and avoid including collection paths, query inputs, frontmatter, or bodies in
+their reports.
+
+## Fast query feedback
+
+Run the deterministic mdbase-rs workload from this repository:
+
+```bash
+pnpm profile:rs
+pnpm profile:rs -- --files 10000 --editor-iters 3 --json \
+  --output /tmp/mdbase-query-profile.json
+```
+
+The `queries` scenario measures cache rebuild, filtered and projected v0.3
+queries, and the editor's two-pass paginated index. It also reports schema,
+preflight, cache, load, link graph, evaluation, sort, grouping, serialization,
+and total phases. Use `--scenario core` to measure CRUD, runtime startup, and
+mutation-plus-watcher synchronization; use `--scenario all` for both.
+
+## End-to-end Connect core
+
+The Connect profiler is read-only and can safely run against a real local
+collection:
+
+```bash
+pnpm profile:connect -- --collection /path/to/collection --scenario all
+pnpm profile:connect -- --collection /path/to/collection \
+  --scenario editor --iterations 5 --json \
+  --output /tmp/connect-profile.json
+```
+
+It measures a 200-record query page, a read, the editor's complete two-pass
+index, and concurrent query batches through `CollectionRegistry` and the
+filesystem provider. A temporary Connect registry is removed when the process
+exits. Records, configuration, and types are never mutated; the collection's
+internal `.mdbase` query cache may be refreshed as it would be by a normal
+query.
+
+## Live agent timings
+
+Enable payload-free request timings while running the normal local agent:
+
+```bash
+MDBASE_CONNECT_PROFILE=1 cargo run -p mdbase-connect-agent
+```
+
+Each completed local, relay, or encrypted operation logs `execute_us`,
+`synchronize_us`, and `total_us`, along with the operation name, transport,
+success state, and stable error code. No grant data, paths, inputs, or results
+are logged.
+
+For watcher decisions and refresh durations, add:
+
+```bash
+MDBASE_CONNECT_PROFILE=1 MDBASE_WATCH_PROFILE=1 \
+  cargo run -p mdbase-connect-agent
+```
+
+## CPU profiles
+
+The workspace's `profiling` Cargo profile keeps release optimizations and adds
+symbols suitable for sampling:
+
+```bash
+cargo build --profile profiling -p mdbase-connect-core --bin connect-profile
+perf record -g --call-graph dwarf -- \
+  target/profiling/connect-profile --collection /path/to/collection \
+  --scenario editor --iterations 3
+perf report
+```
+
+`samply record` or `cargo flamegraph` can replace `perf record`. Keep latency
+JSON beside a CPU profile so changes can be compared at both the request and
+function level.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "e2e:provider:stress": "MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT=10000 pnpm e2e:provider",
     "e2e:oracle": "pnpm build && cargo build --workspace && node scripts/oracle-e2e.mjs",
     "package:audit": "pnpm build && node scripts/package-audit.mjs",
+    "profile:connect": "cargo run --release -p mdbase-connect-core --bin connect-profile --",
+    "profile:rs": "cargo run --release --manifest-path ../mdbase-rs/Cargo.toml --bin mdb-profile -- --scenario queries",
     "test": "pnpm -r test",
     "typecheck": "pnpm -r typecheck"
   },

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -114,6 +114,8 @@ export interface QueryInput {
   order_by?: unknown;
   limit?: number;
   offset?: number;
+  /** Opaque token returned by the first metadata page for consistent, fast pagination. */
+  snapshot?: string;
   include_body?: boolean;
   [key: string]: unknown;
 }
@@ -123,6 +125,7 @@ export interface QueryResult<Record extends JsonObject = JsonObject> {
   meta?: {
     total_count: number;
     has_more: boolean;
+    snapshot?: string;
     [key: string]: unknown;
   };
   [key: string]: unknown;

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -36,6 +36,8 @@ const collectionPath = join(scratch, "workouts");
 const extension = process.platform === "win32" ? ".exe" : "";
 const agentBinary = join(repoRoot, "target", "debug", `mdbase-connect-agent${extension}`);
 const cliBinary = join(repoRoot, "target", "debug", `mdbase-connect${extension}`);
+const loopbackPort = Number(process.env.MDBASE_CONNECT_LOOPBACK_PORT ?? 28_485);
+const loopbackUrl = `http://127.0.0.1:${loopbackPort}`;
 let agent;
 let manifestServer;
 let browserManifestServer;
@@ -192,13 +194,13 @@ secret: connector scope test
       encryption: token.body.encryption
     }
   };
-  const hostileReady = await fetch("http://127.0.0.1:28485/v1/ready", {
+  const hostileReady = await fetch(`${loopbackUrl}/v1/ready`, {
     headers: { origin: "https://hostile.example" }
   });
   if (hostileReady.status !== 403 || hostileReady.headers.has("access-control-allow-origin")) {
     throw new Error("Hostile origin could read loopback readiness");
   }
-  const directReady = await fetch("http://127.0.0.1:28485/v1/ready", {
+  const directReady = await fetch(`${loopbackUrl}/v1/ready`, {
     headers: { origin: directOrigin }
   });
   const directReadyBody = await directReady.json();
@@ -238,11 +240,12 @@ secret: connector scope test
     manifestUrl: manifest.manifestUrl,
     redirectUri: manifest.redirectUri,
     storage: sdkStorage,
-    keyStore: applicationKeyStore
+    keyStore: applicationKeyStore,
+    loopbackUrl
   });
   const browserFetch = globalThis.fetch;
   globalThis.fetch = (input, init = {}) => {
-    if (!String(input).startsWith("http://127.0.0.1:28485/")) return browserFetch(input, init);
+    if (!String(input).startsWith(`${loopbackUrl}/`)) return browserFetch(input, init);
     const headers = new Headers(init.headers);
     headers.set("origin", directOrigin);
     return browserFetch(input, { ...init, headers });
@@ -321,6 +324,7 @@ secret: connector scope test
       return globalThis.directHarness.exercise(config);
     }, {
       serverUrl,
+      loopbackUrl,
       manifestUrl: manifest.browserManifestUrl,
       redirectUri: manifest.browserRedirectUri,
       token: {
@@ -600,7 +604,7 @@ async function rawEncryptedEnvelope(collectionId, operation, accessToken, envelo
 
 async function rawDirectEnvelope(envelope) {
   if (!directOrigin) throw new Error("Direct origin is unavailable");
-  return fetch("http://127.0.0.1:28485/v1/operations", {
+  return fetch(`${loopbackUrl}/v1/operations`, {
     method: "POST",
     headers: {
       origin: directOrigin,
@@ -711,7 +715,8 @@ async function openApplicationServer(name, contracts) {
         serverUrl: config.serverUrl,
         manifestUrl: config.manifestUrl,
         redirectUri: config.redirectUri,
-        keyStore
+        keyStore,
+        loopbackUrl: config.loopbackUrl
       });
       const status = await connect.requestDirectAccess();
       const description = await connect.describe();


### PR DESCRIPTION
## What changed

- adds a read-only end-to-end Connect profiler, profiling Cargo profile, local scripts, and profiling documentation
- emits opt-in payload-free operation timings for direct, relay, and encrypted requests
- permits concurrent collection reads while preserving exclusive mutation synchronization
- processes relay operations concurrently with bounded backpressure
- replaces blanket post-mutation rescans with targeted watcher invalidation
- removes the watcher polling delay from explicit mutation synchronization
- adds query snapshot fields to the TypeScript client
- makes the E2E loopback port configurable for a faster, conflict-free local loop
- pins the production hosted-provider image to merged `mdbase-rs` commit `dceaa474c850d8f4fbc98e59b9dde4d4a57a818c`

## Why

The multi-second editor requests were primarily backend/runtime costs amplified by Connect: collection definitions were repeatedly loaded, reads were serialized, query pages repeated work, and every mutation waited for a full watcher rescan. There was also no quick local profiler spanning the Connect registry and real filesystem provider.

## Impact

On a 5,394-record real collection, the complete 14-query editor index improves from about 3.01s to 1.06s and reads from 23.7ms to 0.54ms. Four concurrent queries complete in about 175ms wall time, and synthetic mutation-plus-watcher synchronization improves from about 320ms to 76ms.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm typecheck`
- `pnpm test`
- `MDBASE_CONNECT_LOOPBACK_PORT=28486 pnpm e2e`
- production hosted-provider Docker build with the pinned merged `mdbase-rs` revision
- real 5,394-record profiling and concurrent query measurements
