### PR TITLE
Add hosted multi-collection MCP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ application and contract adapter—not a collection kind or platform default.
   activity, tray operation, and launch-at-login.
 - `services/server`: Fastify control plane and transient relay backed by
   PostgreSQL.
+- `services/mcp`: separately deployed remote MCP gateway for Claude, ChatGPT,
+  and other OAuth-capable hosts. It maps one host connection to independently
+  approved collection grants and keeps its credentials in a separate database.
 - `crates/connect-hosted-provider`: encrypted PostgreSQL authority for hosted
   collections, with direct app operations and the versioned sync data plane.
 - `apps/portal`: deliberately small account, computer management, secure
@@ -133,6 +136,12 @@ The private hosted relay is defined by [`render.yaml`](render.yaml). See
 deployment, DNS, and verification checklist, and
 [`docs/google-auth.md`](docs/google-auth.md) for Google sign-in setup.
 
+The hosted MCP endpoint is `https://mcp.mdbase.dev/mcp`; users add that URL as
+a remote/custom connector and authorize their first collection through mdbase
+connect. The `add_connection` tool creates a short-lived approval link for each
+additional collection. See [`docs/mcp-gateway.md`](docs/mcp-gateway.md) for the
+trust boundary, development workflow, tools, and production checklist.
+
 ## Security status
 
 The local connector is the final authorization boundary: the server cannot
@@ -141,6 +150,12 @@ tokens are stored encrypted by Electron, and cloud tokens are hashed at rest.
 New SDK authorizations require encrypted relay protocol 3 by default. Operation
 inputs and results remain ciphertext at the control plane; identifiers,
 operation names, timing, and sizes remain visible.
+
+The MCP gateway is an authorized application endpoint, not part of the blind
+control plane. It decrypts local relay responses in memory so it can return
+them to the MCP host. It does not persist record payloads, local filesystem
+paths, or operation results. Its upstream tokens and P-256 private keys are
+encrypted under a deployment master key in a separate database.
 
 The same envelopes protect direct loopback operations. The connector requires
 the grant's exact browser origin, an exact loopback `Host`, non-simple JSON, and

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -1,0 +1,32 @@
+FROM node:24-bookworm-slim AS build
+
+RUN corepack enable
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/protocol/package.json packages/protocol/package.json
+COPY packages/client/package.json packages/client/package.json
+COPY services/mcp/package.json services/mcp/package.json
+
+RUN pnpm install --frozen-lockfile --filter @mdbase/connect-mcp...
+
+COPY packages/protocol packages/protocol
+COPY packages/client packages/client
+COPY services/mcp services/mcp
+
+RUN pnpm --filter @mdbase/connect-protocol build \
+ && pnpm --filter @mdbase/connect build \
+ && pnpm --filter @mdbase/connect-mcp build
+
+FROM node:24-bookworm-slim AS runtime
+
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=8790
+
+WORKDIR /app
+COPY --from=build /app /app
+
+EXPOSE 8790
+USER node
+CMD ["node", "services/mcp/dist/index.js"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,13 +8,16 @@ applications. Domain packages such as `@mdbase/tasknotes` interpret optional
 type extensions without adding TaskNotes behavior to the mdbase specification
 or the relay.
 
-Four trust zones make up the local-hosted path:
+Five trust zones make up the local-hosted path:
 
 1. An independently hosted frontend application.
 2. A hosted or self-hosted Connect control plane and transient relay.
 3. A user-owned connector agent with a browser-only loopback service and
    outbound network connections.
 4. User-owned mdbase collections on the local filesystem.
+5. Optional application gateways, such as the hosted MCP service, which act as
+   authorized Connect applications and translate an external protocol without
+   weakening the connector's exact grant.
 
 The connector is the authority for local data and policy. The server routes a
 request only when its access token and grant allow the operation. The connector
@@ -31,6 +34,9 @@ checks its local policy copy again before it opens a collection.
   control socket.
 - `connect-server` owns accounts, pairing, app discovery, grants, token
   issuance, audit metadata, and transient request routing.
+- `connect-mcp` owns MCP host OAuth sessions and encrypted upstream Connect
+  credentials. It uses one exact Connect grant per approved collection and
+  never shares a collection grant across MCP connection sets.
 - `@mdbase/connect` provides OAuth with PKCE, typed operation envelopes,
   collection discovery, end-to-end encrypted relay operations, and cursor-based
   subscriptions.

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -1,16 +1,20 @@
 # Private Render deployment
 
-The Render Blueprint provisions two public services in Singapore:
+The Render Blueprint provisions three public services in Singapore:
 
 - `mdbase-connect`, the account/control plane and transient encrypted relay;
 - `mdbase-connect-hosted-provider`, the Rust hosted data plane at
   `sync.mdbase.dev`.
+- `mdbase-mcp`, the remote MCP resource and OAuth server at
+  `mcp.mdbase.dev`.
 
-Each service has its own paid, private PostgreSQL database. Hosted record
+Each stateful boundary has its own paid, private PostgreSQL database. Hosted record
 payloads never pass through or persist in the control-plane database. The data
 plane database stores encrypted canonical records and change payloads; record
 paths use keyed lookup tokens. Render-generated 256-bit secrets bind the two
-services and protect the provider's wrapped per-collection data keys.
+services and protect the provider's wrapped per-collection data keys. The MCP
+database stores OAuth metadata plus encrypted Connect tokens and private grant
+keys; it never stores collection records or operation results.
 
 ## Before creating the Blueprint
 
@@ -47,10 +51,15 @@ empty Google allowlist rejects all Google accounts and logs the verified
 subject needed to bootstrap the first invitation. Leaving both unset keeps the
 existing GitHub-only preview unchanged.
 
-The Blueprint generates the provider internal token and master key. Do not
+The Blueprint generates the provider internal token, provider master key, and
+MCP master key. Do not
 replace the master key on an existing provider database: startup deliberately
 fails if it cannot decrypt the durable key check. Key rotation must rewrap every
 collection data key transactionally before the old key is retired.
+
+Do not replace `MDBASE_MCP_MASTER_KEY` on an existing MCP database either.
+Current gateway credentials are encrypted under that value; changing it forces
+every host connection and collection grant to be authorized again.
 
 Both databases deny public network connections. The hosted database uses paid
 PostgreSQL 18 with storage autoscaling and point-in-time recovery. Automatic
@@ -63,6 +72,7 @@ Attach and verify both DNS names before testing browser OAuth:
 
 - `connect.mdbase.dev` → control-plane Render hostname
 - `sync.mdbase.dev` → hosted-provider Render hostname
+- `mcp.mdbase.dev` → MCP gateway Render hostname
 
 Render terminates TLS. The control plane refuses a non-HTTPS public origin, and
 the provider binds browser capabilities to each application's exact manifest
@@ -73,7 +83,7 @@ collection-scoped replica credential.
 
 Before any invitation:
 
-1. Confirm `/health` and `/ready` on both services.
+1. Confirm `/health` and `/ready` on all three services.
 2. Sign in through GitHub and create a hosted mdbase collection.
 3. Authorize the current `mdbase-editor` build and perform create, read, query,
    update, rename, and delete operations.

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -1,0 +1,143 @@
+# Hosted MCP gateway
+
+## Purpose and boundary
+
+`services/mcp` is the deployable `mdbase-mcp` service. It gives OAuth-capable
+MCP hosts one remote endpoint:
+
+```text
+https://mcp.mdbase.dev/mcp
+```
+
+It remains in the `mdbase-connect` repository because its upstream grants,
+relay cryptography, and request path must stay compatible with Connect. It is a
+separate deployment and database because it terminates application-side relay
+encryption and can see operation inputs and results in memory. The Connect
+control plane remains payload-blind.
+
+The gateway persists only:
+
+- MCP OAuth clients, access tokens, refresh tokens, and connection-set IDs;
+- collection IDs, display names, exact operations, and contract scopes;
+- encrypted upstream Connect credentials;
+- encrypted P-256 private keys and monotonic relay counters.
+
+It does not persist record payloads, operation results, collection-relative
+record paths, or local filesystem paths. Local filesystem paths are never sent
+to either the gateway or the Connect control plane.
+
+## Authorization flow
+
+The gateway implements Streamable HTTP MCP, OAuth 2.1-style authorization code
+with PKCE, Dynamic Client Registration, authorization-server metadata, and
+OAuth Protected Resource Metadata.
+
+1. An MCP host connects to `/mcp` and receives an OAuth resource challenge.
+2. The host dynamically registers and starts the gateway OAuth flow.
+3. The gateway redirects to the existing mdbase connect authorization screen.
+4. The user chooses one collection and its exact operations.
+5. Connect issues one collection-scoped capability to the gateway.
+6. The gateway issues the MCP host a capability for that new connection set.
+
+`add_connection` creates a random, single-use browser link valid for ten
+minutes. Following it repeats steps 3–5 and adds one independently approved
+collection to the same set. Every tool call still requires the opaque
+`connection_id`; there is no implicit cross-collection query or write.
+
+Revoking or narrowing the application grant in mdbase connect remains the final
+authorization control. The local connector independently enforces its cached
+exact grant before opening a local collection.
+
+## Tools
+
+Read access provides:
+
+- `list_connections`, `add_connection`, and `describe_collection`;
+- `list_changes`, `query_records`, `read_record`, and `validate_collection`;
+- `read_type`.
+
+When the MCP OAuth grant includes `mdbase:write`, the gateway also advertises:
+
+- `create_record`, `update_record`, `delete_record`, and `rename_record`;
+- `create_type` and `update_type`.
+
+The Connect grant may be narrower than the MCP OAuth scope. In that case the
+gateway rejects an unavailable operation and tells the user to reconnect with
+broader collection access; it never expands the upstream grant itself.
+
+## Local development
+
+Run both TypeScript services directly on the host so each loopback origin can
+fetch the other's development manifest:
+
+```bash
+MDBASE_CONNECT_DEV_AUTH=1 \
+MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS=1 \
+DATABASE_URL=memory \
+PUBLIC_URL=http://127.0.0.1:8787 \
+pnpm --filter @mdbase/connect-server dev
+```
+
+In another terminal:
+
+```bash
+MDBASE_MCP_MASTER_KEY=local-development-master-key-change-me \
+MDBASE_CONNECT_URL=http://127.0.0.1:8787 \
+DATABASE_URL=memory \
+PUBLIC_URL=http://127.0.0.1:8790 \
+pnpm --filter @mdbase/connect-mcp dev
+```
+
+The local connector still points at `http://127.0.0.1:8787`. Generic MCP
+clients point at `http://127.0.0.1:8790/mcp`. A hosted Claude or ChatGPT service
+cannot reach a loopback development URL; use a secure development tunnel when
+testing those hosts.
+
+## Runtime configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `PUBLIC_URL` | Exact public MCP origin, with no path |
+| `DATABASE_URL` | Gateway-only PostgreSQL connection |
+| `MDBASE_CONNECT_URL` | Exact Connect control-plane origin |
+| `MDBASE_MCP_MASTER_KEY` | Stable random secret, at least 32 characters |
+| `MDBASE_MCP_TRUST_PROXY` | `1` only behind the trusted production proxy |
+| `HOST`, `PORT` | Listener address; defaults are `127.0.0.1:8790` |
+
+The master key is not recoverable from the database. Back it up in the hosting
+provider's secret store. Rotating it without a credential re-encryption
+migration requires users to reconnect. Startup verifies a durable encrypted
+marker and fails closed when the configured key does not match the database.
+
+## Production finalization
+
+The Render Blueprint already defines the `mdbase-mcp` service, its private
+PostgreSQL database, health check, migration command, generated master key, and
+`mcp.mdbase.dev` custom domain.
+
+After deploying the branch:
+
+1. In Render, create or update the Blueprint and confirm the MCP service and
+   `mdbase-mcp-db` are provisioned in the same region as Connect.
+2. Preserve the generated `MDBASE_MCP_MASTER_KEY`; do not regenerate it on
+   routine deploys.
+3. Add `mcp.mdbase.dev` as the service's custom domain. Render will show the
+   exact DNS target for that service.
+4. At the authoritative DNS provider, create a CNAME named `mcp` pointing to
+   that Render target. Remove any conflicting A, AAAA, or CNAME record first.
+5. Wait for Render to verify the domain and issue TLS before testing OAuth.
+6. Confirm these endpoints return success over HTTPS:
+   `/health`, `/ready`, `/.well-known/oauth-protected-resource/mcp`,
+   `/.well-known/oauth-authorization-server`, and
+   `/.well-known/mdbase-app.json`.
+7. Add `https://mcp.mdbase.dev/mcp` as a Claude custom connector or a ChatGPT
+   developer-mode app. Complete OAuth, approve one collection, call
+   `list_connections`, then use `add_connection` to approve a second.
+8. Revoke one collection grant in mdbase connect and verify its next tool call
+   fails while the other collection remains available.
+
+For a public launch, `MDBASE_CONNECT_REGISTRATION` must either be `open` or the
+intended users must be present in the configured identity-provider allowlists.
+Opening registration also requires the account lifecycle, privacy, support,
+monitoring, backup, and abuse-response gates described elsewhere in this
+repository.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,9 +29,12 @@ import {
 } from "./crypto.js";
 
 export {
+  decryptRelayResponse,
+  encryptRelayRequest,
   IndexedDbGrantKeyStore,
   MemoryGrantKeyStore,
   RelayCryptoError,
+  type RelayBinding,
   type GrantKeyRecord,
   type GrantKeyStore
 } from "./crypto.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,58 @@ importers:
 
   packages/ui: {}
 
+  services/mcp:
+    dependencies:
+      '@fastify/cors':
+        specifier: ^11.3.0
+        version: 11.3.0
+      '@fastify/formbody':
+        specifier: ^8.0.2
+        version: 8.0.2
+      '@fastify/helmet':
+        specifier: ^13.1.0
+        version: 13.1.0
+      '@fastify/rate-limit':
+        specifier: ^11.1.0
+        version: 11.1.0
+      '@mdbase/connect':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@mdbase/connect-protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
+      fastify:
+        specifier: ^5.10.0
+        version: 5.10.0
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+      pg-mem:
+        specifier: ^3.0.14
+        version: 3.0.14
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   services/server:
     dependencies:
       '@fastify/cookie':
@@ -629,6 +681,12 @@ packages:
   '@fontsource/azeret-mono@5.3.0':
     resolution: {integrity: sha512-Ag/+gN67fUry7i1yLlTnk16Rr1nnTQI2YefA/G7tYcCSr/+TC/ayMrE8Km7O0OKRgI/B5Mfel46Gq9IGY50Uaw==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@inquirer/checkbox@3.0.1':
     resolution: {integrity: sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==}
     engines: {node: '>=18'}
@@ -726,6 +784,16 @@ packages:
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1151,6 +1219,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -1254,6 +1326,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1285,6 +1361,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -1378,12 +1458,32 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-disposition@2.0.1:
     resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1392,6 +1492,10 @@ packages:
   cookie@2.0.1:
     resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
     engines: {node: '>=22'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -1482,6 +1586,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-installer-common@0.10.4:
     resolution: {integrity: sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q==}
     engines: {node: '>= 10.0.0'}
@@ -1515,6 +1622,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1598,12 +1709,24 @@ packages:
     resolution: {integrity: sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==}
     engines: {node: '>=6.0.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
@@ -1615,6 +1738,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1690,6 +1823,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -1709,6 +1846,14 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -1855,6 +2000,10 @@ packages:
     resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
     engines: {node: '>=18.0.0'}
 
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -1877,6 +2026,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   immutable@4.3.9:
     resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
 
@@ -1894,6 +2047,14 @@ packages:
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -1926,6 +2087,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
@@ -1956,6 +2120,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
@@ -1967,6 +2134,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify@1.3.0:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
@@ -2136,9 +2306,17 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   mem@4.3.0:
     resolution: {integrity: sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==}
     engines: {node: '>=6'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2154,6 +2332,10 @@ packages:
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -2266,6 +2448,10 @@ packages:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -2322,9 +2508,17 @@ packages:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
     engines: {node: '>=4'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-hash@2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -2337,6 +2531,10 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2389,6 +2587,10 @@ packages:
     resolution: {integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==}
     engines: {node: '>=0.10.0'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -2415,6 +2617,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@2.0.0:
     resolution: {integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==}
@@ -2527,6 +2732,10 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
@@ -2589,8 +2798,16 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2608,6 +2825,14 @@ packages:
   randexp@0.4.6:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
     engines: {node: '>=0.12'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -2705,6 +2930,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2748,9 +2977,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -2777,6 +3014,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2970,6 +3223,10 @@ packages:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
@@ -3002,6 +3259,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3017,6 +3278,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -3226,6 +3491,11 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3751,6 +4021,10 @@ snapshots:
 
   '@fontsource/azeret-mono@5.3.0': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.31)':
+    dependencies:
+      hono: 4.12.31
+
   '@inquirer/checkbox@3.0.1':
     dependencies:
       '@inquirer/core': 9.2.1
@@ -3889,6 +4163,28 @@ snapshots:
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
+
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.31)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.6.0(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      hono: 4.12.31
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -4245,6 +4541,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -4316,6 +4617,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0(supports-color@8.1.1):
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -4349,6 +4664,8 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  bytes@3.1.2: {}
 
   cacheable-lookup@5.0.4: {}
 
@@ -4436,13 +4753,28 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
   content-disposition@2.0.1: {}
 
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   cookie@2.0.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-dirname@0.1.0: {}
 
@@ -4532,6 +4864,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   electron-installer-common@0.10.4(supports-color@8.1.1):
     dependencies:
       '@electron/asar': 3.4.1
@@ -4603,6 +4937,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -4693,9 +5029,17 @@ snapshots:
 
   eta@3.5.0: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@1.0.0:
     dependencies:
@@ -4710,6 +5054,47 @@ snapshots:
   expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.6.0(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      express: 5.2.1(supports-color@8.1.1)
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1(supports-color@8.1.1):
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@8.1.1)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -4809,6 +5194,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4834,6 +5230,10 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -5034,6 +5434,8 @@ snapshots:
 
   helmet@8.3.0: {}
 
+  hono@4.12.31: {}
+
   hosted-git-info@2.8.9: {}
 
   http-cache-semantics@4.2.0: {}
@@ -5062,6 +5464,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   immutable@4.3.9: {}
 
   inflight@1.0.6:
@@ -5074,6 +5480,10 @@ snapshots:
   ini@2.0.0: {}
 
   interpret@3.1.1: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.4.0: {}
 
@@ -5095,6 +5505,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-stream@1.1.0: {}
 
   is-unicode-supported@0.1.0: {}
@@ -5115,6 +5527,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
@@ -5126,6 +5540,8 @@ snapshots:
       dequal: 2.0.3
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify@1.3.0:
     dependencies:
@@ -5290,11 +5706,15 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
   mem@4.3.0:
     dependencies:
       map-age-cleaner: 0.1.3
       mimic-fn: 2.1.0
       p-is-promise: 2.1.0
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -5306,6 +5726,10 @@ snapshots:
       picomatch: 2.3.2
 
   mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@3.0.0: {}
 
@@ -5371,6 +5795,8 @@ snapshots:
       railroad-diagrams: 1.0.0
       randexp: 0.4.6
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   nice-try@1.0.5: {}
@@ -5427,13 +5853,21 @@ snapshots:
     dependencies:
       path-key: 2.0.1
 
+  object-assign@4.1.1: {}
+
   object-hash@2.2.0: {}
+
+  object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
 
   obug@2.1.4: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -5477,6 +5911,8 @@ snapshots:
     dependencies:
       error-ex: 1.3.4
 
+  parseurl@1.3.3: {}
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -5493,6 +5929,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   path-type@2.0.0:
     dependencies:
@@ -5582,6 +6020,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
 
+  pkce-challenge@5.0.1: {}
+
   playwright-core@1.61.1: {}
 
   playwright@1.61.1:
@@ -5631,10 +6071,20 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
 
@@ -5648,6 +6098,15 @@ snapshots:
     dependencies:
       discontinuous-range: 1.0.0
       ret: 0.1.15
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -5760,6 +6219,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  router@2.2.0(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5794,10 +6263,35 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  serve-static@2.2.1(supports-color@8.1.1):
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.2: {}
 
@@ -5823,6 +6317,34 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -6001,6 +6523,12 @@ snapshots:
 
   type-fest@1.4.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.4.5: {}
 
   typescript@7.0.2:
@@ -6039,6 +6567,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
       browserslist: 4.28.6
@@ -6056,6 +6586,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
@@ -6233,5 +6765,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/render.yaml
+++ b/render.yaml
@@ -92,6 +92,39 @@ services:
       - key: MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS
         value: "0"
 
+  - type: web
+    name: mdbase-mcp
+    runtime: docker
+    repo: https://github.com/mdbase-dev/mdbase-connect
+    branch: main
+    plan: starter
+    region: singapore
+    dockerfilePath: ./deploy/docker/Dockerfile.mcp
+    dockerContext: .
+    preDeployCommand: node services/mcp/dist/migrate.js
+    healthCheckPath: /ready
+    maxShutdownDelaySeconds: 60
+    autoDeployTrigger: checksPass
+    domains:
+      - mcp.mdbase.dev
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: HOST
+        value: 0.0.0.0
+      - key: PUBLIC_URL
+        value: https://mcp.mdbase.dev
+      - key: DATABASE_URL
+        fromDatabase:
+          name: mdbase-mcp-db
+          property: connectionString
+      - key: MDBASE_CONNECT_URL
+        value: https://connect.mdbase.dev
+      - key: MDBASE_MCP_MASTER_KEY
+        generateValue: true
+      - key: MDBASE_MCP_TRUST_PROXY
+        value: "1"
+
 databases:
   - name: mdbase-connect-hosted-db
     region: singapore
@@ -109,4 +142,12 @@ databases:
     postgresMajorVersion: "17"
     databaseName: mdbase_connect
     user: mdbase_connect
+    ipAllowList: []
+
+  - name: mdbase-mcp-db
+    region: singapore
+    plan: basic-256mb
+    postgresMajorVersion: "17"
+    databaseName: mdbase_mcp
+    user: mdbase_mcp
     ipAllowList: []

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -17,6 +17,11 @@ import { MdbaseConnect } from "../packages/client/dist/index.js";
 process.env.NODE_ENV = "test";
 const run = promisify(execFile);
 const repoRoot = resolve(import.meta.dirname, "..");
+const loopbackPort = Number(process.env.MDBASE_CONNECT_E2E_LOOPBACK_PORT ?? 28_485);
+if (!Number.isInteger(loopbackPort) || loopbackPort < 1 || loopbackPort > 65_535) {
+  throw new Error("MDBASE_CONNECT_E2E_LOOPBACK_PORT must be a valid TCP port");
+}
+const loopbackUrl = `http://127.0.0.1:${loopbackPort}`;
 const { buildApp } = await import("../services/server/dist/app.js");
 const { createDatabase } = await import("../services/server/dist/db.js");
 const database = await createDatabase("memory");
@@ -192,13 +197,13 @@ secret: connector scope test
       encryption: token.body.encryption
     }
   };
-  const hostileReady = await fetch("http://127.0.0.1:28485/v1/ready", {
+  const hostileReady = await fetch(`${loopbackUrl}/v1/ready`, {
     headers: { origin: "https://hostile.example" }
   });
   if (hostileReady.status !== 403 || hostileReady.headers.has("access-control-allow-origin")) {
     throw new Error("Hostile origin could read loopback readiness");
   }
-  const directReady = await fetch("http://127.0.0.1:28485/v1/ready", {
+  const directReady = await fetch(`${loopbackUrl}/v1/ready`, {
     headers: { origin: directOrigin }
   });
   const directReadyBody = await directReady.json();
@@ -238,11 +243,12 @@ secret: connector scope test
     manifestUrl: manifest.manifestUrl,
     redirectUri: manifest.redirectUri,
     storage: sdkStorage,
-    keyStore: applicationKeyStore
+    keyStore: applicationKeyStore,
+    loopbackUrl
   });
   const browserFetch = globalThis.fetch;
   globalThis.fetch = (input, init = {}) => {
-    if (!String(input).startsWith("http://127.0.0.1:28485/")) return browserFetch(input, init);
+    if (!String(input).startsWith(`${loopbackUrl}/`)) return browserFetch(input, init);
     const headers = new Headers(init.headers);
     headers.set("origin", directOrigin);
     return browserFetch(input, { ...init, headers });
@@ -323,6 +329,7 @@ secret: connector scope test
       serverUrl,
       manifestUrl: manifest.browserManifestUrl,
       redirectUri: manifest.browserRedirectUri,
+      loopbackUrl,
       token: {
         accessToken: browserToken.body.access_token,
         refreshToken: browserToken.body.refresh_token,
@@ -539,7 +546,11 @@ async function cliJson(args) {
 }
 
 function startAgent(extraArgs) {
-  const child = spawn(agentBinary, ["--state-dir", stateDir, ...extraArgs], {
+  const child = spawn(agentBinary, [
+    "--state-dir", stateDir,
+    "--loopback-port", String(loopbackPort),
+    ...extraArgs
+  ], {
     cwd: repoRoot,
     stdio: ["ignore", "pipe", "pipe"]
   });
@@ -600,7 +611,7 @@ async function rawEncryptedEnvelope(collectionId, operation, accessToken, envelo
 
 async function rawDirectEnvelope(envelope) {
   if (!directOrigin) throw new Error("Direct origin is unavailable");
-  return fetch("http://127.0.0.1:28485/v1/operations", {
+  return fetch(`${loopbackUrl}/v1/operations`, {
     method: "POST",
     headers: {
       origin: directOrigin,
@@ -711,7 +722,8 @@ async function openApplicationServer(name, contracts) {
         serverUrl: config.serverUrl,
         manifestUrl: config.manifestUrl,
         redirectUri: config.redirectUri,
-        keyStore
+        keyStore,
+        loopbackUrl: config.loopbackUrl
       });
       const status = await connect.requestDirectAccess();
       const description = await connect.describe();

--- a/services/mcp/.env.example
+++ b/services/mcp/.env.example
@@ -1,0 +1,12 @@
+HOST=127.0.0.1
+PORT=8790
+PUBLIC_URL=http://127.0.0.1:8790
+DATABASE_URL=postgres://mdbase_mcp:replace-this-password@127.0.0.1:5432/mdbase_mcp
+MDBASE_CONNECT_URL=http://127.0.0.1:8787
+
+# Use a stable, randomly generated value of at least 32 characters. Changing
+# this value makes existing stored Connect credentials and grant keys unreadable.
+MDBASE_MCP_MASTER_KEY=local-development-master-key-change-me
+
+# Enable only behind a trusted reverse proxy such as Render.
+MDBASE_MCP_TRUST_PROXY=0

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@mdbase/connect-mcp",
+  "version": "0.1.0-alpha.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "migrate": "node dist/migrate.js",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.3.0",
+    "@fastify/formbody": "^8.0.2",
+    "@fastify/helmet": "^13.1.0",
+    "@fastify/rate-limit": "^11.1.0",
+    "@mdbase/connect": "workspace:*",
+    "@mdbase/connect-protocol": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "fastify": "^5.10.0",
+    "pg": "^8.22.0",
+    "pg-mem": "^3.0.14",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/pg": "^8.20.0",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+import type { McpRuntimeConfig } from "./config.js";
+import { SecretBox, pkceChallenge } from "./security.js";
+
+const applicationId = "10000000-0000-4000-8000-000000000001";
+const firstCollectionId = "20000000-0000-4000-8000-000000000001";
+const secondCollectionId = "20000000-0000-4000-8000-000000000002";
+const firstGrantId = "30000000-0000-4000-8000-000000000001";
+const secondGrantId = "30000000-0000-4000-8000-000000000002";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("mdbase MCP gateway", () => {
+  it("publishes OAuth metadata and challenges unauthenticated MCP requests", async () => {
+    const db = await createDatabase("memory");
+    const { app } = await buildApp({ db, config: testConfig() });
+    const metadata = await app.inject({ method: "GET", url: "/.well-known/oauth-protected-resource/mcp" });
+    expect(metadata.statusCode).toBe(200);
+    expect(metadata.json()).toMatchObject({
+      resource: "https://mcp.example/mcp",
+      authorization_servers: ["https://mcp.example"],
+      scopes_supported: ["mdbase:read", "mdbase:write"]
+    });
+    const denied = await app.inject({
+      method: "POST",
+      url: "/mcp",
+      payload: { jsonrpc: "2.0", id: 1, method: "tools/list" }
+    });
+    expect(denied.statusCode).toBe(401);
+    expect(denied.headers["www-authenticate"]).toContain("oauth-protected-resource/mcp");
+    await app.close();
+    await db.end();
+  });
+
+  it("authorizes a host, adds multiple collections, and routes MCP tools by connection ID", async () => {
+    const upstream = await fakeUpstream(globalThis.fetch);
+    vi.stubGlobal("fetch", upstream.fetch);
+    const db = await createDatabase("memory");
+    const { app, oauth, gateway } = await buildApp({ db, config: testConfig() });
+
+    const registration = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      payload: {
+        client_name: "Test MCP host",
+        redirect_uris: ["https://client.example/callback"],
+        token_endpoint_auth_method: "none"
+      }
+    });
+    expect(registration.statusCode).toBe(201);
+    const clientId = registration.json().client_id as string;
+    const verifier = "host-pkce-verifier-that-is-long-enough-for-s256-0001";
+    const authorization = await app.inject({
+      method: "GET",
+      url: `/oauth/authorize?${new URLSearchParams({
+        response_type: "code",
+        client_id: clientId,
+        redirect_uri: "https://client.example/callback",
+        code_challenge: pkceChallenge(verifier),
+        code_challenge_method: "S256",
+        state: "host-state",
+        scope: "mdbase:read mdbase:write",
+        resource: "https://mcp.example/mcp"
+      })}`
+    });
+    expect(authorization.statusCode).toBe(302);
+    const firstUpstream = new URL(authorization.headers.location!);
+    expect(firstUpstream.origin).toBe("https://connect.example");
+    expect(firstUpstream.searchParams.get("operations")).toContain("create");
+    expect(firstUpstream.searchParams.get("relay_protocol")).toBe("3");
+    upstream.applicationPublicKeys.push(firstUpstream.searchParams.get("application_public_key")!);
+
+    const firstCallback = await app.inject({
+      method: "GET",
+      url: `/oauth/connect/callback?${new URLSearchParams({
+        state: firstUpstream.searchParams.get("state")!,
+        code: "first-upstream-code"
+      })}`
+    });
+    expect(firstCallback.statusCode).toBe(302);
+    const hostCallback = new URL(firstCallback.headers.location!);
+    expect(hostCallback.origin).toBe("https://client.example");
+    expect(hostCallback.searchParams.get("state")).toBe("host-state");
+
+    const token = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: hostCallback.searchParams.get("code")!,
+        client_id: clientId,
+        redirect_uri: "https://client.example/callback",
+        code_verifier: verifier,
+        resource: "https://mcp.example/mcp"
+      }).toString()
+    });
+    expect(token.statusCode).toBe(200);
+    const originalRefreshToken = token.json().refresh_token as string;
+    const refreshed = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: originalRefreshToken,
+        client_id: clientId,
+        resource: "https://mcp.example/mcp"
+      }).toString()
+    });
+    expect(refreshed.statusCode).toBe(200);
+    const reusedRefresh = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      payload: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: originalRefreshToken,
+        client_id: clientId,
+        resource: "https://mcp.example/mcp"
+      }).toString()
+    });
+    expect(reusedRefresh.statusCode).toBe(400);
+    expect(reusedRefresh.json().error).toBe("invalid_grant");
+    const accessToken = refreshed.json().access_token as string;
+    const context = await oauth.authenticate(accessToken);
+    expect(context).not.toBeNull();
+
+    const addUrl = await oauth.createConnectionTicket(context!);
+    const additional = await app.inject({ method: "GET", url: `${new URL(addUrl).pathname}${new URL(addUrl).search}` });
+    expect(additional.statusCode).toBe(302);
+    const secondUpstream = new URL(additional.headers.location!);
+    upstream.applicationPublicKeys.push(secondUpstream.searchParams.get("application_public_key")!);
+    const secondCallback = await app.inject({
+      method: "GET",
+      url: `/oauth/connect/callback?${new URLSearchParams({
+        state: secondUpstream.searchParams.get("state")!,
+        code: "second-upstream-code"
+      })}`
+    });
+    expect(secondCallback.statusCode).toBe(200);
+    expect(secondCallback.body).toContain("Second collection");
+
+    const connections = await gateway.listConnections(context!.connectionSetId);
+    expect(connections.map((connection) => connection.display_name)).toEqual([
+      "First collection",
+      "Second collection"
+    ]);
+
+    const stored = await db.query<{ credentials_ciphertext: string }>(
+      "SELECT credentials_ciphertext FROM mcp_connections"
+    );
+    expect(stored.rows).toHaveLength(2);
+    expect(stored.rows.every((row) => !row.credentials_ciphertext.includes("upstream-access"))).toBe(true);
+
+    const address = await app.listen({ host: "127.0.0.1", port: 0 });
+    const client = new Client({ name: "gateway-test", version: "1.0.0" });
+    const transport = new StreamableHTTPClientTransport(new URL(`${address}/mcp`), {
+      requestInit: { headers: { authorization: `Bearer ${accessToken}` } }
+    });
+    await client.connect(transport);
+    const tools = await client.listTools();
+    expect(tools.tools.map((tool) => tool.name)).toContain("add_connection");
+    expect(tools.tools.map((tool) => tool.name)).toContain("create_record");
+    const listed = await client.callTool({ name: "list_connections", arguments: {} });
+    expect((listed.structuredContent as any).connections).toHaveLength(2);
+    const queried = await client.callTool({
+      name: "query_records",
+      arguments: { connection_id: connections[1].id, types: ["note"], limit: 10 }
+    });
+    expect(queried.structuredContent).toMatchObject({
+      valid: true,
+      result: { results: [{ path: "notes/second.md" }] }
+    });
+    expect(upstream.operationAuthorizations).toContain("Bearer hosted-access-two");
+    const localQuery = await client.callTool({
+      name: "query_records",
+      arguments: { connection_id: connections[0].id, types: ["note"], limit: 5 }
+    });
+    expect(localQuery.structuredContent).toMatchObject({
+      valid: true,
+      result: { results: [{ path: "notes/local.md" }] }
+    });
+    expect(upstream.localInputs).toContainEqual({ types: ["note"], limit: 5 });
+    expect(upstream.operationAuthorizations).toContain("Bearer upstream-access-one");
+
+    await client.close();
+    await app.close();
+    await db.end();
+  });
+});
+
+function testConfig(): McpRuntimeConfig {
+  return {
+    host: "127.0.0.1",
+    port: 8790,
+    publicUrl: "https://mcp.example",
+    connectUrl: "https://connect.example",
+    resource: "https://mcp.example/mcp",
+    masterKey: new SecretBox(Buffer.alloc(32, 7)),
+    trustProxy: false
+  };
+}
+
+async function fakeUpstream(realFetch: typeof fetch) {
+  const applicationPublicKeys: string[] = [];
+  const operationAuthorizations: string[] = [];
+  const localInputs: unknown[] = [];
+  const connectorKeys = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"]
+  ) as CryptoKeyPair;
+  const connectorPublicKey = Buffer.from(
+    await crypto.subtle.exportKey("raw", connectorKeys.publicKey)
+  ).toString("base64url");
+  const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+    if (url.href === "https://connect.example/v1/apps/discover") {
+      return Response.json({ application: { id: applicationId } });
+    }
+    if (url.href === "https://connect.example/oauth/token") {
+      const body = new URLSearchParams(String(init?.body));
+      const second = body.get("code") === "second-upstream-code";
+      return Response.json({
+        access_token: second ? "upstream-access-two" : "upstream-access-one",
+        refresh_token: second ? "upstream-refresh-two" : "upstream-refresh-one",
+        token_type: "Bearer",
+        expires_in: 3_600,
+        refresh_expires_in: 2_592_000,
+        collection_id: second ? secondCollectionId : firstCollectionId,
+        collection_name: second ? "Second collection" : "First collection",
+        operations: ["describe", "changes", "read", "query", "validate", "read_type", "create", "update", "delete", "rename", "create_type", "update_type"],
+        scope: { contracts: [] },
+        grant_id: second ? secondGrantId : firstGrantId,
+        encryption: second ? null : {
+          protocol_version: 3,
+          suite: "P256-HKDF-SHA256-AES256GCM",
+          key_id: "local-key-1",
+          scope_epoch: 1,
+          connector_id: "50000000-0000-4000-8000-000000000001",
+          collection_id: firstCollectionId,
+          application_public_key: applicationPublicKeys[0],
+          connector_public_key: connectorPublicKey
+        },
+        ...(second ? { hosted: {
+          provider_url: "https://sync.example",
+          replica_id: "40000000-0000-4000-8000-000000000002",
+          access_token: "hosted-access-two"
+        } } : {})
+      });
+    }
+    if (url.origin === "https://connect.example" && url.pathname.endsWith("/operations/query")) {
+      operationAuthorizations.push(new Headers(init?.headers).get("authorization")!);
+      const envelope = JSON.parse(String(init?.body));
+      const input = await decryptConnectorRequest(connectorKeys.privateKey, applicationPublicKeys[0], envelope);
+      localInputs.push(input);
+      const responseEnvelope = await encryptConnectorResponse(connectorKeys.privateKey, applicationPublicKeys[0], envelope, {
+        valid: true,
+        result: { results: [{ path: "notes/local.md", frontmatter: { title: "Local" }, types: ["note"] }] },
+        diagnostics: []
+      });
+      return Response.json({ envelope: responseEnvelope });
+    }
+    if (url.origin === "https://sync.example" && url.pathname.endsWith("/operations/query")) {
+      operationAuthorizations.push(new Headers(init?.headers).get("authorization")!);
+      return Response.json({
+        result: {
+          valid: true,
+          result: { results: [{ path: "notes/second.md", frontmatter: { title: "Second" }, types: ["note"] }] },
+          diagnostics: []
+        }
+      });
+    }
+    if (url.hostname === "127.0.0.1") return realFetch(input, init);
+    return Response.json({ error: { code: "unexpected_fetch", message: url.href } }, { status: 500 });
+  });
+  return { fetch: fetchMock, applicationPublicKeys, operationAuthorizations, localInputs };
+}
+
+async function decryptConnectorRequest(privateKey: CryptoKey, applicationPublicKey: string, envelope: any): Promise<unknown> {
+  const key = await relayKey(privateKey, applicationPublicKey, envelope, "request");
+  const plaintext = await crypto.subtle.decrypt({
+    name: "AES-GCM",
+    iv: nonce(envelope.counter),
+    additionalData: new TextEncoder().encode(relayAad(envelope, "request")),
+    tagLength: 128
+  }, key, Uint8Array.from(Buffer.from(envelope.ciphertext, "base64url")).buffer);
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+async function encryptConnectorResponse(privateKey: CryptoKey, applicationPublicKey: string, envelope: any, result: unknown) {
+  const key = await relayKey(privateKey, applicationPublicKey, envelope, "response");
+  const ciphertext = await crypto.subtle.encrypt({
+    name: "AES-GCM",
+    iv: nonce(envelope.counter),
+    additionalData: new TextEncoder().encode(relayAad(envelope, "response")),
+    tagLength: 128
+  }, key, new TextEncoder().encode(JSON.stringify({ ok: true, result })));
+  return {
+    ...envelope,
+    type: "encrypted_operation_response",
+    ciphertext: Buffer.from(ciphertext).toString("base64url")
+  };
+}
+
+async function relayKey(privateKey: CryptoKey, applicationPublicKey: string, envelope: any, direction: "request" | "response") {
+  const applicationPublic = await crypto.subtle.importKey(
+    "raw",
+    Uint8Array.from(Buffer.from(applicationPublicKey, "base64url")).buffer,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+  const shared = await crypto.subtle.deriveBits({ name: "ECDH", public: applicationPublic }, privateKey, 256);
+  const material = await crypto.subtle.importKey("raw", shared, "HKDF", false, ["deriveKey"]);
+  const salt = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(relayContext(envelope)));
+  return crypto.subtle.deriveKey({
+    name: "HKDF",
+    hash: "SHA-256",
+    salt,
+    info: new TextEncoder().encode(`mdbase-connect relay ${direction} key v3`)
+  }, material, { name: "AES-GCM", length: 256 }, false, direction === "request" ? ["decrypt"] : ["encrypt"]);
+}
+
+function relayContext(envelope: any): string {
+  return [
+    "mdbase-connect",
+    envelope.protocol_version,
+    envelope.suite,
+    envelope.grant_id,
+    envelope.application_id,
+    envelope.connector_id,
+    envelope.collection_id,
+    envelope.scope_epoch,
+    envelope.key_id
+  ].join("|");
+}
+
+function relayAad(envelope: any, direction: "request" | "response"): string {
+  return [relayContext(envelope), envelope.request_id, direction, envelope.operation, envelope.counter].join("|");
+}
+
+function nonce(counter: string): Uint8Array<ArrayBuffer> {
+  const value = new Uint8Array(new ArrayBuffer(12));
+  new DataView(value.buffer).setBigUint64(4, BigInt(counter), false);
+  return value;
+}

--- a/services/mcp/src/app.ts
+++ b/services/mcp/src/app.ts
@@ -1,0 +1,242 @@
+import Fastify, { LogController } from "fastify";
+import formbody from "@fastify/formbody";
+import helmet from "@fastify/helmet";
+import rateLimit from "@fastify/rate-limit";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { ZodError, z } from "zod";
+import type { DatabasePool } from "./db.js";
+import type { McpRuntimeConfig } from "./config.js";
+import { PostgresGrantKeyStore } from "./key-store.js";
+import { ConnectGateway } from "./connect.js";
+import { createMcpServer } from "./mcp.js";
+import { MCP_SCOPES, OAuthError, OAuthService } from "./oauth.js";
+import { verifyMasterKey } from "./security.js";
+
+interface BuildOptions {
+  db: DatabasePool;
+  config: McpRuntimeConfig;
+  revision?: string;
+}
+
+export async function buildApp(options: BuildOptions) {
+  const { config } = options;
+  await verifyMasterKey(options.db, config.masterKey);
+  const app = Fastify({
+    logger: process.env.NODE_ENV !== "test",
+    logController: new LogController({ disableRequestLogging: true }),
+    trustProxy: config.trustProxy,
+    bodyLimit: 2 * 1024 * 1024,
+    requestTimeout: 40_000
+  });
+  const keyStore = new PostgresGrantKeyStore(options.db, config.masterKey);
+  const gateway = new ConnectGateway(
+    options.db,
+    config.masterKey,
+    keyStore,
+    config.connectUrl,
+    `${config.publicUrl}/.well-known/mdbase-app.json`,
+    `${config.publicUrl}/oauth/connect/callback`
+  );
+  const oauth = new OAuthService(options.db, gateway, keyStore, config.publicUrl, config.resource);
+  const resourceMetadataUrl = `${config.publicUrl}/.well-known/oauth-protected-resource/mcp`;
+
+  await app.register(formbody);
+  await app.register(helmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'none'"],
+        baseUri: ["'none'"],
+        formAction: ["'none'"],
+        frameAncestors: ["'none'"],
+        styleSrc: ["'unsafe-inline'"]
+      }
+    },
+    crossOriginEmbedderPolicy: false
+  });
+  await app.register(rateLimit, { global: true, max: 300, timeWindow: "1 minute" });
+
+  app.setErrorHandler((error, request, reply) => {
+    if (error instanceof OAuthError) {
+      return reply.code(400).send({ error: error.code, error_description: error.message });
+    }
+    if (error instanceof ZodError) {
+      return reply.code(400).send({
+        error: "invalid_request",
+        error_description: "The request is invalid.",
+        issues: error.issues.map((issue) => ({ path: issue.path.join("."), message: issue.message }))
+      });
+    }
+    request.log.error({ err: error }, "MCP gateway request failed");
+    return reply.code(500).send({ error: "server_error", error_description: "The MCP gateway request failed." });
+  });
+
+  app.get("/health", async () => ({ ok: true, service: "mdbase-mcp", revision: options.revision ?? null }));
+  app.get("/ready", async (_request, reply) => {
+    try {
+      await options.db.query("SELECT 1");
+      return { ok: true };
+    } catch {
+      return reply.code(503).send({ ok: false });
+    }
+  });
+
+  app.get("/", async (_request, reply) => reply.type("text/html; charset=utf-8").send(page(
+    "mdbase",
+    "Connect Claude, ChatGPT, and other MCP clients to collections you explicitly approve in mdbase connect."
+  )));
+
+  app.get("/.well-known/mdbase-app.json", async () => ({
+    manifest_version: 1,
+    name: "mdbase",
+    homepage: config.publicUrl,
+    redirect_uris: [`${config.publicUrl}/oauth/connect/callback`],
+    requirements: { contracts: [] },
+    provisions: { types: [] }
+  }));
+
+  const protectedResourceMetadata = {
+    resource: config.resource,
+    authorization_servers: [config.publicUrl],
+    scopes_supported: MCP_SCOPES,
+    bearer_methods_supported: ["header"],
+    resource_name: "mdbase collections"
+  };
+  app.get("/.well-known/oauth-protected-resource", async () => protectedResourceMetadata);
+  app.get("/.well-known/oauth-protected-resource/mcp", async () => protectedResourceMetadata);
+  app.get("/.well-known/oauth-authorization-server", async () => ({
+    issuer: config.publicUrl,
+    authorization_endpoint: `${config.publicUrl}/oauth/authorize`,
+    token_endpoint: `${config.publicUrl}/oauth/token`,
+    registration_endpoint: `${config.publicUrl}/oauth/register`,
+    scopes_supported: MCP_SCOPES,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"]
+  }));
+
+  app.post("/oauth/register", async (request, reply) => {
+    const client = await oauth.registerClient(request.body);
+    return reply.code(201).send(client);
+  });
+
+  app.get("/oauth/authorize", async (request, reply) => {
+    const redirect = await oauth.beginAuthorization(request.query);
+    return reply.redirect(redirect);
+  });
+
+  app.post("/oauth/token", async (request) => oauth.exchangeToken(request.body));
+
+  app.get("/oauth/connect/callback", async (request, reply) => {
+    const query = z.object({
+      state: z.string().optional(),
+      code: z.string().optional(),
+      error: z.string().optional()
+    }).passthrough().parse(request.query);
+    const completed = await oauth.completeUpstream(query);
+    if (completed.redirect) return reply.redirect(completed.redirect);
+    if (completed.error) return reply.code(400).type("text/html; charset=utf-8").send(page("Access not added", completed.error));
+    return reply.type("text/html; charset=utf-8").send(page(
+      "Collection connected",
+      `${completed.connectionName ?? "The collection"} is now available. Return to your MCP application and list connections again.`
+    ));
+  });
+
+  app.get("/connections/new", async (request, reply) => {
+    const { ticket } = z.object({ ticket: z.string().min(1).max(200) }).parse(request.query);
+    const redirect = await oauth.consumeConnectionTicket(ticket);
+    return reply.redirect(redirect);
+  });
+
+  app.post("/mcp", async (request, reply) => {
+    const context = await authenticateRequest(request.headers.authorization, oauth);
+    if (!context) return unauthorized(reply, resourceMetadataUrl);
+    const server = createMcpServer(context, gateway, oauth);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true
+    });
+    try {
+      await server.connect(transport);
+      reply.hijack();
+      await transport.handleRequest(request.raw, reply.raw, request.body);
+    } catch (error) {
+      request.log.error({ err: error }, "MCP protocol request failed");
+      if (!reply.raw.headersSent) {
+        reply.raw.writeHead(500, { "content-type": "application/json" });
+        reply.raw.end(JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32603, message: "Internal server error" },
+          id: null
+        }));
+      }
+    } finally {
+      await transport.close().catch(() => undefined);
+      await server.close().catch(() => undefined);
+    }
+  });
+
+  for (const method of ["GET", "DELETE"] as const) {
+    app.route({
+      method,
+      url: "/mcp",
+      handler: async (request, reply) => {
+        const context = await authenticateRequest(request.headers.authorization, oauth);
+        if (!context) return unauthorized(reply, resourceMetadataUrl);
+        return reply.code(405).send({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Method not allowed for this stateless MCP server." },
+          id: null
+        });
+      }
+    });
+  }
+
+  return { app, oauth, gateway };
+}
+
+async function authenticateRequest(authorization: string | undefined, oauth: OAuthService) {
+  if (!authorization?.startsWith("Bearer ")) return null;
+  return oauth.authenticate(authorization.slice(7));
+}
+
+function unauthorized(reply: any, resourceMetadataUrl: string) {
+  reply.header(
+    "WWW-Authenticate",
+    `Bearer resource_metadata="${resourceMetadataUrl}", scope="${MCP_SCOPES.join(" ")}"`
+  );
+  return reply.code(401).send({
+    jsonrpc: "2.0",
+    error: { code: -32001, message: "Authorization required." },
+    id: null
+  });
+}
+
+function page(title: string, message: string): string {
+  return `<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)} · mdbase</title>
+<style>
+  :root { color: #20242b; background: #fff; font: 15px/1.55 system-ui, sans-serif; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; }
+  main { width: min(36rem, calc(100% - 3rem)); }
+  .brand { font: 600 14px ui-monospace, monospace; margin-bottom: 3rem; }
+  .dot { display: inline-block; width: 7px; height: 7px; margin-right: 8px; border-radius: 50%; background: #2873a5; }
+  h1 { margin: 0 0 .75rem; font-size: 1.55rem; }
+  p { margin: 0; max-width: 60ch; color: #66707c; }
+</style>
+<main><div class="brand"><span class="dot"></span>mdbase</div><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></main>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#39;"
+  })[character]!);
+}

--- a/services/mcp/src/config.ts
+++ b/services/mcp/src/config.ts
@@ -1,0 +1,58 @@
+import { SecretBox } from "./security.js";
+
+export interface McpRuntimeConfig {
+  host: string;
+  port: number;
+  publicUrl: string;
+  connectUrl: string;
+  resource: string;
+  masterKey: SecretBox;
+  trustProxy: boolean;
+}
+
+export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): McpRuntimeConfig {
+  const host = env.HOST?.trim() || "127.0.0.1";
+  const port = integer(env.PORT ?? "8790", "PORT", 1, 65_535);
+  const publicUrl = origin(env.PUBLIC_URL ?? `http://${host}:${port}`, "PUBLIC_URL");
+  const connectUrl = origin(env.MDBASE_CONNECT_URL ?? "http://127.0.0.1:8787", "MDBASE_CONNECT_URL");
+  const publicHost = new URL(publicUrl).hostname;
+  const connectHost = new URL(connectUrl).hostname;
+  if (new URL(publicUrl).protocol !== "https:" && !isLoopback(publicHost)) {
+    throw new Error("PUBLIC_URL must use HTTPS outside loopback development.");
+  }
+  if (new URL(connectUrl).protocol !== "https:" && !isLoopback(connectHost)) {
+    throw new Error("MDBASE_CONNECT_URL must use HTTPS outside loopback development.");
+  }
+  const masterKey = env.MDBASE_MCP_MASTER_KEY?.trim();
+  if (!masterKey) throw new Error("MDBASE_MCP_MASTER_KEY is required.");
+  return {
+    host,
+    port,
+    publicUrl,
+    connectUrl,
+    resource: `${publicUrl}/mcp`,
+    masterKey: SecretBox.fromSecret(masterKey),
+    trustProxy: env.MDBASE_MCP_TRUST_PROXY === "1"
+  };
+}
+
+function origin(value: string, name: string): string {
+  const url = new URL(value);
+  if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`${name} must be an origin without credentials, a path, a query, or a fragment.`);
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error(`${name} must use HTTP or HTTPS.`);
+  return url.origin;
+}
+
+function integer(value: string, name: string, minimum: number, maximum: number): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} must be an integer from ${minimum} through ${maximum}.`);
+  }
+  return parsed;
+}
+
+function isLoopback(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}

--- a/services/mcp/src/connect.ts
+++ b/services/mcp/src/connect.ts
@@ -1,0 +1,427 @@
+import { randomUUID } from "node:crypto";
+import {
+  decryptRelayResponse,
+  encryptRelayRequest,
+  type GrantKeyStore
+} from "@mdbase/connect";
+import type {
+  CollectionOperation,
+  EncryptedRelayOperationResponse,
+  GrantEncryption,
+  GrantScope
+} from "@mdbase/connect-protocol";
+import { z } from "zod";
+import type { DatabasePool } from "./db.js";
+import { SecretBox } from "./security.js";
+
+const grantEncryptionSchema = z.object({
+  protocol_version: z.literal(3),
+  suite: z.literal("P256-HKDF-SHA256-AES256GCM"),
+  key_id: z.string().min(1),
+  scope_epoch: z.number().int().positive(),
+  connector_id: z.uuid(),
+  collection_id: z.uuid(),
+  application_public_key: z.string().min(80),
+  connector_public_key: z.string().min(80)
+}).strict();
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  refresh_token: z.string().min(1),
+  token_type: z.literal("Bearer"),
+  expires_in: z.number().int().positive(),
+  refresh_expires_in: z.number().int().positive(),
+  collection_id: z.uuid(),
+  collection_name: z.string().trim().min(1).max(200).optional(),
+  operations: z.array(z.string()),
+  scope: z.object({
+    contracts: z.array(z.object({ id: z.string(), version: z.number().int().positive() }))
+  }),
+  grant_id: z.uuid(),
+  encryption: grantEncryptionSchema.nullable(),
+  hosted: z.object({
+    provider_url: z.url(),
+    replica_id: z.uuid(),
+    access_token: z.string().min(1)
+  }).optional()
+}).passthrough();
+
+type ConnectTokenResponse = z.infer<typeof tokenResponseSchema>;
+
+interface StoredCredentials {
+  accessToken: string;
+  refreshToken: string;
+  hosted?: {
+    providerUrl: string;
+    replicaId: string;
+    accessToken: string;
+  };
+}
+
+export interface ConnectionSummary {
+  id: string;
+  collection_id: string;
+  display_name: string;
+  operations: CollectionOperation[];
+  scope: GrantScope;
+  authority: "local" | "hosted";
+}
+
+interface ConnectionRow {
+  id: string;
+  connection_set_id: string;
+  upstream_url: string;
+  upstream_client_id: string;
+  collection_id: string;
+  grant_id: string;
+  display_name: string;
+  operations: CollectionOperation[];
+  scope: GrantScope;
+  encryption: GrantEncryption | null;
+  key_handle: string | null;
+  credentials_ciphertext: string;
+  access_expires_at: Date | string;
+  refresh_expires_at: Date | string;
+}
+
+export class ConnectGateway {
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly secrets: SecretBox,
+    private readonly keyStore: GrantKeyStore,
+    readonly connectUrl: string,
+    private readonly manifestUrl: string,
+    readonly callbackUrl: string
+  ) {}
+
+  async discoverApplication(): Promise<{ id: string }> {
+    const response = await fetch(`${this.connectUrl}/v1/apps/discover`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ manifest_url: this.manifestUrl })
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || typeof body?.application?.id !== "string") {
+      throw upstreamError(body, "Connect could not discover the MCP application.");
+    }
+    return { id: body.application.id };
+  }
+
+  async exchangeAuthorization(input: {
+    code: string;
+    verifier: string;
+    applicationId: string;
+    connectionSetId: string;
+    keyHandle: string;
+  }): Promise<ConnectionSummary> {
+    const response = await fetch(`${this.connectUrl}/oauth/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: input.code,
+        client_id: input.applicationId,
+        redirect_uri: this.callbackUrl,
+        code_verifier: input.verifier
+      })
+    });
+    const raw = await response.json().catch(() => null);
+    if (!response.ok) throw upstreamError(raw, "Connect authorization could not be completed.");
+    const token = tokenResponseSchema.parse(raw);
+    await this.assertTokenBinding(token, input.keyHandle, input.applicationId);
+    const connection = await this.saveConnection(input.connectionSetId, input.applicationId, input.keyHandle, token);
+    return summary(connection);
+  }
+
+  async listConnections(connectionSetId: string): Promise<ConnectionSummary[]> {
+    const result = await this.db.query<ConnectionRow>(
+      `SELECT id, connection_set_id, upstream_url, upstream_client_id, collection_id,
+              grant_id, display_name, operations, scope, encryption, key_handle,
+              credentials_ciphertext, access_expires_at, refresh_expires_at
+       FROM mcp_connections WHERE connection_set_id = $1 ORDER BY display_name, id`,
+      [connectionSetId]
+    );
+    return result.rows.map(summary);
+  }
+
+  async operation<Result>(
+    connectionSetId: string,
+    connectionId: string,
+    operation: CollectionOperation,
+    input: unknown
+  ): Promise<Result> {
+    let connection = await this.freshConnection(connectionSetId, connectionId, false);
+    if (!connection.operations.includes(operation)) {
+      throw new GatewayOperationError(
+        "insufficient_collection_access",
+        `${connection.display_name} was not approved for ${operation}. Reconnect it with broader access.`
+      );
+    }
+    let attempt = await this.sendOperation<Result>(connection, operation, input);
+    if (attempt.status === 401) {
+      connection = await this.freshConnection(connectionSetId, connectionId, true);
+      attempt = await this.sendOperation<Result>(connection, operation, input);
+    }
+    if (!attempt.ok) throw upstreamError(attempt.body, `The ${operation} operation failed.`);
+    if (!attempt.request) return attempt.body?.result as Result;
+    if (!connection.encryption || !connection.key_handle) {
+      throw new GatewayOperationError("missing_grant_key", "The encrypted collection grant is incomplete.");
+    }
+    const envelope = attempt.body?.envelope as EncryptedRelayOperationResponse | undefined;
+    if (!envelope) throw new GatewayOperationError("invalid_encrypted_response", "Connect returned no encrypted response.");
+    const decrypted = await decryptRelayResponse<Result>(
+      this.keyStore,
+      connection.key_handle,
+      {
+        grantId: connection.grant_id,
+        applicationId: connection.upstream_client_id,
+        encryption: connection.encryption
+      },
+      attempt.request,
+      envelope
+    );
+    if (!decrypted.ok) throw new GatewayOperationError(decrypted.error.code, decrypted.error.message);
+    return decrypted.result;
+  }
+
+  private async sendOperation<Result>(
+    connection: ConnectionRow,
+    operation: CollectionOperation,
+    input: unknown
+  ): Promise<{
+    ok: boolean;
+    status: number;
+    body: any;
+    request?: Awaited<ReturnType<typeof encryptRelayRequest>>;
+  }> {
+    const credentials = this.credentials(connection);
+    let request: Awaited<ReturnType<typeof encryptRelayRequest>> | undefined;
+    let body: unknown = input ?? {};
+    let url: string;
+    let bearer: string;
+    if (credentials.hosted) {
+      url = `${stripTrailingSlash(credentials.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(connection.collection_id)}/operations/${operation}`;
+      bearer = credentials.hosted.accessToken;
+    } else {
+      if (!connection.encryption || !connection.key_handle) {
+        throw new GatewayOperationError("encryption_required", "Local collection access requires an encrypted grant.");
+      }
+      request = await encryptRelayRequest(
+        this.keyStore,
+        connection.key_handle,
+        {
+          grantId: connection.grant_id,
+          applicationId: connection.upstream_client_id,
+          encryption: connection.encryption
+        },
+        operation,
+        input
+      );
+      body = request;
+      url = `${connection.upstream_url}/v1/collections/${encodeURIComponent(connection.collection_id)}/operations/${operation}`;
+      bearer = credentials.accessToken;
+    }
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearer}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(body)
+    });
+    return {
+      ok: response.ok,
+      status: response.status,
+      body: await response.json().catch(() => null),
+      request
+    };
+  }
+
+  private async freshConnection(setId: string, connectionId: string, force: boolean): Promise<ConnectionRow> {
+    const client = await this.db.connect();
+    try {
+      await client.query("BEGIN");
+      const selected = await client.query<ConnectionRow>(
+        `SELECT id, connection_set_id, upstream_url, upstream_client_id, collection_id,
+                grant_id, display_name, operations, scope, encryption, key_handle,
+                credentials_ciphertext, access_expires_at, refresh_expires_at
+         FROM mcp_connections WHERE id = $1 AND connection_set_id = $2 FOR UPDATE`,
+        [connectionId, setId]
+      );
+      let connection = selected.rows[0];
+      if (!connection) throw new GatewayOperationError("connection_not_found", "That collection connection is unavailable.");
+      if (!force && new Date(connection.access_expires_at).getTime() > Date.now() + 30_000) {
+        await client.query("COMMIT");
+        return connection;
+      }
+      if (new Date(connection.refresh_expires_at).getTime() <= Date.now()) {
+        throw new GatewayOperationError("connection_expired", `Reconnect ${connection.display_name} to continue.`);
+      }
+      const credentials = this.credentials(connection);
+      const response = await fetch(`${connection.upstream_url}/oauth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: credentials.refreshToken,
+          client_id: connection.upstream_client_id
+        })
+      });
+      const raw = await response.json().catch(() => null);
+      if (!response.ok) throw upstreamError(raw, `Reconnect ${connection.display_name} to continue.`);
+      const token = tokenResponseSchema.parse(raw);
+      if (token.collection_id !== connection.collection_id || token.grant_id !== connection.grant_id) {
+        throw new GatewayOperationError("authorization_changed", "Connect returned a different collection grant.");
+      }
+      await this.assertTokenBinding(token, connection.key_handle, connection.upstream_client_id);
+      const updated = await client.query<ConnectionRow>(
+        `UPDATE mcp_connections
+         SET display_name = $2, operations = $3::jsonb, scope = $4::jsonb,
+             encryption = $5::jsonb, credentials_ciphertext = $6,
+             access_expires_at = $7, refresh_expires_at = $8, updated_at = now()
+         WHERE id = $1
+         RETURNING id, connection_set_id, upstream_url, upstream_client_id, collection_id,
+                   grant_id, display_name, operations, scope, encryption, key_handle,
+                   credentials_ciphertext, access_expires_at, refresh_expires_at`,
+        [
+          connection.id,
+          token.collection_name ?? connection.display_name,
+          JSON.stringify(token.operations),
+          JSON.stringify(token.scope),
+          token.encryption ? JSON.stringify(token.encryption) : null,
+          this.secrets.encrypt(JSON.stringify(credentialsFromToken(token))),
+          new Date(Date.now() + token.expires_in * 1_000),
+          new Date(Date.now() + token.refresh_expires_in * 1_000)
+        ]
+      );
+      connection = updated.rows[0];
+      await client.query("COMMIT");
+      return connection;
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async assertTokenBinding(
+    token: ConnectTokenResponse,
+    keyHandle: string | null,
+    applicationId: string
+  ): Promise<void> {
+    if (token.hosted) return;
+    if (!token.encryption || !keyHandle) {
+      throw new GatewayOperationError("encryption_required", "Connect did not establish encrypted local access.");
+    }
+    const key = await this.keyStore.get(keyHandle);
+    if (!key || key.publicKey !== token.encryption.application_public_key) {
+      throw new GatewayOperationError("grant_key_mismatch", "Connect returned a grant for a different encryption key.");
+    }
+    if (token.encryption.connector_id.length === 0 || applicationId.length === 0) {
+      throw new GatewayOperationError("invalid_encryption_binding", "Connect returned an incomplete encryption binding.");
+    }
+  }
+
+  private async saveConnection(
+    setId: string,
+    applicationId: string,
+    keyHandle: string,
+    token: ConnectTokenResponse
+  ): Promise<ConnectionRow> {
+    const previous = await this.db.query<{ key_handle: string | null }>(
+      `SELECT key_handle FROM mcp_connections
+       WHERE connection_set_id = $1 AND upstream_url = $2 AND collection_id = $3`,
+      [setId, this.connectUrl, token.collection_id]
+    );
+    const previousKey = previous.rows[0]?.key_handle ?? null;
+    const storedKey = token.hosted ? null : keyHandle;
+    if (token.hosted) await this.keyStore.delete(keyHandle);
+    const result = await this.db.query<ConnectionRow>(
+      `INSERT INTO mcp_connections
+         (id, connection_set_id, upstream_url, upstream_client_id, collection_id,
+          grant_id, display_name, operations, scope, encryption, key_handle,
+          credentials_ciphertext, access_expires_at, refresh_expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10::jsonb, $11, $12, $13, $14)
+       ON CONFLICT(connection_set_id, upstream_url, collection_id) DO UPDATE
+       SET upstream_client_id = excluded.upstream_client_id,
+           grant_id = excluded.grant_id,
+           display_name = excluded.display_name,
+           operations = excluded.operations,
+           scope = excluded.scope,
+           encryption = excluded.encryption,
+           key_handle = excluded.key_handle,
+           credentials_ciphertext = excluded.credentials_ciphertext,
+           access_expires_at = excluded.access_expires_at,
+           refresh_expires_at = excluded.refresh_expires_at,
+           updated_at = now()
+       RETURNING id, connection_set_id, upstream_url, upstream_client_id, collection_id,
+                 grant_id, display_name, operations, scope, encryption, key_handle,
+                 credentials_ciphertext, access_expires_at, refresh_expires_at`,
+      [
+        randomUUID(),
+        setId,
+        this.connectUrl,
+        applicationId,
+        token.collection_id,
+        token.grant_id,
+        token.collection_name ?? `Collection ${token.collection_id.slice(0, 8)}`,
+        JSON.stringify(token.operations),
+        JSON.stringify(token.scope),
+        token.encryption ? JSON.stringify(token.encryption) : null,
+        storedKey,
+        this.secrets.encrypt(JSON.stringify(credentialsFromToken(token))),
+        new Date(Date.now() + token.expires_in * 1_000),
+        new Date(Date.now() + token.refresh_expires_in * 1_000)
+      ]
+    );
+    if (previousKey && previousKey !== storedKey) await this.keyStore.delete(previousKey);
+    return result.rows[0];
+  }
+
+  private credentials(connection: ConnectionRow): StoredCredentials {
+    return JSON.parse(this.secrets.decrypt(connection.credentials_ciphertext)) as StoredCredentials;
+  }
+}
+
+export class GatewayOperationError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+function credentialsFromToken(token: ConnectTokenResponse): StoredCredentials {
+  return {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    ...(token.hosted ? {
+      hosted: {
+        providerUrl: token.hosted.provider_url,
+        replicaId: token.hosted.replica_id,
+        accessToken: token.hosted.access_token
+      }
+    } : {})
+  };
+}
+
+function summary(connection: ConnectionRow): ConnectionSummary {
+  return {
+    id: connection.id,
+    collection_id: connection.collection_id,
+    display_name: connection.display_name,
+    operations: connection.operations,
+    scope: connection.scope,
+    authority: connection.encryption ? "local" : "hosted"
+  };
+}
+
+function upstreamError(body: any, fallback: string): GatewayOperationError {
+  return new GatewayOperationError(
+    typeof body?.error?.code === "string" ? body.error.code : "upstream_error",
+    typeof body?.error?.message === "string" ? body.error.message : fallback
+  );
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/$/, "");
+}

--- a/services/mcp/src/db.ts
+++ b/services/mcp/src/db.ts
@@ -1,0 +1,145 @@
+import pg, { type Pool, type QueryResult, type QueryResultRow } from "pg";
+
+export interface DatabaseQueryable {
+  query<Row extends QueryResultRow = any>(text: string, values?: unknown[]): Promise<QueryResult<Row>>;
+}
+
+export interface DatabaseConnection extends DatabaseQueryable {
+  release(): void;
+}
+
+export interface DatabasePool extends DatabaseQueryable {
+  connect(): Promise<DatabaseConnection>;
+  end(): Promise<void>;
+}
+
+export async function createDatabase(databaseUrl = process.env.DATABASE_URL): Promise<DatabasePool> {
+  let pool: DatabasePool;
+  if (!databaseUrl || databaseUrl === "memory") {
+    const { newDb } = await import("pg-mem");
+    const memory = newDb({ autoCreateForeignKeyIndices: true });
+    const adapter = memory.adapters.createPg();
+    pool = new adapter.Pool() as unknown as DatabasePool;
+  } else {
+    pool = new pg.Pool({ connectionString: databaseUrl }) as Pool;
+  }
+  await migrate(pool);
+  return pool;
+}
+
+export async function migrate(db: DatabaseQueryable): Promise<void> {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS mcp_settings (
+      key text PRIMARY KEY,
+      value text NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS mcp_clients (
+      id text PRIMARY KEY,
+      client_name text NOT NULL,
+      redirect_uris jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_connection_sets (
+      id uuid PRIMARY KEY,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_authorization_requests (
+      id uuid PRIMARY KEY,
+      client_id text NOT NULL REFERENCES mcp_clients(id) ON DELETE CASCADE,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      redirect_uri text NOT NULL,
+      state text,
+      code_challenge text NOT NULL,
+      resource text NOT NULL,
+      scopes jsonb NOT NULL,
+      expires_at timestamptz NOT NULL,
+      completed_at timestamptz,
+      denied_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_upstream_authorizations (
+      id uuid PRIMARY KEY,
+      state_hash text NOT NULL UNIQUE,
+      kind text NOT NULL CHECK (kind IN ('initial', 'additional')),
+      authorization_request_id uuid REFERENCES mcp_authorization_requests(id) ON DELETE CASCADE,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      scopes jsonb NOT NULL,
+      code_verifier text NOT NULL,
+      key_handle text NOT NULL,
+      expires_at timestamptz NOT NULL,
+      completed_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_grant_keys (
+      handle text PRIMARY KEY,
+      public_key text NOT NULL,
+      private_key_ciphertext text NOT NULL,
+      counter numeric(20, 0) NOT NULL DEFAULT 0,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_connections (
+      id uuid PRIMARY KEY,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      upstream_url text NOT NULL,
+      upstream_client_id uuid NOT NULL,
+      collection_id uuid NOT NULL,
+      grant_id uuid NOT NULL,
+      display_name text NOT NULL,
+      operations jsonb NOT NULL,
+      scope jsonb NOT NULL,
+      encryption jsonb,
+      key_handle text REFERENCES mcp_grant_keys(handle) ON DELETE SET NULL,
+      credentials_ciphertext text NOT NULL,
+      access_expires_at timestamptz NOT NULL,
+      refresh_expires_at timestamptz NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE(connection_set_id, upstream_url, collection_id)
+    );
+    CREATE TABLE IF NOT EXISTS mcp_authorization_codes (
+      id uuid PRIMARY KEY,
+      code_hash text NOT NULL UNIQUE,
+      client_id text NOT NULL REFERENCES mcp_clients(id) ON DELETE CASCADE,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      redirect_uri text NOT NULL,
+      code_challenge text NOT NULL,
+      resource text NOT NULL,
+      scopes jsonb NOT NULL,
+      expires_at timestamptz NOT NULL,
+      used_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_access_tokens (
+      id uuid PRIMARY KEY,
+      token_hash text NOT NULL UNIQUE,
+      client_id text NOT NULL REFERENCES mcp_clients(id) ON DELETE CASCADE,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      resource text NOT NULL,
+      scopes jsonb NOT NULL,
+      expires_at timestamptz NOT NULL,
+      revoked_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_refresh_tokens (
+      id uuid PRIMARY KEY,
+      token_hash text NOT NULL UNIQUE,
+      client_id text NOT NULL REFERENCES mcp_clients(id) ON DELETE CASCADE,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      resource text NOT NULL,
+      scopes jsonb NOT NULL,
+      expires_at timestamptz NOT NULL,
+      used_at timestamptz,
+      revoked_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS mcp_connection_tickets (
+      id uuid PRIMARY KEY,
+      token_hash text NOT NULL UNIQUE,
+      connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
+      scopes jsonb NOT NULL,
+      expires_at timestamptz NOT NULL,
+      used_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+}

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -1,0 +1,17 @@
+import { buildApp } from "./app.js";
+import { runtimeConfigFromEnv } from "./config.js";
+import { createDatabase } from "./db.js";
+
+const config = runtimeConfigFromEnv(process.env);
+const db = await createDatabase();
+const { app } = await buildApp({ db, config, revision: process.env.RENDER_GIT_COMMIT });
+
+await app.listen({ host: config.host, port: config.port });
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, async () => {
+    await app.close();
+    await db.end();
+    process.exit(0);
+  });
+}

--- a/services/mcp/src/key-store.test.ts
+++ b/services/mcp/src/key-store.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createDatabase } from "./db.js";
+import { PostgresGrantKeyStore } from "./key-store.js";
+import { SecretBox } from "./security.js";
+
+describe("PostgresGrantKeyStore", () => {
+  it("persists encrypted P-256 keys and advances counters atomically", async () => {
+    const db = await createDatabase("memory");
+    const store = new PostgresGrantKeyStore(db, new SecretBox(Buffer.alloc(32, 9)));
+    const created = await store.create("grant:test");
+    expect(created.publicKey).toMatch(/^[A-Za-z0-9_-]+$/);
+    const persisted = await db.query<{ private_key_ciphertext: string }>(
+      "SELECT private_key_ciphertext FROM mcp_grant_keys WHERE handle = $1",
+      ["grant:test"]
+    );
+    expect(persisted.rows[0].private_key_ciphertext).not.toContain(created.publicKey);
+    const loaded = await store.get("grant:test");
+    expect(loaded?.publicKey).toBe(created.publicKey);
+    expect(await Promise.all([store.nextCounter("grant:test"), store.nextCounter("grant:test")])).toEqual(["1", "2"]);
+    await store.delete("grant:test");
+    expect(await store.get("grant:test")).toBeNull();
+    await db.end();
+  });
+});

--- a/services/mcp/src/key-store.ts
+++ b/services/mcp/src/key-store.ts
@@ -1,0 +1,72 @@
+import type { GrantKeyRecord, GrantKeyStore } from "@mdbase/connect";
+import type { DatabasePool } from "./db.js";
+import { SecretBox } from "./security.js";
+
+const MAX_U64 = "18446744073709551615";
+
+export class PostgresGrantKeyStore implements GrantKeyStore {
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly secrets: SecretBox
+  ) {}
+
+  async create(handle: string): Promise<GrantKeyRecord> {
+    const generated = await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveBits"]
+    ) as CryptoKeyPair;
+    const publicKey = Buffer.from(await crypto.subtle.exportKey("raw", generated.publicKey)).toString("base64url");
+    const privatePkcs8 = Buffer.from(await crypto.subtle.exportKey("pkcs8", generated.privateKey));
+    await this.db.query(
+      `INSERT INTO mcp_grant_keys (handle, public_key, private_key_ciphertext)
+       VALUES ($1, $2, $3)`,
+      [handle, publicKey, this.secrets.encrypt(privatePkcs8.toString("base64url"))]
+    );
+    return {
+      handle,
+      publicKey,
+      privateKey: await importPrivateKey(privatePkcs8)
+    };
+  }
+
+  async get(handle: string): Promise<GrantKeyRecord | null> {
+    const result = await this.db.query<{ public_key: string; private_key_ciphertext: string }>(
+      "SELECT public_key, private_key_ciphertext FROM mcp_grant_keys WHERE handle = $1",
+      [handle]
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    const privatePkcs8 = Buffer.from(this.secrets.decrypt(row.private_key_ciphertext), "base64url");
+    return {
+      handle,
+      publicKey: row.public_key,
+      privateKey: await importPrivateKey(privatePkcs8)
+    };
+  }
+
+  async nextCounter(handle: string): Promise<string> {
+    const result = await this.db.query<{ counter: string }>(
+      `UPDATE mcp_grant_keys SET counter = counter + 1
+       WHERE handle = $1 AND counter < $2::numeric
+       RETURNING counter::text`,
+      [handle, MAX_U64]
+    );
+    if (!result.rows[0]) throw new Error("The encrypted grant key is missing or its counter is exhausted.");
+    return result.rows[0].counter;
+  }
+
+  async delete(handle: string): Promise<void> {
+    await this.db.query("DELETE FROM mcp_grant_keys WHERE handle = $1", [handle]);
+  }
+}
+
+function importPrivateKey(pkcs8: Buffer): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "pkcs8",
+    Uint8Array.from(pkcs8).buffer,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    ["deriveBits"]
+  );
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -1,0 +1,208 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CollectionOperation } from "@mdbase/connect-protocol";
+import { z } from "zod";
+import { ConnectGateway, GatewayOperationError } from "./connect.js";
+import { OAuthService, type McpAuthContext } from "./oauth.js";
+
+const connectionId = z.uuid().describe("Opaque connection ID returned by list_connections");
+const path = z.string().min(1).max(1_024).describe("Collection-relative record path");
+const revision = z.string().min(1).max(500);
+const object = z.record(z.string(), z.unknown());
+
+export function createMcpServer(
+  context: McpAuthContext,
+  gateway: ConnectGateway,
+  oauth: OAuthService
+): McpServer {
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-alpha.1" });
+
+  server.registerTool("list_connections", {
+    title: "List mdbase collections",
+    description: "List the mdbase collections approved for this connector. Use the returned connection_id on every collection operation.",
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, async () => toolResult({ connections: await gateway.listConnections(context.connectionSetId) }));
+
+  server.registerTool("add_connection", {
+    title: "Connect another mdbase collection",
+    description: "Create a short-lived browser link where the user can explicitly approve another collection and its permissions.",
+    annotations: { readOnlyHint: false, openWorldHint: true }
+  }, async () => {
+    const authorizationUrl = await oauth.createConnectionTicket(context);
+    return toolResult({
+      authorization_url: authorizationUrl,
+      expires_in: 600,
+      instruction: "Ask the user to open this link and approve a collection, then call list_connections again."
+    });
+  });
+
+  server.registerTool("describe_collection", {
+    title: "Describe an mdbase collection",
+    description: "Return collection metadata, supported operations, types and contracts.",
+    inputSchema: { connection_id: connectionId },
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, ({ connection_id }) => operationTool(gateway, context, connection_id, "describe", {}));
+
+  server.registerTool("list_changes", {
+    title: "List collection changes",
+    description: "List changes after an optional collection change cursor.",
+    inputSchema: {
+      connection_id: connectionId,
+      after: z.number().int().nonnegative().optional(),
+      limit: z.number().int().min(1).max(200).optional()
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "changes", input));
+
+  server.registerTool("query_records", {
+    title: "Query mdbase records",
+    description: "Query records in one approved collection. Filters use the collection's native mdbase query format.",
+    inputSchema: {
+      connection_id: connectionId,
+      types: z.array(z.string().min(1).max(200)).max(50).optional(),
+      where: z.unknown().optional(),
+      order_by: z.unknown().optional(),
+      limit: z.number().int().min(1).max(200).optional(),
+      offset: z.number().int().nonnegative().optional(),
+      include_body: z.boolean().optional()
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "query", input));
+
+  server.registerTool("read_record", {
+    title: "Read an mdbase record",
+    description: "Read one record by its collection-relative path.",
+    inputSchema: { connection_id: connectionId, path },
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, ({ connection_id, path }) => operationTool(gateway, context, connection_id, "read", { path }));
+
+  server.registerTool("validate_collection", {
+    title: "Validate an mdbase collection",
+    description: "Run collection validation. Optional input is passed to the collection's validation operation.",
+    inputSchema: { connection_id: connectionId, input: object.optional() },
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, ({ connection_id, input }) => operationTool(gateway, context, connection_id, "validate", input ?? {}));
+
+  server.registerTool("read_type", {
+    title: "Read an mdbase type",
+    description: "Read a type definition by name or collection-relative path.",
+    inputSchema: {
+      connection_id: connectionId,
+      name: z.string().min(1).max(200).optional(),
+      path: path.optional()
+    },
+    annotations: { readOnlyHint: true, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "read_type", input));
+
+  if (context.scopes.includes("mdbase:write")) registerWriteTools(server, context, gateway);
+  return server;
+}
+
+function registerWriteTools(server: McpServer, context: McpAuthContext, gateway: ConnectGateway): void {
+  server.registerTool("create_record", {
+    title: "Create an mdbase record",
+    description: "Create a record in one approved collection.",
+    inputSchema: {
+      connection_id: connectionId,
+      path: path.optional(),
+      type: z.string().min(1).max(200).optional(),
+      frontmatter: object,
+      body: z.string().max(2_000_000).optional(),
+      if_revision: revision.optional()
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "create", input));
+
+  server.registerTool("update_record", {
+    title: "Update an mdbase record",
+    description: "Partially update a record. Supply if_revision when available to prevent overwriting a concurrent edit.",
+    inputSchema: {
+      connection_id: connectionId,
+      path,
+      patch: object,
+      body: z.string().max(2_000_000).optional(),
+      if_revision: revision.optional()
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "update", input));
+
+  server.registerTool("delete_record", {
+    title: "Delete an mdbase record",
+    description: "Delete one record. Supply if_revision when available and check_backlinks before removing referenced records.",
+    inputSchema: {
+      connection_id: connectionId,
+      path,
+      check_backlinks: z.boolean().optional(),
+      if_revision: revision.optional()
+    },
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "delete", input));
+
+  server.registerTool("rename_record", {
+    title: "Rename an mdbase record",
+    description: "Rename or move a record within its collection and optionally update references.",
+    inputSchema: {
+      connection_id: connectionId,
+      from: path,
+      to: path,
+      update_refs: z.boolean().optional(),
+      if_revision: revision.optional()
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "rename", input));
+
+  server.registerTool("create_type", {
+    title: "Create an mdbase type",
+    description: "Create a portable mdbase type definition in an approved collection.",
+    inputSchema: {
+      connection_id: connectionId,
+      document: z.string().min(1).max(1_000_000),
+      path: path.optional()
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "create_type", input));
+
+  server.registerTool("update_type", {
+    title: "Update an mdbase type",
+    description: "Update a portable mdbase type definition using its current revision.",
+    inputSchema: {
+      connection_id: connectionId,
+      name: z.string().min(1).max(200).optional(),
+      path: path.optional(),
+      document: z.string().min(1).max(1_000_000),
+      if_revision: revision
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
+  }, ({ connection_id, ...input }) => operationTool(gateway, context, connection_id, "update_type", input));
+}
+
+async function operationTool(
+  gateway: ConnectGateway,
+  context: McpAuthContext,
+  connectionId: string,
+  operation: CollectionOperation,
+  input: unknown
+) {
+  try {
+    return toolResult(await gateway.operation(context.connectionSetId, connectionId, operation, input));
+  } catch (error) {
+    const value = error instanceof GatewayOperationError
+      ? { error: { code: error.code, message: error.message } }
+      : { error: { code: "operation_failed", message: "The collection operation failed." } };
+    return {
+      ...toolResult(value),
+      isError: true
+    };
+  }
+}
+
+function toolResult(value: unknown) {
+  const structuredContent = isObject(value) ? value : { result: value };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+    structuredContent
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/services/mcp/src/migrate.ts
+++ b/services/mcp/src/migrate.ts
@@ -1,0 +1,4 @@
+import { createDatabase } from "./db.js";
+
+const db = await createDatabase();
+await db.end();

--- a/services/mcp/src/oauth.ts
+++ b/services/mcp/src/oauth.ts
@@ -1,0 +1,483 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { DatabasePool } from "./db.js";
+import { ConnectGateway } from "./connect.js";
+import type { GrantKeyStore } from "@mdbase/connect";
+import { pkceChallenge, randomToken, safeEqual, tokenHash } from "./security.js";
+
+export const MCP_SCOPES = ["mdbase:read", "mdbase:write"] as const;
+export type McpScope = typeof MCP_SCOPES[number];
+
+export const READ_OPERATIONS = ["describe", "changes", "read", "query", "validate", "read_type"] as const;
+export const WRITE_OPERATIONS = ["create", "update", "delete", "rename", "create_type", "update_type"] as const;
+
+interface ClientRow {
+  id: string;
+  client_name: string;
+  redirect_uris: string[];
+}
+
+interface UpstreamAuthorizationRow {
+  id: string;
+  kind: "initial" | "additional";
+  authorization_request_id: string | null;
+  connection_set_id: string;
+  scopes: McpScope[];
+  code_verifier: string;
+  key_handle: string;
+  expires_at: Date | string;
+  completed_at: Date | string | null;
+}
+
+interface AuthorizationRequestRow {
+  id: string;
+  client_id: string;
+  connection_set_id: string;
+  redirect_uri: string;
+  state: string | null;
+  code_challenge: string;
+  resource: string;
+  scopes: McpScope[];
+  expires_at: Date | string;
+  completed_at: Date | string | null;
+  denied_at: Date | string | null;
+}
+
+export interface McpAuthContext {
+  clientId: string;
+  connectionSetId: string;
+  scopes: McpScope[];
+}
+
+export class OAuthService {
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly gateway: ConnectGateway,
+    private readonly keyStore: GrantKeyStore,
+    private readonly publicUrl: string,
+    readonly resource: string
+  ) {}
+
+  async registerClient(input: unknown): Promise<Record<string, unknown>> {
+    const body = z.object({
+      client_name: z.string().trim().min(1).max(200).default("MCP client"),
+      redirect_uris: z.array(z.url()).min(1).max(20),
+      token_endpoint_auth_method: z.literal("none").optional(),
+      grant_types: z.array(z.string()).optional(),
+      response_types: z.array(z.string()).optional()
+    }).passthrough().parse(input);
+    const redirectUris = [...new Set(body.redirect_uris.map(validRedirectUri))];
+    if (body.grant_types && !body.grant_types.includes("authorization_code")) {
+      throw new OAuthError("invalid_client_metadata", "Only the authorization_code grant is supported.");
+    }
+    if (body.response_types && !body.response_types.includes("code")) {
+      throw new OAuthError("invalid_client_metadata", "Only the code response type is supported.");
+    }
+    const clientId = randomToken("client");
+    await this.db.query(
+      `INSERT INTO mcp_clients (id, client_name, redirect_uris) VALUES ($1, $2, $3::jsonb)`,
+      [clientId, body.client_name, JSON.stringify(redirectUris)]
+    );
+    return {
+      client_id: clientId,
+      client_name: body.client_name,
+      redirect_uris: redirectUris,
+      client_id_issued_at: Math.floor(Date.now() / 1_000),
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none"
+    };
+  }
+
+  async beginAuthorization(input: unknown): Promise<string> {
+    const query = z.object({
+      response_type: z.literal("code"),
+      client_id: z.string().min(1),
+      redirect_uri: z.url(),
+      code_challenge: z.string().min(43).max(128),
+      code_challenge_method: z.literal("S256"),
+      state: z.string().max(1_000).optional(),
+      scope: z.string().max(500).optional(),
+      resource: z.url().optional()
+    }).parse(input);
+    const client = await this.client(query.client_id);
+    if (!client.redirect_uris.includes(query.redirect_uri)) {
+      throw new OAuthError("invalid_request", "The redirect_uri is not registered for this client.");
+    }
+    const resource = canonicalResource(query.resource ?? this.resource, this.resource);
+    const scopes = parseScopes(query.scope);
+    const setId = randomUUID();
+    const requestId = randomUUID();
+    await this.db.query("INSERT INTO mcp_connection_sets (id) VALUES ($1)", [setId]);
+    await this.db.query(
+      `INSERT INTO mcp_authorization_requests
+         (id, client_id, connection_set_id, redirect_uri, state, code_challenge,
+          resource, scopes, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)`,
+      [
+        requestId,
+        client.id,
+        setId,
+        query.redirect_uri,
+        query.state ?? null,
+        query.code_challenge,
+        resource,
+        JSON.stringify(scopes),
+        new Date(Date.now() + 10 * 60_000)
+      ]
+    );
+    return this.beginUpstream("initial", setId, scopes, requestId);
+  }
+
+  async completeUpstream(input: { state?: string; code?: string; error?: string }): Promise<{
+    kind: "initial" | "additional";
+    redirect?: string;
+    connectionName?: string;
+    error?: string;
+  }> {
+    if (!input.state) throw new OAuthError("invalid_request", "The Connect callback is missing state.");
+    const result = await this.db.query<UpstreamAuthorizationRow>(
+      `SELECT id, kind, authorization_request_id, connection_set_id, scopes,
+              code_verifier, key_handle, expires_at, completed_at
+       FROM mcp_upstream_authorizations
+       WHERE state_hash = $1`,
+      [tokenHash(input.state)]
+    );
+    const pending = result.rows[0];
+    if (!pending || pending.completed_at || new Date(pending.expires_at).getTime() <= Date.now()) {
+      throw new OAuthError("invalid_request", "This Connect authorization has expired or was already used.");
+    }
+    if (input.error || !input.code) {
+      await this.keyStore.delete(pending.key_handle);
+      await this.db.query("UPDATE mcp_upstream_authorizations SET completed_at = now() WHERE id = $1", [pending.id]);
+      if (pending.kind === "initial" && pending.authorization_request_id) {
+        const authorization = await this.authorizationRequest(pending.authorization_request_id);
+        await this.db.query("UPDATE mcp_authorization_requests SET denied_at = now() WHERE id = $1", [authorization.id]);
+        return {
+          kind: "initial",
+          redirect: oauthRedirect(authorization.redirect_uri, {
+            error: "access_denied",
+            error_description: "Collection access was not approved.",
+            state: authorization.state ?? undefined
+          })
+        };
+      }
+      return { kind: "additional", error: "Collection access was not approved." };
+    }
+    const application = await this.gateway.discoverApplication();
+    const connection = await this.gateway.exchangeAuthorization({
+      code: input.code,
+      verifier: pending.code_verifier,
+      applicationId: application.id,
+      connectionSetId: pending.connection_set_id,
+      keyHandle: pending.key_handle
+    });
+    await this.db.query("UPDATE mcp_upstream_authorizations SET completed_at = now() WHERE id = $1", [pending.id]);
+    if (pending.kind === "additional") {
+      return { kind: "additional", connectionName: connection.display_name };
+    }
+    if (!pending.authorization_request_id) throw new OAuthError("server_error", "The OAuth request is incomplete.");
+    const authorization = await this.authorizationRequest(pending.authorization_request_id);
+    const code = randomToken("code");
+    await this.db.query(
+      `INSERT INTO mcp_authorization_codes
+         (id, code_hash, client_id, connection_set_id, redirect_uri, code_challenge,
+          resource, scopes, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)`,
+      [
+        randomUUID(),
+        tokenHash(code),
+        authorization.client_id,
+        authorization.connection_set_id,
+        authorization.redirect_uri,
+        authorization.code_challenge,
+        authorization.resource,
+        JSON.stringify(authorization.scopes),
+        new Date(Date.now() + 2 * 60_000)
+      ]
+    );
+    await this.db.query("UPDATE mcp_authorization_requests SET completed_at = now() WHERE id = $1", [authorization.id]);
+    return {
+      kind: "initial",
+      redirect: oauthRedirect(authorization.redirect_uri, {
+        code,
+        state: authorization.state ?? undefined,
+        iss: this.publicUrl
+      })
+    };
+  }
+
+  async exchangeToken(input: unknown): Promise<Record<string, unknown>> {
+    const body = z.discriminatedUnion("grant_type", [
+      z.object({
+        grant_type: z.literal("authorization_code"),
+        code: z.string().min(1),
+        client_id: z.string().min(1),
+        redirect_uri: z.url(),
+        code_verifier: z.string().min(43).max(128),
+        resource: z.url().optional()
+      }),
+      z.object({
+        grant_type: z.literal("refresh_token"),
+        refresh_token: z.string().min(1),
+        client_id: z.string().min(1),
+        resource: z.url().optional()
+      })
+    ]).parse(input);
+    if (body.grant_type === "authorization_code") {
+      const result = await this.db.query<{
+        id: string;
+        client_id: string;
+        connection_set_id: string;
+        redirect_uri: string;
+        code_challenge: string;
+        resource: string;
+        scopes: McpScope[];
+      }>(
+        `SELECT id, client_id, connection_set_id, redirect_uri, code_challenge, resource, scopes
+         FROM mcp_authorization_codes
+         WHERE code_hash = $1 AND used_at IS NULL AND expires_at > now()`,
+        [tokenHash(body.code)]
+      );
+      const code = result.rows[0];
+      if (!code
+          || code.client_id !== body.client_id
+          || code.redirect_uri !== body.redirect_uri
+          || !safeEqual(code.code_challenge, pkceChallenge(body.code_verifier))
+          || canonicalResource(body.resource ?? code.resource, this.resource) !== code.resource) {
+        throw new OAuthError("invalid_grant", "The authorization code is invalid or expired.");
+      }
+      const used = await this.db.query(
+        "UPDATE mcp_authorization_codes SET used_at = now() WHERE id = $1 AND used_at IS NULL RETURNING id",
+        [code.id]
+      );
+      if (!used.rows[0]) throw new OAuthError("invalid_grant", "The authorization code was already used.");
+      return this.issueTokens(code);
+    }
+    const result = await this.db.query<{
+      id: string;
+      client_id: string;
+      connection_set_id: string;
+      resource: string;
+      scopes: McpScope[];
+    }>(
+      `SELECT id, client_id, connection_set_id, resource, scopes
+       FROM mcp_refresh_tokens
+       WHERE token_hash = $1 AND used_at IS NULL AND revoked_at IS NULL AND expires_at > now()`,
+      [tokenHash(body.refresh_token)]
+    );
+    const refresh = result.rows[0];
+    if (!refresh
+        || refresh.client_id !== body.client_id
+        || canonicalResource(body.resource ?? refresh.resource, this.resource) !== refresh.resource) {
+      throw new OAuthError("invalid_grant", "The refresh token is invalid or expired.");
+    }
+    const used = await this.db.query(
+      "UPDATE mcp_refresh_tokens SET used_at = now() WHERE id = $1 AND used_at IS NULL RETURNING id",
+      [refresh.id]
+    );
+    if (!used.rows[0]) throw new OAuthError("invalid_grant", "The refresh token was already used.");
+    return this.issueTokens(refresh);
+  }
+
+  async authenticate(bearer: string): Promise<McpAuthContext | null> {
+    const result = await this.db.query<{
+      client_id: string;
+      connection_set_id: string;
+      resource: string;
+      scopes: McpScope[];
+    }>(
+      `SELECT client_id, connection_set_id, resource, scopes FROM mcp_access_tokens
+       WHERE token_hash = $1 AND expires_at > now() AND revoked_at IS NULL`,
+      [tokenHash(bearer)]
+    );
+    const token = result.rows[0];
+    if (!token || token.resource !== this.resource) return null;
+    return {
+      clientId: token.client_id,
+      connectionSetId: token.connection_set_id,
+      scopes: token.scopes
+    };
+  }
+
+  async createConnectionTicket(context: McpAuthContext): Promise<string> {
+    const token = randomToken("add");
+    await this.db.query(
+      `INSERT INTO mcp_connection_tickets
+         (id, token_hash, connection_set_id, scopes, expires_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5)`,
+      [randomUUID(), tokenHash(token), context.connectionSetId, JSON.stringify(context.scopes), new Date(Date.now() + 10 * 60_000)]
+    );
+    return `${this.publicUrl}/connections/new?ticket=${encodeURIComponent(token)}`;
+  }
+
+  async consumeConnectionTicket(token: string): Promise<string> {
+    const result = await this.db.query<{
+      id: string;
+      connection_set_id: string;
+      scopes: McpScope[];
+    }>(
+      `UPDATE mcp_connection_tickets SET used_at = now()
+       WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now()
+       RETURNING id, connection_set_id, scopes`,
+      [tokenHash(token)]
+    );
+    const ticket = result.rows[0];
+    if (!ticket) throw new OAuthError("invalid_request", "This add-collection link is invalid or expired.");
+    return this.beginUpstream("additional", ticket.connection_set_id, ticket.scopes, null);
+  }
+
+  private async beginUpstream(
+    kind: "initial" | "additional",
+    connectionSetId: string,
+    scopes: McpScope[],
+    authorizationRequestId: string | null
+  ): Promise<string> {
+    const application = await this.gateway.discoverApplication();
+    const state = randomToken("state");
+    const verifier = randomToken("pkce");
+    const keyHandle = `mcp:${randomUUID()}`;
+    const key = await this.keyStore.create(keyHandle);
+    await this.db.query(
+      `INSERT INTO mcp_upstream_authorizations
+         (id, state_hash, kind, authorization_request_id, connection_set_id,
+          scopes, code_verifier, key_handle, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9)`,
+      [
+        randomUUID(),
+        tokenHash(state),
+        kind,
+        authorizationRequestId,
+        connectionSetId,
+        JSON.stringify(scopes),
+        verifier,
+        keyHandle,
+        new Date(Date.now() + 10 * 60_000)
+      ]
+    );
+    const authorize = new URL(`${this.gateway.connectUrl}/oauth/authorize`);
+    authorize.searchParams.set("client_id", application.id);
+    authorize.searchParams.set("redirect_uri", this.gateway.callbackUrl);
+    authorize.searchParams.set("code_challenge", pkceChallenge(verifier));
+    authorize.searchParams.set("code_challenge_method", "S256");
+    authorize.searchParams.set("state", state);
+    authorize.searchParams.set("operations", operationsForScopes(scopes).join(","));
+    authorize.searchParams.set("relay_protocol", "3");
+    authorize.searchParams.set("application_public_key", key.publicKey);
+    return authorize.href;
+  }
+
+  private async issueTokens(input: {
+    client_id: string;
+    connection_set_id: string;
+    resource: string;
+    scopes: McpScope[];
+  }): Promise<Record<string, unknown>> {
+    const accessToken = randomToken("mcp");
+    const refreshToken = randomToken("mrf");
+    await this.db.query(
+      `INSERT INTO mcp_access_tokens
+         (id, token_hash, client_id, connection_set_id, resource, scopes, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)`,
+      [
+        randomUUID(),
+        tokenHash(accessToken),
+        input.client_id,
+        input.connection_set_id,
+        input.resource,
+        JSON.stringify(input.scopes),
+        new Date(Date.now() + 60 * 60_000)
+      ]
+    );
+    await this.db.query(
+      `INSERT INTO mcp_refresh_tokens
+         (id, token_hash, client_id, connection_set_id, resource, scopes, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)`,
+      [
+        randomUUID(),
+        tokenHash(refreshToken),
+        input.client_id,
+        input.connection_set_id,
+        input.resource,
+        JSON.stringify(input.scopes),
+        new Date(Date.now() + 30 * 24 * 60 * 60_000)
+      ]
+    );
+    return {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      token_type: "Bearer",
+      expires_in: 3_600,
+      scope: input.scopes.join(" ")
+    };
+  }
+
+  private async client(clientId: string): Promise<ClientRow> {
+    const result = await this.db.query<ClientRow>(
+      "SELECT id, client_name, redirect_uris FROM mcp_clients WHERE id = $1",
+      [clientId]
+    );
+    if (!result.rows[0]) throw new OAuthError("invalid_request", "The OAuth client is not registered.");
+    return result.rows[0];
+  }
+
+  private async authorizationRequest(id: string): Promise<AuthorizationRequestRow> {
+    const result = await this.db.query<AuthorizationRequestRow>(
+      `SELECT id, client_id, connection_set_id, redirect_uri, state, code_challenge,
+              resource, scopes, expires_at, completed_at, denied_at
+       FROM mcp_authorization_requests WHERE id = $1`,
+      [id]
+    );
+    const request = result.rows[0];
+    if (!request || request.completed_at || request.denied_at || new Date(request.expires_at).getTime() <= Date.now()) {
+      throw new OAuthError("invalid_request", "The OAuth authorization request is no longer active.");
+    }
+    return request;
+  }
+}
+
+export class OAuthError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+function operationsForScopes(scopes: McpScope[]): string[] {
+  return scopes.includes("mdbase:write")
+    ? [...READ_OPERATIONS, ...WRITE_OPERATIONS]
+    : [...READ_OPERATIONS];
+}
+
+function parseScopes(value: string | undefined): McpScope[] {
+  const requested = value?.trim() ? [...new Set(value.trim().split(/\s+/))] : [...MCP_SCOPES];
+  if (requested.length === 0 || requested.some((scope) => !MCP_SCOPES.includes(scope as McpScope))) {
+    throw new OAuthError("invalid_scope", "Supported scopes are mdbase:read and mdbase:write.");
+  }
+  return requested as McpScope[];
+}
+
+function canonicalResource(value: string, expected: string): string {
+  const resource = new URL(value);
+  if (resource.username || resource.password || resource.search || resource.hash || resource.href !== expected) {
+    throw new OAuthError("invalid_target", "The OAuth resource does not identify this MCP server.");
+  }
+  return resource.href;
+}
+
+function validRedirectUri(value: string): string {
+  const url = new URL(value);
+  if (url.username || url.password || url.hash) throw new OAuthError("invalid_redirect_uri", "Redirect URIs cannot contain credentials or fragments.");
+  if (url.protocol === "https:") return value;
+  if (url.protocol === "http:" && isLoopback(url.hostname)) return value;
+  throw new OAuthError("invalid_redirect_uri", "Redirect URIs must use HTTPS or loopback HTTP.");
+}
+
+function isLoopback(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]";
+}
+
+function oauthRedirect(base: string, values: Record<string, string | undefined>): string {
+  const url = new URL(base);
+  for (const [key, value] of Object.entries(values)) if (value !== undefined) url.searchParams.set(key, value);
+  return url.href;
+}

--- a/services/mcp/src/security.test.ts
+++ b/services/mcp/src/security.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createDatabase } from "./db.js";
+import { SecretBox, verifyMasterKey } from "./security.js";
+
+describe("SecretBox", () => {
+  it("encrypts service credentials with authenticated random nonces", () => {
+    const box = new SecretBox(Buffer.alloc(32, 3));
+    const first = box.encrypt("sensitive-token");
+    const second = box.encrypt("sensitive-token");
+    expect(first).not.toBe(second);
+    expect(first).not.toContain("sensitive-token");
+    expect(box.decrypt(first)).toBe("sensitive-token");
+    const [version, nonce, sealedText] = first.split(".");
+    const sealed = Buffer.from(sealedText, "base64url");
+    sealed[0] ^= 1;
+    expect(() => box.decrypt(`${version}.${nonce}.${sealed.toString("base64url")}`)).toThrow();
+  });
+
+  it("fails closed when a deployment uses the wrong master key", async () => {
+    const db = await createDatabase("memory");
+    await expect(verifyMasterKey(db, new SecretBox(Buffer.alloc(32, 1)))).resolves.toBeUndefined();
+    await expect(verifyMasterKey(db, new SecretBox(Buffer.alloc(32, 2))))
+      .rejects.toThrow("does not match the gateway database");
+    await db.end();
+  });
+});

--- a/services/mcp/src/security.ts
+++ b/services/mcp/src/security.ts
@@ -1,0 +1,75 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import type { DatabaseQueryable } from "./db.js";
+
+export function randomToken(prefix: string, bytes = 32): string {
+  return `${prefix}_${randomBytes(bytes).toString("base64url")}`;
+}
+
+export function tokenHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function pkceChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+export function safeEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export class SecretBox {
+  constructor(private readonly key: Buffer) {
+    if (key.length !== 32) throw new Error("The MCP master key must decode to exactly 32 bytes.");
+  }
+
+  static fromBase64Url(value: string): SecretBox {
+    if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error("MDBASE_MCP_MASTER_KEY must be base64url encoded.");
+    return new SecretBox(Buffer.from(value, "base64url"));
+  }
+
+  /** Accept a high-entropy deployment secret and derive a fixed AES-256 key. */
+  static fromSecret(value: string): SecretBox {
+    if (value.length < 32) throw new Error("MDBASE_MCP_MASTER_KEY must contain at least 32 characters.");
+    return new SecretBox(createHash("sha256").update(value, "utf8").digest());
+  }
+
+  encrypt(value: string): string {
+    const nonce = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", this.key, nonce);
+    const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return `v1.${nonce.toString("base64url")}.${Buffer.concat([ciphertext, tag]).toString("base64url")}`;
+  }
+
+  decrypt(value: string): string {
+    const [version, nonceText, sealedText] = value.split(".");
+    if (version !== "v1" || !nonceText || !sealedText) throw new Error("Unsupported encrypted secret format.");
+    const nonce = Buffer.from(nonceText, "base64url");
+    const sealed = Buffer.from(sealedText, "base64url");
+    if (nonce.length !== 12 || sealed.length < 17) throw new Error("Encrypted secret is malformed.");
+    const ciphertext = sealed.subarray(0, -16);
+    const tag = sealed.subarray(-16);
+    const decipher = createDecipheriv("aes-256-gcm", this.key, nonce);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+  }
+}
+
+export async function verifyMasterKey(db: DatabaseQueryable, secrets: SecretBox): Promise<void> {
+  const marker = "mdbase-mcp-master-key-check-v1";
+  await db.query(
+    `INSERT INTO mcp_settings (key, value) VALUES ('master_key_check', $1)
+     ON CONFLICT(key) DO NOTHING`,
+    [secrets.encrypt(marker)]
+  );
+  const result = await db.query<{ value: string }>(
+    "SELECT value FROM mcp_settings WHERE key = 'master_key_check'"
+  );
+  try {
+    if (!result.rows[0] || secrets.decrypt(result.rows[0].value) !== marker) throw new Error();
+  } catch {
+    throw new Error("MDBASE_MCP_MASTER_KEY does not match the gateway database.");
+  }
+}

--- a/services/mcp/tsconfig.json
+++ b/services/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/services/mcp/vitest.config.ts
+++ b/services/mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+});

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -2323,6 +2323,7 @@ async function issueApplicationTokens(
   expires_in: number;
   refresh_expires_in: number;
   collection_id: string;
+  collection_name: string;
   operations: string[];
   scope: GrantScope;
   grant_id: string;
@@ -2336,6 +2337,7 @@ async function issueApplicationTokens(
 }> {
   const grant = await db.query<{
     collection_id: string;
+    collection_name: string;
     hosted_collection_id: string | null;
     hosted_replica_id: string | null;
     provider_url: string | null;
@@ -2345,12 +2347,14 @@ async function issueApplicationTokens(
     application_origin: string;
   }>(
     `SELECT COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
+            COALESCE(col.display_name, hosted.display_name) AS collection_name,
             g.hosted_collection_id, g.hosted_replica_id, hosted.provider_url,
             g.operations, g.scope, g.encryption,
             CASE WHEN g.application_origin = '' THEN app.homepage
                  ELSE g.application_origin END AS application_origin
      FROM grants g
      JOIN applications app ON app.id = g.application_id
+     LEFT JOIN collections col ON col.id = g.collection_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
      WHERE g.id = $1 AND g.revoked_at IS NULL`,
     [grantId]
@@ -2388,6 +2392,7 @@ async function issueApplicationTokens(
     expires_in: 3600,
     refresh_expires_in: 30 * 24 * 60 * 60,
     collection_id: grant.rows[0].collection_id,
+    collection_name: grant.rows[0].collection_name,
     operations: grant.rows[0].operations,
     scope: grant.rows[0].scope,
     grant_id: grantId,


### PR DESCRIPTION
## What changed

- adds a separately deployed `mdbase-mcp` Streamable HTTP MCP gateway
- implements OAuth discovery, DCR, PKCE, rotating refresh tokens, and resource binding
- supports explicit access to multiple approved collections through opaque connection IDs
- routes hosted collections directly and local collections through the existing encrypted Connect relay
- adds Render service/database configuration, container image, deployment documentation, and end-to-end coverage

## Why

Claude, ChatGPT, and other MCP clients need a hosted, standards-based endpoint that can access user-approved mdbase collections without exposing local paths or weakening the connector's exact-grant authorization boundary.

## User impact

Users can add `https://mcp.mdbase.dev/mcp` as a custom connector, approve one collection during OAuth, and add further collections explicitly with the `add_connection` tool.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `MDBASE_CONNECT_E2E_LOOPBACK_PORT=28486 pnpm e2e`
- MCP Docker image build and `/ready` container smoke test
- Render YAML parse check
- `git diff --check`
