### PR TITLE
Fix hosted application offline sync

### DIFF
--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{DefaultBodyLimit, Path, Query, Request, State},
     http::{
         header::{AUTHORIZATION, CONTENT_TYPE, ORIGIN},
-        HeaderMap, HeaderName, HeaderValue, Method, StatusCode,
+        HeaderMap, HeaderName, Method, StatusCode,
     },
     middleware::{self, Next},
     response::Response,
@@ -24,7 +24,6 @@ use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     trace::TraceLayer,
 };
-use url::Url;
 use uuid::Uuid;
 
 use crate::{
@@ -40,36 +39,20 @@ const MAX_BODY_BYTES: usize = 3 * 1024 * 1024;
 pub struct AppState {
     provider: HostedProvider,
     internal_token_hash: [u8; 32],
-    allowed_origins: Vec<HeaderValue>,
     request_slots: Arc<Semaphore>,
 }
 
 impl AppState {
-    pub fn new(
-        provider: HostedProvider,
-        internal_token: &str,
-        allowed_origins: impl IntoIterator<Item = String>,
-    ) -> ApiResult<Self> {
+    pub fn new(provider: HostedProvider, internal_token: &str) -> ApiResult<Self> {
         if internal_token.len() < 32 {
             return Err(ApiError::bad_request(
                 "invalid_internal_token",
                 "The provider internal credential must contain at least 32 characters.",
             ));
         }
-        let allowed_origins = allowed_origins
-            .into_iter()
-            .map(|origin| canonical_origin(&origin))
-            .collect::<ApiResult<Vec<_>>>()?;
-        if allowed_origins.is_empty() {
-            return Err(ApiError::bad_request(
-                "missing_allowed_origins",
-                "At least one browser application origin must be configured.",
-            ));
-        }
         Ok(Self {
             provider,
             internal_token_hash: Sha256::digest(internal_token.as_bytes()).into(),
-            allowed_origins,
             request_slots: Arc::new(Semaphore::new(128)),
         })
     }
@@ -85,18 +68,6 @@ impl AppState {
                 "The provider internal credential is invalid.",
             ))
         }
-    }
-
-    fn authorize_sync_origin(&self, headers: &HeaderMap) -> ApiResult<()> {
-        if let Some(origin) = headers.get(ORIGIN) {
-            if !self.allowed_origins.iter().any(|allowed| allowed == origin) {
-                return Err(ApiError::forbidden(
-                    "origin_denied",
-                    "Browser sync is unavailable from this origin.",
-                ));
-            }
-        }
-        Ok(())
     }
 }
 
@@ -198,10 +169,7 @@ pub fn app(state: AppState) -> Router {
             "/v1/hosted/collections/{collection_id}/sync/mutations",
             post(mutate),
         )
-        .route_layer(middleware::from_fn_with_state(
-            state.clone(),
-            require_sync_bearer_request,
-        ));
+        .route_layer(middleware::from_fn(require_bearer_request));
     let operations = Router::new()
         .route(
             "/v1/hosted/collections/{collection_id}/operations/{operation}",
@@ -256,16 +224,6 @@ async fn authorize_internal_request(
 
 async fn require_bearer_request(request: Request, next: Next) -> ApiResult<Response> {
     bearer(request.headers())?;
-    Ok(next.run(request).await)
-}
-
-async fn require_sync_bearer_request(
-    State(state): State<AppState>,
-    request: Request,
-    next: Next,
-) -> ApiResult<Response> {
-    bearer(request.headers())?;
-    state.authorize_sync_origin(request.headers())?;
     Ok(next.run(request).await)
 }
 
@@ -394,8 +352,12 @@ async fn open_session(
     Path(collection_id): Path<Uuid>,
 ) -> ApiResult<Json<SyncSession>> {
     let token = bearer(&headers)?;
+    let origin = request_origin(&headers);
     Ok(Json(
-        state.provider.open_session(collection_id, token).await?,
+        state
+            .provider
+            .open_session(collection_id, token, origin)
+            .await?,
     ))
 }
 
@@ -406,6 +368,7 @@ async fn snapshot(
     Query(query): Query<SnapshotQuery>,
 ) -> ApiResult<Json<SyncSnapshotPage>> {
     let token = bearer(&headers)?;
+    let origin = request_origin(&headers);
     Ok(Json(
         state
             .provider
@@ -414,6 +377,7 @@ async fn snapshot(
                 token,
                 query.snapshot_id,
                 query.page.as_deref(),
+                origin,
             )
             .await?,
     ))
@@ -426,11 +390,12 @@ async fn changes(
     Query(query): Query<ChangesQuery>,
 ) -> ApiResult<Json<SyncChangesPage>> {
     let token = bearer(&headers)?;
+    let origin = request_origin(&headers);
     let limit = validate_limit(query.limit)?;
     Ok(Json(
         state
             .provider
-            .changes(collection_id, token, query.after, limit)
+            .changes(collection_id, token, query.after, limit, origin)
             .await?,
     ))
 }
@@ -442,10 +407,11 @@ async fn mutate(
     Json(mutation): Json<SyncMutation>,
 ) -> ApiResult<Json<SyncMutationReceipt>> {
     let token = bearer(&headers)?;
+    let origin = request_origin(&headers);
     Ok(Json(
         state
             .provider
-            .mutate(collection_id, token, mutation)
+            .mutate(collection_id, token, mutation, origin)
             .await?,
     ))
 }
@@ -475,12 +441,16 @@ async fn operation(
     Json(input): Json<Value>,
 ) -> ApiResult<Json<Value>> {
     let token = bearer(&headers)?;
-    let origin = headers.get(ORIGIN).and_then(|value| value.to_str().ok());
+    let origin = request_origin(&headers);
     let result = state
         .provider
         .operation(collection_id, token, &operation, input, origin)
         .await?;
     Ok(Json(json!({ "ok": true, "result": result })))
+}
+
+fn request_origin(headers: &HeaderMap) -> Option<&str> {
+    headers.get(ORIGIN).and_then(|value| value.to_str().ok())
 }
 
 fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
@@ -492,35 +462,6 @@ fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
         .ok_or_else(|| {
             ApiError::unauthorized("missing_bearer_token", "A bearer credential is required.")
         })
-}
-
-fn canonical_origin(value: &str) -> ApiResult<HeaderValue> {
-    let url = Url::parse(value).map_err(|_| {
-        ApiError::bad_request(
-            "invalid_allowed_origin",
-            "Hosted provider allowed origins must be absolute HTTP(S) origins.",
-        )
-    })?;
-    let loopback = matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
-    if !matches!(url.scheme(), "http" | "https")
-        || (url.scheme() != "https" && !loopback)
-        || !url.username().is_empty()
-        || url.password().is_some()
-        || url.path() != "/"
-        || url.query().is_some()
-        || url.fragment().is_some()
-    {
-        return Err(ApiError::bad_request(
-            "invalid_allowed_origin",
-            "Hosted provider origins must be canonical HTTPS origins outside loopback development.",
-        ));
-    }
-    HeaderValue::from_str(url.origin().ascii_serialization().as_str()).map_err(|_| {
-        ApiError::bad_request(
-            "invalid_allowed_origin",
-            "Hosted provider allowed origin is not a valid HTTP header value.",
-        )
-    })
 }
 
 #[cfg(test)]
@@ -543,16 +484,5 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(input.display_name, None);
-    }
-
-    #[test]
-    fn allowed_origins_are_canonical_and_tls_bound() {
-        assert_eq!(
-            canonical_origin("https://app.example/").unwrap(),
-            "https://app.example"
-        );
-        assert!(canonical_origin("http://app.example").is_err());
-        assert!(canonical_origin("https://app.example/path").is_err());
-        assert!(canonical_origin("http://127.0.0.1:5173").is_ok());
     }
 }

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -16,8 +16,6 @@ struct Arguments {
     internal_token: String,
     #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY")]
     master_key: String,
-    #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_ALLOWED_ORIGINS")]
-    allowed_origins: String,
     #[arg(long, env = "HOST", default_value = "127.0.0.1")]
     host: IpAddr,
     #[arg(long, env = "PORT", default_value_t = 8790)]
@@ -85,13 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_replicas_per_collection: arguments.max_replicas_per_collection,
     };
     let provider = HostedProvider::connect(&arguments.database_url, crypto, limits).await?;
-    let allowed_origins = arguments
-        .allowed_origins
-        .split(',')
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
-    let state = AppState::new(provider.clone(), &arguments.internal_token, allowed_origins)?;
+    let state = AppState::new(provider.clone(), &arguments.internal_token)?;
     let maintenance = tokio::spawn(maintain_history(
         provider,
         arguments.retain_changes,

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -105,6 +105,7 @@ pub struct ProviderCollection {
 #[derive(Debug, Clone)]
 struct Replica {
     id: Uuid,
+    purpose: ReplicaPurpose,
     mode: SyncReplicaMode,
     allowed_types: Vec<String>,
     allowed_operations: Vec<String>,
@@ -663,9 +664,14 @@ impl HostedProvider {
         Ok(compacted)
     }
 
-    pub async fn open_session(&self, collection_id: Uuid, token: &str) -> ApiResult<SyncSession> {
+    pub async fn open_session(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        request_origin: Option<&str>,
+    ) -> ApiResult<SyncSession> {
         let replica = self
-            .authenticate_for(collection_id, token, ReplicaPurpose::Mirror)
+            .authenticate_for_sync(collection_id, token, "read", request_origin)
             .await?;
         let row = sqlx::query(
             r#"SELECT head, retained_after, resource_revision, wrapped_data_key, resources_ciphertext
@@ -731,9 +737,10 @@ impl HostedProvider {
         token: &str,
         snapshot_id: Uuid,
         page: Option<&str>,
+        request_origin: Option<&str>,
     ) -> ApiResult<SyncSnapshotPage> {
         let replica = self
-            .authenticate_for(collection_id, token, ReplicaPurpose::Mirror)
+            .authenticate_for_sync(collection_id, token, "read", request_origin)
             .await?;
         let after_record_id = page
             .map(|value| {
@@ -831,9 +838,10 @@ impl HostedProvider {
         token: &str,
         after: u64,
         limit: u32,
+        request_origin: Option<&str>,
     ) -> ApiResult<SyncChangesPage> {
         let replica = self
-            .authenticate_for(collection_id, token, ReplicaPurpose::Mirror)
+            .authenticate_for_sync(collection_id, token, "changes", request_origin)
             .await?;
         let collection = sqlx::query(
             "SELECT head, retained_after, wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
@@ -971,8 +979,30 @@ impl HostedProvider {
         collection_id: Uuid,
         token: &str,
         mutation: SyncMutation,
+        request_origin: Option<&str>,
     ) -> ApiResult<SyncMutationReceipt> {
-        self.mutate_for(collection_id, token, mutation, ReplicaPurpose::Mirror)
+        self.mutate_for_sync(collection_id, token, mutation, request_origin)
+            .await
+    }
+
+    async fn mutate_for_sync(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        mutation: SyncMutation,
+        request_origin: Option<&str>,
+    ) -> ApiResult<SyncMutationReceipt> {
+        let mut transaction = self.pool.begin().await?;
+        let required_operation = mutation_operation_name(mutation.operation);
+        let replica = authenticate_in_for_sync(
+            &mut transaction,
+            collection_id,
+            token,
+            required_operation,
+            request_origin,
+        )
+        .await?;
+        self.mutate_in_transaction(transaction, collection_id, mutation, replica)
             .await
     }
 
@@ -985,6 +1015,17 @@ impl HostedProvider {
     ) -> ApiResult<SyncMutationReceipt> {
         let mut transaction = self.pool.begin().await?;
         let replica = authenticate_in(&mut transaction, collection_id, token, purpose).await?;
+        self.mutate_in_transaction(transaction, collection_id, mutation, replica)
+            .await
+    }
+
+    async fn mutate_in_transaction(
+        &self,
+        mut transaction: Transaction<'_, Postgres>,
+        collection_id: Uuid,
+        mutation: SyncMutation,
+        replica: Replica,
+    ) -> ApiResult<SyncMutationReceipt> {
         if mutation.replica_id != replica.id {
             return Err(ApiError::forbidden(
                 "replica_scope_denied",
@@ -2267,6 +2308,29 @@ impl HostedProvider {
         replica_from_row(row)
     }
 
+    async fn authenticate_for_sync(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        required_operation: &str,
+        request_origin: Option<&str>,
+    ) -> ApiResult<Replica> {
+        let row = sqlx::query(
+            r#"SELECT id, purpose, mode, allowed_types, allowed_operations,
+                      allowed_origin, scope_epoch
+               FROM hosted_provider_replicas
+               WHERE collection_id = $1 AND token_hash = $2
+                 AND revoked_at IS NULL AND token_expires_at > now()"#,
+        )
+        .bind(collection_id)
+        .bind(token_hash(token))
+        .fetch_optional(&self.pool)
+        .await?;
+        let replica = replica_from_row(row)?;
+        authorize_sync_access(&replica, required_operation, request_origin)?;
+        Ok(replica)
+    }
+
     fn collection_key(&self, collection_id: Uuid, wrapped: &[u8]) -> ApiResult<[u8; 32]> {
         self.crypto
             .unwrap_data_key(wrapped, &collection_key_aad(collection_id))
@@ -2333,6 +2397,30 @@ async fn authenticate_in(
     replica_from_row(row)
 }
 
+async fn authenticate_in_for_sync(
+    transaction: &mut Transaction<'_, Postgres>,
+    collection_id: Uuid,
+    token: &str,
+    required_operation: &str,
+    request_origin: Option<&str>,
+) -> ApiResult<Replica> {
+    let row = sqlx::query(
+        r#"SELECT id, purpose, mode, allowed_types, allowed_operations,
+                  allowed_origin, scope_epoch
+           FROM hosted_provider_replicas
+           WHERE collection_id = $1 AND token_hash = $2
+             AND revoked_at IS NULL AND token_expires_at > now()
+           FOR SHARE"#,
+    )
+    .bind(collection_id)
+    .bind(token_hash(token))
+    .fetch_optional(&mut **transaction)
+    .await?;
+    let replica = replica_from_row(row)?;
+    authorize_sync_access(&replica, required_operation, request_origin)?;
+    Ok(replica)
+}
+
 fn replica_from_row(row: Option<sqlx::postgres::PgRow>) -> ApiResult<Replica> {
     let row = row.ok_or_else(|| {
         ApiError::unauthorized(
@@ -2347,6 +2435,11 @@ fn replica_from_row(row: Option<sqlx::postgres::PgRow>) -> ApiResult<Replica> {
     }
     Ok(Replica {
         id: row.get("id"),
+        purpose: match purpose.as_str() {
+            "mirror" => ReplicaPurpose::Mirror,
+            "application" => ReplicaPurpose::Application,
+            _ => return Err(ApiError::internal("Stored replica purpose is invalid.")),
+        },
         mode: match mode.as_str() {
             "read_only" => SyncReplicaMode::ReadOnly,
             "read_write" => SyncReplicaMode::ReadWrite,
@@ -2622,6 +2715,32 @@ fn authorize_application_operation(
         }
     }
     Ok(())
+}
+
+fn authorize_sync_access(
+    replica: &Replica,
+    required_operation: &str,
+    request_origin: Option<&str>,
+) -> ApiResult<()> {
+    match replica.purpose {
+        ReplicaPurpose::Application => {
+            authorize_application_operation(replica, required_operation, request_origin)
+        }
+        ReplicaPurpose::Mirror if request_origin.is_none() => Ok(()),
+        ReplicaPurpose::Mirror => Err(ApiError::forbidden(
+            "origin_denied",
+            "Mirror credentials cannot be used by browser applications.",
+        )),
+    }
+}
+
+fn mutation_operation_name(operation: SyncMutationOperation) -> &'static str {
+    match operation {
+        SyncMutationOperation::Create => "create",
+        SyncMutationOperation::Update => "update",
+        SyncMutationOperation::Rename => "rename",
+        SyncMutationOperation::Delete => "delete",
+    }
 }
 
 fn result_string<'a>(value: &'a Value, field: &str) -> ApiResult<&'a str> {
@@ -3070,6 +3189,7 @@ mod tests {
         validate_replica_capability(&capability).unwrap();
         let replica = Replica {
             id: capability.replica_id,
+            purpose: capability.purpose,
             mode: capability.mode,
             allowed_types: capability.allowed_types,
             allowed_operations: capability.allowed_operations,
@@ -3088,6 +3208,59 @@ mod tests {
                 .unwrap_err()
                 .code,
             "origin_denied"
+        );
+        authorize_sync_access(&replica, "query", Some("https://tasks.example")).unwrap();
+        assert_eq!(
+            authorize_sync_access(&replica, "changes", Some("https://tasks.example"))
+                .unwrap_err()
+                .code,
+            "insufficient_access"
+        );
+        assert_eq!(
+            authorize_sync_access(&replica, "query", Some("https://evil.example"))
+                .unwrap_err()
+                .code,
+            "origin_denied"
+        );
+    }
+
+    #[test]
+    fn mirror_sync_credentials_are_not_browser_capabilities() {
+        let replica = Replica {
+            id: Uuid::new_v4(),
+            purpose: ReplicaPurpose::Mirror,
+            mode: SyncReplicaMode::ReadOnly,
+            allowed_types: Vec::new(),
+            allowed_operations: Vec::new(),
+            allowed_origin: None,
+            scope_epoch: 1,
+        };
+        authorize_sync_access(&replica, "read", None).unwrap();
+        assert_eq!(
+            authorize_sync_access(&replica, "read", Some("https://tasks.example"))
+                .unwrap_err()
+                .code,
+            "origin_denied"
+        );
+    }
+
+    #[test]
+    fn sync_mutations_use_their_matching_application_permission() {
+        assert_eq!(
+            mutation_operation_name(SyncMutationOperation::Create),
+            "create"
+        );
+        assert_eq!(
+            mutation_operation_name(SyncMutationOperation::Update),
+            "update"
+        );
+        assert_eq!(
+            mutation_operation_name(SyncMutationOperation::Rename),
+            "rename"
+        );
+        assert_eq!(
+            mutation_operation_name(SyncMutationOperation::Delete),
+            "delete"
         );
     }
 

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -75,9 +75,10 @@ Attach and verify both DNS names before testing browser OAuth:
 - `mcp.mdbase.dev` → MCP gateway Render hostname
 
 Render terminates TLS. The control plane refuses a non-HTTPS public origin, and
-the provider binds browser capabilities to each application's exact manifest
-origin. CLI mirrors have no `Origin` header and authenticate with their own
-collection-scoped replica credential.
+the provider binds each browser capability to the application's exact manifest
+origin. This binding is stored with the capability, so applications do not need
+to be added to a deployment-wide origin list. CLI mirrors have no `Origin`
+header and authenticate with their own collection-scoped replica credential.
 
 ## Acceptance check
 

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -16,6 +16,14 @@ control plane does not proxy or persist them. The provider rechecks collection,
 operation, mode, contract scope, scope epoch, expiry, and revocation before it
 opens authoritative state.
 
+Application capabilities also authorize the scoped replication stream used by
+offline caches. Session and snapshot reads require record-read access, change
+pages require change access, and each queued mutation requires its corresponding
+create, update, rename, or delete permission. Browser requests are checked
+against the exact origin stored on that application capability. Mirror
+credentials have no browser origin and are rejected when presented by browser
+JavaScript.
+
 `mdbase-rs` remains the only collection-semantics implementation. The provider
 materializes a collection working set from canonical PostgreSQL documents and
 resources, invokes the normative v0.3 operation facade, captures the resulting

--- a/render.yaml
+++ b/render.yaml
@@ -25,8 +25,6 @@ services:
         generateValue: true
       - key: MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY
         generateValue: true
-      - key: MDBASE_CONNECT_HOSTED_PROVIDER_ALLOWED_ORIGINS
-        value: https://connect.mdbase.dev
       - key: MDBASE_CONNECT_HOSTED_MAX_RECORDS_PER_COLLECTION
         value: "100000"
       - key: MDBASE_CONNECT_HOSTED_MAX_BYTES_PER_COLLECTION

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -17,7 +17,10 @@ import { MdbaseConnect } from "../packages/client/dist/index.js";
 process.env.NODE_ENV = "test";
 const run = promisify(execFile);
 const repoRoot = resolve(import.meta.dirname, "..");
-const loopbackPort = Number(process.env.MDBASE_CONNECT_E2E_LOOPBACK_PORT ?? 28_485);
+const configuredLoopbackPort = process.env.MDBASE_CONNECT_E2E_LOOPBACK_PORT;
+const loopbackPort = configuredLoopbackPort === undefined
+  ? await availableTcpPort()
+  : Number(configuredLoopbackPort);
 if (!Number.isInteger(loopbackPort) || loopbackPort < 1 || loopbackPort > 65_535) {
   throw new Error("MDBASE_CONNECT_E2E_LOOPBACK_PORT must be a valid TCP port");
 }
@@ -41,8 +44,6 @@ const collectionPath = join(scratch, "workouts");
 const extension = process.platform === "win32" ? ".exe" : "";
 const agentBinary = join(repoRoot, "target", "debug", `mdbase-connect-agent${extension}`);
 const cliBinary = join(repoRoot, "target", "debug", `mdbase-connect${extension}`);
-const loopbackPort = Number(process.env.MDBASE_CONNECT_LOOPBACK_PORT ?? 28_485);
-const loopbackUrl = `http://127.0.0.1:${loopbackPort}`;
 let agent;
 let manifestServer;
 let browserManifestServer;
@@ -673,6 +674,20 @@ async function poll(action, failureMessage) {
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
   }
   throw new Error(failureMessage);
+}
+
+async function availableTcpPort() {
+  const server = createServer();
+  await new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Could not reserve an end-to-end loopback port");
+  }
+  await new Promise((resolveClose) => server.close(resolveClose));
+  return address.port;
 }
 
 async function openManifestServer() {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -413,9 +413,22 @@ try {
   const appReplicaId = storedHostedToken.hosted.replicaId;
   const appSync = await rawRequest(provider.url, syncPath(genericCollectionId, "sessions"), {
     method: "POST",
-    token: appToken
+    token: appToken,
+    headers: { origin: manifest.origin }
   });
-  assert.equal(appSync.status, 401);
+  assert.equal(appSync.status, 200);
+  assert.equal(appSync.body.replica_id, appReplicaId);
+  const wrongSyncOrigin = await rawRequest(
+    provider.url,
+    syncPath(genericCollectionId, "sessions"),
+    {
+      method: "POST",
+      token: appToken,
+      headers: { origin: "https://evil.example" }
+    }
+  );
+  assert.equal(wrongSyncOrigin.status, 403);
+  assert.equal(wrongSyncOrigin.body.error.code, "origin_denied");
   const wrongOrigin = await rawRequest(
     provider.url,
     `/v1/hosted/collections/${genericCollectionId}/operations/query`,
@@ -463,6 +476,19 @@ try {
     path: "Writing/Draft.md",
     if_revision: sdkRenamed.result.revision
   })).valid, true);
+  const hostedSync = hostedSdk.hostedSync();
+  assert.ok(hostedSync);
+  const offline = new OfflineReplica(hostedSync.transport, store(hostedSync.replicaId));
+  await offline.initialize();
+  await offline.queueCreate({
+    recordId: crypto.randomUUID(),
+    path: "Offline.md",
+    frontmatter: { title: "Created through application sync" },
+    body: "",
+    types: []
+  });
+  await offline.sync();
+  assert.equal((await offline.records())[0].frontmatter.title, "Created through application sync");
   globalThis.fetch = originalFetch;
   const dashboardWithApp = await controlRequest(controlUrl, "/v1/me", cookie);
   const hostedGrant = dashboardWithApp.grants.find((grant) => grant.collection_id === genericCollectionId);
@@ -499,6 +525,17 @@ try {
   );
   assert.equal(deniedWrite.status, 403);
   assert.equal(deniedWrite.body.error.code, "insufficient_access");
+  const deniedChanges = await rawRequest(
+    provider.url,
+    `${syncPath(genericCollectionId, "changes")}?after=0&limit=10`,
+    {
+      method: "GET",
+      token: appToken,
+      headers: { origin: manifest.origin }
+    }
+  );
+  assert.equal(deniedChanges.status, 403);
+  assert.equal(deniedChanges.body.error.code, "insufficient_access");
   await controlRequest(controlUrl, `/v1/grants/${hostedGrant.id}`, cookie, { method: "DELETE" });
   const revokedApp = await rawRequest(
     provider.url,
@@ -1215,7 +1252,6 @@ async function startProvider(
       DATABASE_URL: databaseUrl,
       MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: internalToken,
       MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY: providerMasterKey,
-      MDBASE_CONNECT_HOSTED_PROVIDER_ALLOWED_ORIGINS: "http://127.0.0.1",
       HOST: "127.0.0.1",
       PORT: String(port),
       RUST_LOG: "warn",


### PR DESCRIPTION
## What changed

- authorize hosted offline sync with the same application capability issued by OAuth
- enforce the capability's exact browser origin and per-operation permissions on sessions, snapshots, changes, and mutations
- keep mirror credentials outside browser JavaScript
- replace the provider-wide origin allowlist with per-capability origin binding
- exercise the full application offline path against the Rust/PostgreSQL provider
- isolate the general end-to-end test from an already-running desktop connector

## Root cause

The SDK correctly exposed `hostedSync()`, but the Rust provider accepted only mirror-purpose credentials on its sync routes. Production also checked browser requests against a deployment-wide allowlist containing only `connect.mdbase.dev`, so TaskNotes was rejected before its grant could be evaluated. The existing SDK test mocked the provider response, while the real-provider suite explicitly expected application sync to fail.

## Impact

TaskNotes and other authorized browser applications can initialize and maintain scoped offline caches for hosted collections. Their sync access remains limited to the collection, record types, origin, mode, and operations approved in the grant.

## Validation

- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:provider`
