### PR TITLE
Require hosted collections for sync applications

### DIFF
--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -103,6 +103,7 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  collection_kind?: "hosted";
 }
 
 export interface TypeProvision {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -741,6 +741,9 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
         {request.requirements.contracts.length > 0 && (
           <small>{scopeDescription(request.requirements.contracts)}</small>
         )}
+        {request.requirements.collection_kind === "hosted" && (
+          <small>Requires an mdbase cloud collection</small>
+        )}
       </div>
     </div>
   );
@@ -881,9 +884,12 @@ function compatibleCollections<T extends { contracts: ContractRequirement[] }>(
   request: PendingAuthorization,
   collections: Array<T & { kind?: "local" | "hosted" }>
 ): T[] {
+  const candidates = request.requirements.collection_kind === "hosted"
+    ? collections.filter((collection) => collection.kind === "hosted")
+    : collections;
   const required = request.requirements.contracts;
-  if (required.length === 0) return collections;
-  return collections.filter((collection) => required.every((requirement) =>
+  if (required.length === 0) return candidates;
+  return candidates.filter((collection) => required.every((requirement) =>
     hasContract(collection.contracts, requirement)
     || (collection.kind === "hosted" && request.provisions.types.some((provision) =>
       provision.provides.some((provided) => sameContract(provided, requirement))

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -92,6 +92,7 @@ type definitions for the connector to install during approval:
   "homepage": "https://tasks.example",
   "redirect_uris": ["https://tasks.example/auth/mdbase/callback"],
   "requirements": {
+    "collection_kind": "hosted",
     "contracts": [{ "id": "tasknotes.task", "version": 1 }]
   },
   "provisions": {
@@ -103,6 +104,10 @@ type definitions for the connector to install during approval:
   }
 }
 ```
+
+Set `collection_kind` to `hosted` when the application needs a durable
+provider-backed collection and the offline sync transport returned by
+`hostedSync()`. Connect then offers and accepts hosted collections only.
 
 Provisioning is part of the approval flow. The connector validates and
 installs only the missing type definitions, verifies that they expose the

--- a/packages/protocol/schemas/mdbase-app.schema.json
+++ b/packages/protocol/schemas/mdbase-app.schema.json
@@ -55,6 +55,10 @@
       "additionalProperties": false,
       "required": ["contracts"],
       "properties": {
+        "collection_kind": {
+          "const": "hosted",
+          "description": "Require a durable provider-backed collection with direct sync support."
+        },
         "contracts": {
           "type": "array",
           "maxItems": 20,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -68,6 +68,8 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  /** Restrict authorization to durable provider-backed collections. */
+  collection_kind?: "hosted";
 }
 
 export interface TypeProvision {

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -41,7 +41,10 @@ test("application manifests declare connector-controlled type provisioning", () 
     name: "Tasks",
     homepage: "https://tasks.example/",
     redirect_uris: ["https://tasks.example/callback"],
-    requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+    requirements: {
+      collection_kind: "hosted",
+      contracts: [{ id: "tasknotes.task", version: 1 }]
+    },
     provisions: {
       types: [{
         name: "Task",
@@ -52,6 +55,10 @@ test("application manifests declare connector-controlled type provisioning", () 
   };
   assert.equal(validate(manifest), true, JSON.stringify(validate.errors));
   assert.equal(validate({ ...manifest, manifest_version: 2 }), false);
+  assert.equal(validate({
+    ...manifest,
+    requirements: { ...manifest.requirements, collection_kind: "local" }
+  }), false);
   assert.equal(validate({ ...manifest, provisions: { types: [{ ...manifest.provisions.types[0], provides: [] }] } }), false);
 });
 

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import { createECDH } from "node:crypto";
+import type { ApplicationRequirements } from "@mdbase/connect-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
@@ -481,6 +482,30 @@ describe("mdbase connect server", () => {
     });
     const setCookie = session.headers["set-cookie"]!;
     const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const connectorResponse = await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Writing computer" }
+    });
+    const connector = connectorResponse.json();
+    const localCollectionId = "32f95339-c600-427f-a187-85758dc2662e";
+    const synchronized = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: {
+        collections: [{
+          id: localCollectionId,
+          display_name: "Local writing",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    });
+    expect(synchronized.statusCode).toBe(200);
+    const localControlCollectionId = synchronized.json().collections[0].id as string;
     const collection = await app.inject({
       method: "POST",
       url: "/v1/hosted/collections",
@@ -489,7 +514,10 @@ describe("mdbase connect server", () => {
     });
     const collectionId = collection.json().collection.id as string;
 
-    const manifestServer = await startManifestServer({ contracts: [] }, "Writing Editor");
+    const manifestServer = await startManifestServer(
+      { contracts: [], collection_kind: "hosted" },
+      "Writing Editor"
+    );
     resources.push(manifestServer.close);
     const discovered = await app.inject({
       method: "POST",
@@ -504,6 +532,37 @@ describe("mdbase connect server", () => {
       headers: { cookie }
     });
     const requestId = authorization.headers.location!.split("/").at(-1)!;
+    const pending = await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${requestId}`,
+      headers: { cookie }
+    });
+    expect(pending.json().authorization.requirements).toEqual({
+      contracts: [],
+      collection_kind: "hosted"
+    });
+    expect(pending.json().collections).toEqual([
+      expect.objectContaining({ id: collectionId, kind: "hosted" })
+    ]);
+    const connectorControl = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/control",
+      headers: { authorization: `Bearer ${connector.token}` }
+    });
+    expect(connectorControl.json().pending_authorizations).toEqual([]);
+    const localApproval = await app.inject({
+      method: "POST",
+      url: `/v1/authorization-requests/${requestId}/approve`,
+      headers: { cookie },
+      payload: {
+        collection_id: localControlCollectionId,
+        operations: ["describe", "query", "create", "update"]
+      }
+    });
+    expect(localApproval.statusCode).toBe(400);
+    expect(localApproval.json().error.message).toBe(
+      "This application requires an mdbase cloud collection."
+    );
     const approved = await app.inject({
       method: "POST",
       url: `/v1/authorization-requests/${requestId}/approve`,
@@ -693,7 +752,9 @@ describe("mdbase connect server", () => {
 });
 
 async function startManifestServer(
-  requirements = { contracts: [{ id: "workout.record", version: 1 }] },
+  requirements: ApplicationRequirements = {
+    contracts: [{ id: "workout.record", version: 1 }]
+  },
   name = "Workout Tracker",
   provisions?: {
     types: Array<{

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -838,6 +838,7 @@ export async function buildApp(options: BuildOptions) {
         application_origin: new URL(grant.application_origin).origin
       })),
       pending_authorizations: pendingAuthorizations.rows
+        .filter((authorization) => !requiresHostedCollection(authorization.requirements))
     };
   });
 
@@ -899,6 +900,12 @@ export async function buildApp(options: BuildOptions) {
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
+    if (requiresHostedCollection(application.rows[0].requirements)) {
+      return reply.code(409).send(apiError(
+        "incompatible_collection",
+        "This application requires an mdbase cloud collection."
+      ));
+    }
     const scope = scopeForRequirements(application.rows[0].requirements);
     if (!contractsSatisfy(collection.rows[0].contracts, scope.contracts)) {
       return reply.code(409).send(apiError(
@@ -1314,6 +1321,12 @@ export async function buildApp(options: BuildOptions) {
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
+    if (requiresHostedCollection(application.rows[0].requirements)) {
+      return reply.code(409).send(apiError(
+        "incompatible_collection",
+        "This application requires an mdbase cloud collection."
+      ));
+    }
     const scope = scopeForRequirements(application.rows[0].requirements);
     if (!contractsSatisfy(ownership.rows[0].contracts, scope.contracts)) {
       return reply.code(409).send(apiError(
@@ -1518,18 +1531,21 @@ export async function buildApp(options: BuildOptions) {
           [user.id]
         )
       : { rows: [] };
+    const availableCollections = [
+      ...collections.rows.map((collection) => ({ ...collection, kind: "local" as const })),
+      ...hosted.rows.map((collection) => ({
+        ...collection,
+        kind: "hosted" as const,
+        connector_name: "Hosted by mdbase",
+        spec_version: "0.3.0",
+        contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template))
+      }))
+    ];
     return {
       authorization: authorization.rows[0],
-      collections: [
-        ...collections.rows.map((collection) => ({ ...collection, kind: "local" })),
-        ...hosted.rows.map((collection) => ({
-          ...collection,
-          kind: "hosted",
-          connector_name: "Hosted by mdbase",
-          spec_version: "0.3.0",
-          contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template))
-        }))
-      ]
+      collections: requiresHostedCollection(authorization.rows[0].requirements)
+        ? availableCollections.filter((collection) => collection.kind === "hosted")
+        : availableCollections
     };
   });
 
@@ -1928,7 +1944,10 @@ async function reconcileApplicationGrants(
     const availableContracts = grant.template
       ? contractRequirements(hostedDescriptors)
       : grant.local_contracts ?? [];
-    const collectionCompatible = contractsSatisfy(availableContracts, desiredScope.contracts);
+    const collectionKindCompatible = !requiresHostedCollection(application.requirements)
+      || grant.template !== null;
+    const collectionCompatible = collectionKindCompatible
+      && contractsSatisfy(availableContracts, desiredScope.contracts);
     const scopeMatches = scopesEqual(grant.scope, desiredScope);
     const desiredAllowedTypes = grant.template
       ? typesForContracts(hostedDescriptors, desiredScope.contracts)
@@ -2039,6 +2058,9 @@ async function approveAuthorization(
   );
   const pending = authorization.rows[0];
   if (!pending) return false;
+  if (requiresHostedCollection(pending.requirements)) {
+    throw new RequestValidationError("This application requires an mdbase cloud collection.");
+  }
   if (input.operations.some((operation) => !pending.requested_operations.includes(operation))) {
     throw new RequestValidationError("Approved operations must be requested by the application.");
   }
@@ -2410,6 +2432,12 @@ function scopeForRequirements(requirements: ApplicationRequirements | null | und
       contract
     ])).values()]
   };
+}
+
+function requiresHostedCollection(
+  requirements: ApplicationRequirements | null | undefined
+): boolean {
+  return requirements?.collection_kind === "hosted";
 }
 
 function matchesGrantEncryption(

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -14,7 +14,10 @@ const contractsSchema = z.array(contractSchema).max(20).refine(
   (contracts) => new Set(contracts.map((contract) => `${contract.id}@${contract.version}`)).size === contracts.length,
   "Contracts must be unique."
 );
-const requirementsSchema = z.object({ contracts: contractsSchema }).strict().default({ contracts: [] });
+const requirementsSchema = z.object({
+  contracts: contractsSchema,
+  collection_kind: z.literal("hosted").optional()
+}).strict().default({ contracts: [] });
 const manifestSchema = z.object({
   manifest_version: z.literal(1),
   name: z.string().trim().min(1).max(100),


### PR DESCRIPTION
## What changed

- add an optional `requirements.collection_kind: "hosted"` app-manifest constraint
- filter authorization choices to hosted collections and enforce the constraint server-side
- keep hosted-only requests out of local connector approval queues
- revoke incompatible local grants when a manifest changes to require hosted storage
- document and test the requirement

## Why

TaskNotes cloud mode requires the provider sync transport, but Connect could offer a compatible local TaskNotes vault first. Approving that vault produced a valid OAuth connection without hosted credentials, so TaskNotes failed before opening.

## Impact

Applications that require offline provider sync can declare the constraint once. Connect will only offer and accept durable hosted collections; existing applications remain unrestricted unless they opt in.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm package:audit`
- `pnpm e2e`
- `pnpm e2e:provider`
- TaskNotes full cloud browser E2E against this branch
