### PR TITLE
Group application access records

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -3,6 +3,7 @@ import "@fontsource/atkinson-hyperlegible/latin-700.css";
 import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
+import { groupApplicationAccess, type ApplicationAccessGroup } from "@mdbase/connect-ui/access";
 import "@mdbase/connect-ui/styles.css";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -372,6 +373,7 @@ function Access({ cloud, access, collections, busy, onAct, onNotice, onPairingCo
   onNotice(value: string): void;
   onPairingComplete(): void;
 }) {
+  const applicationAccess = useMemo(() => groupApplicationAccess(access.grants), [access.grants]);
   if (!cloud.configured) return <PairingPanel onComplete={onPairingComplete} />;
   return (
     <div className="workspace-stack">
@@ -387,16 +389,52 @@ function Access({ cloud, access, collections, busy, onAct, onNotice, onPairingCo
       </section>
 
       <section>
-        <SectionHeading title="Connected applications" note="Change allowed operations or revoke access immediately." count={access.grants.length} />
-        {access.grants.length === 0 ? (
+        <SectionHeading title="Connected applications" note="Applications are grouped here; expand one to review its collection access." count={applicationAccess.length} />
+        {applicationAccess.length === 0 ? (
           <Empty title="No applications connected" text="Connect from an mdbase-enabled website, or inspect a published application manifest below." />
         ) : (
-          <div className="grant-list">{access.grants.map((grant) => <GrantEditor key={grant.id} grant={grant} busy={busy} onAct={onAct} onNotice={onNotice} />)}</div>
+          <div className="application-access-list">{applicationAccess.map((group) => (
+            <ApplicationGrantGroup key={group.applicationId} group={group} busy={busy} onAct={onAct} onNotice={onNotice} />
+          ))}</div>
         )}
       </section>
 
       <ManualApplication collections={collections} busy={busy} onAct={onAct} onNotice={onNotice} />
     </div>
+  );
+}
+
+function ApplicationGrantGroup({ group, busy, onAct, onNotice }: {
+  group: ApplicationAccessGroup<GrantSummary>;
+  busy: boolean;
+  onAct(action: () => Promise<void>): Promise<void>;
+  onNotice(value: string): void;
+}) {
+  const identity = group.grants[0];
+  return (
+    <details className="application-grant-group">
+      <summary>
+        <div><strong>{group.applicationName}</strong><code>{host(identity.application_homepage)}</code></div>
+        <span>{group.collectionCount} {plural(group.collectionCount, "collection", "collections")}</span>
+        <span>{group.grants.length} {plural(group.grants.length, "access record", "access records")}</span>
+        <b>Review</b>
+      </summary>
+      <div className="application-grant-body">
+        <div className="grant-list">{group.grants.map((grant) => (
+          <GrantEditor key={grant.id} grant={grant} busy={busy} onAct={onAct} onNotice={onNotice} />
+        ))}</div>
+        <div className="application-grant-actions">
+          <small>Revokes this application from every collection on this computer.</small>
+          <button className="quiet-action danger" disabled={busy} onClick={() => {
+            if (!window.confirm(`Revoke all ${group.applicationName} access from this computer?`)) return;
+            void onAct(async () => {
+              for (const grant of group.grants) await window.mdbaseConnect.revokeGrant(grant.id);
+              onNotice(`${group.applicationName} access from this computer was revoked.`);
+            });
+          }}>Revoke from this computer</button>
+        </div>
+      </div>
+    </details>
   );
 }
 
@@ -452,8 +490,7 @@ function GrantEditor({ grant, busy, onAct, onNotice }: { grant: GrantSummary; bu
   useEffect(() => setOperations(grant.operations), [grant.operations]);
   return (
     <article className="grant-row">
-      <div className="identity-mark">{initials(grant.application_name)}</div>
-      <div className="grant-identity"><strong>{grant.application_name}</strong><code>{host(grant.application_homepage)}</code><small>{grant.collection_name}</small>{grant.scope.contracts.length > 0 && <small>{scopeDescription(grant.scope.contracts)}</small>}</div>
+      <div className="grant-identity"><strong>{grant.collection_name}</strong><code>{host(grant.application_origin || grant.application_homepage)}</code><small>Connected {relativeTime(grant.created_at)}</small>{grant.scope.contracts.length > 0 && <small>{scopeDescription(grant.scope.contracts)}</small>}</div>
       <OperationChoices allowed={allowedOperations} selected={operations} onChange={setOperations} compact />
       <div className="row-actions">
         <button className="quiet-action" disabled={busy || !changed || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.updateGrant({ grantId: grant.id, operations }); onNotice(`${grant.application_name} permissions were updated.`); })}>Save</button>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -69,6 +69,21 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 
 .collection-section, .activity-section { margin-top: 30px; }
 .collection-list, .grant-list, .activity-list { display: grid; margin-top: 10px; }
+.application-access-list { margin-top: 10px; border-top: 1px solid var(--line); }
+.application-grant-group { border-bottom: 1px solid var(--line); }
+.application-grant-group > summary { display: grid; grid-template-columns: minmax(160px, 1fr) auto auto auto; align-items: center; gap: 20px; min-height: 72px; cursor: pointer; list-style: none; }
+.application-grant-group > summary::-webkit-details-marker { display: none; }
+.application-grant-group > summary > div { display: grid; gap: 3px; min-width: 0; }
+.application-grant-group > summary strong { overflow: hidden; font-size: var(--type-row-title); font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
+.application-grant-group > summary code, .application-grant-group > summary > span { overflow: hidden; color: var(--muted); font-size: var(--type-metadata); text-overflow: ellipsis; white-space: nowrap; }
+.application-grant-group > summary b { color: var(--ink); font-family: var(--mono); font-size: var(--type-action); font-weight: 500; }
+.application-grant-group > summary b::after { content: " +"; color: var(--muted); }
+.application-grant-group[open] > summary b::after { content: " −"; }
+.application-grant-body { padding: 0 0 16px 20px; border-top: 1px solid var(--line); }
+.application-grant-body .grant-list { margin-top: 0; }
+.application-grant-body .grant-row:first-child { border-top: 0; }
+.application-grant-actions { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding-top: 12px; }
+.application-grant-actions small { color: var(--muted); font-size: var(--type-action); }
 .collection-card { border-bottom: 1px solid var(--line); }
 .collection-card:first-child { border-top: 1px solid var(--line); }
 .collection-summary { display: grid; grid-template-columns: minmax(170px, 1fr) auto auto; align-items: center; gap: 18px; min-height: 68px; padding: 10px 0; }
@@ -177,6 +192,8 @@ fieldset legend { margin-bottom: 6px; }
 @media (max-width: 1000px) {
   .request-panel { grid-template-columns: minmax(130px, 0.7fr) minmax(280px, 1.3fr); }
   .decision-actions { grid-column: 1 / -1; display: flex; justify-content: flex-end; }
+  .application-grant-group > summary { grid-template-columns: minmax(150px, 1fr) auto auto; }
+  .application-grant-group > summary > span:last-of-type { display: none; }
   .grant-row { grid-template-columns: minmax(120px, 0.7fr) minmax(220px, 1.3fr); }
   .grant-row .row-actions { grid-column: 1 / -1; }
   .manual-grant { grid-template-columns: 1fr 1fr; }
@@ -186,6 +203,11 @@ fieldset legend { margin-bottom: 6px; }
 @media (max-width: 780px) {
   .content { padding-inline: 24px; }
   .readiness-panel, .pairing-panel { grid-template-columns: 1fr; gap: 24px; }
+  .application-grant-group > summary { grid-template-columns: minmax(0, 1fr) auto; gap: 8px 16px; padding: 10px 0; }
+  .application-grant-group > summary > span { grid-column: 1; }
+  .application-grant-group > summary > b { grid-column: 2; grid-row: 1; }
+  .application-grant-body { padding-left: 12px; }
+  .application-grant-actions { align-items: flex-start; flex-direction: column; }
   .overview-row { grid-template-columns: 95px minmax(0, 1fr) auto; }
   .pairing-form { grid-template-columns: 1fr; }
   .pairing-form .button { grid-column: 1; }

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -50,6 +50,7 @@ export interface DashboardData {
     application_id: string;
     application_name: string;
     homepage: string;
+    application_origin: string;
     icon: string | null;
   }>;
   pending_authorizations: PendingAuthorization[];

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -3,6 +3,7 @@ import "@fontsource/atkinson-hyperlegible/latin-700.css";
 import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
+import { groupApplicationAccess, type ApplicationAccessGroup } from "@mdbase/connect-ui/access";
 import "@mdbase/connect-ui/styles.css";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -263,6 +264,8 @@ function Dashboard() {
     return () => window.clearInterval(timer);
   }, []);
   if (!data) return <Loading error={error} />;
+  const activeGrants = data.grants.filter((grant) => !grant.revoked_at);
+  const applicationAccess = groupApplicationAccess(activeGrants);
 
   return (
     <div className="account-shell">
@@ -308,14 +311,19 @@ function Dashboard() {
           <HostedCollections collections={data.hosted_collections} onChanged={refresh} onError={setError} />
         </section>
         <section id="permissions">
-          <SectionHeading title="Application access" note="Review exact permissions, narrow them, or revoke access immediately." count={data.grants.filter((grant) => !grant.revoked_at).length} />
-          {data.grants.every((grant) => grant.revoked_at) ? (
+          <SectionHeading title="Application access" note="Applications are grouped here; expand one to review its collection access." count={applicationAccess.length} />
+          {applicationAccess.length === 0 ? (
             <Empty title="No applications connected" text="Approved website connections will appear here." />
           ) : (
-            <div className="portal-grant-list">{data.grants.filter((grant) => !grant.revoked_at).map((grant) => {
-              const collection = data.collections.find((candidate) => candidate.id === grant.collection_id);
-              return <PortalGrant key={grant.id} grant={grant} connectorName={grant.collection_kind === "hosted" ? "Hosted by mdbase" : collection?.connector_name ?? "Unknown computer"} onChanged={refresh} onError={setError} />;
-            })}</div>
+            <div className="portal-application-list">{applicationAccess.map((group) => (
+              <PortalApplicationAccess
+                key={group.applicationId}
+                group={group}
+                collections={data.collections}
+                onChanged={refresh}
+                onError={setError}
+              />
+            ))}</div>
           )}
         </section>
         <section id="computers">
@@ -566,9 +574,61 @@ function ComputerRow({ connector, collectionCount, availableCount, onChanged, on
   </div>;
 }
 
-function PortalGrant({ grant, connectorName, onChanged, onError }: {
+type PortalGrantRecord = DashboardData["grants"][number];
+
+function PortalApplicationAccess({ group, collections, onChanged, onError }: {
+  group: ApplicationAccessGroup<PortalGrantRecord>;
+  collections: DashboardData["collections"];
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const identity = group.grants[0];
+
+  async function revokeApplication() {
+    const collectionLabel = pluralLabel(group.collectionCount, "collection", "collections");
+    if (!window.confirm(`Revoke all ${group.applicationName} access across ${collectionLabel}?`)) return;
+    setBusy(true);
+    try {
+      for (const grant of group.grants) {
+        await api(`/v1/grants/${grant.id}`, { method: "DELETE" });
+      }
+      await onChanged();
+    } catch (reason) {
+      await onChanged().catch(() => undefined);
+      onError(message(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return <details className="portal-application-access">
+    <summary>
+      <div className="application-access-identity"><strong>{group.applicationName}</strong><small>{host(identity.homepage)}</small></div>
+      <span>{pluralLabel(group.collectionCount, "collection", "collections")}</span>
+      <span>{pluralLabel(group.grants.length, "access record", "access records")}</span>
+      <b>Review</b>
+    </summary>
+    <div className="portal-application-body">
+      <div className="portal-grant-list">{group.grants.map((grant) => {
+        const collection = collections.find((candidate) => candidate.id === grant.collection_id);
+        const connectorName = grant.collection_kind === "hosted"
+          ? "Hosted by mdbase"
+          : collection?.connector_name ?? "Unknown computer";
+        return <PortalGrant key={grant.id} grant={grant} connectorName={connectorName} disabled={busy} onChanged={onChanged} onError={onError} />;
+      })}</div>
+      <div className="application-access-actions">
+        <span>Revokes every active access record for this application.</span>
+        <button className="quiet-danger" disabled={busy} onClick={() => void revokeApplication()}>Revoke application</button>
+      </div>
+    </div>
+  </details>;
+}
+
+function PortalGrant({ grant, connectorName, disabled, onChanged, onError }: {
   grant: DashboardData["grants"][number];
   connectorName: string;
+  disabled?: boolean;
   onChanged(): Promise<void>;
   onError(value: string): void;
 }) {
@@ -580,6 +640,7 @@ function PortalGrant({ grant, connectorName, onChanged, onError }: {
     ...grant.operations.filter((operation) => !allOperations.includes(operation))
   ];
   const changed = orderedOperations.some((operation) => operations.has(operation) !== grant.operations.includes(operation));
+  const inactive = busy || disabled;
 
   function toggle(operation: string) {
     setOperations((current) => {
@@ -618,15 +679,15 @@ function PortalGrant({ grant, connectorName, onChanged, onError }: {
 
   return <details className="portal-grant">
     <summary>
-      <div><strong>{grant.application_name}</strong><small>{host(grant.homepage)}</small></div>
       <div><strong>{grant.collection_name}</strong><small>{connectorName}</small></div>
       <span>{grant.operations.length} {grant.operations.length === 1 ? "permission" : "permissions"}</span>
+      <span>{relativeTime(grant.created_at)}</span>
       <b>Review</b>
     </summary>
     <div className="portal-grant-detail">
-      <div><p className="detail-label">Allowed actions</p><div className="permission-options grant-permissions">{orderedOperations.map((operation) => <label key={operation}><input type="checkbox" checked={operations.has(operation)} disabled={busy} onChange={() => toggle(operation)} /><span>{operationLabel(operation)}</span></label>)}</div></div>
-      <div className="grant-context"><p><span>Scope</span><strong>{grant.scope.contracts.length ? scopeDescription(grant.scope.contracts) : "All record types in this collection."}</strong></p><p><span>Connected</span><strong>{relativeTime(grant.created_at)}</strong></p></div>
-      <div className="grant-actions"><button className="button secondary" disabled={busy || !changed || operations.size === 0} onClick={() => void save()}>Save narrower access</button><button className="quiet-danger" disabled={busy} onClick={() => void revoke()}>Revoke access</button></div>
+      <div><p className="detail-label">Allowed actions</p><div className="permission-options grant-permissions">{orderedOperations.map((operation) => <label key={operation}><input type="checkbox" checked={operations.has(operation)} disabled={inactive} onChange={() => toggle(operation)} /><span>{operationLabel(operation)}</span></label>)}</div></div>
+      <div className="grant-context"><p><span>Scope</span><strong>{grant.scope.contracts.length ? scopeDescription(grant.scope.contracts) : "All record types in this collection."}</strong></p><p><span>Application origin</span><strong className="mono-detail">{grant.application_origin}</strong></p><p><span>Connected</span><strong>{relativeTime(grant.created_at)}</strong></p></div>
+      <div className="grant-actions"><button className="button secondary" disabled={inactive || !changed || operations.size === 0} onClick={() => void save()}>Save narrower access</button><button className="quiet-danger" disabled={inactive} onClick={() => void revoke()}>Revoke access</button></div>
     </div>
   </details>;
 }
@@ -869,6 +930,7 @@ function Loading({ error = "" }: { error?: string }) { return <main className="l
 function initials(value: string) { return value.split(/\s+/).map((part) => part[0]).join("").slice(0, 2).toUpperCase(); }
 function message(value: unknown) { return value instanceof Error ? value.message : String(value); }
 function host(value: string) { try { return new URL(value).host; } catch { return value; } }
+function pluralLabel(count: number, singular: string, pluralValue: string) { return `${count} ${count === 1 ? singular : pluralValue}`; }
 function operationLabel(operation: string) {
   return ({
     query: "Search and query",

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -126,7 +126,8 @@ h1 {
 .hosted-list,
 .account-rows,
 .request-list,
-.portal-grant-list {
+.portal-grant-list,
+.portal-application-list {
   border-top: 1px solid var(--line);
 }
 
@@ -398,30 +399,33 @@ h1 {
   cursor: not-allowed;
 }
 
-.portal-grant {
+.portal-application-access {
   border-bottom: 1px solid var(--line);
 }
 
-.portal-grant summary {
+.portal-application-access > summary {
   display: grid;
   grid-template-columns: minmax(10rem, 1fr) minmax(10rem, 1fr) auto auto;
   align-items: center;
   gap: 1.25rem;
-  min-height: 4.5rem;
+  min-height: 4.8rem;
   cursor: pointer;
   list-style: none;
 }
 
+.portal-application-access > summary::-webkit-details-marker,
 .portal-grant summary::-webkit-details-marker {
   display: none;
 }
 
+.portal-application-access > summary > div,
 .portal-grant summary > div {
   display: grid;
   gap: 0.2rem;
   min-width: 0;
 }
 
+.portal-application-access > summary strong,
 .portal-grant summary strong {
   overflow: hidden;
   font-size: 0.82rem;
@@ -429,6 +433,8 @@ h1 {
   white-space: nowrap;
 }
 
+.portal-application-access > summary small,
+.portal-application-access > summary > span,
 .portal-grant summary small,
 .portal-grant summary > span {
   overflow: hidden;
@@ -438,10 +444,12 @@ h1 {
   white-space: nowrap;
 }
 
+.portal-application-access > summary small,
 .portal-grant summary small {
   font-family: var(--mono);
 }
 
+.portal-application-access > summary b,
 .portal-grant summary b {
   color: var(--ink-soft);
   font-family: var(--mono);
@@ -449,13 +457,38 @@ h1 {
   font-weight: 600;
 }
 
+.portal-application-access > summary b::after,
 .portal-grant summary b::after {
   content: " +";
   color: var(--ink-muted);
 }
 
+.portal-application-access[open] > summary b::after,
 .portal-grant[open] summary b::after {
   content: " −";
+}
+
+.portal-application-body {
+  padding: 0 0 1.2rem 1.2rem;
+  border-top: 1px solid var(--line);
+}
+
+.portal-application-body .portal-grant-list {
+  border-top: 0;
+}
+
+.portal-grant {
+  border-bottom: 1px solid var(--line);
+}
+
+.portal-grant summary {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto auto auto;
+  align-items: center;
+  gap: 1.25rem;
+  min-height: 4rem;
+  cursor: pointer;
+  list-style: none;
 }
 
 .portal-grant-detail {
@@ -463,6 +496,19 @@ h1 {
   grid-template-columns: minmax(16rem, 1.2fr) minmax(13rem, 0.8fr);
   gap: 1.4rem 2.5rem;
   padding: 0.2rem 0 1.4rem;
+}
+
+.application-access-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.9rem;
+}
+
+.application-access-actions > span {
+  color: var(--ink-muted);
+  font-size: 0.68rem;
 }
 
 .detail-label {
@@ -497,6 +543,12 @@ h1 {
   font-size: 0.72rem;
   font-weight: 400;
   line-height: 1.45;
+}
+
+.grant-context .mono-detail {
+  overflow-wrap: anywhere;
+  font-family: var(--mono);
+  font-size: 0.66rem;
 }
 
 .grant-actions {
@@ -953,20 +1005,31 @@ select {
     grid-template-columns: 1fr;
   }
 
+  .portal-application-access > summary,
   .portal-grant summary {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.55rem 1rem;
     padding: 0.8rem 0;
   }
 
-  .portal-grant summary > div:nth-child(2),
+  .portal-application-access > summary > span,
   .portal-grant summary > span {
     grid-column: 1;
   }
 
+  .portal-application-access > summary > b,
   .portal-grant summary > b {
     grid-column: 2;
     grid-row: 1;
+  }
+
+  .portal-application-body {
+    padding-left: 0.75rem;
+  }
+
+  .application-access-actions {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .availability {

--- a/packages/ui/access.test.ts
+++ b/packages/ui/access.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { groupApplicationAccess } from "./access.ts";
+
+test("groups repeated grants under a stable application identity", () => {
+  const groups = groupApplicationAccess([
+    grant("second", "app-b", "Budget", "collection-b", "2026-07-22T02:00:00Z"),
+    grant("newest", "app-a", "Notes", "collection-a", "2026-07-22T03:00:00Z"),
+    grant("oldest", "app-a", "Notes", "collection-a", "2026-07-22T01:00:00Z"),
+    grant("other", "app-a", "Archive", "collection-c", "2026-07-22T02:00:00Z")
+  ]);
+
+  assert.deepEqual(groups.map((group) => group.applicationId), ["app-a", "app-b"]);
+  assert.equal(groups[0].collectionCount, 2);
+  assert.deepEqual(groups[0].grants.map((item) => item.id), ["other", "newest", "oldest"]);
+});
+
+test("does not mutate the incoming grant order", () => {
+  const grants = [
+    grant("newest", "app-a", "Notes", "collection-a", "2026-07-22T03:00:00Z"),
+    grant("oldest", "app-a", "Notes", "collection-a", "2026-07-22T01:00:00Z")
+  ];
+
+  groupApplicationAccess(grants);
+
+  assert.deepEqual(grants.map((item) => item.id), ["newest", "oldest"]);
+});
+
+function grant(id: string, applicationId: string, collectionName: string, collectionId: string, createdAt: string) {
+  return {
+    id,
+    application_id: applicationId,
+    application_name: applicationId === "app-a" ? "Alpha" : "Beta",
+    collection_id: collectionId,
+    collection_name: collectionName,
+    created_at: createdAt
+  };
+}

--- a/packages/ui/access.ts
+++ b/packages/ui/access.ts
@@ -1,0 +1,51 @@
+export interface ApplicationAccessGrant {
+  application_id: string;
+  application_name: string;
+  collection_id: string;
+  collection_name: string;
+  created_at: string;
+}
+
+export interface ApplicationAccessGroup<Grant extends ApplicationAccessGrant> {
+  applicationId: string;
+  applicationName: string;
+  collectionCount: number;
+  grants: Grant[];
+}
+
+export function groupApplicationAccess<Grant extends ApplicationAccessGrant>(
+  grants: readonly Grant[]
+): ApplicationAccessGroup<Grant>[] {
+  const groups = new Map<string, ApplicationAccessGroup<Grant>>();
+
+  for (const grant of grants) {
+    const current = groups.get(grant.application_id);
+    if (current) {
+      current.grants.push(grant);
+      continue;
+    }
+    groups.set(grant.application_id, {
+      applicationId: grant.application_id,
+      applicationName: grant.application_name,
+      collectionCount: 0,
+      grants: [grant]
+    });
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      collectionCount: new Set(group.grants.map((grant) => grant.collection_id)).size,
+      grants: [...group.grants].sort(compareGrants)
+    }))
+    .sort((left, right) => compareText(left.applicationName, right.applicationName));
+}
+
+function compareGrants<Grant extends ApplicationAccessGrant>(left: Grant, right: Grant): number {
+  return compareText(left.collection_name, right.collection_name)
+    || right.created_at.localeCompare(left.created_at);
+}
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { sensitivity: "base" });
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0-alpha.1",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "node --test access.test.ts"
+  },
   "exports": {
+    "./access": "./access.ts",
     "./styles.css": "./styles.css"
   }
 }


### PR DESCRIPTION
## What changed

- group portal and Electron access records by stable application identity
- keep collection-specific credentials visible inside each application group
- add application-level revoke controls and responsive grouped layouts
- share and test the grouping logic across both interfaces

## Why

Disconnecting and reconnecting can create several valid access records for one application. The flat list made those records noisy and obscured the application-level relationship.

## Impact

Authorization records and their exact credential semantics remain unchanged. Users see one expandable application row with collection and access-record counts, and can inspect or revoke the underlying grants.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- responsive portal and Electron visual checks with repeated grant fixtures
