### PR TITLE
Add saved views across collection providers

### DIFF
--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -103,6 +103,7 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  access?: "contract" | "full_collection";
   collection_kind?: "hosted";
 }
 

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -103,6 +103,7 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  collection_kind?: "hosted";
 }
 
 export interface TypeProvision {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -738,7 +738,9 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
         {large && <p className="eyebrow">Application access</p>}
         {large ? <h1>{request.application_name}</h1> : <strong>{request.application_name}</strong>}
         <small>{host(request.homepage)} · expires {relativeTime(request.expires_at)}</small>
-        {request.requirements.contracts.length > 0 && (
+        {request.requirements.access === "full_collection" ? (
+          <small>Requests access to all record types in the selected collection.</small>
+        ) : request.requirements.contracts.length > 0 && (
           <small>{scopeDescription(request.requirements.contracts)}</small>
         )}
         {request.requirements.collection_kind === "hosted" && (
@@ -875,6 +877,8 @@ function host(value: string) { try { return new URL(value).host; } catch { retur
 function operationLabel(operation: string) {
   return ({
     query: "Search and query",
+    list_views: "See saved views",
+    execute_view: "Run saved views",
     read_type: "Inspect type definitions",
     create_type: "Create type definitions",
     update_type: "Change type definitions"

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -741,6 +741,9 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
         {request.requirements.contracts.length > 0 && (
           <small>{scopeDescription(request.requirements.contracts)}</small>
         )}
+        {request.requirements.collection_kind === "hosted" && (
+          <small>Requires an mdbase cloud collection</small>
+        )}
       </div>
     </div>
   );
@@ -881,9 +884,12 @@ function compatibleCollections<T extends { contracts: ContractRequirement[] }>(
   request: PendingAuthorization,
   collections: Array<T & { kind?: "local" | "hosted" }>
 ): T[] {
+  const candidates = request.requirements.collection_kind === "hosted"
+    ? collections.filter((collection) => collection.kind === "hosted")
+    : collections;
   const required = request.requirements.contracts;
-  if (required.length === 0) return collections;
-  return collections.filter((collection) => required.every((requirement) =>
+  if (required.length === 0) return candidates;
+  return candidates.filter((collection) => required.every((requirement) =>
     hasContract(collection.contracts, requirement)
     || (collection.kind === "hosted" && request.provisions.types.some((provision) =>
       provision.provides.some((provided) => sameContract(provided, requirement))

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -735,6 +735,10 @@ impl CollectionRegistry {
                 ensure_query_stays_within_record(&input)?;
                 execute_loaded(collection, operation, &input)
             }
+            "list_views" | "execute_view" => Err(ConnectError::AccessDenied(
+                "Saved views require full collection access because their source may select any record type."
+                    .to_string(),
+            )),
             "read" => {
                 let result = execute_loaded(collection, operation, input)?;
                 ensure_result_in_scope(&result, &allowed_types)?;
@@ -1890,6 +1894,8 @@ fn execute_loaded(
         let result = match operation {
             "read" => operations.read(input),
             "query" => operations.query(input),
+            "list_views" => operations.list_views(input),
+            "execute_view" => operations.execute_view(input),
             "validate" => operations.validate(input),
             "create" => operations.create(input),
             "update" => operations.update(input),
@@ -1958,6 +1964,8 @@ fn supported_operations() -> &'static [&'static str] {
         "changes",
         "read",
         "query",
+        "list_views",
+        "execute_view",
         "validate",
         "create",
         "update",
@@ -2201,6 +2209,7 @@ schema:
                 id: "workout.record".to_string(),
                 version: 1,
             }],
+            ..Default::default()
         };
         let provision = TypeProvision {
             name: "Workout".to_string(),
@@ -2486,7 +2495,8 @@ schema:
             .is_compatible(
                 collection.id,
                 &ApplicationRequirements {
-                    contracts: scope.contracts.clone()
+                    contracts: scope.contracts.clone(),
+                    ..Default::default()
                 }
             )
             .unwrap());
@@ -2506,6 +2516,19 @@ schema:
                 collection.id,
                 "read",
                 &json!({ "path": "private/one.md" }),
+                &scope
+            ),
+            Err(ConnectError::AccessDenied(_))
+        ));
+        assert!(matches!(
+            registry.scoped_operation(collection.id, "list_views", &json!({}), &scope),
+            Err(ConnectError::AccessDenied(_))
+        ));
+        assert!(matches!(
+            registry.scoped_operation(
+                collection.id,
+                "execute_view",
+                &json!({ "path": "views/tasks.md", "view": "all" }),
                 &scope
             ),
             Err(ConnectError::AccessDenied(_))
@@ -2606,6 +2629,85 @@ schema:
             .unwrap();
         assert_eq!(changes["events"].as_array().unwrap().len(), 2);
         assert_eq!(changes["events"][0]["payload"]["path"], "tasks/changed.md");
+    }
+
+    #[test]
+    fn full_collection_scope_lists_and_executes_saved_views() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("views");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let collection = registry.create(&root, Some("Views")).unwrap();
+        fs::write(
+            root.join("_types/view.md"),
+            r#"---
+kind: mdbase.type
+name: view
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value: { type: object }
+---
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("_types/task.md"),
+            r#"---
+kind: mdbase.type
+name: task
+version: 1
+schema:
+  dialect: json-schema-2020-12
+  value: { type: object }
+---
+"#,
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("tasks")).unwrap();
+        fs::create_dir_all(root.join("views")).unwrap();
+        fs::write(
+            root.join("tasks/one.md"),
+            "---\ntype: task\ntitle: One\n---\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("views/tasks.md"),
+            r#"---
+type: view
+id: task.views
+version: 1
+name: Task views
+query:
+  types: [task]
+views:
+  - id: all
+    name: All tasks
+    select: [title]
+    presentation:
+      type: tasknotes.task-list
+---
+"#,
+        )
+        .unwrap();
+
+        let listed = registry
+            .operation(collection.id, "list_views", &json!({}))
+            .unwrap();
+        assert_eq!(listed["valid"], true, "{listed}");
+        assert_eq!(listed["result"]["meta"]["total_count"], 1);
+        assert_eq!(listed["result"]["views"][0]["id"], "task.views");
+
+        let executed = registry
+            .operation(
+                collection.id,
+                "execute_view",
+                &json!({ "path": "views/tasks.md", "view": "all" }),
+            )
+            .unwrap();
+        assert_eq!(executed["valid"], true, "{executed}");
+        assert_eq!(executed["result"]["meta"]["total_count"], 1);
+        assert_eq!(executed["result"]["results"][0]["path"], "tasks/one.md");
     }
 
     #[test]

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -1492,12 +1492,14 @@ impl HostedProvider {
             .authenticate_for(collection_id, token, ReplicaPurpose::Application)
             .await?;
         authorize_application_operation(&replica, operation, request_origin)?;
-        if matches!(operation, "read_type" | "create_type" | "update_type")
-            && !replica.allowed_types.is_empty()
+        if matches!(
+            operation,
+            "read_type" | "create_type" | "update_type" | "list_views" | "execute_view"
+        ) && !replica.allowed_types.is_empty()
         {
             return Err(ApiError::forbidden(
                 "scope_denied",
-                "Type definitions can only be managed with full collection access.",
+                "This operation requires full collection access.",
             ));
         }
         match operation {
@@ -1506,7 +1508,7 @@ impl HostedProvider {
                 self.changes_operation(collection_id, &replica, &input)
                     .await
             }
-            "read" | "query" | "validate" | "read_type" => {
+            "read" | "query" | "validate" | "read_type" | "list_views" | "execute_view" => {
                 let scoped_input = scope_read_input(operation, input, &replica.allowed_types)?;
                 let result = self
                     .execute_read_operation(collection_id, operation, &scoped_input)
@@ -3058,6 +3060,8 @@ fn validate_operations(operations: &[String], mode: SyncReplicaMode) -> ApiResul
         "read_type",
         "create_type",
         "update_type",
+        "list_views",
+        "execute_view",
     ];
     const WRITES: &[&str] = &[
         "create",
@@ -3181,7 +3185,11 @@ mod tests {
             purpose: ReplicaPurpose::Application,
             mode: SyncReplicaMode::ReadOnly,
             allowed_types: vec!["task".to_string()],
-            allowed_operations: vec!["query".to_string()],
+            allowed_operations: vec![
+                "query".to_string(),
+                "list_views".to_string(),
+                "execute_view".to_string(),
+            ],
             allowed_origin: Some("https://tasks.example".to_string()),
             token: "x".repeat(40),
             token_ttl_seconds: Some(3600),
@@ -3197,6 +3205,10 @@ mod tests {
             scope_epoch: 1,
         };
         authorize_application_operation(&replica, "query", Some("https://tasks.example")).unwrap();
+        authorize_application_operation(&replica, "list_views", Some("https://tasks.example"))
+            .unwrap();
+        authorize_application_operation(&replica, "execute_view", Some("https://tasks.example"))
+            .unwrap();
         assert_eq!(
             authorize_application_operation(&replica, "create", None)
                 .unwrap_err()

--- a/crates/connect-hosted-provider/src/workspace.rs
+++ b/crates/connect-hosted-provider/src/workspace.rs
@@ -175,6 +175,8 @@ impl WorkingSet {
             // the hosted build, so only the common legacy envelope is adapted
             // at this storage boundary.
             "query" => Ok(query_result(&collection, input)),
+            "list_views" => Ok(operations.list_views(input)),
+            "execute_view" => Ok(operations.execute_view(input)),
             "validate" => Ok(operations.validate(input)),
             _ => Err(ApiError::bad_request(
                 "unsupported_operation",

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -481,6 +481,15 @@ pub struct ContractRequirement {
 pub struct ApplicationRequirements {
     #[serde(default)]
     pub contracts: Vec<ContractRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access: Option<ApplicationAccess>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplicationAccess {
+    Contract,
+    FullCollection,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ checks its local policy copy again before it opens a collection.
 Connect protocol 2 exposes these grantable operations:
 
 - `describe`, `changes`
-- `read`, `query`, `validate`
+- `read`, `query`, `validate`, `list_views`, `execute_view`
 - `create`, `update`, `delete`, `rename`
 
 mdbase operations retain the canonical `{ valid, result, diagnostics }`
@@ -58,16 +58,16 @@ envelope. Reads and successful writes carry opaque revisions. Mutations accept
 `if_revision`, which allows clients to prevent lost updates without knowing
 how a provider constructs its revision token.
 
-An application manifest may require exact domain contract versions. Approval
-turns those requirements into a grant scope. The connector resolves each
-contract to its current local type and applies the scope to discovery, queries,
-direct record access, mutations, and change delivery. Query type filters are
-constrained locally; direct paths are checked against matched record types; and
-updates and renames are checked against their prospective type membership
-before writing. Collection-wide validation and cross-record reference rewriting
-are unavailable to a contract-scoped grant. Scoped queries reject link
-traversal into other records until the query engine can carry the grant scope
-through link resolution.
+An application manifest may require exact domain contract versions. These
+requirements determine collection compatibility and provisioning. Access is
+contract-scoped by default: the connector resolves each contract to its current
+local type and applies that scope to discovery, queries, direct record access,
+mutations, and change delivery. Applications that need collection-level
+features such as saved views may declare `requirements.access` as
+`full_collection`; their contract requirements continue to govern compatibility
+and setup. Query type filters are constrained locally for contract-scoped
+grants; direct paths are checked against matched record types; and updates and
+renames are checked against their prospective type membership before writing.
 
 An application manifest may pair required contracts with portable type provisions.
 A collection is then either ready, provisionable, or incompatible. During

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -92,6 +92,7 @@ type definitions for the connector to install during approval:
   "homepage": "https://tasks.example",
   "redirect_uris": ["https://tasks.example/auth/mdbase/callback"],
   "requirements": {
+    "collection_kind": "hosted",
     "contracts": [{ "id": "tasknotes.task", "version": 1 }]
   },
   "provisions": {
@@ -103,6 +104,10 @@ type definitions for the connector to install during approval:
   }
 }
 ```
+
+Set `collection_kind` to `hosted` when the application needs a durable
+provider-backed collection and the offline sync transport returned by
+`hostedSync()`. Connect then offers and accepts hosted collections only.
 
 Provisioning is part of the approval flow. The connector validates and
 installs only the missing type definitions, verifies that they expose the

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -93,6 +93,7 @@ type definitions for the connector to install during approval:
   "redirect_uris": ["https://tasks.example/auth/mdbase/callback"],
   "requirements": {
     "collection_kind": "hosted",
+    "access": "full_collection",
     "contracts": [{ "id": "tasknotes.task", "version": 1 }]
   },
   "provisions": {
@@ -108,6 +109,11 @@ type definitions for the connector to install during approval:
 Set `collection_kind` to `hosted` when the application needs a durable
 provider-backed collection and the offline sync transport returned by
 `hostedSync()`. Connect then offers and accepts hosted collections only.
+
+Access defaults to the record types supplied by `requirements.contracts`.
+Set `access` to `full_collection` when the application needs collection-level
+features such as saved views. Required contracts still determine compatibility
+and are provisioned during approval.
 
 Provisioning is part of the approval flow. The connector validates and
 installs only the missing type definitions, verifies that they expose the

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -56,6 +56,33 @@ describe("provider-neutral collection client", () => {
     ]);
   });
 
+  it("exposes provider-neutral saved-view discovery and execution", async () => {
+    const calls: Array<{ operation: string; input: unknown }> = [];
+    const client = new MdbaseCollectionClient({
+      async operation<Result>(operation: string, input: unknown) {
+        calls.push({ operation, input });
+        return { valid: true, result: {}, diagnostics: [] } as Result;
+      }
+    });
+    await client.listViews();
+    await client.executeView({
+      path: "TaskNotes/Views/tasks.base",
+      view: "kanban-board",
+      limit: 50
+    });
+    expect(calls).toEqual([
+      { operation: "list_views", input: {} },
+      {
+        operation: "execute_view",
+        input: {
+          path: "TaskNotes/Views/tasks.base",
+          view: "kanban-board",
+          limit: 50
+        }
+      }
+    ]);
+  });
+
   it("surfaces cursor resets from any transport", async () => {
     const client = new MdbaseCollectionClient({
       async operation<Result>() {
@@ -528,7 +555,7 @@ async function encryptedConnection() {
     clientId: "01922222-2222-7222-8222-222222222222",
     collectionId,
     operations: [
-      "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
+      "describe", "changes", "read", "query", "list_views", "execute_view", "validate", "create", "update", "delete", "rename",
       "read_type", "create_type", "update_type"
     ],
     scope: { contracts: [] },

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,12 +7,15 @@ import type {
   CollectionTypeDocument,
   EncryptedRelayOperationRequest,
   EncryptedRelayOperationResponse,
+  ExecuteViewInput,
   GrantEncryption,
   GrantScope,
   JsonObject,
   MdbaseOperationEnvelope,
   RecordSummary,
   RecordResult,
+  SavedViewExecution,
+  SavedViewList,
   SyncChangesPage,
   SyncMutation,
   SyncMutationReceipt,
@@ -58,6 +61,13 @@ export type {
   MdbaseOperationEnvelope,
   RecordResult,
   RecordSummary,
+  SavedNamedView,
+  SavedViewDocument,
+  SavedViewExecution,
+  SavedViewList,
+  SavedViewPresentation,
+  SavedViewSource,
+  ExecuteViewInput,
   TypeProvision
 } from "@mdbase/connect-protocol";
 
@@ -244,6 +254,14 @@ export class MdbaseCollectionClient<Frontmatter extends JsonObject = JsonObject>
 
   query(input: QueryInput = {}): Promise<MdbaseOperationEnvelope<QueryResult<Frontmatter>>> {
     return this.operation("query", input);
+  }
+
+  listViews(): Promise<MdbaseOperationEnvelope<SavedViewList>> {
+    return this.operation("list_views", {});
+  }
+
+  executeView(input: ExecuteViewInput): Promise<MdbaseOperationEnvelope<SavedViewExecution<Frontmatter>>> {
+    return this.operation("execute_view", input);
   }
 
   create(input: CreateInput<Frontmatter>): Promise<MdbaseOperationEnvelope<RecordResult<Frontmatter>>> {
@@ -595,6 +613,14 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
 
   query(input: QueryInput = {}): Promise<MdbaseOperationEnvelope<QueryResult<Frontmatter>>> {
     return this.collectionClient.query(input);
+  }
+
+  listViews(): Promise<MdbaseOperationEnvelope<SavedViewList>> {
+    return this.collectionClient.listViews();
+  }
+
+  executeView(input: ExecuteViewInput): Promise<MdbaseOperationEnvelope<SavedViewExecution<Frontmatter>>> {
+    return this.collectionClient.executeView(input);
   }
 
   create(input: CreateInput<Frontmatter>): Promise<MdbaseOperationEnvelope<RecordResult<Frontmatter>>> {

--- a/packages/protocol/schemas/connect-protocol.v2.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v2.schema.json
@@ -14,7 +14,7 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
     "operation": {
-      "enum": ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"]
+      "enum": ["describe", "changes", "read", "query", "list_views", "execute_view", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"]
     },
     "contractRequirement": {
       "type": "object",

--- a/packages/protocol/schemas/encrypted-relay.v3.schema.json
+++ b/packages/protocol/schemas/encrypted-relay.v3.schema.json
@@ -14,7 +14,7 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
     "operation": {
-      "enum": ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"]
+      "enum": ["describe", "changes", "read", "query", "list_views", "execute_view", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"]
     },
     "envelope": {
       "type": "object",

--- a/packages/protocol/schemas/mdbase-app.schema.json
+++ b/packages/protocol/schemas/mdbase-app.schema.json
@@ -55,6 +55,10 @@
       "additionalProperties": false,
       "required": ["contracts"],
       "properties": {
+        "collection_kind": {
+          "const": "hosted",
+          "description": "Require a durable provider-backed collection with direct sync support."
+        },
         "contracts": {
           "type": "array",
           "maxItems": 20,

--- a/packages/protocol/schemas/mdbase-app.schema.json
+++ b/packages/protocol/schemas/mdbase-app.schema.json
@@ -54,8 +54,12 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["contracts"],
-      "properties": {
-        "collection_kind": {
+    "properties": {
+      "access": {
+        "enum": ["contract", "full_collection"],
+        "description": "Access boundary requested after compatibility and provisioning checks."
+      },
+      "collection_kind": {
           "const": "hosted",
           "description": "Require a durable provider-backed collection with direct sync support."
         },

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -42,6 +42,8 @@ export type CollectionOperation =
   | "changes"
   | "read"
   | "query"
+  | "list_views"
+  | "execute_view"
   | "validate"
   | "create"
   | "update"
@@ -68,6 +70,8 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  /** Access boundary requested after compatibility and provisioning checks. */
+  access?: "contract" | "full_collection";
   /** Restrict authorization to durable provider-backed collections. */
   collection_kind?: "hosted";
 }
@@ -279,6 +283,62 @@ export interface MdbaseOperationEnvelope<Result = JsonObject> {
   valid: boolean;
   result: Result;
   diagnostics: MdbaseDiagnostic[];
+}
+
+export interface SavedViewPresentation extends JsonObject {
+  type: string;
+  fallback?: string;
+  mappings?: Record<string, string>;
+  options?: JsonObject;
+}
+
+export interface SavedViewSource {
+  path: string;
+  format: string;
+  revision: string;
+  writable: boolean;
+}
+
+export interface SavedNamedView {
+  id: string;
+  name: string;
+  presentation?: SavedViewPresentation;
+}
+
+export interface SavedViewDocument {
+  id: string;
+  name: string;
+  source: SavedViewSource;
+  views: SavedNamedView[];
+}
+
+export interface SavedViewList {
+  views: SavedViewDocument[];
+  meta: { total_count: number };
+}
+
+export interface ExecuteViewInput {
+  path: string;
+  view: string;
+  context?: { path: string } | null;
+  limit?: number;
+  offset?: number;
+  render?: boolean;
+}
+
+export interface SavedViewExecution<Frontmatter extends JsonObject = JsonObject> {
+  results: Array<RecordSummary<Frontmatter> & { values?: JsonObject }>;
+  meta: {
+    total_count: number;
+    has_more: boolean;
+    view: { path: string; id: string };
+    context?: { path: string };
+    groups?: Array<{
+      values: JsonObject;
+      count: number;
+      summaries: JsonObject;
+    }>;
+  };
 }
 
 export interface CollectionFileMetadata extends JsonObject {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -68,6 +68,8 @@ export interface ContractRequirement {
 
 export interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  /** Restrict authorization to durable provider-backed collections. */
+  collection_kind?: "hosted";
 }
 
 export interface TypeProvision {

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -41,7 +41,10 @@ test("application manifests declare connector-controlled type provisioning", () 
     name: "Tasks",
     homepage: "https://tasks.example/",
     redirect_uris: ["https://tasks.example/callback"],
-    requirements: { contracts: [{ id: "tasknotes.task", version: 1 }] },
+    requirements: {
+      collection_kind: "hosted",
+      contracts: [{ id: "tasknotes.task", version: 1 }]
+    },
     provisions: {
       types: [{
         name: "Task",
@@ -52,6 +55,10 @@ test("application manifests declare connector-controlled type provisioning", () 
   };
   assert.equal(validate(manifest), true, JSON.stringify(validate.errors));
   assert.equal(validate({ ...manifest, manifest_version: 2 }), false);
+  assert.equal(validate({
+    ...manifest,
+    requirements: { ...manifest.requirements, collection_kind: "local" }
+  }), false);
   assert.equal(validate({ ...manifest, provisions: { types: [{ ...manifest.provisions.types[0], provides: [] }] } }), false);
 });
 

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -43,6 +43,7 @@ test("application manifests declare connector-controlled type provisioning", () 
     redirect_uris: ["https://tasks.example/callback"],
     requirements: {
       collection_kind: "hosted",
+      access: "full_collection",
       contracts: [{ id: "tasknotes.task", version: 1 }]
     },
     provisions: {
@@ -58,6 +59,10 @@ test("application manifests declare connector-controlled type provisioning", () 
   assert.equal(validate({
     ...manifest,
     requirements: { ...manifest.requirements, collection_kind: "local" }
+  }), false);
+  assert.equal(validate({
+    ...manifest,
+    requirements: { ...manifest.requirements, access: "everything" }
   }), false);
   assert.equal(validate({ ...manifest, provisions: { types: [{ ...manifest.provisions.types[0], provides: [] }] } }), false);
 });

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -81,6 +81,22 @@ try {
     "collection", "create", collectionPath,
     "--name", "Workouts"
   ]);
+  await writeFile(
+    join(collectionPath, "mdbase.yaml"),
+    `${await readFile(join(collectionPath, "mdbase.yaml"), "utf8")}\nx-obsidian:\n  bases:\n    include: ["TaskNotes/Views/**/*.base"]\n`
+  );
+  await mkdir(join(collectionPath, "TaskNotes", "Views"), { recursive: true });
+  await writeFile(join(collectionPath, "TaskNotes", "Views", "tasks.base"), `views:
+  - type: tasknotesKanban
+    name: Open tasks
+    filters:
+      and:
+        - 'status == "open"'
+    groupBy:
+      property: status
+      direction: ASC
+    order: [status, file.name]
+`);
   await mkdir(join(collectionPath, "_types"), { recursive: true });
   await writeFile(join(collectionPath, "_types", "task.md"), `---
 kind: mdbase.type
@@ -287,7 +303,7 @@ secret: connector scope test
     const browserChallenge = createHash("sha256").update(browserVerifier).digest("base64url");
     const browserOperations = [
       "describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename",
-      "read_type", "create_type", "update_type"
+      "read_type", "create_type", "update_type", "list_views", "execute_view"
     ];
     const browserAuthorize = await fetch(
       `${serverUrl}/oauth/authorize?client_id=${browserAppId}&redirect_uri=${encodeURIComponent(manifest.browserRedirectUri)}&code_challenge=${browserChallenge}&code_challenge_method=S256&state=browser-e2e&operations=${browserOperations.join(",")}&relay_protocol=3&application_public_key=${encodeURIComponent(browserPublicKey)}`,
@@ -360,6 +376,8 @@ secret: connector scope test
         || !browserResult.createdType
         || !browserResult.readType
         || !browserResult.updatedType
+        || !browserResult.listedView
+        || !browserResult.executedView
         || !browserResult.changed
         || !browserResult.deleted) {
       throw new Error(`Real browser direct-operation matrix failed: ${JSON.stringify(browserResult)}`);
@@ -695,7 +713,7 @@ async function openManifestServer() {
     "MVP Workout App",
     [{ id: "tasknotes.task", version: 1 }]
   );
-  const browser = await openApplicationServer("Browser direct E2E", []);
+  const browser = await openApplicationServer("Browser direct E2E", [], "full_collection");
   return {
     server: primary.server,
     browserServer: browser.server,
@@ -708,7 +726,7 @@ async function openManifestServer() {
   };
 }
 
-async function openApplicationServer(name, contracts) {
+async function openApplicationServer(name, contracts, access) {
   const server = createServer(async (request, response) => {
     const address = server.address();
     const origin = `http://localhost:${address.port}`;
@@ -784,6 +802,11 @@ schema:
         document: typeDocument.replace("Browser note", "Updated browser note"),
         if_revision: readType.result.revision
       });
+      const views = await connect.listViews();
+      const executedView = await connect.executeView({
+        path: "TaskNotes/Views/tasks.base",
+        view: "open-tasks"
+      });
       const changed = await connect.changes({ after: description.change_cursor });
       const deleted = await connect.delete({ path: "browser/renamed.md" });
       return {
@@ -797,6 +820,14 @@ schema:
         createdType: createdType.valid && createdType.result.path === "_types/browsernote.md",
         readType: readType.valid && readType.result.document.includes("Browser note"),
         updatedType: updatedType.valid && updatedType.result.document.includes("Updated browser note"),
+        listedView: views.valid
+          && views.result.views.some((document) =>
+            document.source.path === "TaskNotes/Views/tasks.base"
+              && document.views.some((view) => view.id === "open-tasks")
+          ),
+        executedView: executedView.valid
+          && executedView.result.results.length === 1000
+          && executedView.result.meta.groups[0].values.status === "open",
         changed: changed.events.length > 0,
         deleted: deleted.result.deleted
       };
@@ -811,7 +842,7 @@ schema:
       name,
       homepage: origin,
       redirect_uris: [`${origin}/auth/mdbase/callback`],
-      requirements: { contracts }
+      requirements: { contracts, ...(access ? { access } : {}) }
     }));
   });
   await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -382,7 +382,9 @@ try {
   );
 
   phase("authorizing the browser SDK directly against the hosted data plane");
-  const manifest = await openManifestServer();
+  const manifest = await openManifestServer({
+    requirements: { contracts: [], access: "full_collection" }
+  });
   manifestServer = manifest.server;
   const storage = memoryStorage();
   let authorizationUrl;
@@ -397,7 +399,10 @@ try {
     storage,
     keyStore: new MemoryGrantKeyStore()
   });
-  void hostedSdk.authorize(["describe", "changes", "read", "query", "create", "update", "delete", "rename"]);
+  void hostedSdk.authorize([
+    "describe", "changes", "read", "query", "list_views", "execute_view",
+    "create", "update", "delete", "rename", "create_type"
+  ]);
   await waitFor(() => authorizationUrl, "SDK did not start hosted authorization");
   const callbackUrl = await authorizeHostedApplication(
     authorizationUrl,
@@ -472,6 +477,54 @@ try {
   });
   assert.equal(sdkRenamed.valid, true);
   assert.equal((await hostedSdk.query()).result.results[0].path, "Writing/Draft.md");
+  const viewType = await hostedSdk.createType({
+    document: `---
+kind: mdbase.type
+name: view
+version: 1
+match:
+  where:
+    type: view
+schema:
+  dialect: json-schema-2020-12
+  value:
+    type: object
+---
+`
+  });
+  assert.equal(viewType.valid, true);
+  const viewRecord = await hostedSdk.create({
+    path: "Views/writing.md",
+    frontmatter: {
+      type: "view",
+      id: "writing.views",
+      version: 1,
+      name: "Writing views",
+      query: { where: 'file.path != "Views/writing.md"' },
+      views: [{
+        id: "all",
+        name: "All writing",
+        select: ["title"]
+      }]
+    }
+  });
+  assert.equal(viewRecord.valid, true);
+  const listedViews = await hostedSdk.listViews();
+  assert.equal(listedViews.valid, true);
+  assert.equal(listedViews.result.views[0].views[0].id, "all");
+  const executedView = await hostedSdk.executeView({
+    path: "Views/writing.md",
+    view: "all"
+  });
+  assert.equal(executedView.valid, true);
+  assert.deepEqual(
+    executedView.result.results.map((record) => record.path),
+    ["Writing/Draft.md"]
+  );
+  assert.equal((await hostedSdk.delete({
+    path: "Views/writing.md",
+    if_revision: viewRecord.result.revision
+  })).valid, true);
   assert.equal((await hostedSdk.delete({
     path: "Writing/Draft.md",
     if_revision: sdkRenamed.result.revision
@@ -1169,7 +1222,15 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     await collection.selectOption(collectionId);
     await expect(collection.locator("option:checked")).toHaveText("Hosted writing · Hosted by mdbase");
     await page.getByRole("button", { name: "Allow access" }).click();
-    await page.waitForURL((url) => url.origin === callbackOrigin && url.searchParams.has("code"));
+    const outcome = await Promise.race([
+      page.waitForURL(
+        (url) => url.origin === callbackOrigin && url.searchParams.has("code")
+      ).then(() => "approved"),
+      page.locator(".message.error").waitFor({ state: "visible" }).then(() => "error")
+    ]);
+    if (outcome === "error") {
+      throw new Error(`Hosted authorization failed: ${await page.locator(".message.error").innerText()}`);
+    }
     return page.url();
   } finally {
     await browser.close();

--- a/scripts/oracle-e2e.mjs
+++ b/scripts/oracle-e2e.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { createServer } from "node:http";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -19,6 +20,7 @@ const agentBinary = join(repoRoot, "target", "debug", `mdbase-connect-agent${ext
 const cliBinary = join(repoRoot, "target", "debug", `mdbase-connect${extension}`);
 const benchmarkIterations = parseBenchmarkIterations(process.env.MDBASE_CONNECT_BENCHMARK_ITERATIONS);
 const encryptedRelay = process.env.MDBASE_CONNECT_ORACLE_ENCRYPTION === "required";
+const loopbackPort = await availableTcpPort();
 const scratch = await mkdtemp(join(tmpdir(), "mdbase-connect-oracle-e2e-"));
 const stateDir = join(scratch, "state");
 const collectionPath = join(scratch, "tasks");
@@ -324,13 +326,31 @@ async function cliJson(args) {
 }
 
 function startAgent(extraArgs) {
-  const child = spawn(agentBinary, ["--state-dir", stateDir, ...extraArgs], {
+  const child = spawn(agentBinary, [
+    "--state-dir", stateDir,
+    "--loopback-port", String(loopbackPort),
+    ...extraArgs
+  ], {
     cwd: repoRoot,
     stdio: ["ignore", "pipe", "pipe"]
   });
   child.stdout.on("data", (chunk) => process.stderr.write(`[oracle-agent] ${chunk}`));
   child.stderr.on("data", (chunk) => process.stderr.write(`[oracle-agent] ${chunk}`));
   return child;
+}
+
+async function availableTcpPort() {
+  const server = createServer();
+  await new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Could not reserve an Oracle connector loopback port");
+  }
+  await new Promise((resolveClose) => server.close(resolveClose));
+  return address.port;
 }
 
 async function stopAgent(child) {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -605,7 +605,7 @@ describe("mdbase connect server", () => {
     expect(reconciled.rows[0].allowed_types).toEqual([]);
   });
 
-  it("provisions missing hosted types before creating a contract-scoped grant", async () => {
+  it("provisions required types before creating a full-collection grant", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());
     const contract = {
@@ -653,7 +653,10 @@ describe("mdbase connect server", () => {
     const collectionId = collection.json().collection.id as string;
     const typeDocument = "---\nkind: mdbase.type\nname: workout\nversion: 1\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\nx-workout:\n  contract: workout.record\n  version: 1\n---\n";
     const manifestServer = await startManifestServer(
-      { contracts: [{ id: "workout.record", version: 1 }] },
+      {
+        contracts: [{ id: "workout.record", version: 1 }],
+        access: "full_collection"
+      },
       "Workout Tracker",
       { types: [{
         name: "Workout",
@@ -696,8 +699,13 @@ describe("mdbase connect server", () => {
     );
     expect(hostedProvider.registerReplica).toHaveBeenCalledWith(
       collectionId,
-      expect.objectContaining({ allowedTypes: ["workout"] })
+      expect.objectContaining({ allowedTypes: [] })
     );
+    const grant = await db.query<{ scope: { contracts: unknown[] } }>(
+      "SELECT scope FROM grants WHERE hosted_collection_id = $1",
+      [collectionId]
+    );
+    expect(grant.rows[0].scope.contracts).toEqual([]);
     const stored = await db.query<{ contracts: unknown[] }>(
       "SELECT contracts FROM hosted_collections WHERE id = $1",
       [collectionId]

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import { createECDH } from "node:crypto";
+import type { ApplicationRequirements } from "@mdbase/connect-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
@@ -481,6 +482,30 @@ describe("mdbase connect server", () => {
     });
     const setCookie = session.headers["set-cookie"]!;
     const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const connectorResponse = await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Writing computer" }
+    });
+    const connector = connectorResponse.json();
+    const localCollectionId = "32f95339-c600-427f-a187-85758dc2662e";
+    const synchronized = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: {
+        collections: [{
+          id: localCollectionId,
+          display_name: "Local writing",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    });
+    expect(synchronized.statusCode).toBe(200);
+    const localControlCollectionId = synchronized.json().collections[0].id as string;
     const collection = await app.inject({
       method: "POST",
       url: "/v1/hosted/collections",
@@ -489,7 +514,10 @@ describe("mdbase connect server", () => {
     });
     const collectionId = collection.json().collection.id as string;
 
-    const manifestServer = await startManifestServer({ contracts: [] }, "Writing Editor");
+    const manifestServer = await startManifestServer(
+      { contracts: [], collection_kind: "hosted" },
+      "Writing Editor"
+    );
     resources.push(manifestServer.close);
     const discovered = await app.inject({
       method: "POST",
@@ -504,6 +532,37 @@ describe("mdbase connect server", () => {
       headers: { cookie }
     });
     const requestId = authorization.headers.location!.split("/").at(-1)!;
+    const pending = await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${requestId}`,
+      headers: { cookie }
+    });
+    expect(pending.json().authorization.requirements).toEqual({
+      contracts: [],
+      collection_kind: "hosted"
+    });
+    expect(pending.json().collections).toEqual([
+      expect.objectContaining({ id: collectionId, kind: "hosted" })
+    ]);
+    const connectorControl = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/control",
+      headers: { authorization: `Bearer ${connector.token}` }
+    });
+    expect(connectorControl.json().pending_authorizations).toEqual([]);
+    const localApproval = await app.inject({
+      method: "POST",
+      url: `/v1/authorization-requests/${requestId}/approve`,
+      headers: { cookie },
+      payload: {
+        collection_id: localControlCollectionId,
+        operations: ["describe", "query", "create", "update"]
+      }
+    });
+    expect(localApproval.statusCode).toBe(400);
+    expect(localApproval.json().error.message).toBe(
+      "This application requires an mdbase cloud collection."
+    );
     const approved = await app.inject({
       method: "POST",
       url: `/v1/authorization-requests/${requestId}/approve`,
@@ -693,7 +752,9 @@ describe("mdbase connect server", () => {
 });
 
 async function startManifestServer(
-  requirements = { contracts: [{ id: "workout.record", version: 1 }] },
+  requirements: ApplicationRequirements = {
+    contracts: [{ id: "workout.record", version: 1 }]
+  },
   name = "Workout Tracker",
   provisions?: {
     types: Array<{

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -56,7 +56,22 @@ import {
 } from "./google-auth.js";
 import type { RegistrationMode } from "./runtime-config.js";
 
-const OPERATIONS = ["describe", "changes", "read", "query", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type"] as const;
+const OPERATIONS = [
+  "describe",
+  "changes",
+  "read",
+  "query",
+  "validate",
+  "list_views",
+  "execute_view",
+  "create",
+  "update",
+  "delete",
+  "rename",
+  "read_type",
+  "create_type",
+  "update_type"
+] as const;
 const operationSchema = z.enum(OPERATIONS);
 const contractRequirementSchema = z.object({
   id: z.string().trim().min(1).max(100),
@@ -907,7 +922,10 @@ export async function buildApp(options: BuildOptions) {
       ));
     }
     const scope = scopeForRequirements(application.rows[0].requirements);
-    if (!contractsSatisfy(collection.rows[0].contracts, scope.contracts)) {
+    if (!contractsSatisfy(
+      collection.rows[0].contracts,
+      requiredContractsForRequirements(application.rows[0].requirements)
+    )) {
       return reply.code(409).send(apiError(
         "incompatible_collection",
         "This collection does not provide the contracts required by the application."
@@ -1328,7 +1346,10 @@ export async function buildApp(options: BuildOptions) {
       ));
     }
     const scope = scopeForRequirements(application.rows[0].requirements);
-    if (!contractsSatisfy(ownership.rows[0].contracts, scope.contracts)) {
+    if (!contractsSatisfy(
+      ownership.rows[0].contracts,
+      requiredContractsForRequirements(application.rows[0].requirements)
+    )) {
       return reply.code(409).send(apiError(
         "incompatible_collection",
         "This collection does not provide the contracts required by the application."
@@ -1913,6 +1934,7 @@ async function reconcileApplicationGrants(
   application: { id: string; requirements: ApplicationRequirements }
 ): Promise<void> {
   const desiredScope = scopeForRequirements(application.requirements);
+  const requiredContracts = requiredContractsForRequirements(application.requirements);
   const grants = await db.query<{
     id: string;
     user_id: string;
@@ -1947,10 +1969,10 @@ async function reconcileApplicationGrants(
     const collectionKindCompatible = !requiresHostedCollection(application.requirements)
       || grant.template !== null;
     const collectionCompatible = collectionKindCompatible
-      && contractsSatisfy(availableContracts, desiredScope.contracts);
+      && contractsSatisfy(availableContracts, requiredContracts);
     const scopeMatches = scopesEqual(grant.scope, desiredScope);
     const desiredAllowedTypes = grant.template
-      ? typesForContracts(hostedDescriptors, desiredScope.contracts)
+      ? allowedTypesForRequirements(hostedDescriptors, application.requirements)
       : [];
     const replicaScopeMatches = !grant.hosted_replica_id
       || sameStrings(grant.allowed_types ?? [], desiredAllowedTypes);
@@ -2075,7 +2097,10 @@ async function approveAuthorization(
     [input.collectionId, input.connectorId]
   );
   const scope = scopeForRequirements(pending.requirements);
-  if (!collection.rows[0] || !contractsSatisfy(collection.rows[0].contracts, scope.contracts)) {
+  if (!collection.rows[0] || !contractsSatisfy(
+    collection.rows[0].contracts,
+    requiredContractsForRequirements(pending.requirements)
+  )) {
     throw new RequestValidationError(
       "This collection does not provide the contracts required by the application."
     );
@@ -2175,9 +2200,10 @@ async function approveHostedAuthorization(
       throw new RequestValidationError("Approved operations must be requested by the application.");
     }
     const scope = scopeForRequirements(pending.requirements);
+    const requiredContracts = requiredContractsForRequirements(pending.requirements);
     let availableDescriptors = input.contracts;
     let availableContracts = contractRequirements(availableDescriptors);
-    if (!contractsSatisfy(availableContracts, scope.contracts)) {
+    if (!contractsSatisfy(availableContracts, requiredContracts)) {
       const provisions = requiredTypeProvisions(pending.requirements, pending.provisions, availableContracts);
       if (!provisions) {
         throw new RequestValidationError(
@@ -2191,12 +2217,15 @@ async function approveHostedAuthorization(
         [input.collectionId, JSON.stringify(availableDescriptors)]
       );
     }
-    if (!contractsSatisfy(availableContracts, scope.contracts)) {
+    if (!contractsSatisfy(availableContracts, requiredContracts)) {
       throw new RequestValidationError(
         "This hosted collection does not provide the contracts required by the application."
       );
     }
-    const allowedTypes = typesForContracts(availableDescriptors, scope.contracts);
+    const allowedTypes = allowedTypesForRequirements(
+      availableDescriptors,
+      pending.requirements
+    );
     await provider.renameCollection(input.collectionId, input.displayName);
     const operations = [...new Set(input.operations)];
     const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type"].includes(operation));
@@ -2425,6 +2454,7 @@ async function issueApplicationTokens(
 }
 
 function scopeForRequirements(requirements: ApplicationRequirements | null | undefined): GrantScope {
+  if (requirements?.access === "full_collection") return { contracts: [] };
   const contracts = requirements?.contracts ?? [];
   return {
     contracts: [...new Map(contracts.map((contract) => [
@@ -2432,6 +2462,25 @@ function scopeForRequirements(requirements: ApplicationRequirements | null | und
       contract
     ])).values()]
   };
+}
+
+function requiredContractsForRequirements(
+  requirements: ApplicationRequirements | null | undefined
+): ContractRequirement[] {
+  const contracts = requirements?.contracts ?? [];
+  return [...new Map(contracts.map((contract) => [
+    `${contract.id}@${contract.version}`,
+    contract
+  ])).values()];
+}
+
+function allowedTypesForRequirements(
+  descriptors: CollectionContractDescriptor[],
+  requirements: ApplicationRequirements
+): string[] {
+  return requirements.access === "full_collection"
+    ? []
+    : typesForContracts(descriptors, requiredContractsForRequirements(requirements));
 }
 
 function requiresHostedCollection(

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -838,6 +838,7 @@ export async function buildApp(options: BuildOptions) {
         application_origin: new URL(grant.application_origin).origin
       })),
       pending_authorizations: pendingAuthorizations.rows
+        .filter((authorization) => !requiresHostedCollection(authorization.requirements))
     };
   });
 
@@ -899,6 +900,12 @@ export async function buildApp(options: BuildOptions) {
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
+    if (requiresHostedCollection(application.rows[0].requirements)) {
+      return reply.code(409).send(apiError(
+        "incompatible_collection",
+        "This application requires an mdbase cloud collection."
+      ));
+    }
     const scope = scopeForRequirements(application.rows[0].requirements);
     if (!contractsSatisfy(collection.rows[0].contracts, scope.contracts)) {
       return reply.code(409).send(apiError(
@@ -1314,6 +1321,12 @@ export async function buildApp(options: BuildOptions) {
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
+    if (requiresHostedCollection(application.rows[0].requirements)) {
+      return reply.code(409).send(apiError(
+        "incompatible_collection",
+        "This application requires an mdbase cloud collection."
+      ));
+    }
     const scope = scopeForRequirements(application.rows[0].requirements);
     if (!contractsSatisfy(ownership.rows[0].contracts, scope.contracts)) {
       return reply.code(409).send(apiError(
@@ -1518,18 +1531,21 @@ export async function buildApp(options: BuildOptions) {
           [user.id]
         )
       : { rows: [] };
+    const availableCollections = [
+      ...collections.rows.map((collection) => ({ ...collection, kind: "local" as const })),
+      ...hosted.rows.map((collection) => ({
+        ...collection,
+        kind: "hosted" as const,
+        connector_name: "Hosted by mdbase",
+        spec_version: "0.3.0",
+        contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template))
+      }))
+    ];
     return {
       authorization: authorization.rows[0],
-      collections: [
-        ...collections.rows.map((collection) => ({ ...collection, kind: "local" })),
-        ...hosted.rows.map((collection) => ({
-          ...collection,
-          kind: "hosted",
-          connector_name: "Hosted by mdbase",
-          spec_version: "0.3.0",
-          contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template))
-        }))
-      ]
+      collections: requiresHostedCollection(authorization.rows[0].requirements)
+        ? availableCollections.filter((collection) => collection.kind === "hosted")
+        : availableCollections
     };
   });
 
@@ -1928,7 +1944,10 @@ async function reconcileApplicationGrants(
     const availableContracts = grant.template
       ? contractRequirements(hostedDescriptors)
       : grant.local_contracts ?? [];
-    const collectionCompatible = contractsSatisfy(availableContracts, desiredScope.contracts);
+    const collectionKindCompatible = !requiresHostedCollection(application.requirements)
+      || grant.template !== null;
+    const collectionCompatible = collectionKindCompatible
+      && contractsSatisfy(availableContracts, desiredScope.contracts);
     const scopeMatches = scopesEqual(grant.scope, desiredScope);
     const desiredAllowedTypes = grant.template
       ? typesForContracts(hostedDescriptors, desiredScope.contracts)
@@ -2039,6 +2058,9 @@ async function approveAuthorization(
   );
   const pending = authorization.rows[0];
   if (!pending) return false;
+  if (requiresHostedCollection(pending.requirements)) {
+    throw new RequestValidationError("This application requires an mdbase cloud collection.");
+  }
   if (input.operations.some((operation) => !pending.requested_operations.includes(operation))) {
     throw new RequestValidationError("Approved operations must be requested by the application.");
   }
@@ -2410,6 +2432,12 @@ function scopeForRequirements(requirements: ApplicationRequirements | null | und
       contract
     ])).values()]
   };
+}
+
+function requiresHostedCollection(
+  requirements: ApplicationRequirements | null | undefined
+): boolean {
+  return requirements?.collection_kind === "hosted";
 }
 
 function matchesGrantEncryption(

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -14,7 +14,10 @@ const contractsSchema = z.array(contractSchema).max(20).refine(
   (contracts) => new Set(contracts.map((contract) => `${contract.id}@${contract.version}`)).size === contracts.length,
   "Contracts must be unique."
 );
-const requirementsSchema = z.object({ contracts: contractsSchema }).strict().default({ contracts: [] });
+const requirementsSchema = z.object({
+  contracts: contractsSchema,
+  collection_kind: z.literal("hosted").optional()
+}).strict().default({ contracts: [] });
 const manifestSchema = z.object({
   manifest_version: z.literal(1),
   name: z.string().trim().min(1).max(100),

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -16,6 +16,7 @@ const contractsSchema = z.array(contractSchema).max(20).refine(
 );
 const requirementsSchema = z.object({
   contracts: contractsSchema,
+  access: z.enum(["contract", "full_collection"]).optional(),
   collection_kind: z.literal("hosted").optional()
 }).strict().default({ contracts: [] });
 const manifestSchema = z.object({


### PR DESCRIPTION
## What changed

- add provider-neutral list and execute view operations across protocol, SDK, relay, and hosted provider
- separate compatibility contracts from full-collection access grants
- extend direct, encrypted, hosted, and oracle end-to-end coverage

## Why

Consuming applications should use the same collection API for local relay and hosted collections.

## Validation

- cargo test --workspace
- pnpm typecheck
- pnpm test
- direct, sync, oracle, and hosted-provider end-to-end suites
