### PR TITLE
Scale relay routing with transient NATS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ MDBASE_CONNECT_REGISTRATION=closed
 # Leave hosted collection routes unavailable during the relay-only preview.
 MDBASE_CONNECT_HOSTED_COLLECTIONS=0
 
+# Optional shared Core NATS transport. Omit both values for a lightweight,
+# single-process self-host. Set both to run multiple Connect instances.
+# A comma-separated URL list can point at a NATS cluster.
+# MDBASE_CONNECT_RELAY_NATS_URL=nats://127.0.0.1:4222
+# MDBASE_CONNECT_RELAY_NATS_TOKEN=replace-with-at-least-32-random-characters
+
 # Enable only behind a trusted reverse proxy such as Render.
 MDBASE_CONNECT_TRUST_PROXY=0
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -75,4 +75,5 @@ jobs:
       # dependencies from making a clean checkout unreproducible.
       - run: cargo test --locked --workspace
       - run: cargo build --locked -p mdbase-connect-hosted-provider
+      - run: node scripts/relay-e2e.mjs
       - run: node scripts/hosted-provider-e2e.mjs

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: docker build --file deploy/docker/Dockerfile.server --tag mdbase-connect-server:test .
       - run: docker build --file deploy/docker/Dockerfile.hosted-provider --tag mdbase-connect-hosted-provider:test .
+      - run: docker build --file deploy/docker/Dockerfile.nats --tag mdbase-connect-nats:test .
 
   hosted-provider:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ application and contract adapter—not a collection kind or platform default.
 - `apps/desktop`: Electron controller for collection registration, application
   metadata and availability, application access, browser pairing, local
   activity, tray operation, and launch-at-login.
-- `services/server`: Fastify control plane and transient relay backed by
-  PostgreSQL.
+- `services/server`: Fastify control plane and transient, horizontally scalable
+  relay backed by PostgreSQL and optional Core NATS request/reply.
 - `services/mcp`: separately deployed remote MCP gateway for Claude, ChatGPT,
   and other OAuth-capable hosts. It maps one host connection to independently
   approved collection grants and keeps its credentials in a separate database.
@@ -72,6 +72,7 @@ pnpm build
 pnpm typecheck
 pnpm test
 pnpm e2e
+pnpm e2e:relay
 pnpm e2e:sync
 pnpm e2e:provider
 ```
@@ -88,6 +89,13 @@ rejected. It also crosses the JavaScript/Rust encryption boundary and verifies
 tamper and plaintext-downgrade rejection. It also proves that an identical
 direct-to-relay retry returns a durable encrypted receipt without executing a
 mutation twice.
+
+`pnpm e2e:relay` runs two control-plane instances against disposable real
+PostgreSQL and Core NATS containers. It verifies cross-instance operations and
+policy delivery, generation-fenced socket replacement, concurrent and large
+payloads, fail-closed broker readiness, subscription recovery after a broker
+restart, connector reconnects, and the absence of payloads in control-plane
+audit storage.
 
 `pnpm e2e:sync` exercises the hosted TaskNotes vertical slice through the real
 HTTP server, including offline writes, two-client convergence, idempotency,

--- a/deploy/docker/Dockerfile.nats
+++ b/deploy/docker/Dockerfile.nats
@@ -1,0 +1,7 @@
+FROM nats:2.12.7-alpine
+
+COPY deploy/nats/nats.conf /etc/nats/mdbase-connect.conf
+COPY deploy/nats/start-nats.sh /usr/local/bin/start-mdbase-connect-nats
+
+EXPOSE 4222
+ENTRYPOINT ["/bin/sh", "/usr/local/bin/start-mdbase-connect-nats"]

--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -1,0 +1,10 @@
+# Core NATS only: relay messages are transient and are never written to disk.
+host: 0.0.0.0
+port: 4222
+http: 127.0.0.1:8222
+
+# Encrypted relay envelopes can approach the Connect HTTP body's 2 MiB limit
+# after JSON encoding. Keep this below NATS's recommended 8 MiB ceiling.
+max_payload: 4MB
+max_pending: 32MB
+write_deadline: "10s"

--- a/deploy/nats/start-nats.sh
+++ b/deploy/nats/start-nats.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+token=${NATS_AUTH_TOKEN:-}
+if [ "${#token}" -lt 32 ]; then
+  echo "NATS_AUTH_TOKEN must contain at least 32 characters" >&2
+  exit 1
+fi
+
+exec nats-server -c /etc/nats/mdbase-connect.conf --auth "$token"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,35 @@ services:
       timeout: 3s
       retries: 12
 
+  relay-broker:
+    build:
+      context: .
+      dockerfile: deploy/docker/Dockerfile.nats
+    environment:
+      PORT: 4222
+      NATS_AUTH_TOKEN: ${MDBASE_CONNECT_RELAY_NATS_TOKEN:-replace-this-relay-token-with-at-least-32-characters}
+    ports:
+      - "4222:4222"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8222/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+    restart: unless-stopped
+
   connect:
     build:
       context: .
       dockerfile: deploy/docker/Dockerfile.server
     depends_on:
       postgres:
+        condition: service_healthy
+      relay-broker:
         condition: service_healthy
     environment:
       HOST: 0.0.0.0
@@ -36,6 +59,8 @@ services:
       MDBASE_CONNECT_HOSTED_COLLECTIONS: ${MDBASE_CONNECT_HOSTED_COLLECTIONS:-0}
       MDBASE_CONNECT_TRUST_PROXY: ${MDBASE_CONNECT_TRUST_PROXY:-0}
       MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS: ${MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS:-0}
+      MDBASE_CONNECT_RELAY_NATS_URL: nats://relay-broker:4222
+      MDBASE_CONNECT_RELAY_NATS_TOKEN: ${MDBASE_CONNECT_RELAY_NATS_TOKEN:-replace-this-relay-token-with-at-least-32-characters}
     ports:
       - "8787:8787"
     init: true

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -1,12 +1,14 @@
 # Private Render deployment
 
-The Render Blueprint provisions three public services in Singapore:
+The Render Blueprint provisions three public services and one private service
+in Singapore:
 
 - `mdbase-connect`, the account/control plane and transient encrypted relay;
 - `mdbase-connect-hosted-provider`, the Rust hosted data plane at
   `sync.mdbase.dev`.
 - `mdbase-mcp`, the remote MCP resource and OAuth server at
   `mcp.mdbase.dev`.
+- `mdbase-connect-relay-broker`, a private Core NATS request/reply transport.
 
 Each stateful boundary has its own paid, private PostgreSQL database. Hosted record
 payloads never pass through or persist in the control-plane database. The data
@@ -51,8 +53,9 @@ empty Google allowlist rejects all Google accounts and logs the verified
 subject needed to bootstrap the first invitation. Leaving both unset keeps the
 existing GitHub-only preview unchanged.
 
-The Blueprint generates the provider internal token, provider master key, and
-MCP master key. Do not
+The Blueprint generates the provider internal token, provider master key, MCP
+master key, and relay broker token. The broker has no public endpoint and runs
+without JetStream or a persistent disk. Do not
 replace the master key on an existing provider database: startup deliberately
 fails if it cannot decrypt the durable key check. Key rotation must rewrap every
 collection data key transactionally before the old key is retired.
@@ -61,10 +64,11 @@ Do not replace `MDBASE_MCP_MASTER_KEY` on an existing MCP database either.
 Current gateway credentials are encrypted under that value; changing it forces
 every host connection and collection grant to be authorized again.
 
-Both databases deny public network connections. The hosted database uses paid
+All databases deny public network connections. The hosted database uses paid
 PostgreSQL 18 with storage autoscaling and point-in-time recovery. Automatic
-deploys wait for GitHub checks, and both services use `/ready` as a database-aware
-health check.
+deploys wait for GitHub checks. Public services use `/ready`; the control-plane
+readiness check verifies PostgreSQL, the hosted provider, and NATS. Render
+applies a TCP health check to the private broker.
 
 ## Domains
 
@@ -116,9 +120,17 @@ snapshot reset; it does not prevent retention indefinitely. Tune
 `MDBASE_CONNECT_HOSTED_RETAIN_CHANGES` only after measuring database growth and
 reset frequency in the production region.
 
-The relay still coordinates live WebSockets and in-flight requests in process,
-so keep the control plane at one instance until relay routing moves to shared
-infrastructure. Hosted data-plane scaling does not change that constraint.
+The control plane is horizontally correct. PostgreSQL allocates a generation
+for every connector session, and Core NATS routes transient requests to the
+instance holding that exact WebSocket. A newer connection fences and closes
+older sessions across instances. Policy snapshots use the same route, while
+the connector remains the final authorization boundary.
+
+The Blueprint starts with one broker instance. That is enough to scale the
+control plane but makes new relay operations dependent on that broker. For
+higher availability, run three clustered NATS private services and provide all
+three addresses in `MDBASE_CONNECT_RELAY_NATS_URL`. Keep JetStream disabled:
+relay request and response bodies must remain transient.
 
 Provider logs include request IDs, routes, statuses, durations, and internal
 errors through structured tracing. They must never log authorization headers,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -15,11 +15,27 @@ Never expose that mode to the public internet.
 
 The stack consists of:
 
-- one long-running Connect server serving the portal, HTTP API, OAuth
-  endpoints, and WebSocket relay;
+- one or more Connect servers serving the portal, HTTP API, OAuth endpoints,
+  and WebSocket relay;
 - PostgreSQL for accounts, connector metadata, discovered applications,
   grants, tokens, and audit metadata;
+- Core NATS for transient cross-instance relay delivery;
 - no storage for collection paths or record contents.
+
+Core NATS is optional. A small self-host can omit
+`MDBASE_CONNECT_RELAY_NATS_URL` and `MDBASE_CONNECT_RELAY_NATS_TOKEN`; Connect
+then uses an in-process relay with no additional service. To run more than one
+Connect process, give every process the same PostgreSQL database and NATS
+cluster URLs and token. The broker uses request/reply only: JetStream is not
+enabled, there is no relay stream, and operation payloads are not persisted.
+
+Every connector WebSocket acquires a monotonically increasing generation in
+PostgreSQL. Requests are addressed to that exact generation, so an older
+instance cannot receive new work after a reconnect even if its socket takes
+time to close. Core NATS can itself be clustered by supplying comma-separated
+URLs. A single NATS process removes the Connect scaling constraint but remains
+an availability dependency; use a three-node NATS cluster when broker failover
+is required.
 
 The server applies security headers, a global request limit, a 2 MiB request
 body limit, and public-address checks for application manifest discovery.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "e2e": "pnpm build && cargo build --workspace && node scripts/e2e.mjs",
+    "e2e:relay": "pnpm build && node scripts/relay-e2e.mjs",
     "e2e:sync": "pnpm build && node scripts/sync-e2e.mjs",
     "e2e:provider": "pnpm build && cargo build -p mdbase-connect-hosted-provider && node scripts/hosted-provider-e2e.mjs",
     "e2e:provider:stress": "MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT=10000 pnpm e2e:provider",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       '@mdbase/connect-sync':
         specifier: workspace:*
         version: link:../../packages/sync
+      '@nats-io/transport-node':
+        specifier: ^3.4.0
+        version: 3.4.0
       fastify:
         specifier: ^5.10.0
         version: 5.10.0
@@ -801,6 +804,21 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nats-io/nats-core@3.4.0':
+    resolution: {integrity: sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ==}
+
+  '@nats-io/nkeys@2.0.3':
+    resolution: {integrity: sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==}
+    engines: {node: '>=18.0.0'}
+
+  '@nats-io/nuid@3.0.0':
+    resolution: {integrity: sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg==}
+    engines: {node: '>= 22.x'}
+
+  '@nats-io/transport-node@3.4.0':
+    resolution: {integrity: sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA==}
+    engines: {node: '>= 18.0.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3212,6 +3230,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
@@ -4193,6 +4214,23 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@nats-io/nats-core@3.4.0':
+    dependencies:
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 3.0.0
+
+  '@nats-io/nkeys@2.0.3':
+    dependencies:
+      tweetnacl: 1.0.3
+
+  '@nats-io/nuid@3.0.0': {}
+
+  '@nats-io/transport-node@3.4.0':
+    dependencies:
+      '@nats-io/nats-core': 3.4.0
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 3.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6516,6 +6554,8 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tweetnacl@1.0.3: {}
 
   type-fest@0.13.1:
     optional: true

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,23 @@ previews:
   generation: "off"
 
 services:
+  - type: pserv
+    name: mdbase-connect-relay-broker
+    runtime: docker
+    repo: https://github.com/mdbase-dev/mdbase-connect
+    branch: main
+    plan: starter
+    region: singapore
+    dockerfilePath: ./deploy/docker/Dockerfile.nats
+    dockerContext: .
+    maxShutdownDelaySeconds: 30
+    autoDeployTrigger: checksPass
+    envVars:
+      - key: PORT
+        value: "4222"
+      - key: NATS_AUTH_TOKEN
+        generateValue: true
+
   - type: web
     name: mdbase-connect-hosted-provider
     runtime: docker
@@ -89,6 +106,16 @@ services:
         value: "1"
       - key: MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS
         value: "0"
+      - key: MDBASE_CONNECT_RELAY_NATS_URL
+        fromService:
+          type: pserv
+          name: mdbase-connect-relay-broker
+          property: hostport
+      - key: MDBASE_CONNECT_RELAY_NATS_TOKEN
+        fromService:
+          type: pserv
+          name: mdbase-connect-relay-broker
+          envVarKey: NATS_AUTH_TOKEN
 
   - type: web
     name: mdbase-mcp

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -1,0 +1,510 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { spawn, execFile } from "node:child_process";
+import { createServer } from "node:net";
+import { resolve } from "node:path";
+import { createRequire } from "node:module";
+import { promisify } from "node:util";
+
+process.env.NODE_ENV = "test";
+const run = promisify(execFile);
+const repoRoot = resolve(import.meta.dirname, "..");
+const requireFromServer = createRequire(new URL("../services/server/package.json", import.meta.url));
+const { WebSocket } = requireFromServer("ws");
+const { buildApp } = await import("../services/server/dist/app.js");
+const { createDatabase } = await import("../services/server/dist/db.js");
+const { createRelayBroker } = await import("../services/server/dist/relay-broker.js");
+const { tokenHash } = await import("../services/server/dist/security.js");
+
+const postgresPort = await availableTcpPort();
+const natsPort = await availableTcpPort();
+const suffix = `${process.pid}-${randomBytes(4).toString("hex")}`;
+const postgresName = `mdbase-connect-relay-pg-${suffix}`;
+const natsName = `mdbase-connect-relay-nats-${suffix}`;
+const postgresPassword = randomBytes(24).toString("base64url");
+const natsToken = randomBytes(32).toString("base64url");
+const natsConfig = resolve(repoRoot, "deploy/nats/nats.conf");
+
+let postgresProcess;
+let natsProcess;
+let database;
+let appA;
+let appB;
+let socketA;
+let socketB;
+
+try {
+  postgresProcess = startContainer([
+    "--name", postgresName,
+    "-e", "POSTGRES_DB=mdbase_connect",
+    "-e", "POSTGRES_USER=mdbase",
+    "-e", `POSTGRES_PASSWORD=${postgresPassword}`,
+    "-p", `127.0.0.1:${postgresPort}:5432`,
+    "postgres:17-alpine"
+  ], "postgres");
+  await poll(async () => {
+    try {
+      await run("docker", ["exec", postgresName, "pg_isready", "-U", "mdbase", "-d", "mdbase_connect"]);
+      return true;
+    } catch {
+      return null;
+    }
+  }, "PostgreSQL did not become ready", 200, 100);
+  // The image briefly starts a bootstrap server before restarting PostgreSQL
+  // as PID 1. Do not mistake that initialization window for final readiness.
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_000));
+  await poll(async () => {
+    try {
+      await run("docker", ["exec", postgresName, "pg_isready", "-U", "mdbase", "-d", "mdbase_connect"]);
+      return true;
+    } catch {
+      return null;
+    }
+  }, "PostgreSQL did not become ready after initialization", 100, 100);
+
+  natsProcess = startNats();
+  await waitForTcp(natsPort, "NATS did not become ready");
+
+  database = await createDatabase(
+    `postgres://mdbase:${postgresPassword}@127.0.0.1:${postgresPort}/mdbase_connect`
+  );
+  const config = { servers: [`nats://127.0.0.1:${natsPort}`], token: natsToken };
+  const brokerA = await createRelayBroker(config);
+  const brokerB = await createRelayBroker(config);
+  ({ app: appA } = await buildApp({
+    db: database,
+    devAuth: true,
+    publicUrl: "http://127.0.0.1",
+    relayBroker: brokerA
+  }));
+  const builtB = await buildApp({
+    db: database,
+    devAuth: true,
+    publicUrl: "http://127.0.0.1",
+    relayBroker: brokerB
+  });
+  appB = builtB.app;
+  await Promise.all([
+    appA.listen({ host: "127.0.0.1", port: 0 }),
+    appB.listen({ host: "127.0.0.1", port: 0 })
+  ]);
+  const urlA = appUrl(appA);
+  const urlB = appUrl(appB);
+
+  const fixture = await seed(database, tokenHash);
+  const connectorA = await connectFakeConnector({
+    WebSocket,
+    serverUrl: urlA,
+    token: fixture.connectorToken,
+    owner: "instance-a"
+  });
+  socketA = connectorA.socket;
+  await connectorA.waitForPolicy();
+
+  const crossA = await operation(urlB, fixture, "read", { path: "first.md" });
+  assert(crossA.status === 200 && crossA.body.result?.owner === "instance-a",
+    `Instance B did not route through the socket on A: ${JSON.stringify(crossA)}`);
+
+  const large = "x".repeat(1_500_000);
+  const largeResult = await operation(urlB, fixture, "read", { blob: large });
+  assert(largeResult.status === 200 && largeResult.body.result?.input_bytes === large.length,
+    `Large transient relay payload failed: ${JSON.stringify(largeResult.body)}`);
+
+  await database.query("UPDATE grants SET operations = $2::jsonb WHERE id = $1", [
+    fixture.grantId,
+    JSON.stringify(["read"])
+  ]);
+  const policyCount = connectorA.policies.length;
+  await builtB.relay.pushPolicy(fixture.connectorId);
+  await poll(
+    async () => connectorA.policies.length > policyCount
+      && connectorA.policies.at(-1)?.grants?.[0]?.operations?.length === 1,
+    "A policy update from B did not reach the socket on A"
+  );
+  await database.query("UPDATE grants SET operations = $2::jsonb WHERE id = $1", [
+    fixture.grantId,
+    JSON.stringify(["read", "query"])
+  ]);
+  await builtB.relay.pushPolicy(fixture.connectorId);
+
+  const denied = await operation(urlB, fixture, "read", { deny: true });
+  assert(denied.status === 403 && denied.body.error?.code === "access_denied",
+    `Connector authorization error was not preserved across NATS: ${JSON.stringify(denied)}`);
+
+  const closedA = closed(socketA);
+  const connectorB = await connectFakeConnector({
+    WebSocket,
+    serverUrl: urlB,
+    token: fixture.connectorToken,
+    owner: "instance-b"
+  });
+  socketB = connectorB.socket;
+  await connectorB.waitForPolicy();
+  const [closeCode] = await closedA;
+  assert(closeCode === 4001, `Older cross-instance connector closed with ${closeCode}, not 4001`);
+
+  const crossB = await operation(urlA, fixture, "query", { limit: 5 });
+  assert(crossB.status === 200 && crossB.body.result?.owner === "instance-b",
+    `Instance A did not route through the replacement socket on B: ${JSON.stringify(crossB)}`);
+
+  const burst = await Promise.all(Array.from({ length: 200 }, (_, index) => operation(
+    index % 2 === 0 ? urlA : urlB,
+    fixture,
+    index % 3 === 0 ? "query" : "read",
+    { index }
+  )));
+  assert(burst.every((result) => result.status === 200 && result.body.result?.owner === "instance-b"),
+    "Concurrent cross-instance relay burst was incomplete");
+
+  const encryption = {
+    protocol_version: 3,
+    suite: "P256-HKDF-SHA256-AES256GCM",
+    key_id: `enc_${randomUUID()}`,
+    scope_epoch: 1,
+    connector_id: fixture.connectorId,
+    collection_id: fixture.localCollectionId,
+    application_public_key: Buffer.concat([Buffer.from([4]), randomBytes(64)]).toString("base64url"),
+    connector_public_key: Buffer.concat([Buffer.from([4]), randomBytes(64)]).toString("base64url")
+  };
+  await database.query("UPDATE grants SET encryption = $2::jsonb WHERE id = $1", [
+    fixture.grantId,
+    JSON.stringify(encryption)
+  ]);
+  await builtB.relay.pushPolicy(fixture.connectorId);
+  const encryptedEnvelope = {
+    type: "encrypted_operation_request",
+    protocol_version: 3,
+    suite: encryption.suite,
+    request_id: randomUUID(),
+    grant_id: fixture.grantId,
+    application_id: fixture.applicationId,
+    connector_id: fixture.connectorId,
+    collection_id: fixture.localCollectionId,
+    operation: "read",
+    scope_epoch: encryption.scope_epoch,
+    key_id: encryption.key_id,
+    counter: "1",
+    ciphertext: "A".repeat(1_500_000)
+  };
+  const encryptedResult = await operation(urlA, fixture, "read", encryptedEnvelope);
+  assert(encryptedResult.status === 200
+      && encryptedResult.body.envelope?.type === "encrypted_operation_response"
+      && encryptedResult.body.envelope?.request_id === encryptedEnvelope.request_id
+      && encryptedResult.body.envelope?.ciphertext === encryptedEnvelope.ciphertext,
+  `Large opaque encrypted response failed across instances: ${JSON.stringify({
+    status: encryptedResult.status,
+    envelope: encryptedResult.body.envelope && {
+      ...encryptedResult.body.envelope,
+      ciphertext: `[${encryptedResult.body.envelope.ciphertext?.length} bytes]`
+    }
+  })}`);
+  await database.query("UPDATE grants SET encryption = NULL WHERE id = $1", [fixture.grantId]);
+  await builtB.relay.pushPolicy(fixture.connectorId);
+
+  await stopContainer(natsName, natsProcess);
+  natsProcess = undefined;
+  await poll(async () => {
+    const [readyA, readyB] = await Promise.all([fetch(`${urlA}/ready`), fetch(`${urlB}/ready`)]);
+    return readyA.status === 503 && readyB.status === 503;
+  }, "Connect readiness did not fail closed when NATS stopped", 100, 100);
+  const unavailable = await operation(urlA, fixture, "read", {});
+  assert(unavailable.status === 503 && unavailable.body.error?.code === "connector_offline",
+    `Relay did not fail closed during broker outage: ${JSON.stringify(unavailable)}`);
+
+  natsProcess = startNats();
+  await waitForTcp(natsPort, "Restarted NATS did not become ready");
+  await poll(async () => {
+    const [readyA, readyB] = await Promise.all([fetch(`${urlA}/ready`), fetch(`${urlB}/ready`)]);
+    return readyA.ok && readyB.ok;
+  }, "Connect instances did not recover after NATS restart", 200, 100);
+  const recovered = await operation(urlA, fixture, "read", { recovered: true });
+  assert(recovered.status === 200 && recovered.body.result?.owner === "instance-b",
+    `Relay subscriptions did not recover after broker restart: ${JSON.stringify(recovered)}`);
+
+  socketB.close(1000, "offline test");
+  await closed(socketB);
+  socketB = undefined;
+  await poll(async () => {
+    const result = await operation(urlA, fixture, "read", {});
+    return result.status === 503;
+  }, "Relay kept routing after the connector disconnected");
+
+  const connectorA2 = await connectFakeConnector({
+    WebSocket,
+    serverUrl: urlA,
+    token: fixture.connectorToken,
+    owner: "instance-a-reconnected"
+  });
+  socketA = connectorA2.socket;
+  await connectorA2.waitForPolicy();
+  const reconnected = await operation(urlB, fixture, "read", {});
+  assert(reconnected.status === 200 && reconnected.body.result?.owner === "instance-a-reconnected",
+    `Relay did not follow a post-outage reconnect: ${JSON.stringify(reconnected)}`);
+
+  const generation = await database.query(
+    "SELECT relay_generation::text AS relay_generation FROM connectors WHERE id = $1",
+    [fixture.connectorId]
+  );
+  assert(generation.rows[0]?.relay_generation === "3",
+    `Expected three fenced connector generations, got ${generation.rows[0]?.relay_generation}`);
+  const persisted = await database.query(
+    "SELECT count(*)::int AS count FROM audit_events WHERE metadata::text LIKE $1",
+    [`%${large.slice(0, 64)}%`]
+  );
+  assert(persisted.rows[0]?.count === 0, "Relay operation payload appeared in control-plane audit storage");
+
+  process.stdout.write("multi-instance NATS relay end-to-end path passed\n");
+} finally {
+  for (const socket of [socketA, socketB]) {
+    if (socket?.readyState === WebSocket.OPEN) socket.close(1000, "test cleanup");
+  }
+  await Promise.allSettled([appA?.close(), appB?.close()].filter(Boolean));
+  if (database) await database.end();
+  if (natsProcess) await stopContainer(natsName, natsProcess);
+  if (postgresProcess) await stopContainer(postgresName, postgresProcess);
+}
+
+function startNats() {
+  return startContainer([
+    "--name", natsName,
+    "-e", "PORT=4222",
+    "-e", `NATS_AUTH_TOKEN=${natsToken}`,
+    "-p", `127.0.0.1:${natsPort}:4222`,
+    "-v", `${natsConfig}:/etc/nats/mdbase-connect.conf:ro`,
+    "nats:2.12.7-alpine",
+    "-c", "/etc/nats/mdbase-connect.conf",
+    "--auth", natsToken
+  ], "nats");
+}
+
+function startContainer(args, label) {
+  const child = spawn("docker", ["run", "--rm", ...args], {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  child.stdout.on("data", (chunk) => process.stderr.write(`[relay-e2e:${label}] ${chunk}`));
+  child.stderr.on("data", (chunk) => process.stderr.write(`[relay-e2e:${label}] ${chunk}`));
+  return child;
+}
+
+async function stopContainer(name, child) {
+  if (child.exitCode !== null) return;
+  try {
+    await run("docker", ["stop", "--time", "5", name]);
+  } catch {
+    // The container may already have exited and removed itself.
+  }
+  if (child.exitCode === null) {
+    await Promise.race([
+      new Promise((resolveExit) => child.once("exit", resolveExit)),
+      new Promise((resolveDelay) => setTimeout(resolveDelay, 5_000))
+    ]);
+  }
+}
+
+async function seed(db, hash) {
+  const userId = randomUUID();
+  const connectorId = randomUUID();
+  const collectionId = randomUUID();
+  const localCollectionId = randomUUID();
+  const applicationId = randomUUID();
+  const grantId = randomUUID();
+  const connectorToken = `con_${randomBytes(32).toString("base64url")}`;
+  const accessToken = `acc_${randomBytes(32).toString("base64url")}`;
+  await db.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, $2, $3)",
+    [userId, "relay-e2e@example.com", "Relay E2E"]
+  );
+  await db.query(
+    "INSERT INTO connectors (id, user_id, name, token_hash) VALUES ($1, $2, $3, $4)",
+    [connectorId, userId, "Relay E2E connector", hash(connectorToken)]
+  );
+  await db.query(
+    `INSERT INTO collections (id, connector_id, local_id, display_name, spec_version, contracts)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+    [collectionId, connectorId, localCollectionId, "Relay E2E collection", "0.3.0", "[]"]
+  );
+  await db.query(
+    `INSERT INTO applications
+       (id, canonical_identity, manifest_url, name, homepage, redirect_uris, requirements, provisions)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb)`,
+    [
+      applicationId,
+      "https://relay-e2e.example/.well-known/mdbase-app.json",
+      "https://relay-e2e.example/.well-known/mdbase-app.json",
+      "Relay E2E app",
+      "https://relay-e2e.example",
+      JSON.stringify(["https://relay-e2e.example/callback"]),
+      JSON.stringify({ contracts: [] }),
+      JSON.stringify({ types: [] })
+    ]
+  );
+  await db.query(
+    `INSERT INTO grants
+       (id, user_id, application_id, collection_id, operations, scope, application_origin)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)`,
+    [
+      grantId,
+      userId,
+      applicationId,
+      collectionId,
+      JSON.stringify(["read", "query"]),
+      JSON.stringify({ contracts: [], access: "full_collection" }),
+      "https://relay-e2e.example"
+    ]
+  );
+  await db.query(
+    `INSERT INTO access_tokens (id, token_hash, grant_id, expires_at)
+     VALUES ($1, $2, $3, now() + interval '1 hour')`,
+    [randomUUID(), hash(accessToken), grantId]
+  );
+  return {
+    connectorId,
+    collectionId,
+    localCollectionId,
+    applicationId,
+    grantId,
+    connectorToken,
+    accessToken
+  };
+}
+
+async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner }) {
+  const socket = new Socket(serverUrl.replace(/^http/, "ws") + "/v1/relay", {
+    headers: { authorization: `Bearer ${token}` }
+  });
+  const policies = [];
+  let policyWaiter;
+  socket.on("message", (raw) => {
+    const message = JSON.parse(raw.toString());
+    if (message.type === "policy_snapshot") {
+      policies.push(message);
+      policyWaiter?.();
+      policyWaiter = undefined;
+      return;
+    }
+    if (message.type === "encrypted_operation_request") {
+      socket.send(JSON.stringify({
+        ...message,
+        type: "encrypted_operation_response"
+      }));
+      return;
+    }
+    if (message.type !== "operation_request") return;
+    if (message.input?.deny) {
+      socket.send(JSON.stringify({
+        type: "operation_response",
+        protocol_version: 2,
+        request_id: message.request_id,
+        ok: false,
+        error: { code: "access_denied", message: "Denied by the connector fixture." }
+      }));
+      return;
+    }
+    socket.send(JSON.stringify({
+      type: "operation_response",
+      protocol_version: 2,
+      request_id: message.request_id,
+      ok: true,
+      result: {
+        owner,
+        operation: message.operation,
+        input_bytes: typeof message.input?.blob === "string" ? message.input.blob.length : 0
+      }
+    }));
+  });
+  await new Promise((resolveOpen, reject) => {
+    socket.once("open", resolveOpen);
+    socket.once("error", reject);
+  });
+  return {
+    socket,
+    policies,
+    async waitForPolicy() {
+      if (policies.length > 0) return;
+      await new Promise((resolvePolicy, reject) => {
+        const timer = setTimeout(() => reject(new Error("Connector did not receive a policy snapshot")), 10_000);
+        policyWaiter = () => {
+          clearTimeout(timer);
+          resolvePolicy();
+        };
+      });
+    }
+  };
+}
+
+async function operation(serverUrl, fixture, operationName, input) {
+  const response = await fetch(
+    `${serverUrl}/v1/collections/${fixture.collectionId}/operations/${operationName}`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${fixture.accessToken}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(input)
+    }
+  );
+  return { status: response.status, body: await response.json() };
+}
+
+function appUrl(app) {
+  const address = app.server.address();
+  if (!address || typeof address === "string") throw new Error("Connect did not bind a TCP port");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function closed(socket) {
+  if (socket.readyState === WebSocket.CLOSED) return Promise.resolve([1000, Buffer.alloc(0)]);
+  return new Promise((resolveClose) => socket.once("close", (code, reason) => resolveClose([code, reason])));
+}
+
+async function waitForTcp(port, message) {
+  await poll(() => canConnect(port), message, 200, 50);
+}
+
+function canConnect(port) {
+  return new Promise((resolveConnect) => {
+    const socket = new (requireFromServer("node:net").Socket)();
+    socket.setTimeout(250);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolveConnect(true);
+    });
+    socket.once("error", () => resolveConnect(null));
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolveConnect(null);
+    });
+    socket.connect(port, "127.0.0.1");
+  });
+}
+
+async function availableTcpPort() {
+  const server = createServer();
+  await new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Could not reserve a test port");
+  await new Promise((resolveClose) => server.close(resolveClose));
+  return address.port;
+}
+
+async function poll(action, failureMessage, attempts = 100, delayMs = 100) {
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const result = await action();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, delayMs));
+  }
+  throw new Error(failureMessage, { cause: lastError });
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -21,6 +21,7 @@
     "@fastify/websocket": "^11.3.0",
     "@mdbase/connect-protocol": "workspace:*",
     "@mdbase/connect-sync": "workspace:*",
+    "@nats-io/transport-node": "^3.4.0",
     "fastify": "^5.10.0",
     "google-auth-library": "^10.9.0",
     "pg": "^8.22.0",

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -28,6 +28,7 @@ import { SyncError } from "@mdbase/connect-sync";
 import type { DatabasePool, DatabaseQueryable } from "./db.js";
 import { fetchManifest } from "./manifest.js";
 import { ConnectorOperationError, RelayHub, RelayUnavailableError } from "./relay.js";
+import type { RelayBroker } from "./relay-broker.js";
 import { pkceChallenge, randomToken, safeEqual, tokenHash } from "./security.js";
 import {
   asSyncMutation,
@@ -119,6 +120,7 @@ interface BuildOptions {
   portalDist?: string;
   allowInsecureManifests?: boolean;
   trustProxy?: boolean;
+  relayBroker?: RelayBroker;
 }
 
 interface User {
@@ -147,7 +149,7 @@ export async function buildApp(options: BuildOptions) {
   const publicUrl = options.publicUrl ?? "http://127.0.0.1:8787";
   const revision = options.revision?.trim() || undefined;
   const registration = options.registration ?? "closed";
-  const relay = new RelayHub(options.db);
+  const relay = new RelayHub(options.db, options.relayBroker);
   if (options.hostedProvider && options.hostedReferenceAuthority) {
     throw new Error("Hosted provider and reference authority modes are mutually exclusive.");
   }
@@ -189,6 +191,10 @@ export async function buildApp(options: BuildOptions) {
   await app.register(formbody);
   await app.register(cors, { origin: true, credentials: false });
   await app.register(websocket);
+
+  app.addHook("onClose", async () => {
+    await relay.close();
+  });
 
   app.addHook("onRequest", async (request, reply) => {
     if (!options.hostedCollections && request.url.startsWith("/v1/hosted/")) {
@@ -269,6 +275,7 @@ export async function buildApp(options: BuildOptions) {
   app.get("/ready", async (_request, reply) => {
     try {
       await options.db.query("SELECT 1");
+      await relay.ready();
       if (options.hostedCollections && options.hostedProvider) {
         await options.hostedProvider.ready();
       }

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -80,6 +80,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       name text NOT NULL,
       token_hash text NOT NULL UNIQUE,
+      relay_generation bigint NOT NULL DEFAULT 0,
       last_seen_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now()
     );
@@ -238,6 +239,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "ALTER TABLE grants ADD COLUMN scope jsonb NOT NULL DEFAULT '{\"contracts\":[]}'::jsonb"
   );
   await ensureColumn(db, "connectors", "relay_public_key", "ALTER TABLE connectors ADD COLUMN relay_public_key text");
+  await ensureColumn(
+    db,
+    "connectors",
+    "relay_generation",
+    "ALTER TABLE connectors ADD COLUMN relay_generation bigint NOT NULL DEFAULT 0"
+  );
   await ensureColumn(db, "grants", "encryption", "ALTER TABLE grants ADD COLUMN encryption jsonb");
   await ensureColumn(
     db,

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -3,10 +3,12 @@ import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
 import { runtimeConfigFromEnv } from "./runtime-config.js";
 import { HostedProviderClient } from "./hosted-provider.js";
+import { createRelayBroker } from "./relay-broker.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const runtime = runtimeConfigFromEnv(process.env);
 const db = await createDatabase();
+const relayBroker = await createRelayBroker(runtime.relayBroker);
 const portalDist = process.env.PORTAL_DIST ?? resolve(import.meta.dirname, "../../../apps/portal/dist");
 const { app } = await buildApp({
   db,
@@ -23,7 +25,8 @@ const { app } = await buildApp({
     ? new HostedProviderClient(runtime.hostedProvider)
     : undefined,
   trustProxy: runtime.trustProxy,
-  allowInsecureManifests: process.env.MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS === "1"
+  allowInsecureManifests: process.env.MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS === "1",
+  relayBroker
 });
 
 await app.listen({ port, host: runtime.host });

--- a/services/server/src/relay-broker.test.ts
+++ b/services/server/src/relay-broker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LocalRelayBroker,
+  RelayBrokerUnavailableError,
+  type RelayBrokerCommand
+} from "./relay-broker.js";
+
+const connectorId = "01234567-89ab-4def-8123-456789abcdef";
+const policy: RelayBrokerCommand = {
+  version: 1,
+  kind: "policy",
+  message: { type: "policy_snapshot", grants: [] }
+};
+
+describe("local relay broker", () => {
+  it("routes only to the exact connector session generation", async () => {
+    const broker = new LocalRelayBroker();
+    const handle = vi.fn(async () => ({ version: 1 as const, ok: true as const, value: "delivered" }));
+    const binding = await broker.bind({
+      connectorId,
+      generation: "7",
+      handle,
+      replaced: vi.fn()
+    });
+
+    await expect(broker.request(connectorId, "7", policy, 10)).resolves.toEqual({
+      version: 1,
+      ok: true,
+      value: "delivered"
+    });
+    await expect(broker.request(connectorId, "6", policy, 10))
+      .rejects.toBeInstanceOf(RelayBrokerUnavailableError);
+    expect(handle).toHaveBeenCalledOnce();
+
+    await binding.close();
+    await expect(broker.request(connectorId, "7", policy, 10))
+      .rejects.toBeInstanceOf(RelayBrokerUnavailableError);
+  });
+
+  it("fences older bindings but ignores stale replacement broadcasts", async () => {
+    const broker = new LocalRelayBroker();
+    const replaced = vi.fn();
+    await broker.bind({
+      connectorId,
+      generation: "99",
+      handle: async () => ({ version: 1, ok: true }),
+      replaced
+    });
+
+    await broker.publishReplacement(connectorId, "98");
+    await broker.publishReplacement(connectorId, "99");
+    expect(replaced).not.toHaveBeenCalled();
+
+    await broker.publishReplacement(connectorId, "100");
+    expect(replaced).toHaveBeenCalledOnce();
+  });
+
+  it("fails readiness and routing after shutdown", async () => {
+    const broker = new LocalRelayBroker();
+    await broker.close();
+    await expect(broker.ready()).rejects.toBeInstanceOf(RelayBrokerUnavailableError);
+    await expect(broker.request(connectorId, "1", policy, 10))
+      .rejects.toBeInstanceOf(RelayBrokerUnavailableError);
+  });
+});

--- a/services/server/src/relay-broker.ts
+++ b/services/server/src/relay-broker.ts
@@ -1,0 +1,360 @@
+import {
+  connect,
+  RequestError,
+  TimeoutError,
+  type Msg,
+  type NatsConnection,
+  type Subscription
+} from "@nats-io/transport-node";
+
+const SUBJECT_PREFIX = "mdbase.connect.relay.v1";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface RelayBrokerConfig {
+  servers: string[];
+  token: string;
+}
+
+export interface RelayBrokerCommand {
+  version: 1;
+  kind: "deliver" | "policy";
+  message: unknown;
+}
+
+export type RelayBrokerReply = {
+  version: 1;
+  ok: true;
+  value?: unknown;
+} | {
+  version: 1;
+  ok: false;
+  error: {
+    kind: "unavailable" | "connector" | "internal";
+    code: string;
+    message: string;
+  };
+};
+
+export interface RelayBrokerBinding {
+  close(): Promise<void>;
+}
+
+export interface RelayBroker {
+  bind(input: {
+    connectorId: string;
+    generation: string;
+    handle(command: RelayBrokerCommand): Promise<RelayBrokerReply>;
+    replaced(): void;
+  }): Promise<RelayBrokerBinding>;
+  request(
+    connectorId: string,
+    generation: string,
+    command: RelayBrokerCommand,
+    timeoutMs: number
+  ): Promise<RelayBrokerReply>;
+  publishReplacement(connectorId: string, generation: string): Promise<void>;
+  ready(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export class RelayBrokerUnavailableError extends Error {
+  constructor(message = "The relay broker is unavailable.", options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
+interface LocalBinding {
+  connectorId: string;
+  generation: string;
+  handle(command: RelayBrokerCommand): Promise<RelayBrokerReply>;
+  replaced(): void;
+}
+
+/**
+ * The zero-dependency broker for single-process and embedded deployments.
+ * NATS is an optional transport, not a requirement for self-hosting Connect.
+ */
+export class LocalRelayBroker implements RelayBroker {
+  private readonly bindings = new Map<string, LocalBinding>();
+  private closed = false;
+
+  async bind(input: LocalBinding): Promise<RelayBrokerBinding> {
+    this.assertOpen();
+    const key = deliverySubject(input.connectorId, input.generation);
+    const previous = this.bindings.get(key);
+    if (previous) previous.replaced();
+    this.bindings.set(key, input);
+    return {
+      close: async () => {
+        if (this.bindings.get(key) === input) this.bindings.delete(key);
+      }
+    };
+  }
+
+  async request(
+    connectorId: string,
+    generation: string,
+    command: RelayBrokerCommand,
+    _timeoutMs: number
+  ): Promise<RelayBrokerReply> {
+    this.assertOpen();
+    const binding = this.bindings.get(deliverySubject(connectorId, generation));
+    if (!binding) throw new RelayBrokerUnavailableError("No relay owns the current connector session.");
+    return binding.handle(command);
+  }
+
+  async publishReplacement(connectorId: string, generation: string): Promise<void> {
+    this.assertOpen();
+    for (const binding of this.bindings.values()) {
+      if (binding.connectorId === connectorId && compareGeneration(generation, binding.generation) > 0) {
+        binding.replaced();
+      }
+    }
+  }
+
+  async ready(): Promise<void> {
+    this.assertOpen();
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.bindings.clear();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new RelayBrokerUnavailableError("The relay broker is closed.");
+  }
+}
+
+export class NatsRelayBroker implements RelayBroker {
+  private available = true;
+
+  private constructor(private readonly connection: NatsConnection) {
+    void this.monitorConnection();
+  }
+
+  static async connect(config: RelayBrokerConfig): Promise<NatsRelayBroker> {
+    const connection = await connect({
+      servers: config.servers,
+      token: config.token,
+      name: `mdbase-connect-${process.pid}`,
+      waitOnFirstConnect: true,
+      maxReconnectAttempts: -1,
+      reconnectTimeWait: 500
+    });
+    return new NatsRelayBroker(connection);
+  }
+
+  async bind(input: {
+    connectorId: string;
+    generation: string;
+    handle(command: RelayBrokerCommand): Promise<RelayBrokerReply>;
+    replaced(): void;
+  }): Promise<RelayBrokerBinding> {
+    this.assertAvailable();
+    assertSubjectParts(input.connectorId, input.generation);
+    const delivery = this.connection.subscribe(deliverySubject(input.connectorId, input.generation), {
+      callback: (error, message) => {
+        void this.handleRequest(error, message, input.handle);
+      }
+    });
+    const replacements = this.connection.subscribe(replacementSubject(input.connectorId), {
+      callback: (error, message) => {
+        if (error) return;
+        const replacement = decodeJson(message.data);
+        if (isReplacement(replacement)
+            && compareGeneration(replacement.generation, input.generation) > 0) {
+          input.replaced();
+        }
+      }
+    });
+    await this.connection.flush();
+    return new NatsRelayBinding(delivery, replacements);
+  }
+
+  async request(
+    connectorId: string,
+    generation: string,
+    command: RelayBrokerCommand,
+    timeoutMs: number
+  ): Promise<RelayBrokerReply> {
+    this.assertAvailable();
+    assertSubjectParts(connectorId, generation);
+    try {
+      const response = await this.connection.request(
+        deliverySubject(connectorId, generation),
+        encodeJson(command),
+        { timeout: timeoutMs }
+      );
+      const reply = decodeJson(response.data);
+      if (!isRelayBrokerReply(reply)) {
+        throw new RelayBrokerUnavailableError("The relay broker returned an invalid response.");
+      }
+      return reply;
+    } catch (error) {
+      if (error instanceof RelayBrokerUnavailableError) throw error;
+      if (error instanceof TimeoutError
+          || (error instanceof RequestError && error.isNoResponders())) {
+        throw new RelayBrokerUnavailableError("No relay owns the current connector session.", {
+          cause: error
+        });
+      }
+      throw new RelayBrokerUnavailableError("The relay broker request failed.", { cause: error });
+    }
+  }
+
+  async publishReplacement(connectorId: string, generation: string): Promise<void> {
+    this.assertAvailable();
+    assertSubjectParts(connectorId, generation);
+    this.connection.publish(replacementSubject(connectorId), encodeJson({ version: 1, generation }));
+    await this.connection.flush();
+  }
+
+  async ready(): Promise<void> {
+    this.assertAvailable();
+    await withTimeout(this.connection.flush(), 1_000);
+  }
+
+  async close(): Promise<void> {
+    this.available = false;
+    if (!this.connection.isClosed()) await this.connection.drain();
+  }
+
+  private assertAvailable(): void {
+    if (!this.available || this.connection.isClosed()) {
+      throw new RelayBrokerUnavailableError("The relay broker is disconnected.");
+    }
+  }
+
+  private async monitorConnection(): Promise<void> {
+    for await (const status of this.connection.status()) {
+      if (status.type === "reconnect") this.available = true;
+      if (status.type === "disconnect"
+          || status.type === "reconnecting"
+          || status.type === "staleConnection"
+          || status.type === "forceReconnect"
+          || status.type === "close") {
+        this.available = false;
+      }
+    }
+  }
+
+  private async handleRequest(
+    error: Error | null,
+    message: Msg,
+    handle: (command: RelayBrokerCommand) => Promise<RelayBrokerReply>
+  ): Promise<void> {
+    if (error || !message.reply) return;
+    const decoded = decodeJson(message.data);
+    let reply: RelayBrokerReply;
+    if (!isRelayBrokerCommand(decoded)) {
+      reply = internalError("invalid_broker_command", "The relay command was invalid.");
+    } else {
+      try {
+        reply = await handle(decoded);
+      } catch {
+        reply = internalError("relay_delivery_failed", "The relay could not deliver the request.");
+      }
+    }
+    this.connection.publish(message.reply, encodeJson(reply));
+  }
+}
+
+class NatsRelayBinding implements RelayBrokerBinding {
+  private closed = false;
+
+  constructor(
+    private readonly delivery: Subscription,
+    private readonly replacements: Subscription
+  ) {}
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.delivery.unsubscribe();
+    this.replacements.unsubscribe();
+  }
+}
+
+export async function createRelayBroker(config: RelayBrokerConfig | null): Promise<RelayBroker> {
+  return config ? NatsRelayBroker.connect(config) : new LocalRelayBroker();
+}
+
+function deliverySubject(connectorId: string, generation: string): string {
+  return `${SUBJECT_PREFIX}.deliver.${connectorId}.${generation}`;
+}
+
+function replacementSubject(connectorId: string): string {
+  return `${SUBJECT_PREFIX}.replace.${connectorId}`;
+}
+
+function assertSubjectParts(connectorId: string, generation: string): void {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(connectorId)
+      || !/^[0-9]+$/.test(generation)) {
+    throw new RelayBrokerUnavailableError("Invalid relay routing metadata.");
+  }
+}
+
+function compareGeneration(left: string, right: string): number {
+  const a = BigInt(left);
+  const b = BigInt(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function encodeJson(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value));
+}
+
+function decodeJson(data: Uint8Array): unknown {
+  try {
+    return JSON.parse(decoder.decode(data));
+  } catch {
+    return null;
+  }
+}
+
+function isRelayBrokerCommand(value: unknown): value is RelayBrokerCommand {
+  if (!isObject(value) || value.version !== 1) return false;
+  return (value.kind === "deliver" || value.kind === "policy") && "message" in value;
+}
+
+function isRelayBrokerReply(value: unknown): value is RelayBrokerReply {
+  if (!isObject(value) || value.version !== 1 || typeof value.ok !== "boolean") return false;
+  if (value.ok) return true;
+  return isObject(value.error)
+    && (value.error.kind === "unavailable"
+      || value.error.kind === "connector"
+      || value.error.kind === "internal")
+    && typeof value.error.code === "string"
+    && typeof value.error.message === "string";
+}
+
+function isReplacement(value: unknown): value is { version: 1; generation: string } {
+  return isObject(value)
+    && value.version === 1
+    && typeof value.generation === "string"
+    && /^[0-9]+$/.test(value.generation);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function internalError(code: string, message: string): RelayBrokerReply {
+  return { version: 1, ok: false, error: { kind: "internal", code, message } };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new RelayBrokerUnavailableError()), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -5,26 +5,82 @@ import type {
   EncryptedRelayOperationResponse
 } from "@mdbase/connect-protocol";
 import type { DatabasePool } from "./db.js";
+import {
+  LocalRelayBroker,
+  RelayBrokerUnavailableError,
+  type RelayBroker,
+  type RelayBrokerBinding,
+  type RelayBrokerCommand,
+  type RelayBrokerReply
+} from "./relay-broker.js";
 import type { WebSocket } from "ws";
+
+const OPERATION_TIMEOUT_MS = 30_000;
+const BROKER_OPERATION_TIMEOUT_MS = OPERATION_TIMEOUT_MS + 1_000;
+const POLICY_TIMEOUT_MS = 5_000;
 
 interface PendingRequest {
   resolve(value: unknown): void;
   reject(error: Error): void;
   timer: NodeJS.Timeout;
+  socket: WebSocket;
   expectedEncrypted?: EncryptedRelayEnvelope;
 }
 
+interface ConnectorSession {
+  generation: string;
+  socket: WebSocket;
+  binding: RelayBrokerBinding;
+}
+
 export class RelayHub {
-  private readonly connectors = new Map<string, WebSocket>();
+  private readonly connectors = new Map<string, ConnectorSession>();
   private readonly pending = new Map<string, PendingRequest>();
 
-  constructor(private readonly db: DatabasePool) {}
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly broker: RelayBroker = new LocalRelayBroker()
+  ) {}
 
   async attach(connectorId: string, socket: WebSocket): Promise<void> {
-    this.connectors.get(connectorId)?.close(4001, "Replaced by a newer connector session");
-    this.connectors.set(connectorId, socket);
-    await this.db.query("UPDATE connectors SET last_seen_at = now() WHERE id = $1", [connectorId]);
-    await this.pushPolicy(connectorId);
+    const updated = await this.db.query<{ relay_generation: string | number }>(
+      `UPDATE connectors
+       SET last_seen_at = now(), relay_generation = relay_generation + 1
+       WHERE id = $1
+       RETURNING relay_generation`,
+      [connectorId]
+    );
+    const row = updated.rows[0];
+    if (!row) {
+      socket.close(4003, "Invalid connector credential");
+      return;
+    }
+    const generation = String(row.relay_generation);
+    let session: ConnectorSession;
+    const binding = await this.broker.bind({
+      connectorId,
+      generation,
+      handle: (command) => this.handleBrokerCommand(connectorId, generation, command),
+      replaced: () => {
+        const current = this.connectors.get(connectorId);
+        if (current?.generation === generation && current.socket === socket) {
+          socket.close(4001, "Replaced by a newer connector session");
+        }
+      }
+    });
+    if (await this.currentGeneration(connectorId) !== generation) {
+      await binding.close();
+      socket.close(4001, "Replaced by a newer connector session");
+      return;
+    }
+    session = { generation, socket, binding };
+
+    const previous = this.connectors.get(connectorId);
+    this.connectors.set(connectorId, session);
+    if (previous) {
+      previous.socket.close(4001, "Replaced by a newer connector session");
+      await previous.binding.close();
+    }
 
     socket.on("message", (raw) => {
       try {
@@ -48,14 +104,15 @@ export class RelayHub {
         };
         if (!message.request_id) return;
         const pending = this.pending.get(message.request_id);
-        if (!pending) return;
+        if (!pending || pending.socket !== socket) return;
         if (message.type === "encrypted_operation_rejected") {
-          clearTimeout(pending.timer);
-          this.pending.delete(message.request_id);
-          pending.reject(new ConnectorOperationError(
-            "encrypted_relay_rejected",
-            "The connector rejected the encrypted relay request."
-          ));
+          this.rejectPending(
+            message.request_id,
+            new ConnectorOperationError(
+              "encrypted_relay_rejected",
+              "The connector rejected the encrypted relay request."
+            )
+          );
           return;
         }
         if (pending.expectedEncrypted) {
@@ -64,43 +121,57 @@ export class RelayHub {
                 message as Partial<EncryptedRelayOperationResponse>,
                 pending.expectedEncrypted
               )) {
-            clearTimeout(pending.timer);
-            this.pending.delete(message.request_id);
-            pending.reject(new ConnectorOperationError(
-              "invalid_encrypted_response",
-              "The connector returned an invalid encrypted response."
-            ));
+            this.rejectPending(
+              message.request_id,
+              new ConnectorOperationError(
+                "invalid_encrypted_response",
+                "The connector returned an invalid encrypted response."
+              )
+            );
             return;
           }
-          clearTimeout(pending.timer);
-          this.pending.delete(message.request_id);
-          pending.resolve(message);
+          this.resolvePending(message.request_id, message);
           return;
         }
         if (message.type !== "operation_response") return;
-        clearTimeout(pending.timer);
-        this.pending.delete(message.request_id);
-        if (message.ok) pending.resolve(message.result);
-        else pending.reject(new ConnectorOperationError(
-          message.error?.code ?? "connector_operation_failed",
-          message.error?.message ?? "Connector operation failed."
-        ));
+        if (message.ok) this.resolvePending(message.request_id, message.result);
+        else {
+          this.rejectPending(
+            message.request_id,
+            new ConnectorOperationError(
+              message.error?.code ?? "connector_operation_failed",
+              message.error?.message ?? "Connector operation failed."
+            )
+          );
+        }
       } catch {
         socket.close(4002, "Invalid relay message");
       }
     });
     socket.once("close", () => {
-      if (this.connectors.get(connectorId) === socket) this.connectors.delete(connectorId);
+      const current = this.connectors.get(connectorId);
+      if (current?.socket === socket && current.generation === generation) {
+        this.connectors.delete(connectorId);
+      }
+      void binding.close();
+      this.rejectForSocket(socket, new RelayUnavailableError());
     });
+
+    try {
+      await this.broker.publishReplacement(connectorId, generation);
+    } catch (error) {
+      // The generation in PostgreSQL is the hard fence. Replacement broadcast
+      // only accelerates closing a stale socket when the broker is available.
+      if (!(error instanceof RelayBrokerUnavailableError)) throw error;
+    }
+    await this.pushPolicy(connectorId);
   }
 
   isConnected(connectorId: string): boolean {
-    return this.connectors.get(connectorId)?.readyState === 1;
+    return this.connectors.get(connectorId)?.socket.readyState === 1;
   }
 
   async pushPolicy(connectorId: string): Promise<void> {
-    const socket = this.connectors.get(connectorId);
-    if (!socket || socket.readyState !== 1) return;
     const grants = await this.db.query<{
       id: string;
       application_id: string;
@@ -128,7 +199,9 @@ export class RelayHub {
        WHERE c.connector_id = $1 AND g.revoked_at IS NULL`,
       [connectorId]
     );
-    socket.send(JSON.stringify({
+    const generation = await this.currentGeneration(connectorId);
+    if (!generation) return;
+    const message = {
       type: "policy_snapshot",
       protocol_version: 2,
       grants: grants.rows.map((grant) => ({
@@ -145,10 +218,22 @@ export class RelayHub {
         created_at: grant.created_at,
         ...(grant.encryption ? { encryption: grant.encryption } : {})
       }))
-    }));
+    };
+    try {
+      await this.broker.request(
+        connectorId,
+        generation,
+        { version: 1, kind: "policy", message },
+        POLICY_TIMEOUT_MS
+      );
+    } catch (error) {
+      // Policy snapshots are best effort while a connector is offline. The
+      // complete snapshot is sent again whenever the connector reconnects.
+      if (!(error instanceof RelayBrokerUnavailableError)) throw error;
+    }
   }
 
-  route(input: {
+  async route(input: {
     connectorId: string;
     localCollectionId: string;
     grantId: string;
@@ -156,39 +241,127 @@ export class RelayHub {
     operation: string;
     operationInput: unknown;
   }): Promise<unknown> {
-    const socket = this.connectors.get(input.connectorId);
-    if (!socket || socket.readyState !== 1) {
-      return Promise.reject(new RelayUnavailableError());
-    }
+    const generation = await this.requireCurrentGeneration(input.connectorId);
     const requestId = randomUUID();
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(requestId);
-        reject(new Error("Connector operation timed out."));
-      }, 30_000);
-      this.pending.set(requestId, { resolve, reject, timer });
-      socket.send(JSON.stringify({
-        type: "operation_request",
-        protocol_version: 2,
-        request_id: requestId,
-        grant_id: input.grantId,
-        collection_id: input.localCollectionId,
-        application_id: input.applicationId,
-        operation: input.operation,
-        input: input.operationInput
-      }));
+    return this.deliver(input.connectorId, generation, {
+      type: "operation_request",
+      protocol_version: 2,
+      request_id: requestId,
+      grant_id: input.grantId,
+      collection_id: input.localCollectionId,
+      application_id: input.applicationId,
+      operation: input.operation,
+      input: input.operationInput
     });
   }
 
-  routeEncrypted(
+  async routeEncrypted(
     connectorId: string,
     envelope: EncryptedRelayOperationRequest
   ): Promise<EncryptedRelayOperationResponse> {
-    const socket = this.connectors.get(connectorId);
-    if (!socket || socket.readyState !== 1) {
-      return Promise.reject(new RelayUnavailableError());
+    const generation = await this.requireCurrentGeneration(connectorId);
+    const response = await this.deliver(connectorId, generation, envelope);
+    if (!matchesEncryptedMetadata(
+      response as Partial<EncryptedRelayOperationResponse>,
+      envelope
+    )) {
+      throw new ConnectorOperationError(
+        "invalid_encrypted_response",
+        "The connector returned an invalid encrypted response."
+      );
     }
-    if (this.pending.has(envelope.request_id)) {
+    return response as EncryptedRelayOperationResponse;
+  }
+
+  async ready(): Promise<void> {
+    await this.broker.ready();
+  }
+
+  async close(): Promise<void> {
+    const sessions = [...this.connectors.values()];
+    this.connectors.clear();
+    await Promise.allSettled(sessions.map((session) => session.binding.close()));
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new RelayUnavailableError());
+    }
+    this.pending.clear();
+    await this.broker.close();
+  }
+
+  private async deliver(
+    connectorId: string,
+    generation: string,
+    message: unknown
+  ): Promise<unknown> {
+    let reply: RelayBrokerReply;
+    try {
+      reply = await this.broker.request(
+        connectorId,
+        generation,
+        { version: 1, kind: "deliver", message },
+        BROKER_OPERATION_TIMEOUT_MS
+      );
+    } catch (error) {
+      if (error instanceof RelayBrokerUnavailableError) throw new RelayUnavailableError();
+      throw error;
+    }
+    if (reply.ok) return reply.value;
+    if (reply.error.kind === "unavailable") throw new RelayUnavailableError();
+    throw new ConnectorOperationError(reply.error.code, reply.error.message);
+  }
+
+  private async handleBrokerCommand(
+    connectorId: string,
+    generation: string,
+    command: RelayBrokerCommand
+  ): Promise<RelayBrokerReply> {
+    const session = this.connectors.get(connectorId);
+    if (!session
+        || session.generation !== generation
+        || session.socket.readyState !== 1
+        || await this.currentGeneration(connectorId) !== generation) {
+      return brokerError("unavailable", "connector_offline", "The computer hosting this collection is offline.");
+    }
+    if (command.kind === "policy") {
+      try {
+        session.socket.send(JSON.stringify(command.message));
+        return { version: 1, ok: true };
+      } catch {
+        return brokerError("unavailable", "connector_offline", "The computer hosting this collection is offline.");
+      }
+    }
+    const requestId = requestIdFromMessage(command.message);
+    if (!requestId) {
+      return brokerError("internal", "invalid_relay_request", "The relay request did not contain a request ID.");
+    }
+    const expectedEncrypted = encryptedRequestFromMessage(command.message);
+    try {
+      const value = await this.sendToConnector(
+        session.socket,
+        requestId,
+        command.message,
+        expectedEncrypted
+      );
+      return { version: 1, ok: true, value };
+    } catch (error) {
+      if (error instanceof RelayUnavailableError) {
+        return brokerError("unavailable", "connector_offline", error.message);
+      }
+      if (error instanceof ConnectorOperationError) {
+        return brokerError("connector", error.code, error.message);
+      }
+      return brokerError("internal", "relay_delivery_failed", "The relay could not deliver the request.");
+    }
+  }
+
+  private sendToConnector(
+    socket: WebSocket,
+    requestId: string,
+    message: unknown,
+    expectedEncrypted?: EncryptedRelayEnvelope
+  ): Promise<unknown> {
+    if (this.pending.has(requestId)) {
       return Promise.reject(new ConnectorOperationError(
         "duplicate_request_id",
         "The encrypted request ID is already in use."
@@ -196,25 +369,86 @@ export class RelayHub {
     }
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.pending.delete(envelope.request_id);
-        reject(new Error("Connector operation timed out."));
-      }, 30_000);
-      this.pending.set(envelope.request_id, {
-        resolve,
-        reject,
-        timer,
-        expectedEncrypted: envelope
-      });
-      socket.send(JSON.stringify(envelope));
+        this.pending.delete(requestId);
+        reject(new ConnectorOperationError(
+          "connector_timeout",
+          "The connector operation timed out."
+        ));
+      }, OPERATION_TIMEOUT_MS);
+      this.pending.set(requestId, { resolve, reject, timer, socket, expectedEncrypted });
+      try {
+        socket.send(JSON.stringify(message), (error) => {
+          if (error) this.rejectPending(requestId, new RelayUnavailableError());
+        });
+      } catch {
+        this.rejectPending(requestId, new RelayUnavailableError());
+      }
     });
   }
+
+  private async currentGeneration(connectorId: string): Promise<string | null> {
+    const result = await this.db.query<{ relay_generation: string | number }>(
+      "SELECT relay_generation FROM connectors WHERE id = $1",
+      [connectorId]
+    );
+    return result.rows[0] ? String(result.rows[0].relay_generation) : null;
+  }
+
+  private async requireCurrentGeneration(connectorId: string): Promise<string> {
+    const generation = await this.currentGeneration(connectorId);
+    if (!generation || generation === "0") throw new RelayUnavailableError();
+    return generation;
+  }
+
+  private resolvePending(requestId: string, value: unknown): void {
+    const pending = this.pending.get(requestId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(requestId);
+    pending.resolve(value);
+  }
+
+  private rejectPending(requestId: string, error: Error): void {
+    const pending = this.pending.get(requestId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(requestId);
+    pending.reject(error);
+  }
+
+  private rejectForSocket(socket: WebSocket, error: Error): void {
+    for (const [requestId, pending] of this.pending) {
+      if (pending.socket === socket) this.rejectPending(requestId, error);
+    }
+  }
+}
+
+function requestIdFromMessage(message: unknown): string | null {
+  if (typeof message !== "object" || message === null || Array.isArray(message)) return null;
+  const requestId = (message as { request_id?: unknown }).request_id;
+  return typeof requestId === "string" && requestId.length > 0 ? requestId : null;
+}
+
+function encryptedRequestFromMessage(message: unknown): EncryptedRelayEnvelope | undefined {
+  if (typeof message !== "object" || message === null || Array.isArray(message)) return undefined;
+  return (message as { type?: unknown }).type === "encrypted_operation_request"
+    ? message as EncryptedRelayEnvelope
+    : undefined;
+}
+
+function brokerError(
+  kind: "unavailable" | "connector" | "internal",
+  code: string,
+  message: string
+): RelayBrokerReply {
+  return { version: 1, ok: false, error: { kind, code, message } };
 }
 
 function matchesEncryptedMetadata(
   response: Partial<EncryptedRelayOperationResponse>,
   request: EncryptedRelayEnvelope
 ): response is EncryptedRelayOperationResponse {
-  return response.protocol_version === request.protocol_version
+  return response?.protocol_version === request.protocol_version
     && response.suite === request.suite
     && response.request_id === request.request_id
     && response.grant_id === request.grant_id

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -13,6 +13,7 @@ function config(overrides: Partial<Parameters<typeof validateRuntimeConfig>[0]> 
     hostedCollections: false,
     hostedProvider: null,
     trustProxy: false,
+    relayBroker: null,
     ...overrides
   };
 }
@@ -153,5 +154,30 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: "x".repeat(40)
     });
     expect(value.hostedProvider?.url).toBe("http://127.0.0.1:8790");
+  });
+
+  it("validates an optional private NATS relay transport", () => {
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_RELAY_NATS_URL: "nats://relay-a:4222,nats://relay-b:4222",
+      MDBASE_CONNECT_RELAY_NATS_TOKEN: "x".repeat(40)
+    });
+    expect(value.relayBroker?.servers).toEqual([
+      "nats://relay-a:4222",
+      "nats://relay-b:4222"
+    ]);
+
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_RELAY_NATS_URL: "nats://relay:4222"
+    })).toThrow(/configured together/);
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_RELAY_NATS_URL: "https://relay.example:4222",
+      MDBASE_CONNECT_RELAY_NATS_TOKEN: "x".repeat(40)
+    })).toThrow(/nats:\/\//);
   });
 });

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -1,6 +1,7 @@
 import type { GitHubAuthConfig } from "./github-auth.js";
 import type { GoogleAuthConfig } from "./google-auth.js";
 import type { HostedProviderConfig } from "./hosted-provider.js";
+import type { RelayBrokerConfig } from "./relay-broker.js";
 
 export type RegistrationMode = "closed" | "open";
 
@@ -15,6 +16,7 @@ export interface RuntimeConfig {
   hostedCollections: boolean;
   hostedProvider: HostedProviderConfig | null;
   trustProxy: boolean;
+  relayBroker: RelayBrokerConfig | null;
 }
 
 export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
@@ -81,6 +83,15 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
     }
     hostedProvider = { ...hostedProvider, url: providerUrl.origin };
   }
+  if (config.relayBroker) {
+    if (config.relayBroker.token.length < 32) {
+      throw new Error("The relay broker token must contain at least 32 characters.");
+    }
+    for (const server of config.relayBroker.servers) validateRelayBrokerServer(server);
+    if (config.relayBroker.servers.length === 0) {
+      throw new Error("At least one relay broker server must be configured.");
+    }
+  }
   return { ...config, publicUrl: publicUrl.origin, hostedProvider };
 }
 
@@ -104,6 +115,19 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   const hostedProviderInternalToken =
     env.MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN?.trim() ?? "";
   const hostedProviderConfigured = Boolean(hostedProviderUrl || hostedProviderInternalToken);
+  const relayBrokerServers = (env.MDBASE_CONNECT_RELAY_NATS_URL ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const normalizedRelayBrokerServers = relayBrokerServers.map((value) => (
+    value.includes("://") ? value : `nats://${value}`
+  ));
+  const relayBrokerToken = env.MDBASE_CONNECT_RELAY_NATS_TOKEN?.trim() ?? "";
+  if ((relayBrokerServers.length > 0) !== Boolean(relayBrokerToken)) {
+    throw new Error(
+      "MDBASE_CONNECT_RELAY_NATS_URL and MDBASE_CONNECT_RELAY_NATS_TOKEN must be configured together."
+    );
+  }
   return validateRuntimeConfig({
     host,
     publicUrl: env.PUBLIC_URL ?? `http://${host}:${port}`,
@@ -118,7 +142,10 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
     hostedProvider: hostedProviderConfigured
       ? { url: hostedProviderUrl, internalToken: hostedProviderInternalToken }
       : null,
-    trustProxy: env.MDBASE_CONNECT_TRUST_PROXY === "1"
+    trustProxy: env.MDBASE_CONNECT_TRUST_PROXY === "1",
+    relayBroker: normalizedRelayBrokerServers.length > 0
+      ? { servers: normalizedRelayBrokerServers, token: relayBrokerToken }
+      : null
   });
 }
 
@@ -136,4 +163,18 @@ function registrationMode(value: string | undefined): RegistrationMode {
 
 function isLoopback(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+
+function validateRelayBrokerServer(server: string): void {
+  const url = new URL(server);
+  if ((url.protocol !== "nats:" && url.protocol !== "tls:")
+      || url.username
+      || url.password
+      || url.pathname !== ""
+      || url.search
+      || url.hash
+      || !url.hostname
+      || !url.port) {
+    throw new Error("Relay broker servers must be nats:// or tls:// host-and-port URLs without credentials.");
+  }
 }


### PR DESCRIPTION
## What changed

- route connector operations and policy snapshots across Connect instances with Core NATS request/reply
- fence connector WebSocket ownership with a PostgreSQL session generation
- retain the in-process relay when NATS is not configured, keeping small self-hosts simple
- add a private, non-persistent NATS service to Docker Compose and the Render Blueprint
- make readiness fail closed when the shared broker is unavailable
- add a real PostgreSQL/NATS two-instance E2E suite and enforce it in CI

## Why

The previous relay kept WebSockets and in-flight requests in one process. Scaling the Render web service horizontally could therefore send an application request to an instance that did not own the connector socket.

The broker is transport-only: JetStream is disabled, no disk is attached, and record payloads remain transient. PostgreSQL stores only the connector generation used for routing and fencing.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:relay`
- `pnpm e2e:sync`
- `pnpm e2e:provider`
- `pnpm e2e:provider:stress` (10,002 records)
- clean-worktree `pnpm build && pnpm typecheck && pnpm test && node scripts/relay-e2e.mjs`
- Render Blueprint validation
- NATS Docker image build/start/health smoke test
