### PR TITLE
Separate relay and health-check identities

### DIFF
--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -8,3 +8,27 @@ http: 127.0.0.1:8222
 max_payload: 4MB
 max_pending: 32MB
 write_deadline: "10s"
+
+# Render checks private services with a bare TCP connection. Map connections
+# without credentials to a principal that cannot publish or subscribe, keeping
+# those checks quiet without weakening the authenticated relay principal.
+authorization {
+  users: [
+    {
+      user: mdbase-connect
+      password: $MDBASE_NATS_PASSWORD
+      permissions: {
+        publish: ["mdbase.connect.relay.v1.>", "_INBOX.>"]
+        subscribe: ["mdbase.connect.relay.v1.>", "_INBOX.>"]
+      }
+    }
+    {
+      user: health
+      permissions: {
+        publish: []
+        subscribe: []
+      }
+    }
+  ]
+}
+no_auth_user: health

--- a/deploy/nats/start-nats.sh
+++ b/deploy/nats/start-nats.sh
@@ -7,4 +7,15 @@ if [ "${#token}" -lt 32 ]; then
   exit 1
 fi
 
-exec nats-server -c /etc/nats/mdbase-connect.conf --auth "$token"
+case "$token" in
+  *[!A-Za-z0-9_+=./-]*)
+    echo "NATS_AUTH_TOKEN contains unsupported characters" >&2
+    exit 1
+    ;;
+esac
+
+# The constant prefix guarantees that an unquoted NATS config variable cannot
+# be parsed as a number when a generated secret happens to start with a digit.
+MDBASE_NATS_PASSWORD="mdbase_${token}"
+export MDBASE_NATS_PASSWORD
+exec nats-server -c /etc/nats/mdbase-connect.conf

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -268,11 +268,11 @@ function startNats() {
     "--name", natsName,
     "-e", "PORT=4222",
     "-e", `NATS_AUTH_TOKEN=${natsToken}`,
+    "-e", `MDBASE_NATS_PASSWORD=mdbase_${natsToken}`,
     "-p", `127.0.0.1:${natsPort}:4222`,
     "-v", `${natsConfig}:/etc/nats/mdbase-connect.conf:ro`,
     "nats:2.12.7-alpine",
-    "-c", "/etc/nats/mdbase-connect.conf",
-    "--auth", natsToken
+    "-c", "/etc/nats/mdbase-connect.conf"
   ], "nats");
 }
 

--- a/services/server/src/relay-broker.ts
+++ b/services/server/src/relay-broker.ts
@@ -137,7 +137,8 @@ export class NatsRelayBroker implements RelayBroker {
   static async connect(config: RelayBrokerConfig): Promise<NatsRelayBroker> {
     const connection = await connect({
       servers: config.servers,
-      token: config.token,
+      user: "mdbase-connect",
+      pass: `mdbase_${config.token}`,
       name: `mdbase-connect-${process.pid}`,
       waitOnFirstConnect: true,
       maxReconnectAttempts: -1,

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -179,5 +179,11 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_RELAY_NATS_URL: "https://relay.example:4222",
       MDBASE_CONNECT_RELAY_NATS_TOKEN: "x".repeat(40)
     })).toThrow(/nats:\/\//);
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_RELAY_NATS_URL: "nats://relay:4222",
+      MDBASE_CONNECT_RELAY_NATS_TOKEN: `unsafe ${"x".repeat(40)}`
+    })).toThrow(/unsupported characters/);
   });
 });

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -87,6 +87,9 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
     if (config.relayBroker.token.length < 32) {
       throw new Error("The relay broker token must contain at least 32 characters.");
     }
+    if (!/^[A-Za-z0-9_+=./-]+$/.test(config.relayBroker.token)) {
+      throw new Error("The relay broker token contains unsupported characters.");
+    }
     for (const server of config.relayBroker.servers) validateRelayBrokerServer(server);
     if (config.relayBroker.servers.length === 0) {
       throw new Error("At least one relay broker server must be configured.");


### PR DESCRIPTION
## What changed

- map Render's unauthenticated TCP probe to a no-permission NATS health identity
- authenticate Connect instances with a separate subject-restricted username/password identity
- validate broker secret characters before interpolating the ephemeral NATS configuration
- update the multi-instance E2E harness for the production authentication shape

## Why

Render's private-service TCP probe does not send NATS credentials. Token-only authentication treated each probe as an authentication timeout and emitted an error every second even though the broker was healthy.

The health identity cannot publish or subscribe. Connect instances can access only the versioned relay and request inbox subjects.

## Validation

- server typecheck and 61 unit tests
- full two-instance PostgreSQL/NATS E2E, including broker restart
- NATS config validation
- production image build and health smoke
- three bare TCP probes with no authentication-error logs
