### PR TITLE
Scale production relay and isolate NATS health probes

### DIFF
--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -1,7 +1,9 @@
 # Core NATS only: relay messages are transient and are never written to disk.
 host: 0.0.0.0
 port: 4222
-http: 127.0.0.1:8222
+# Render sends HTTP health probes to PORT. Keep those probes on NATS's
+# monitoring server and the authenticated relay protocol on its standard port.
+http: $MDBASE_NATS_HTTP_ADDR
 
 # Encrypted relay envelopes can approach the Connect HTTP body's 2 MiB limit
 # after JSON encoding. Keep this below NATS's recommended 8 MiB ceiling.
@@ -9,9 +11,6 @@ max_payload: 4MB
 max_pending: 32MB
 write_deadline: "10s"
 
-# Render checks private services with a bare TCP connection. Map connections
-# without credentials to a principal that cannot publish or subscribe, keeping
-# those checks quiet without weakening the authenticated relay principal.
 authorization {
   users: [
     {
@@ -22,13 +21,5 @@ authorization {
         subscribe: ["mdbase.connect.relay.v1.>", "_INBOX.>"]
       }
     }
-    {
-      user: health
-      permissions: {
-        publish: []
-        subscribe: []
-      }
-    }
   ]
 }
-no_auth_user: health

--- a/deploy/nats/start-nats.sh
+++ b/deploy/nats/start-nats.sh
@@ -2,10 +2,18 @@
 set -eu
 
 token=${NATS_AUTH_TOKEN:-}
+port=${PORT:-}
 if [ "${#token}" -lt 32 ]; then
   echo "NATS_AUTH_TOKEN must contain at least 32 characters" >&2
   exit 1
 fi
+
+case "$port" in
+  ""|*[!0-9]*)
+    echo "PORT must be a numeric HTTP monitoring port" >&2
+    exit 1
+    ;;
+esac
 
 case "$token" in
   *[!A-Za-z0-9_+=./-]*)
@@ -17,5 +25,6 @@ esac
 # The constant prefix guarantees that an unquoted NATS config variable cannot
 # be parsed as a number when a generated secret happens to start with a digit.
 MDBASE_NATS_PASSWORD="mdbase_${token}"
-export MDBASE_NATS_PASSWORD
+MDBASE_NATS_HTTP_ADDR="0.0.0.0:${port}"
+export MDBASE_NATS_PASSWORD MDBASE_NATS_HTTP_ADDR
 exec nats-server -c /etc/nats/mdbase-connect.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       context: .
       dockerfile: deploy/docker/Dockerfile.nats
     environment:
-      PORT: 4222
+      PORT: 8222
       NATS_AUTH_TOKEN: ${MDBASE_CONNECT_RELAY_NATS_TOKEN:-replace-this-relay-token-with-at-least-32-characters}
     ports:
       - "4222:4222"

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -10,6 +10,9 @@ in Singapore:
   `mcp.mdbase.dev`.
 - `mdbase-connect-relay-broker`, a private Core NATS request/reply transport.
 
+The broker keeps authenticated NATS traffic on port 4222 and exposes NATS's
+HTTP monitoring server on Render's `PORT` solely for platform health checks.
+
 Each stateful boundary has its own paid, private PostgreSQL database. Hosted record
 payloads never pass through or persist in the control-plane database. The data
 plane database stores encrypted canonical records and change payloads; record

--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,8 @@ services:
     maxShutdownDelaySeconds: 30
     autoDeployTrigger: checksPass
     envVars:
+      - key: PORT
+        value: "10000"
       - key: NATS_AUTH_TOKEN
         generateValue: true
 

--- a/render.yaml
+++ b/render.yaml
@@ -14,8 +14,6 @@ services:
     maxShutdownDelaySeconds: 30
     autoDeployTrigger: checksPass
     envVars:
-      - key: PORT
-        value: "4222"
       - key: NATS_AUTH_TOKEN
         generateValue: true
 
@@ -111,7 +109,7 @@ services:
         fromService:
           type: pserv
           name: mdbase-connect-relay-broker
-          property: hostport
+          property: host
       - key: MDBASE_CONNECT_RELAY_NATS_TOKEN
         fromService:
           type: pserv

--- a/render.yaml
+++ b/render.yaml
@@ -61,6 +61,7 @@ services:
     repo: https://github.com/mdbase-dev/mdbase-connect
     branch: main
     plan: starter
+    numInstances: 2
     region: singapore
     dockerfilePath: ./deploy/docker/Dockerfile.server
     dockerContext: .

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -266,9 +266,10 @@ try {
 function startNats() {
   return startContainer([
     "--name", natsName,
-    "-e", "PORT=4222",
+    "-e", "PORT=8222",
     "-e", `NATS_AUTH_TOKEN=${natsToken}`,
     "-e", `MDBASE_NATS_PASSWORD=mdbase_${natsToken}`,
+    "-e", "MDBASE_NATS_HTTP_ADDR=0.0.0.0:8222",
     "-p", `127.0.0.1:${natsPort}:4222`,
     "-v", `${natsConfig}:/etc/nats/mdbase-connect.conf:ro`,
     "nats:2.12.7-alpine",

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -168,6 +168,16 @@ describe("public runtime configuration", () => {
       "nats://relay-b:4222"
     ]);
 
+    const renderHost = runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_RELAY_NATS_URL: "mdbase-connect-relay-broker",
+      MDBASE_CONNECT_RELAY_NATS_TOKEN: "x".repeat(40)
+    });
+    expect(renderHost.relayBroker?.servers).toEqual([
+      "nats://mdbase-connect-relay-broker:4222"
+    ]);
+
     expect(() => runtimeConfigFromEnv({
       PUBLIC_URL: "http://localhost:8787",
       MDBASE_CONNECT_DEV_AUTH: "1",

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -122,9 +122,7 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean);
-  const normalizedRelayBrokerServers = relayBrokerServers.map((value) => (
-    value.includes("://") ? value : `nats://${value}`
-  ));
+  const normalizedRelayBrokerServers = relayBrokerServers.map(normalizeRelayBrokerServer);
   const relayBrokerToken = env.MDBASE_CONNECT_RELAY_NATS_TOKEN?.trim() ?? "";
   if ((relayBrokerServers.length > 0) !== Boolean(relayBrokerToken)) {
     throw new Error(
@@ -180,4 +178,10 @@ function validateRelayBrokerServer(server: string): void {
       || !url.port) {
     throw new Error("Relay broker servers must be nats:// or tls:// host-and-port URLs without credentials.");
   }
+}
+
+function normalizeRelayBrokerServer(value: string): string {
+  const url = new URL(value.includes("://") ? value : `nats://${value}`);
+  if (!url.port) url.port = "4222";
+  return url.toString();
 }


### PR DESCRIPTION
Run the production Connect web tier on two Render instances now that connector ownership is coordinated through Core NATS. Route Render's HTTP health probes to the NATS monitoring listener on PORT while keeping authenticated relay traffic isolated on 4222.\n\nValidation:\n- render blueprints validate render.yaml\n- pnpm build\n- pnpm typecheck\n- pnpm test\n- pnpm e2e:relay\n- production NATS image with repeated HTTP HEAD health probes and clean logs\n- docker compose config --quiet