### PR TITLE
Permit zero-capability Render TCP probes

### DIFF
--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -21,5 +21,15 @@ authorization {
         subscribe: ["mdbase.connect.relay.v1.>", "_INBOX.>"]
       }
     }
+    {
+      # Render also performs a bare TCP probe against every detected port.
+      # Permit the handshake but grant it no messaging capability.
+      user: health
+      permissions: {
+        publish: []
+        subscribe: []
+      }
+    }
   ]
 }
+no_auth_user: health


### PR DESCRIPTION
Render probes every detected private-service port: HTTP on the monitoring listener and a bare TCP handshake on the NATS client listener. Map credential-free TCP handshakes to a health principal with empty publish and subscribe permissions, while retaining scoped user/password authentication for all relay traffic.\n\nValidated with ten HTTP HEAD probes, ten bare TCP probes, clean NATS logs, the 61 server tests, and the full multi-instance relay outage/recovery E2E.