### PR TITLE
Route Render probes away from NATS

### DIFF
--- a/deploy/docker/Dockerfile.nats
+++ b/deploy/docker/Dockerfile.nats
@@ -1,7 +1,10 @@
 FROM nats:2.12.7-alpine
 
+RUN apk add --no-cache haproxy
+
 COPY deploy/nats/nats.conf /etc/nats/mdbase-connect.conf
+COPY deploy/nats/haproxy.cfg /etc/haproxy/mdbase-connect.cfg
 COPY deploy/nats/start-nats.sh /usr/local/bin/start-mdbase-connect-nats
 
-EXPOSE 4222
+EXPOSE 4222 10000
 ENTRYPOINT ["/bin/sh", "/usr/local/bin/start-mdbase-connect-nats"]

--- a/deploy/nats/haproxy.cfg
+++ b/deploy/nats/haproxy.cfg
@@ -1,0 +1,25 @@
+global
+  maxconn 4096
+
+defaults
+  mode tcp
+  timeout connect 2s
+  timeout client 10m
+  timeout server 10m
+  option tcpka
+
+frontend relay
+  bind 0.0.0.0:4222
+  tcp-request inspect-delay 75ms
+  acl render_http_probe req.payload(0,4) -m str HEAD
+  acl render_http_probe req.payload(0,3) -m str GET
+  tcp-request content accept if render_http_probe
+  tcp-request content accept if WAIT_END
+  use_backend monitoring if render_http_probe
+  default_backend nats
+
+backend monitoring
+  server monitoring "127.0.0.1:${PORT}"
+
+backend nats
+  server nats 127.0.0.1:4223

--- a/deploy/nats/nats.conf
+++ b/deploy/nats/nats.conf
@@ -1,8 +1,8 @@
 # Core NATS only: relay messages are transient and are never written to disk.
-host: 0.0.0.0
-port: 4222
-# Render sends HTTP health probes to PORT. Keep those probes on NATS's
-# monitoring server and the authenticated relay protocol on its standard port.
+host: 127.0.0.1
+port: 4223
+# HAProxy sends Render's HTTP health probes to PORT. Keep monitoring off the
+# loopback-only authenticated relay listener.
 http: $MDBASE_NATS_HTTP_ADDR
 
 # Encrypted relay envelopes can approach the Connect HTTP body's 2 MiB limit

--- a/deploy/nats/start-nats.sh
+++ b/deploy/nats/start-nats.sh
@@ -27,4 +27,36 @@ esac
 MDBASE_NATS_PASSWORD="mdbase_${token}"
 MDBASE_NATS_HTTP_ADDR="0.0.0.0:${port}"
 export MDBASE_NATS_PASSWORD MDBASE_NATS_HTTP_ADDR
-exec nats-server -c /etc/nats/mdbase-connect.conf
+
+nats-server -t -c /etc/nats/mdbase-connect.conf
+haproxy -c -f /etc/haproxy/mdbase-connect.cfg
+
+nats-server -c /etc/nats/mdbase-connect.conf &
+nats_pid=$!
+haproxy -db -f /etc/haproxy/mdbase-connect.cfg &
+proxy_pid=$!
+
+shutdown() {
+  trap - INT TERM
+  kill -TERM "$proxy_pid" "$nats_pid" 2>/dev/null || true
+  wait "$proxy_pid" 2>/dev/null || true
+  wait "$nats_pid" 2>/dev/null || true
+  exit 0
+}
+trap shutdown INT TERM
+
+while kill -0 "$nats_pid" 2>/dev/null && kill -0 "$proxy_pid" 2>/dev/null; do
+  sleep 1
+done
+
+status=1
+if ! kill -0 "$nats_pid" 2>/dev/null; then
+  wait "$nats_pid" || status=$?
+fi
+if ! kill -0 "$proxy_pid" 2>/dev/null; then
+  wait "$proxy_pid" || status=$?
+fi
+kill -TERM "$proxy_pid" "$nats_pid" 2>/dev/null || true
+wait "$proxy_pid" 2>/dev/null || true
+wait "$nats_pid" 2>/dev/null || true
+exit "$status"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       context: .
       dockerfile: deploy/docker/Dockerfile.nats
     environment:
-      PORT: 8222
+      PORT: 10000
       NATS_AUTH_TOKEN: ${MDBASE_CONNECT_RELAY_NATS_TOKEN:-replace-this-relay-token-with-at-least-32-characters}
     ports:
       - "4222:4222"
@@ -28,7 +28,7 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8222/healthz"]
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:10000/healthz"]
       interval: 5s
       timeout: 3s
       retries: 12

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -12,6 +12,10 @@ in Singapore:
 
 The broker keeps authenticated NATS traffic on port 4222 and exposes NATS's
 HTTP monitoring server on Render's `PORT` solely for platform health checks.
+Render probes every detected port with HTTP, so a small HAProxy front door on
+4222 recognizes `HEAD` and `GET` probes and sends only those to monitoring;
+all other connections reach the loopback-only NATS listener. This prevents
+platform probes from polluting NATS authentication and protocol logs.
 
 Each stateful boundary has its own paid, private PostgreSQL database. Hosted record
 payloads never pass through or persist in the control-plane database. The data

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -28,6 +28,10 @@ then uses an in-process relay with no additional service. To run more than one
 Connect process, give every process the same PostgreSQL database and NATS
 cluster URLs and token. The broker uses request/reply only: JetStream is not
 enabled, there is no relay stream, and operation payloads are not persisted.
+The included broker image listens for NATS clients on 4222 and serves monitoring
+on `PORT` (10000 in Docker Compose). Its 4222 front door also turns platform
+`HEAD` and `GET` probes into monitoring requests; normal NATS clients remain
+authenticated and restricted to relay and reply subjects.
 
 Every connector WebSocket acquires a monotonically increasing generation in
 PostgreSQL. Requests are addressed to that exact generation, so an older

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -17,15 +17,17 @@ const { tokenHash } = await import("../services/server/dist/security.js");
 
 const postgresPort = await availableTcpPort();
 const natsPort = await availableTcpPort();
+const natsMonitorPort = await availableTcpPort();
 const suffix = `${process.pid}-${randomBytes(4).toString("hex")}`;
 const postgresName = `mdbase-connect-relay-pg-${suffix}`;
 const natsName = `mdbase-connect-relay-nats-${suffix}`;
 const postgresPassword = randomBytes(24).toString("base64url");
 const natsToken = randomBytes(32).toString("base64url");
-const natsConfig = resolve(repoRoot, "deploy/nats/nats.conf");
+const natsImage = `mdbase-connect-nats-e2e-${suffix}`;
 
 let postgresProcess;
 let natsProcess;
+let natsImageBuilt = false;
 let database;
 let appA;
 let appB;
@@ -61,8 +63,21 @@ try {
     }
   }, "PostgreSQL did not become ready after initialization", 100, 100);
 
+  await run("docker", [
+    "build",
+    "--file", "deploy/docker/Dockerfile.nats",
+    "--tag", natsImage,
+    "."
+  ], { cwd: repoRoot });
+  natsImageBuilt = true;
   natsProcess = startNats();
   await waitForTcp(natsPort, "NATS did not become ready");
+  await poll(async () => {
+    const response = await fetch(`http://127.0.0.1:${natsMonitorPort}/healthz`);
+    return response.ok ? true : null;
+  }, "NATS monitoring did not become ready");
+  const renderProbe = await fetch(`http://127.0.0.1:${natsPort}/`, { method: "HEAD" });
+  assert(renderProbe.ok, `Render-style HTTP probe on the NATS port returned ${renderProbe.status}`);
 
   database = await createDatabase(
     `postgres://mdbase:${postgresPassword}@127.0.0.1:${postgresPort}/mdbase_connect`
@@ -261,19 +276,21 @@ try {
   if (database) await database.end();
   if (natsProcess) await stopContainer(natsName, natsProcess);
   if (postgresProcess) await stopContainer(postgresName, postgresProcess);
+  if (natsImageBuilt) {
+    await removeImage(natsImage).catch((error) => {
+      process.stderr.write(`[relay-e2e:nats] could not remove temporary image: ${error.message}\n`);
+    });
+  }
 }
 
 function startNats() {
   return startContainer([
     "--name", natsName,
-    "-e", "PORT=8222",
+    "-e", "PORT=10000",
     "-e", `NATS_AUTH_TOKEN=${natsToken}`,
-    "-e", `MDBASE_NATS_PASSWORD=mdbase_${natsToken}`,
-    "-e", "MDBASE_NATS_HTTP_ADDR=0.0.0.0:8222",
     "-p", `127.0.0.1:${natsPort}:4222`,
-    "-v", `${natsConfig}:/etc/nats/mdbase-connect.conf:ro`,
-    "nats:2.12.7-alpine",
-    "-c", "/etc/nats/mdbase-connect.conf"
+    "-p", `127.0.0.1:${natsMonitorPort}:10000`,
+    natsImage
   ], "nats");
 }
 
@@ -290,7 +307,7 @@ function startContainer(args, label) {
 async function stopContainer(name, child) {
   if (child.exitCode !== null) return;
   try {
-    await run("docker", ["stop", "--time", "5", name]);
+    await run("docker", ["stop", "--timeout", "5", name]);
   } catch {
     // The container may already have exited and removed itself.
   }
@@ -299,6 +316,18 @@ async function stopContainer(name, child) {
       new Promise((resolveExit) => child.once("exit", resolveExit)),
       new Promise((resolveDelay) => setTimeout(resolveDelay, 5_000))
     ]);
+  }
+}
+
+async function removeImage(image) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      await run("docker", ["image", "rm", "--force", image]);
+      return;
+    } catch (error) {
+      if (attempt === 19) throw error;
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

- put a small HAProxy protocol-aware front door on the broker's public NATS port
- route Render `HEAD`/`GET` probes to NATS monitoring while sending real NATS clients to a loopback listener
- supervise and validate both NATS and HAProxy from the broker entrypoint
- exercise the production broker image, Render-style probes, cross-node routing, fencing, large payloads, and outage recovery in the relay E2E
- document the Render and self-hosted port behavior

## Why

Render probes every detected service port with HTTP. Directing those probes at the authenticated NATS listener generated continuous authentication or parser errors. The front door distinguishes the platform probes before NATS sees them, without weakening relay credentials or subject permissions.

## Validation

- `cargo fmt --all`
- `cargo test --workspace` against the production-pinned `mdbase-rs` revision
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e:relay`
- `docker compose config --quiet`
- `render blueprints validate render.yaml`
- broker entrypoint negative tests for missing/short configuration
