### PR TITLE
Add managed native push and signed notification webhooks

### DIFF
--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -37,6 +37,23 @@ interface ApplicationProvisions {
   types: TypeProvision[];
 }
 
+interface NotificationCriterion {
+  id: string;
+  event: ContractRequirement;
+  if?: { $expr: string };
+  debounce?: string;
+  minimum_interval?: string;
+  presentation: {
+    title: string;
+    body?: string;
+    tag?: string;
+  };
+}
+
+interface ApplicationNotifications {
+  criteria: NotificationCriterion[];
+}
+
 interface GrantScope {
   contracts: ContractRequirement[];
 }
@@ -65,6 +82,7 @@ interface ApplicationSummary {
   icon?: string;
   requirements: ApplicationRequirements;
   provisions?: ApplicationProvisions;
+  notifications: ApplicationNotifications;
 }
 
 interface GrantSummary {
@@ -90,6 +108,7 @@ interface PendingAuthorization {
   requested_operations: string[];
   requirements: ApplicationRequirements;
   provisions: ApplicationProvisions;
+  notifications: ApplicationNotifications;
   compatible_collection_ids: string[];
   provisionable_collection_ids: string[];
   expires_at: string;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -473,12 +473,29 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
         {available.length === 0 && <small>No registered collection supports all requested operations and contracts.</small>}
         {setup.length > 0 && <small>Allowing access will add {provisionNames(setup)} to this collection.</small>}
         <fieldset><legend>Requested operations</legend><OperationChoices allowed={request.requested_operations} selected={operations} onChange={setOperations} /></fieldset>
+        <NotificationAccess notifications={request.notifications} />
       </div>
       <div className="decision-actions">
         <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
         <button className="button primary" disabled={busy || !collectionId || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.approveAuthorization({ requestId: request.id, collectionId, operations }); onNotice(`${request.application_name} can now use the selected operations.`); })}>Allow access</button>
       </div>
     </article>
+  );
+}
+
+function NotificationAccess({ notifications }: { notifications: ApplicationNotifications }) {
+  if (notifications.criteria.length === 0) return null;
+  return (
+    <div className="notification-request">
+      <strong>Change notifications</strong>
+      <small>If enabled in the app, these rules run inside the collection and pushes contain no record content.</small>
+      <ul>{notifications.criteria.map((criterion) => (
+        <li key={criterion.id}>
+          <span>{criterion.presentation.title}</span>
+          <code>{criterion.event.id} v{criterion.event.version}</code>
+        </li>
+      ))}</ul>
+    </div>
   );
 }
 
@@ -536,6 +553,7 @@ function ManualApplication({ collections, busy, onAct, onNotice }: { collections
               <label><span>Collection</span><select value={collectionId} disabled={compatible.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{compatible.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}{neededProvisions(application.requirements, application.provisions, collection).length ? " · setup required" : ""}</option>)}</select></label>
               {compatible.length === 0 && <small>No registered collection provides the required contracts and the app cannot install them.</small>}
               {setup.length > 0 && <small>Connecting will add {provisionNames(setup)} to this collection.</small>}
+              <NotificationAccess notifications={application.notifications} />
               <fieldset><legend>Allow</legend><OperationChoices allowed={allOperations} selected={operations} onChange={setOperations} compact /></fieldset>
               <button className="button primary" disabled={busy || !collectionId || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.createGrant({ applicationId: application.id, collectionId, operations }); onNotice(`${application.name} is connected.`); setApplication(null); setManifestUrl(""); setExpanded(false); })}>Connect app</button>
             </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -121,6 +121,12 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 label > span, fieldset > legend { color: var(--muted); font-size: var(--type-supporting); font-weight: 700; }
 input, select { width: 100%; min-height: 36px; padding: 0 10px; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font-size: var(--type-body); }
 .request-fields > label, .manual-app label, .manual-grant > label, .pairing-form label { display: grid; gap: 5px; }
+.notification-request { display: grid; grid-column: 1 / -1; grid-template-columns: minmax(130px, 0.65fr) minmax(190px, 1.35fr); gap: 4px 16px; padding: 10px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.notification-request > strong { font-size: var(--type-supporting); }
+.notification-request > small { color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.notification-request ul { display: grid; grid-column: 2; gap: 4px; margin: 2px 0 0; padding: 0; list-style: none; }
+.notification-request li { display: flex; justify-content: space-between; gap: 8px; font-size: var(--type-supporting); }
+.notification-request li code { color: var(--muted); font-size: var(--type-action); white-space: nowrap; }
 fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
 fieldset legend { margin-bottom: 6px; }
 .operation-choices { display: grid; grid-template-columns: repeat(2, minmax(105px, 1fr)); gap: 5px 10px; }

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -92,6 +92,7 @@ export interface PendingAuthorization {
   icon: string | null;
   requirements: ApplicationRequirements;
   provisions: ApplicationProvisions;
+  notifications: ApplicationNotifications;
 }
 
 export interface AvailableCollection {
@@ -123,6 +124,23 @@ export interface TypeProvision {
 
 export interface ApplicationProvisions {
   types: TypeProvision[];
+}
+
+export interface NotificationCriterion {
+  id: string;
+  event: ContractRequirement;
+  if?: { $expr: string };
+  debounce?: string;
+  minimum_interval?: string;
+  presentation: {
+    title: string;
+    body?: string;
+    tag?: string;
+  };
+}
+
+export interface ApplicationNotifications {
+  criteria: NotificationCriterion[];
 }
 
 export interface GrantScope {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -1010,11 +1010,32 @@ function ApprovalForm({
           </label>
         ))}</div>
       </fieldset>
+      <NotificationAccess notifications={request.notifications} />
       {error && <div className="message error compact">{error}</div>}
       <div className="approval-actions">
         <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
         <button className="button primary" type="button" disabled={submitting !== null || !collectionId || operations.size === 0} onClick={() => void decide("approved")}>{submitting === "approved" ? "Approving…" : "Allow access"}</button>
       </div>
+    </div>
+  );
+}
+
+function NotificationAccess({ notifications }: {
+  notifications: PendingAuthorization["notifications"];
+}) {
+  if (notifications.criteria.length === 0) return null;
+  return (
+    <div className="notification-access">
+      <div>
+        <strong>Change notifications</strong>
+        <small>If you turn these on in the app, rules run inside the collection and pushes contain no record content.</small>
+      </div>
+      <ul>{notifications.criteria.map((criterion) => (
+        <li key={criterion.id}>
+          <span>{criterion.presentation.title}</span>
+          <code>{criterion.event.id} v{criterion.event.version}</code>
+        </li>
+      ))}</ul>
     </div>
   );
 }

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -732,6 +732,54 @@ select {
   grid-column: 1 / -1;
 }
 
+.notification-access {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.9fr) minmax(15rem, 1.2fr) auto;
+  grid-column: 1 / -1;
+  gap: 1rem;
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.notification-access > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.notification-access strong {
+  font-size: 0.76rem;
+}
+
+.notification-access small {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.notification-access ul {
+  display: grid;
+  grid-column: 2 / -1;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.notification-access li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.72rem;
+}
+
+.notification-access code {
+  color: var(--ink-muted);
+  font-size: 0.65rem;
+  white-space: nowrap;
+}
+
 .field-note {
   margin: -0.35rem 0 0;
   color: var(--ink-muted);
@@ -1105,6 +1153,14 @@ select {
 
   .approval-form {
     grid-template-columns: 1fr;
+  }
+
+  .notification-access {
+    grid-template-columns: 1fr;
+  }
+
+  .notification-access ul {
+    grid-column: 1;
   }
 
   .approval-actions {

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -3161,7 +3161,7 @@ fn application_change(
         ),
         (Some(record), None) => (
             "mdbase.record.deleted",
-            json!({ "path": record.path, "previous_types": record.types }),
+            json!({ "path": record.path, "types": record.types }),
         ),
         (Some(before), Some(after)) if before.path != after.path => (
             "mdbase.record.renamed",
@@ -3510,6 +3510,25 @@ pub fn validate_limit(limit: Option<u32>) -> ApiResult<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deleted_record_events_use_the_portable_types_field() {
+        let record = SyncRecord {
+            record_id: Uuid::new_v4(),
+            path: "tasks/deleted.md".to_string(),
+            revision: "sha256:deleted".to_string(),
+            frontmatter: Default::default(),
+            body: String::new(),
+            types: vec!["task".to_string()],
+        };
+        assert_eq!(
+            application_change(Some(&record), None),
+            (
+                "mdbase.record.deleted",
+                json!({ "path": "tasks/deleted.md", "types": ["task"] }),
+            )
+        );
+    }
 
     #[test]
     fn scopes_resources_and_records_consistently() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,12 +113,20 @@ dispatch. Durable one-shot timers use the same path and wake after authority
 restart.
 
 The authority sends only an idempotent signal ID, grant ID, criterion ID, and
-opaque cursor to the control plane. The control plane maps that signal to
-registered Web Push installations and retries delivery through a leased
-outbox. Static manifest presentation is added there. Paths, record payloads,
-runtime event payloads, and collection contents never cross this boundary.
-Applications treat a push as a wake-up hint and read current authorized state
-after opening. See [Runtime-backed notifications](./notifications.md).
+opaque cursor to the control plane. The control plane adds static manifest
+presentation and retries delivery through a leased outbox. Delivery can target
+registered Web Push installations, registered FCM tokens when the application
+opts into Connect-managed sending, or one signed application webhook. Paths,
+record payloads, runtime event payloads, and collection contents never cross
+this boundary. Applications treat a notification as a wake-up hint and read
+current authorized state after opening. See
+[Runtime-backed notifications](./notifications.md).
+
+Notification criteria are snapshotted into the grant at approval. Manifest
+rediscovery can retain exactly equivalent criteria or remove changed ones, but
+cannot add evaluation logic to an existing grant. Changed criteria therefore
+require explicit reauthorization before the authority receives an updated
+policy.
 
 ## Domain contracts
 

--- a/docs/deploying-render.md
+++ b/docs/deploying-render.md
@@ -54,10 +54,29 @@ In Render, create a Blueprint from `mdbase-dev/mdbase-connect` and
 - `MDBASE_CONNECT_VAPID_SUBJECT`
 - `MDBASE_CONNECT_VAPID_PUBLIC_KEY`
 - `MDBASE_CONNECT_VAPID_PRIVATE_KEY`
+- `MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID`
+- `MDBASE_CONNECT_WEBHOOK_SIGNING_PRIVATE_KEY`
 
 Generate the VAPID keypair once with a standards-compliant Web Push tool. Keep
 the private key secret and retain the pair across deployments; replacing it
 invalidates existing browser subscriptions.
+
+Generate a stable Ed25519 webhook-signing key and a human-readable rotation ID.
+Keep the private key secret. During a rotation, put the prior public JWK in
+`MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON` until every delivery made
+before the rotation has expired. Webhook consumers discover the current and
+retained public keys at `/v1/notifications/webhook-signing-keys`.
+
+Connect-managed native delivery is off by default. To enable it, set
+`MDBASE_CONNECT_FCM_ENABLED=1` and provide
+`MDBASE_CONNECT_FCM_CREDENTIALS_JSON`, or configure Google Application Default
+Credentials in the service environment. Grant that sender identity only
+`cloudmessaging.messages.create` in each participating application's Firebase
+project. Do not upload an application's APNs key to Connect; the application
+owner uploads it directly to Firebase. See
+[Runtime-backed notifications](./notifications.md) for the managed-sender
+security tradeoff and the recommended signed-webhook boundary for third-party
+applications.
 
 Google sign-in can be enabled alongside GitHub after creating the production
 web client described in [Google authentication](./google-auth.md). Set both
@@ -120,6 +139,13 @@ Before any invitation:
 8. Register an installed PWA for a manifest notification criterion, perform a
    matching hosted mutation while the app is closed, receive the push, and
    confirm the control-plane database contains only opaque signal metadata.
+9. Send one signed notification webhook to a verifier using
+   `@mdbase/connect-webhooks`; confirm a modified body and an expired timestamp
+   are rejected, retry the same delivery ID, and confirm the consumer processes
+   it only once.
+10. When managed FCM is enabled, register one Android and one iOS installation,
+    rotate an FCM token, and confirm only the current token receives a
+    content-free wake-up notification.
 
 Render provides continuous PITR for paid PostgreSQL. PITR is not a substitute
 for the restore drill: recovery creates another database and the service must be

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,11 +1,18 @@
 # Runtime-backed notifications
 
-Connect notifications wake an application through the platform Web Push
-service even when the application is not running. Applications declare
-criteria; the collection authority evaluates them with the mdbase Runtime and
-sends an opaque signal to the Connect control plane. The control plane owns
-device subscriptions and durable push delivery, but it never receives a record
-path, frontmatter, body, or runtime event payload.
+Connect notifications wake an application even when it is not running.
+Applications declare criteria; the collection authority evaluates them with
+the mdbase Runtime and sends an opaque signal to the Connect control plane.
+Connect never receives a record path, frontmatter, body, or runtime event
+payload.
+
+Delivery is deliberately separate from evaluation. An application may use any
+combination of:
+
+- standards-based Web Push for browsers and installed PWAs;
+- Connect-managed Firebase Cloud Messaging (FCM) for native iOS and Android;
+- a signed developer webhook that sends through the application's own
+  notification infrastructure.
 
 ## Application manifest
 
@@ -22,41 +29,51 @@ Notifications require application manifest version 2:
   },
   "notifications": {
     "criteria": [{
-      "id": "task.ready",
+      "id": "task.changed",
       "event": {
         "id": "mdbase.record.modified",
         "version": 1
       },
       "if": {
-        "language": "cel",
-        "expression": "\"status\" in event.payload.changed_fields"
+        "$expr": "\"task\" in event.payload.types"
       },
       "debounce": "5s",
-      "minimum_interval": "15m",
+      "minimum_interval": "1m",
       "presentation": {
-        "title": "A task is ready",
-        "body": "Open TaskNotes to review it.",
-        "tag": "task-ready"
+        "title": "Tasks changed",
+        "body": "Open TaskNotes to see the latest changes.",
+        "tag": "task-changes"
       }
-    }]
+    }],
+    "native_delivery": {
+      "mode": "managed_fcm",
+      "firebase_project_id": "tasknotes-production"
+    }
   }
 }
 ```
 
 Criteria use canonical runtime event contracts and CEL. Presentation copy is
 static manifest data; expressions cannot interpolate private record content
-into a push message. Each grant stores an exact copy of the criteria locally or
-at the hosted authority, which remains the final authorization boundary
-immediately before notification dispatch.
+into a notification. Each grant stores an exact copy of the criteria locally
+or at the hosted authority, which remains the final authorization boundary
+immediately before dispatch.
+
+The authorized grant stores an exact snapshot of each criterion. Rediscovery
+may remove a criterion that disappeared or changed, but it never adds or
+rewrites one on an existing grant. Registration returns
+`notification_reauthorization_required` if the application selects a new or
+changed criterion; run the ordinary authorization flow again so the user can
+review it.
 
 `timer.fired` is the portable scheduling event. The authority stores one-shot,
 generation-fenced timers durably and fires overdue timers once after restart.
 An application can use that event for reminders without remaining connected.
 
-## Browser and mobile registration
+## Browser registration
 
-Register a service worker, then enable all declared criteria or an explicit
-subset:
+Register a service worker from a user gesture, then enable all declared
+criteria or an explicit subset:
 
 ```ts
 import { MdbaseConnect } from "@mdbase/connect";
@@ -64,13 +81,13 @@ import { MdbaseConnect } from "@mdbase/connect";
 const worker = await navigator.serviceWorker.register("/service-worker.js");
 await connect.registerNotifications({
   serviceWorker: worker,
-  criteria: ["task.ready"]
+  criteria: ["task.changed"]
 });
 ```
 
 Channel creation and criterion selection are one control-plane transaction.
-Calling `registerNotifications` again refreshes an expired browser subscription
-and atomically replaces the selected criteria for the same installation.
+Calling `registerNotifications` again refreshes an expired subscription and
+atomically replaces the selected criteria for the same installation.
 
 The service worker validates the push envelope and displays its static
 presentation:
@@ -80,45 +97,161 @@ import { showMdbasePushNotification } from "@mdbase/connect";
 
 self.addEventListener("push", (event) => {
   event.waitUntil(
-    showMdbasePushNotification(
-      self.registration,
-      event.data?.json()
-    )
+    showMdbasePushNotification(self.registration, event.data?.json())
   );
 });
 ```
 
-The payload contains only `signal_id`, `criterion_id`, an opaque authority
-cursor, and static presentation. When the user opens the application, use the
-criterion and cursor as a wake-up hint and query the collection through the
-ordinary authorized API. Do not treat a push as collection data or proof that
-the underlying record still matches.
-
-Call `connect.unregisterNotifications(worker)` when the user disables
-notifications. This removes the server channel before unsubscribing the
+Call `connect.unregisterNotifications(worker)` when the user disables browser
+notifications. Connect removes the server channel before unsubscribing the
 browser, so a transient server error can be retried without orphaning a live
 channel.
 
-Native iOS and Android SDK adapters can register APNs or FCM channels against
-the same installation and criterion model. The current public SDK implements
-standards-based Web Push, which also covers installed PWAs.
+## Connect-managed native delivery
 
-## Delivery and recovery
+Use `managed_fcm` when the application owner accepts Connect as part of the
+push-delivery trust boundary. Configure one Firebase project for the
+application, put its public project ID in the manifest, and grant Connect's
+sender identity permission to send messages to that project. The app obtains
+an FCM registration token and registers it after a user explicitly opts in:
+
+```ts
+await connect.registerNativeNotifications({
+  token: await nativeMessaging.getToken(),
+  criteria: ["task.changed"]
+});
+```
+
+Call the method again when Firebase rotates the token. When the user opts out,
+call `connect.unregisterNativeNotifications()` before deleting the local FCM
+token.
+
+FCM is the common delivery API on both platforms: Firebase maps the token to
+Android delivery directly and to APNs for the iOS build. The native application
+still needs its Firebase Android and iOS configuration, notification
+permission handling, an Android channel named `mdbase-updates`, and the APNs
+key uploaded to Firebase.
+
+Managed delivery is convenient for a personal or single-owner application, but
+it has a real security consequence: the Connect sender identity can send a
+notification to installations in every Firebase project that grants it send
+permission. Connect cannot read application data through that permission and
+does not store the application's APNs key, but compromise or misuse of the
+sender could produce misleading notifications. Use a dedicated Firebase
+project per environment, grant only `cloudmessaging.messages.create`, keep
+staging and production separate, and revoke the grant if the integration is no
+longer used.
+
+FCM registration tokens and Web Push endpoint/key material are sensitive
+routing identifiers rather than sender credentials. Connect stores them in its
+control-plane database so delivery survives restarts. Restrict access to that
+database and its backups; disclosure could enable delivery targeting or spam,
+but does not grant access to collection records.
+
+For an application distributed to a broader audience, prefer the signed
+webhook mode below. It keeps Firebase and Apple credentials entirely in the
+developer's infrastructure.
+
+## Developer webhook delivery
+
+Declare one HTTPS endpoint:
+
+```json
+{
+  "notifications": {
+    "criteria": [{
+      "id": "task.changed",
+      "event": {
+        "id": "mdbase.record.modified",
+        "version": 1
+      },
+      "presentation": {
+        "title": "Tasks changed"
+      }
+    }],
+    "native_delivery": {
+      "mode": "webhook",
+      "url": "https://api.tasks.example/webhooks/mdbase"
+    }
+  }
+}
+```
+
+Connect creates one durable webhook delivery for each matched signal; no
+device channel is registered with Connect. The body contains the opaque
+connection ID and notification wake-up hint only:
+
+```json
+{
+  "type": "mdbase.notification.webhook",
+  "version": 1,
+  "delivery_id": "019...",
+  "connection_id": "019...",
+  "notification": {
+    "type": "mdbase.notification",
+    "version": 1,
+    "signal_id": "019...",
+    "criterion_id": "task.changed",
+    "cursor": "42",
+    "presentation": {
+      "title": "Tasks changed",
+      "body": "Open TaskNotes to see the latest changes.",
+      "tag": "task-changes"
+    }
+  }
+}
+```
+
+Verify the signature over the exact raw request body before parsing or
+enqueueing work:
+
+```ts
+import { verifyNotificationWebhook } from "@mdbase/connect-webhooks";
+
+const event = verifyNotificationWebhook({
+  body: rawRequestBody,
+  headers: request.headers,
+  keys: cachedConnectSigningKeys
+});
+
+if (await deliveries.claim(event.delivery_id)) {
+  await sendThroughYourInfrastructure(event.connection_id, event.notification);
+}
+```
+
+Fetch and cache keys from
+`GET /v1/notifications/webhook-signing-keys`. The SDK checks Ed25519
+signatures, the signed delivery ID, and a five-minute replay window. Persist
+`delivery_id` before doing work: Connect treats any 2xx response as success and
+otherwise retries with leases and exponential backoff. A `Retry-After` header
+is respected for retryable responses.
+
+Webhook URLs must use HTTPS. Connect blocks credentials, redirects, loopback,
+link-local, private, and otherwise non-public DNS results to prevent server-side
+request forgery. Do not use the webhook as record data or authorization proof;
+read current state through the ordinary authorized collection API.
+
+## Payload and recovery model
+
+All delivery modes contain only `signal_id`, `criterion_id`, an opaque
+authority cursor, and static presentation. The webhook additionally includes
+opaque `delivery_id` and `connection_id` values so a developer service can
+deduplicate and route work. Treat every notification as a wake-up hint: after
+opening, query the collection through the ordinary authorized API. The
+underlying record may no longer match.
 
 The authority journals the triggering event and runtime run atomically. Action
-invocation IDs become signal IDs, making retries idempotent. The control plane
-creates one delivery per active installation and uses leases, exponential
-backoff, and permanent-endpoint disabling. Local authorities retain their
-runtime store in the connector's private state directory; hosted authorities
-use a collection-fenced PostgreSQL namespace.
+invocation IDs become signal IDs, making retries idempotent. Connect uses
+durable delivery rows, leases, bounded exponential backoff, and permanent
+endpoint disabling. Revoking a grant disables both evaluation and delivery. A
+manifest rediscovery may narrow or remove criteria, but never broadens an
+existing grant's collection access.
 
-Revoking a grant disables both evaluation and delivery. A manifest
-rediscovery may narrow or remove criteria, but never broadens an existing
-grant's collection access.
+## Control-plane deployment
 
-## Deployment
+Enable only the transports the deployment needs.
 
-The control plane requires one VAPID keypair:
+Web Push requires one stable VAPID keypair:
 
 ```text
 MDBASE_CONNECT_VAPID_SUBJECT=mailto:ops@example.com
@@ -126,10 +259,29 @@ MDBASE_CONNECT_VAPID_PUBLIC_KEY=...
 MDBASE_CONNECT_VAPID_PRIVATE_KEY=...
 ```
 
-The hosted provider also requires
-`MDBASE_CONNECT_CONTROL_PLANE_URL` and the same existing internal provider
-credential used by the control plane. The callback carries only opaque signal
-metadata. `MDBASE_CONNECT_HOSTED_NOTIFICATION_INTERVAL_SECONDS` controls
-durable source-outbox recovery and defaults to five seconds. Self-hosters may
-omit VAPID configuration to disable public push registration while retaining
-the rest of Connect.
+Managed FCM uses Google Application Default Credentials, or an explicit JSON
+service-account credential:
+
+```text
+MDBASE_CONNECT_FCM_ENABLED=1
+MDBASE_CONNECT_FCM_CREDENTIALS_JSON={"type":"service_account",...}
+```
+
+Prefer workload identity/ADC where the host supports it. The sender identity
+needs only `cloudmessaging.messages.create` on each opted-in application
+project.
+
+Signed webhooks require a stable Ed25519 private key and key ID:
+
+```text
+MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID=connect-2026-07
+MDBASE_CONNECT_WEBHOOK_SIGNING_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----...
+MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON=[{"kty":"OKP",...}]
+```
+
+During rotation, publish the old public JWK through
+`MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON` while deliveries signed by
+it might still be in flight. The hosted provider also requires
+`MDBASE_CONNECT_CONTROL_PLANE_URL` and the existing internal provider
+credential. `MDBASE_CONNECT_HOSTED_NOTIFICATION_INTERVAL_SECONDS` controls
+durable source-outbox recovery and defaults to five seconds.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -79,6 +79,30 @@ criteria for that installation. See the
 [runtime notifications guide](../../docs/notifications.md) for manifest and
 deployment examples.
 
+Native shells can use one FCM token for Android and iOS when the manifest
+declares `notifications.native_delivery.mode` as `managed_fcm`:
+
+```ts
+await connect.registerNativeNotifications({
+  token: await nativeMessaging.getToken(),
+  criteria: ["workout.reminder"]
+});
+```
+
+Re-register when Firebase rotates the token. Parse the string-valued
+notification data with `parseMdbaseNativeNotificationData()`, refresh current
+collection state, and call `unregisterNativeNotifications()` before deleting
+the token on opt-out. The public Firebase project ID is read from the
+application manifest; service credentials are never embedded in the app.
+
+Connect-managed FCM makes Connect a trusted sender for the application's
+Firebase project. It suits single-owner deployments; applications with a
+broader audience should normally declare signed webhook delivery and keep
+their Apple/Firebase credentials in their own backend. The notifications guide
+documents both threat models. New or changed manifest criteria never silently
+broaden an existing grant: handle `notification_reauthorization_required` by
+running authorization again before retrying registration.
+
 Before opening a feature, inspect its exact authorization gap instead of
 waiting for an operation to fail:
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   MdbaseOperationValidationError,
   isRetryableConnectError,
   MemoryGrantKeyStore,
+  parseMdbaseNativeNotificationData,
   parseMdbasePushPayload,
   showMdbasePushNotification,
   unwrapOperation
@@ -531,6 +532,124 @@ describe("mobile notifications", () => {
     expect(JSON.stringify(showNotification.mock.calls[0])).not.toContain("path");
     expect(() => parseMdbasePushPayload({ ...payload, cursor: 42 }))
       .toThrowError(MdbaseConnectError);
+  });
+
+  it("registers an FCM installation without accepting a client-selected project", async () => {
+    const storage = new MemoryStorage();
+    storage.setItem(tokenKey, JSON.stringify({
+      accessToken: "mdb_notifications",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      collectionId: "00000000-0000-0000-0000-000000000002",
+      operations: ["query"],
+      scope: { contracts: [] },
+      expiresAt: Date.now() + 60_000
+    }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (request, init) => {
+        const url = String(request);
+        if (url.endsWith("/v1/apps/discover")) {
+          return jsonResponse({
+            application: {
+              id: "00000000-0000-0000-0000-000000000001",
+              name: "TaskNotes",
+              homepage: "https://tasks.example",
+              notifications: {
+                native_delivery: {
+                  mode: "managed_fcm",
+                  firebase_project_id: "tasks-production"
+                },
+                criteria: [{ id: "task.ready" }]
+              }
+            }
+          });
+        }
+        if (
+          url.endsWith("/v1/notifications/channels")
+          && init?.method === "POST"
+        ) {
+          return jsonResponse({
+            channel_id: "00000000-0000-0000-0000-000000000004",
+            transport: "fcm",
+            criteria: ["task.ready"]
+          }, 201);
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }
+    );
+    const connect = new MdbaseConnect({
+      serverUrl,
+      manifestUrl,
+      redirectUri: "dev.tasknotes.app://auth/mdbase/callback",
+      storage
+    });
+
+    const registration = await connect.registerNativeNotifications({
+      token: "fcm_registration_token_012345678901234567890123",
+      installationId: "native-installation-0001"
+    });
+
+    expect(registration).toEqual({
+      channelId: "00000000-0000-0000-0000-000000000004",
+      installationId: "native-installation-0001",
+      transport: "fcm",
+      criteria: ["task.ready"]
+    });
+    const request = fetchMock.mock.calls.find(
+      ([value]) => String(value).endsWith("/v1/notifications/channels")
+    );
+    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+      installation_id: "native-installation-0001",
+      criteria: ["task.ready"],
+      transport: "fcm",
+      token: "fcm_registration_token_012345678901234567890123"
+    });
+    expect(String(request?.[1]?.body)).not.toContain("tasks-production");
+  });
+
+  it("keeps a native channel recoverable when authorization is unavailable during opt-out", async () => {
+    const storage = new MemoryStorage();
+    const registrationKey =
+      `mdbase-connect:notifications:${serverUrl}:${manifestUrl}:fcm`;
+    storage.setItem(registrationKey, JSON.stringify({
+      channelId: "00000000-0000-0000-0000-000000000004",
+      installationId: "native-installation-0001",
+      transport: "fcm",
+      criteria: ["task.ready"]
+    }));
+    const connect = new MdbaseConnect({
+      serverUrl,
+      manifestUrl,
+      redirectUri: "dev.tasknotes.app://auth/mdbase/callback",
+      storage
+    });
+
+    await expect(connect.unregisterNativeNotifications()).rejects.toMatchObject({
+      code: "not_authorized"
+    });
+    expect(storage.getItem(registrationKey)).not.toBeNull();
+  });
+
+  it("normalizes string-valued native delivery data", () => {
+    expect(parseMdbaseNativeNotificationData({
+      type: "mdbase.notification",
+      version: "1",
+      signal_id: "signal_opaque",
+      criterion_id: "task.ready",
+      cursor: "42"
+    })).toEqual({
+      type: "mdbase.notification",
+      version: 1,
+      signal_id: "signal_opaque",
+      criterion_id: "task.ready",
+      cursor: "42"
+    });
+    expect(() => parseMdbaseNativeNotificationData({
+      type: "mdbase.notification",
+      version: "1",
+      signal_id: "signal_opaque",
+      criterion_id: "task.ready",
+      cursor: 42
+    })).toThrowError(MdbaseConnectError);
   });
 });
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  ApplicationNotifications,
   CollectionChange,
   CollectionChangesPage,
   CollectionDescription,
@@ -155,6 +156,28 @@ export interface MdbaseNotificationRegistration {
   criteria: string[];
 }
 
+export interface MdbaseNativeNotificationRegistrationOptions {
+  /** Current FCM registration token. Refresh by calling this method again. */
+  token: string;
+  /** Manifest criterion IDs to enable. Omit to enable every declared criterion. */
+  criteria?: string[];
+  /** Stable per-installation ID. The SDK persists one when omitted. */
+  installationId?: string;
+}
+
+export interface MdbaseNativeNotificationRegistration
+  extends MdbaseNotificationRegistration {
+  transport: "fcm";
+}
+
+export interface MdbaseNativeNotificationData {
+  type: "mdbase.notification";
+  version: 1;
+  signal_id: string;
+  criterion_id: string;
+  cursor: string;
+}
+
 export interface MdbasePushPayload {
   type: "mdbase.notification";
   version: 1;
@@ -185,6 +208,38 @@ export function parseMdbasePushPayload(value: unknown): MdbasePushPayload {
     throw new MdbaseConnectError("invalid_push_payload", "The push payload is not an mdbase notification.");
   }
   return payload as MdbasePushPayload;
+}
+
+/** Parse the string-valued data attached to an APNs/FCM notification. */
+export function parseMdbaseNativeNotificationData(
+  value: unknown
+): MdbaseNativeNotificationData {
+  if (!value || typeof value !== "object") {
+    throw new MdbaseConnectError(
+      "invalid_push_payload",
+      "The native notification data is not an object."
+    );
+  }
+  const data = value as Record<string, unknown>;
+  if (
+    data.type !== "mdbase.notification"
+    || (data.version !== 1 && data.version !== "1")
+    || typeof data.signal_id !== "string"
+    || typeof data.criterion_id !== "string"
+    || typeof data.cursor !== "string"
+  ) {
+    throw new MdbaseConnectError(
+      "invalid_push_payload",
+      "The native notification data is not an mdbase notification."
+    );
+  }
+  return {
+    type: "mdbase.notification",
+    version: 1,
+    signal_id: data.signal_id,
+    criterion_id: data.criterion_id,
+    cursor: data.cursor
+  };
 }
 
 /** Display a validated mdbase push from a service worker `push` handler. */
@@ -649,9 +704,7 @@ interface Application {
   id: string;
   name: string;
   homepage: string;
-  notifications?: {
-    criteria: Array<{ id: string }>;
-  };
+  notifications?: ApplicationNotifications;
 }
 
 interface StoredAuthorization {
@@ -1073,6 +1126,110 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     return registration;
   }
 
+  /**
+   * Register an iOS or Android installation for Connect-managed FCM.
+   *
+   * The application manifest selects the Firebase project. Re-register the
+   * same installation whenever Firebase refreshes its token.
+   */
+  async registerNativeNotifications(
+    options: MdbaseNativeNotificationRegistrationOptions
+  ): Promise<MdbaseNativeNotificationRegistration> {
+    const token = await this.authorizedToken();
+    if (!token) {
+      throw new MdbaseConnectError(
+        "not_authorized",
+        "Connect this application before enabling notifications."
+      );
+    }
+    const application = await this.discover();
+    if (application.notifications?.native_delivery?.mode !== "managed_fcm") {
+      throw new MdbaseConnectError(
+        "managed_fcm_not_declared",
+        "This application does not declare Connect-managed native notifications."
+      );
+    }
+    const declared = application.notifications.criteria.map(
+      (criterion) => criterion.id
+    );
+    const criteria = [...new Set(options.criteria ?? declared)];
+    const undeclared = criteria.find((criterion) => !declared.includes(criterion));
+    if (undeclared) {
+      throw new MdbaseConnectError(
+        "notification_criterion_not_declared",
+        `The application manifest does not declare notification criterion ${undeclared}.`
+      );
+    }
+    if (criteria.length === 0) {
+      throw new MdbaseConnectError(
+        "notifications_not_declared",
+        "This application manifest does not declare any notification criteria."
+      );
+    }
+    const storageKey = this.notificationKey("fcm");
+    const previous = parseStored<MdbaseNativeNotificationRegistration>(
+      this.storage.getItem(storageKey)
+    );
+    const installationId = options.installationId
+      ?? previous?.installationId
+      ?? randomBase64Url(24);
+    const response = await fetch(`${this.serverUrl}/v1/notifications/channels`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token.accessToken}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        installation_id: installationId,
+        criteria,
+        transport: "fcm",
+        token: options.token
+      })
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      throw apiError(
+        body,
+        "notification_registration_failed",
+        "Could not register native notifications.",
+        response.status
+      );
+    }
+    if (previous?.channelId && previous.channelId !== body.channel_id) {
+      void this.deleteNotificationChannel(previous.channelId, token.accessToken)
+        .catch(() => undefined);
+    }
+    const registration: MdbaseNativeNotificationRegistration = {
+      channelId: body.channel_id,
+      installationId,
+      transport: "fcm",
+      criteria
+    };
+    this.storage.setItem(storageKey, JSON.stringify(registration));
+    return registration;
+  }
+
+  async unregisterNativeNotifications(): Promise<void> {
+    const storageKey = this.notificationKey("fcm");
+    const registration = parseStored<MdbaseNativeNotificationRegistration>(
+      this.storage.getItem(storageKey)
+    );
+    const token = await this.authorizedToken();
+    if (registration?.channelId && !token) {
+      throw new MdbaseConnectError(
+        "not_authorized",
+        "Reconnect this application before disabling native notifications."
+      );
+    }
+    if (registration?.channelId && token) {
+      await this.deleteNotificationChannel(
+        registration.channelId,
+        token.accessToken
+      );
+    }
+    this.storage.removeItem(storageKey);
+  }
+
   async unregisterNotifications(
     serviceWorker?: ServiceWorkerRegistration
   ): Promise<void> {
@@ -1080,6 +1237,12 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       this.storage.getItem(this.notificationKey())
     );
     const token = await this.authorizedToken();
+    if (registration?.channelId && !token) {
+      throw new MdbaseConnectError(
+        "not_authorized",
+        "Reconnect this application before disabling push notifications."
+      );
+    }
     if (registration?.channelId && token) {
       const response = await fetch(`${this.serverUrl}/v1/notifications/channels/${registration.channelId}`, {
         method: "DELETE",
@@ -1802,8 +1965,30 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
 
   private pendingKey() { return `mdbase-connect:pending:${this.serverUrl}:${this.manifestUrl}`; }
   private tokenKey() { return `mdbase-connect:token:${this.serverUrl}:${this.manifestUrl}`; }
-  private notificationKey() {
-    return `mdbase-connect:notifications:${this.serverUrl}:${this.manifestUrl}`;
+  private notificationKey(transport: "web_push" | "fcm" = "web_push") {
+    const base = `mdbase-connect:notifications:${this.serverUrl}:${this.manifestUrl}`;
+    return transport === "web_push" ? base : `${base}:${transport}`;
+  }
+  private async deleteNotificationChannel(
+    channelId: string,
+    accessToken: string
+  ): Promise<void> {
+    const response = await fetch(
+      `${this.serverUrl}/v1/notifications/channels/${channelId}`,
+      {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${accessToken}` }
+      }
+    );
+    if (!response.ok && response.status !== 404) {
+      const body = await response.json();
+      throw apiError(
+        body,
+        "notification_unregistration_failed",
+        "Could not unregister push notifications.",
+        response.status
+      );
+    }
   }
   private pendingMutationKey() {
     return `mdbase-connect:pending-mutation:${this.serverUrl}:${this.manifestUrl}`;

--- a/packages/devkit/src/index.test.ts
+++ b/packages/devkit/src/index.test.ts
@@ -213,6 +213,27 @@ describe("developer sandbox", () => {
     expect(await client.changes()).toEqual({ events: [], cursor: 0, has_more: false, reset: false });
   });
 
+  it("preserves deleted record types in the canonical event field", async () => {
+    const { client } = createSandbox({
+      records: [
+        {
+          path: "tasks/deleted.md",
+          types: ["task"],
+          frontmatter: { type: "task", title: "Deleted" }
+        }
+      ]
+    });
+    const deleted = await client.delete({ path: "tasks/deleted.md" });
+    expect(deleted.valid).toBe(true);
+    const changes = await client.changes({ after: 0 });
+    expect(changes.events).toHaveLength(1);
+    expect(changes.events[0]).toMatchObject({
+      type: "mdbase.record.deleted",
+      payload: { path: "tasks/deleted.md", types: ["task"] }
+    });
+    expect(changes.events[0]?.payload).not.toHaveProperty("previous_types");
+  });
+
   it("rejects semantic approximations and unsafe paths explicitly", async () => {
     const { client } = createSandbox();
     await expect(client.query({ where: "status == 'open'" })).rejects.toMatchObject({

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -281,7 +281,7 @@ implements MdbaseCollectionTransport {
       });
     }
     this.records.delete(path);
-    this.append("mdbase.record.deleted", current, { path, previous_types: current.types });
+    this.append("mdbase.record.deleted", current, { path, types: current.types });
     return envelope({ path, deleted: true });
   }
 

--- a/packages/protocol/schemas/catalog.json
+++ b/packages/protocol/schemas/catalog.json
@@ -6,6 +6,7 @@
     "contract_extension": "./contract-extension.v1.schema.json",
     "connect_protocol": "./connect-protocol.v2.schema.json",
     "encrypted_relay": "./encrypted-relay.v3.schema.json",
+    "notification_webhook": "./notification-webhook.v1.schema.json",
     "sync": "./sync.v1.schema.json"
   }
 }

--- a/packages/protocol/schemas/mdbase-app.v2.schema.json
+++ b/packages/protocol/schemas/mdbase-app.v2.schema.json
@@ -43,7 +43,8 @@
           "type": "array",
           "maxItems": 50,
           "items": { "$ref": "#/$defs/notificationCriterion" }
-        }
+        },
+        "native_delivery": { "$ref": "#/$defs/nativeNotificationDelivery" }
       }
     }
   },
@@ -133,6 +134,37 @@
           }
         }
       }
+    },
+    "nativeNotificationDelivery": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "firebase_project_id"],
+          "properties": {
+            "mode": { "const": "managed_fcm" },
+            "firebase_project_id": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 63,
+              "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "url"],
+          "properties": {
+            "mode": { "const": "webhook" },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^https://"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/protocol/schemas/notification-webhook.v1.schema.json
+++ b/packages/protocol/schemas/notification-webhook.v1.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/connect/schemas/notification-webhook.v1.json",
+  "title": "mdbase notification webhook v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "version",
+    "delivery_id",
+    "connection_id",
+    "notification"
+  ],
+  "properties": {
+    "type": { "const": "mdbase.notification.webhook" },
+    "version": { "const": 1 },
+    "delivery_id": { "type": "string", "format": "uuid" },
+    "connection_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Opaque application grant reference returned during authorization."
+    },
+    "notification": { "$ref": "#/$defs/notification" }
+  },
+  "$defs": {
+    "notification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "version",
+        "signal_id",
+        "criterion_id",
+        "cursor",
+        "presentation"
+      ],
+      "properties": {
+        "type": { "const": "mdbase.notification" },
+        "version": { "const": 1 },
+        "signal_id": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "criterion_id": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "cursor": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "presentation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["title"],
+          "properties": {
+            "title": { "type": "string", "minLength": 1, "maxLength": 80 },
+            "body": { "type": "string", "maxLength": 160 },
+            "tag": { "type": "string", "minLength": 1, "maxLength": 80 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -32,6 +32,7 @@ export function isNativeRedirectUri(url: URL, publisherHostname?: string): boole
 export const CONNECT_SCHEMA_IDS = {
   appManifest: "https://mdbase.dev/connect/schemas/mdbase-app.v1.json",
   appManifestV2: "https://mdbase.dev/connect/schemas/mdbase-app.v2.json",
+  notificationWebhook: "https://mdbase.dev/connect/schemas/notification-webhook.v1.json",
   contractExtension: "https://mdbase.dev/connect/schemas/contract-extension.v1.json",
   protocol: "https://mdbase.dev/connect/schemas/connect-protocol.v2.json",
   encryptedRelay: "https://mdbase.dev/connect/schemas/encrypted-relay.v3.json",
@@ -85,8 +86,28 @@ export interface NotificationCriterion {
   };
 }
 
+export type NativeNotificationDelivery =
+  | {
+      /**
+       * Connect sends through FCM using revocable, least-privilege authority
+       * granted by the application's Firebase project.
+       */
+      mode: "managed_fcm";
+      firebase_project_id: string;
+    }
+  | {
+      /**
+       * Connect sends a signed, content-free signal to infrastructure operated
+       * by the application developer. That infrastructure owns APNs/FCM.
+       */
+      mode: "webhook";
+      url: string;
+    };
+
 export interface ApplicationNotifications {
   criteria: NotificationCriterion[];
+  /** Optional native delivery route. Web Push registration remains independent. */
+  native_delivery?: NativeNotificationDelivery;
 }
 
 export interface MdbaseAppManifestV2 {
@@ -109,6 +130,30 @@ export interface NotificationSignal {
   criterion_id: string;
   /** Opaque authority cursor used by the app to retrieve current state after waking. */
   cursor: string;
+}
+
+export interface NotificationPresentation {
+  title: string;
+  body?: string;
+  tag?: string;
+}
+
+export interface MdbaseNotification {
+  type: "mdbase.notification";
+  version: 1;
+  signal_id: string;
+  criterion_id: string;
+  cursor: string;
+  presentation: NotificationPresentation;
+}
+
+export interface NotificationWebhook {
+  type: "mdbase.notification.webhook";
+  version: 1;
+  delivery_id: string;
+  /** Opaque application grant reference returned during authorization. */
+  connection_id: string;
+  notification: MdbaseNotification;
 }
 
 export interface ContractRequirement {
@@ -180,7 +225,7 @@ export interface GrantPolicy {
   application_origin?: string;
   application_icon?: string;
   collection_name: string;
-  /** Manifest-declared criteria evaluated only by this collection authority. */
+  /** Approval-time criterion snapshot evaluated only by this collection authority. */
   notification_criteria?: NotificationCriterion[];
   created_at: string;
   encryption?: GrantEncryption;

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -10,6 +10,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const schema = JSON.parse(readFileSync(resolve(here, "../schemas/connect-protocol.v2.schema.json"), "utf8"));
 const manifestSchema = JSON.parse(readFileSync(resolve(here, "../schemas/mdbase-app.schema.json"), "utf8"));
 const manifestV2Schema = JSON.parse(readFileSync(resolve(here, "../schemas/mdbase-app.v2.schema.json"), "utf8"));
+const notificationWebhookSchema = JSON.parse(readFileSync(resolve(here, "../schemas/notification-webhook.v1.schema.json"), "utf8"));
 const contractSchema = JSON.parse(readFileSync(resolve(here, "../schemas/contract-extension.v1.schema.json"), "utf8"));
 const encryptedRelaySchema = JSON.parse(readFileSync(resolve(here, "../schemas/encrypted-relay.v3.schema.json"), "utf8"));
 const syncSchema = JSON.parse(readFileSync(resolve(here, "../schemas/sync.v1.schema.json"), "utf8"));
@@ -18,6 +19,7 @@ addFormats(ajv);
 ajv.addSchema(schema);
 ajv.addSchema(manifestSchema);
 ajv.addSchema(manifestV2Schema);
+ajv.addSchema(notificationWebhookSchema);
 ajv.addSchema(contractSchema);
 ajv.addSchema(encryptedRelaySchema);
 ajv.addSchema(syncSchema);
@@ -32,9 +34,40 @@ test("all canonical schemas compile as strict JSON Schema 2020-12", () => {
   assert.ok(validator(schema.$id));
   assert.ok(validator(manifestSchema.$id));
   assert.ok(validator(manifestV2Schema.$id));
+  assert.ok(validator(notificationWebhookSchema.$id));
   assert.ok(validator(contractSchema.$id));
   assert.ok(validator(encryptedRelaySchema.$id));
   assert.ok(validator(syncSchema.$id));
+});
+
+test("notification webhooks carry only an opaque wake-up signal", () => {
+  const validate = validator(notificationWebhookSchema.$id);
+  const webhook = {
+    type: "mdbase.notification.webhook",
+    version: 1,
+    delivery_id: "01911111-1111-7111-8111-111111111111",
+    connection_id: "01922222-2222-7222-8222-222222222222",
+    notification: {
+      type: "mdbase.notification",
+      version: 1,
+      signal_id: "signal_opaque",
+      criterion_id: "task.changed",
+      cursor: "42",
+      presentation: {
+        title: "Tasks changed",
+        body: "Open TaskNotes to refresh.",
+        tag: "task-change"
+      }
+    }
+  };
+  assert.equal(validate(webhook), true, JSON.stringify(validate.errors));
+  assert.equal(validate({
+    ...webhook,
+    notification: {
+      ...webhook.notification,
+      path: "private/task.md"
+    }
+  }), false);
 });
 
 test("v2 application manifests declare authority-evaluated notification criteria", () => {
@@ -45,6 +78,10 @@ test("v2 application manifests declare authority-evaluated notification criteria
     homepage: "https://tasks.example/",
     redirect_uris: ["https://tasks.example/callback"],
     notifications: {
+      native_delivery: {
+        mode: "managed_fcm",
+        firebase_project_id: "tasks-production"
+      },
       criteria: [{
         id: "task.ready",
         event: { id: "mdbase.record.modified", version: 1 },
@@ -64,13 +101,45 @@ test("v2 application manifests declare authority-evaluated notification criteria
   assert.equal(validate({
     ...manifest,
     notifications: {
+      ...manifest.notifications,
       criteria: [{ ...manifest.notifications.criteria[0], presentation: { title: "${event.payload.path}" } }]
     }
   }), true, JSON.stringify(validate.errors));
   assert.equal(validate({
     ...manifest,
     notifications: {
+      ...manifest.notifications,
       criteria: [{ ...manifest.notifications.criteria[0], event: { id: "../private", version: 1 } }]
+    }
+  }), false);
+  assert.equal(validate({
+    ...manifest,
+    notifications: {
+      ...manifest.notifications,
+      native_delivery: {
+        mode: "webhook",
+        url: "https://hooks.tasks.example/mdbase"
+      }
+    }
+  }), true, JSON.stringify(validate.errors));
+  assert.equal(validate({
+    ...manifest,
+    notifications: {
+      ...manifest.notifications,
+      native_delivery: {
+        mode: "managed_fcm",
+        firebase_project_id: "../other-project"
+      }
+    }
+  }), false);
+  assert.equal(validate({
+    ...manifest,
+    notifications: {
+      ...manifest.notifications,
+      native_delivery: {
+        mode: "webhook",
+        url: "http://127.0.0.1/private"
+      }
     }
   }), false);
 });

--- a/packages/webhooks/README.md
+++ b/packages/webhooks/README.md
@@ -1,0 +1,23 @@
+# `@mdbase/connect-webhooks`
+
+Server-side verification for signed mdbase notification webhooks.
+
+```ts
+import { verifyNotificationWebhook } from "@mdbase/connect-webhooks";
+
+const event = verifyNotificationWebhook({
+  body: rawRequestBody,
+  headers: request.headers,
+  keys: cachedConnectSigningKeys
+});
+
+if (await deliveries.claim(event.delivery_id)) {
+  await sendNativePush(event.connection_id, event.notification);
+}
+```
+
+Fetch and cache verification keys from
+`/v1/notifications/webhook-signing-keys`. Verification requires the exact raw
+request body, rejects modified payloads, and enforces a five-minute replay
+window. Store `delivery_id` before doing work because Connect retries until the
+endpoint returns a successful HTTP response.

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mdbase/connect-webhooks",
+  "version": "0.1.0-beta.1",
+  "private": false,
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
+    "directory": "packages/webhooks"
+  },
+  "homepage": "https://mdbase.dev",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@mdbase/connect-protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/webhooks/src/index.test.ts
+++ b/packages/webhooks/src/index.test.ts
@@ -1,0 +1,89 @@
+import {
+  createPublicKey,
+  generateKeyPairSync,
+  sign
+} from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  NotificationWebhookVerificationError,
+  verifyNotificationWebhook
+} from "./index.js";
+
+const webhook = {
+  type: "mdbase.notification.webhook",
+  version: 1,
+  delivery_id: "01911111-1111-7111-8111-111111111111",
+  connection_id: "01922222-2222-7222-8222-222222222222",
+  notification: {
+    type: "mdbase.notification",
+    version: 1,
+    signal_id: "signal_opaque",
+    criterion_id: "task.changed",
+    cursor: "42",
+    presentation: {
+      title: "Tasks changed",
+      body: "Open TaskNotes to refresh."
+    }
+  }
+} as const;
+
+describe("notification webhook verification", () => {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const keyId = "connect-test";
+  const publicKey = {
+    ...createPublicKey(privateKey).export({ format: "jwk" }),
+    kid: keyId,
+    alg: "EdDSA",
+    use: "sig"
+  } as const;
+  const now = Date.parse("2026-07-24T06:00:00Z");
+  const timestamp = String(now / 1_000);
+
+  function request(body = JSON.stringify(webhook)) {
+    const signature = sign(
+      null,
+      Buffer.from(`${webhook.delivery_id}.${timestamp}.${body}`),
+      privateKey
+    ).toString("base64url");
+    return {
+      body,
+      headers: {
+        "mdbase-webhook-id": webhook.delivery_id,
+        "mdbase-webhook-timestamp": timestamp,
+        "mdbase-webhook-key-id": keyId,
+        "mdbase-webhook-signature": `v1=${signature}`
+      },
+      keys: [publicKey],
+      now
+    };
+  }
+
+  it("returns a verified, typed notification envelope", () => {
+    expect(verifyNotificationWebhook(request())).toEqual(webhook);
+  });
+
+  it("rejects body tampering and replayed timestamps", () => {
+    const valid = request();
+    expect(() => verifyNotificationWebhook({
+      ...valid,
+      body: valid.body.replace("Tasks changed", "Reset your password")
+    })).toThrowError(NotificationWebhookVerificationError);
+    expect(() => verifyNotificationWebhook({
+      ...valid,
+      now: now + 301_000
+    })).toThrowError(expect.objectContaining({ code: "stale_timestamp" }));
+  });
+
+  it("rejects signed envelopes that contain undeclared collection data", () => {
+    const body = JSON.stringify({
+      ...webhook,
+      notification: {
+        ...webhook.notification,
+        path: "tasks/private.md"
+      }
+    });
+    expect(() => verifyNotificationWebhook(request(body))).toThrowError(
+      expect.objectContaining({ code: "invalid_payload" })
+    );
+  });
+});

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,0 +1,202 @@
+import { createPublicKey, verify } from "node:crypto";
+import type {
+  MdbaseNotification,
+  NotificationWebhook
+} from "@mdbase/connect-protocol";
+
+export type { MdbaseNotification, NotificationWebhook };
+
+export interface NotificationSigningKey extends JsonWebKey {
+  kid: string;
+}
+
+export interface VerifyNotificationWebhookOptions {
+  /** Exact UTF-8 request body before JSON parsing. */
+  body: string;
+  headers: Headers | Record<string, string | string[] | undefined>;
+  /** Cached keys from `/v1/notifications/webhook-signing-keys`. */
+  keys: NotificationSigningKey[];
+  /** Override only for deterministic tests. */
+  now?: number;
+  /** Defaults to five minutes. */
+  toleranceSeconds?: number;
+}
+
+export class NotificationWebhookVerificationError extends Error {
+  constructor(
+    readonly code:
+      | "missing_header"
+      | "invalid_timestamp"
+      | "stale_timestamp"
+      | "unknown_key"
+      | "invalid_signature"
+      | "invalid_payload",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export function verifyNotificationWebhook(
+  options: VerifyNotificationWebhookOptions
+): NotificationWebhook {
+  const deliveryId = requiredHeader(options.headers, "mdbase-webhook-id");
+  const timestamp = requiredHeader(options.headers, "mdbase-webhook-timestamp");
+  const keyId = requiredHeader(options.headers, "mdbase-webhook-key-id");
+  const signatureHeader = requiredHeader(
+    options.headers,
+    "mdbase-webhook-signature"
+  );
+  if (!/^[0-9]{1,12}$/.test(timestamp)) {
+    throw new NotificationWebhookVerificationError(
+      "invalid_timestamp",
+      "Webhook timestamp is invalid."
+    );
+  }
+  const timestampMs = Number(timestamp) * 1_000;
+  const tolerance = (options.toleranceSeconds ?? 300) * 1_000;
+  if (Math.abs((options.now ?? Date.now()) - timestampMs) > tolerance) {
+    throw new NotificationWebhookVerificationError(
+      "stale_timestamp",
+      "Webhook timestamp falls outside the replay window."
+    );
+  }
+  const key = options.keys.find((candidate) => candidate.kid === keyId);
+  if (
+    !key
+    || key.kty !== "OKP"
+    || key.crv !== "Ed25519"
+    || typeof key.x !== "string"
+  ) {
+    throw new NotificationWebhookVerificationError(
+      "unknown_key",
+      "Webhook signing key is unknown."
+    );
+  }
+  const match = /^v1=([A-Za-z0-9_-]+)$/.exec(signatureHeader);
+  if (!match) {
+    throw new NotificationWebhookVerificationError(
+      "invalid_signature",
+      "Webhook signature header is invalid."
+    );
+  }
+  const signed = `${deliveryId}.${timestamp}.${options.body}`;
+  const valid = verify(
+    null,
+    Buffer.from(signed),
+    createPublicKey({
+      key: key as unknown as import("node:crypto").JsonWebKey,
+      format: "jwk"
+    }),
+    Buffer.from(match[1], "base64url")
+  );
+  if (!valid) {
+    throw new NotificationWebhookVerificationError(
+      "invalid_signature",
+      "Webhook signature does not match the request body."
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(options.body);
+  } catch {
+    throw new NotificationWebhookVerificationError(
+      "invalid_payload",
+      "Webhook body is not valid JSON."
+    );
+  }
+  const payload = parseWebhook(parsed);
+  if (payload.delivery_id !== deliveryId) {
+    throw new NotificationWebhookVerificationError(
+      "invalid_payload",
+      "Webhook delivery ID does not match its signed header."
+    );
+  }
+  return payload;
+}
+
+function parseWebhook(value: unknown): NotificationWebhook {
+  if (
+    !record(value)
+    || !hasOnlyKeys(value, [
+      "type",
+      "version",
+      "delivery_id",
+      "connection_id",
+      "notification"
+    ])
+  ) invalidPayload();
+  const notification = value.notification;
+  if (
+    value.type !== "mdbase.notification.webhook"
+    || value.version !== 1
+    || typeof value.delivery_id !== "string"
+    || typeof value.connection_id !== "string"
+    || !record(notification)
+    || !hasOnlyKeys(notification, [
+      "type",
+      "version",
+      "signal_id",
+      "criterion_id",
+      "cursor",
+      "presentation"
+    ])
+    || notification.type !== "mdbase.notification"
+    || notification.version !== 1
+    || typeof notification.signal_id !== "string"
+    || typeof notification.criterion_id !== "string"
+    || typeof notification.cursor !== "string"
+    || !record(notification.presentation)
+    || !hasOnlyKeys(notification.presentation, ["title", "body", "tag"])
+    || typeof notification.presentation.title !== "string"
+    || (
+      notification.presentation.body !== undefined
+      && typeof notification.presentation.body !== "string"
+    )
+    || (
+      notification.presentation.tag !== undefined
+      && typeof notification.presentation.tag !== "string"
+    )
+  ) {
+    invalidPayload();
+  }
+  return value as unknown as NotificationWebhook;
+}
+
+function requiredHeader(
+  headers: VerifyNotificationWebhookOptions["headers"],
+  name: string
+): string {
+  const value = headers instanceof Headers
+    ? headers.get(name)
+    : Object.entries(headers).find(
+        ([candidate]) => candidate.toLowerCase() === name
+      )?.[1];
+  const normalized = Array.isArray(value) ? value[0] : value;
+  if (!normalized) {
+    throw new NotificationWebhookVerificationError(
+      "missing_header",
+      `Missing ${name} header.`
+    );
+  }
+  return normalized;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  keys: string[]
+): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function invalidPayload(): never {
+  throw new NotificationWebhookVerificationError(
+    "invalid_payload",
+    "Webhook body is not an mdbase notification."
+  );
+}

--- a/packages/webhooks/tsconfig.json
+++ b/packages/webhooks/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,22 @@ importers:
 
   packages/ui: {}
 
+  packages/webhooks:
+    dependencies:
+      '@mdbase/connect-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   services/mcp:
     dependencies:
       '@fastify/cors':
@@ -341,6 +357,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@mdbase/connect-webhooks':
+        specifier: workspace:*
+        version: link:../../packages/webhooks
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3

--- a/render.yaml
+++ b/render.yaml
@@ -127,6 +127,16 @@ services:
         sync: false
       - key: MDBASE_CONNECT_VAPID_PRIVATE_KEY
         sync: false
+      - key: MDBASE_CONNECT_FCM_ENABLED
+        value: "0"
+      - key: MDBASE_CONNECT_FCM_CREDENTIALS_JSON
+        sync: false
+      - key: MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID
+        sync: false
+      - key: MDBASE_CONNECT_WEBHOOK_SIGNING_PRIVATE_KEY
+        sync: false
+      - key: MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON
+        sync: false
 
   - type: web
     name: mdbase-mcp

--- a/scripts/package-audit.mjs
+++ b/scripts/package-audit.mjs
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 
 const run = promisify(execFile);
 const root = resolve(import.meta.dirname, "..");
-const packages = ["protocol", "client", "devkit", "sync", "tasknotes"];
+const packages = ["protocol", "client", "devkit", "sync", "tasknotes", "webhooks"];
 const scratch = await mkdtemp(join(tmpdir(), "mdbase-connect-packages-"));
 
 try {

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -31,6 +31,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@mdbase/connect-webhooks": "workspace:*",
     "@types/node": "^24.0.0",
     "@types/pg": "^8.20.0",
     "@types/web-push": "^3.6.4",

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -1,6 +1,7 @@
 import { ECDH, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import Fastify, { LogController, type FastifyReply, type FastifyRequest } from "fastify";
 import cookie from "@fastify/cookie";
 import cors from "@fastify/cors";
@@ -19,6 +20,7 @@ import type {
   GrantEncryption,
   GrantPolicy,
   GrantScope,
+  NotificationCriterion,
   TypeProvision
 } from "@mdbase/connect-protocol";
 import {
@@ -61,7 +63,7 @@ import type { RegistrationMode } from "./runtime-config.js";
 import {
   activeGrantForToken,
   NotificationService,
-  type PushTransport
+  type NotificationTransports
 } from "./notifications.js";
 
 const OPERATIONS = [
@@ -133,8 +135,8 @@ interface BuildOptions {
   trustProxy?: boolean;
   relayBroker?: RelayBroker;
   notifications?: {
-    publicKey: string;
-    transport: PushTransport;
+    publicKey?: string;
+    transports: NotificationTransports;
     pollIntervalMs?: number;
   };
 }
@@ -169,7 +171,7 @@ export async function buildApp(options: BuildOptions) {
   const notifications = options.notifications
     ? new NotificationService(
         options.db,
-        options.notifications.transport,
+        options.notifications.transports,
         options.notifications.pollIntervalMs,
         (error) => app.log.error({ err: error }, "notification delivery worker failed")
       )
@@ -994,7 +996,7 @@ export async function buildApp(options: BuildOptions) {
     const pendingAuthorizations = await options.db.query(
       `SELECT ar.id, ar.requested_operations, ar.expires_at,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
-              a.requirements, a.provisions
+              a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
@@ -1158,7 +1160,7 @@ export async function buildApp(options: BuildOptions) {
               a.icon AS application_icon,
               col.local_id AS collection_id, col.display_name AS collection_name,
               g.operations, g.scope, g.encryption, g.created_at,
-              a.notifications->'criteria' AS notification_criteria
+              g.notification_criteria
        FROM grants g
        JOIN applications a ON a.id = g.application_id
        JOIN collections col ON col.id = g.collection_id
@@ -1169,7 +1171,7 @@ export async function buildApp(options: BuildOptions) {
     const pendingAuthorizations = await options.db.query(
       `SELECT ar.id, ar.application_id, a.name AS application_name,
               a.homepage AS application_homepage, a.icon AS application_icon,
-              ar.requested_operations, ar.expires_at, a.requirements, a.provisions
+              ar.requested_operations, ar.expires_at, a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
@@ -1243,8 +1245,9 @@ export async function buildApp(options: BuildOptions) {
       id: string;
       homepage: string;
       requirements: ApplicationRequirements;
+      notifications: ApplicationNotifications;
     }>(
-      "SELECT id, homepage, requirements FROM applications WHERE id = $1",
+      "SELECT id, homepage, requirements, notifications FROM applications WHERE id = $1",
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
@@ -1272,7 +1275,8 @@ export async function buildApp(options: BuildOptions) {
       collectionId: collection.rows[0].id,
       operations: input.operations,
       scope,
-      applicationOrigin: new URL(application.rows[0].homepage).origin
+      applicationOrigin: new URL(application.rows[0].homepage).origin,
+      notificationCriteria: application.rows[0].notifications.criteria
     });
     await relay.pushPolicy(connector.id);
     await audit(options.db, connector.user_id, "grant.created", grant.id, {
@@ -1681,8 +1685,9 @@ export async function buildApp(options: BuildOptions) {
       id: string;
       homepage: string;
       requirements: ApplicationRequirements;
+      notifications: ApplicationNotifications;
     }>(
-      "SELECT id, homepage, requirements FROM applications WHERE id = $1",
+      "SELECT id, homepage, requirements, notifications FROM applications WHERE id = $1",
       [input.application_id]
     );
     if (!application.rows[0]) return reply.code(404).send(apiError("application_not_found", "Application not found."));
@@ -1710,7 +1715,8 @@ export async function buildApp(options: BuildOptions) {
       collectionId: input.collection_id,
       operations: input.operations,
       scope,
-      applicationOrigin: new URL(application.rows[0].homepage).origin
+      applicationOrigin: new URL(application.rows[0].homepage).origin,
+      notificationCriteria: application.rows[0].notifications.criteria
     });
     await relay.pushPolicy(ownership.rows[0].connector_id);
     await audit(options.db, user.id, "grant.created", grant.id, input);
@@ -1891,7 +1897,7 @@ export async function buildApp(options: BuildOptions) {
     const authorization = await options.db.query(
       `SELECT ar.id, ar.requested_operations, ar.expires_at,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
-              a.requirements, a.provisions
+              a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.expires_at > now()`,
       [requestId, user.id]
@@ -2096,10 +2102,22 @@ export async function buildApp(options: BuildOptions) {
   });
 
   app.get("/v1/notifications/vapid-public-key", async (_request, reply) => {
-    if (!options.notifications) {
+    if (!options.notifications?.publicKey) {
       return reply.code(404).send(apiError("notifications_unavailable", "Push notifications are not configured."));
     }
     return { public_key: options.notifications.publicKey };
+  });
+
+  app.get("/v1/notifications/webhook-signing-keys", async (_request, reply) => {
+    const webhook = options.notifications?.transports.webhook;
+    if (!webhook) {
+      return reply.code(404).send(apiError(
+        "webhooks_unavailable",
+        "Signed notification webhooks are not configured."
+      ));
+    }
+    reply.header("cache-control", "public, max-age=300");
+    return { keys: webhook.publicKeys() };
   });
 
   app.post("/v1/notifications/channels", async (request, reply) => {
@@ -2108,18 +2126,29 @@ export async function buildApp(options: BuildOptions) {
     }
     const bearer = bearerToken(request);
     if (!bearer) return reply.code(401).send(apiError("invalid_token", "Bearer token required."));
-    const input = z.object({
+    const baseChannel = {
       installation_id: z.string().min(16).max(200),
-      criteria: z.array(z.string().min(1).max(100)).min(1).max(100),
-      subscription: z.object({
-        endpoint: z.url().refine((value) => new URL(value).protocol === "https:", "Push endpoint must use HTTPS."),
-        expirationTime: z.number().int().positive().nullable().optional(),
-        keys: z.object({
-          p256dh: z.string().min(16).max(512),
-          auth: z.string().min(8).max(256)
+      criteria: z.array(z.string().min(1).max(100)).min(1).max(100)
+    } as const;
+    const input = z.union([
+      z.object({
+        ...baseChannel,
+        transport: z.literal("web_push").optional(),
+        subscription: z.object({
+          endpoint: z.url().refine((value) => new URL(value).protocol === "https:", "Push endpoint must use HTTPS."),
+          expirationTime: z.number().int().positive().nullable().optional(),
+          keys: z.object({
+            p256dh: z.string().min(16).max(512),
+            auth: z.string().min(8).max(256)
+          }).strict()
         }).strict()
+      }).strict(),
+      z.object({
+        ...baseChannel,
+        transport: z.literal("fcm"),
+        token: z.string().min(32).max(4_096)
       }).strict()
-    }).strict().parse(request.body);
+    ]).parse(request.body);
     const criteria = [...new Set(input.criteria)];
     const connection = await options.db.connect();
     try {
@@ -2129,48 +2158,107 @@ export async function buildApp(options: BuildOptions) {
         await connection.query("ROLLBACK");
         return reply.code(401).send(apiError("invalid_token", "Access token is invalid or expired."));
       }
-      const application = await connection.query<{ notifications: ApplicationNotifications }>(
-        `SELECT a.notifications
+      const application = await connection.query<{
+        notifications: ApplicationNotifications;
+        notification_criteria: NotificationCriterion[];
+      }>(
+        `SELECT a.notifications, g.notification_criteria
          FROM grants g
          JOIN applications a ON a.id = g.application_id
          WHERE g.id = $1 AND g.revoked_at IS NULL`,
         [grant.grant_id]
       );
       const declared = new Set(
-        application.rows[0]?.notifications.criteria.map((criterion) => criterion.id) ?? []
+        application.rows[0]?.notification_criteria.map(
+          (criterion) => criterion.id
+        ) ?? []
       );
       const undeclared = criteria.find((criterion) => !declared.has(criterion));
       if (undeclared) {
         await connection.query("ROLLBACK");
         return reply.code(400).send(apiError(
-          "notification_criterion_not_declared",
-          `The application manifest does not declare notification criterion ${undeclared}.`
+          "notification_reauthorization_required",
+          `The current grant does not authorize notification criterion ${undeclared}. Reauthorize the application to accept its updated notification criteria.`
+        ));
+      }
+      const kind = input.transport === "fcm" ? "fcm" : "web_push";
+      const fcmToken = input.transport === "fcm" ? input.token : null;
+      const webSubscription = input.transport === "fcm"
+        ? null
+        : input.subscription;
+      const nativeDelivery = application.rows[0]?.notifications.native_delivery;
+      if (kind === "fcm") {
+        if (nativeDelivery?.mode !== "managed_fcm") {
+          await connection.query("ROLLBACK");
+          return reply.code(400).send(apiError(
+            "managed_fcm_not_declared",
+            "The application manifest does not declare Connect-managed FCM delivery."
+          ));
+        }
+        if (!options.notifications?.transports.fcm) {
+          await connection.query("ROLLBACK");
+          return reply.code(503).send(apiError(
+            "managed_fcm_unavailable",
+            "Connect-managed FCM delivery is not configured."
+          ));
+        }
+        await connection.query(
+          `DELETE FROM push_channels
+           WHERE grant_id IN (
+             SELECT id FROM grants WHERE application_id = $1
+           )
+             AND fcm_token_hash = $2
+             AND NOT (grant_id = $3 AND installation_id = $4)`,
+          [
+            grant.application_id,
+            tokenHash(fcmToken!),
+            grant.grant_id,
+            input.installation_id
+          ]
+        );
+      } else if (!options.notifications?.transports.webPush) {
+        await connection.query("ROLLBACK");
+        return reply.code(503).send(apiError(
+          "web_push_unavailable",
+          "Web Push delivery is not configured."
         ));
       }
       const channel = await connection.query<{ id: string }>(
         `INSERT INTO push_channels
-           (id, grant_id, installation_id, endpoint, endpoint_hash, p256dh, auth, expires_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           (id, grant_id, installation_id, kind, endpoint, endpoint_hash,
+            p256dh, auth, expires_at, fcm_project_id, fcm_token, fcm_token_hash)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
          ON CONFLICT(grant_id, installation_id) DO UPDATE SET
+           kind = excluded.kind,
            endpoint = excluded.endpoint,
            endpoint_hash = excluded.endpoint_hash,
            p256dh = excluded.p256dh,
            auth = excluded.auth,
            expires_at = excluded.expires_at,
+           fcm_project_id = excluded.fcm_project_id,
+           fcm_token = excluded.fcm_token,
+           fcm_token_hash = excluded.fcm_token_hash,
            disabled_at = NULL,
+           last_seen_at = now(),
            updated_at = now()
          RETURNING id`,
         [
           randomUUID(),
           grant.grant_id,
           input.installation_id,
-          input.subscription.endpoint,
-          tokenHash(input.subscription.endpoint),
-          input.subscription.keys.p256dh,
-          input.subscription.keys.auth,
-          input.subscription.expirationTime
-            ? new Date(input.subscription.expirationTime).toISOString()
-            : null
+          kind,
+          webSubscription?.endpoint ?? null,
+          webSubscription ? tokenHash(webSubscription.endpoint) : null,
+          webSubscription?.keys.p256dh ?? null,
+          webSubscription?.keys.auth ?? null,
+          webSubscription?.expirationTime
+            ? new Date(webSubscription.expirationTime).toISOString()
+            : null,
+          kind === "fcm" && nativeDelivery?.mode === "managed_fcm"
+            ? nativeDelivery.firebase_project_id
+            : null,
+          fcmToken,
+          fcmToken ? tokenHash(fcmToken) : null
         ]
       );
       await connection.query(
@@ -2186,7 +2274,11 @@ export async function buildApp(options: BuildOptions) {
         );
       }
       await connection.query("COMMIT");
-      return reply.code(201).send({ channel_id: channel.rows[0].id, criteria });
+      return reply.code(201).send({
+        channel_id: channel.rows[0].id,
+        transport: kind,
+        criteria
+      });
     } catch (error) {
       await connection.query("ROLLBACK");
       throw error;
@@ -2206,12 +2298,11 @@ export async function buildApp(options: BuildOptions) {
     const grant = await activeGrantForToken(options.db, tokenHash(bearer));
     if (!grant) return reply.code(401).send(apiError("invalid_token", "Access token is invalid or expired."));
     const application = await options.db.query<{
-      notifications: ApplicationNotifications;
+      notification_criteria: NotificationCriterion[];
       channel_id: string | null;
     }>(
-      `SELECT a.notifications, pc.id AS channel_id
+      `SELECT g.notification_criteria, pc.id AS channel_id
        FROM grants g
-       JOIN applications a ON a.id = g.application_id
        LEFT JOIN push_channels pc
          ON pc.grant_id = g.id AND pc.id = $2 AND pc.disabled_at IS NULL
        WHERE g.id = $1 AND g.revoked_at IS NULL`,
@@ -2221,10 +2312,12 @@ export async function buildApp(options: BuildOptions) {
     if (!row?.channel_id) {
       return reply.code(404).send(apiError("channel_not_found", "The push channel is not active for this grant."));
     }
-    if (!row.notifications.criteria.some((criterion) => criterion.id === params.criterionId)) {
+    if (!row.notification_criteria.some(
+      (criterion) => criterion.id === params.criterionId
+    )) {
       return reply.code(400).send(apiError(
-        "notification_criterion_not_declared",
-        "The application manifest does not declare this notification criterion."
+        "notification_reauthorization_required",
+        "The current grant does not authorize this notification criterion."
       ));
     }
     const subscription = await options.db.query<{ id: string }>(
@@ -2268,16 +2361,15 @@ export async function buildApp(options: BuildOptions) {
       cursor: z.string().min(1).max(200)
     }).strict().parse(request.body);
     const authorization = await options.db.query<{
-      notifications: ApplicationNotifications;
+      notification_criteria: NotificationCriterion[];
     }>(
-      `SELECT a.notifications
+      `SELECT g.notification_criteria
        FROM grants g
-       JOIN applications a ON a.id = g.application_id
        WHERE g.id = $1 AND g.hosted_collection_id IS NOT NULL
          AND g.revoked_at IS NULL`,
       [input.grant_id]
     );
-    const authorized = authorization.rows[0]?.notifications.criteria.some(
+    const authorized = authorization.rows[0]?.notification_criteria.some(
       (criterion) => criterion.id === input.criterion_id
     );
     if (!authorized) {
@@ -2312,17 +2404,16 @@ export async function buildApp(options: BuildOptions) {
       cursor: z.string().min(1).max(200)
     }).strict().parse(request.body);
     const authorization = await options.db.query<{
-      notifications: ApplicationNotifications;
+      notification_criteria: NotificationCriterion[];
     }>(
-      `SELECT a.notifications
+      `SELECT g.notification_criteria
        FROM grants g
        JOIN collections c ON c.id = g.collection_id
-       JOIN applications a ON a.id = g.application_id
        WHERE g.id = $1 AND c.connector_id = $2
          AND g.revoked_at IS NULL AND c.enabled = true`,
       [input.grant_id, connector.id]
     );
-    const authorized = authorization.rows[0]?.notifications.criteria.some(
+    const authorized = authorization.rows[0]?.notification_criteria.some(
       (criterion) => criterion.id === input.criterion_id
     );
     if (!authorized) {
@@ -2510,6 +2601,7 @@ async function createOrUpdateGrant(
     operations: string[];
     scope: GrantScope;
     applicationOrigin: string;
+    notificationCriteria: NotificationCriterion[];
   }
 ): Promise<{ id: string; operations: string[]; scope: GrantScope }> {
   const operations = [...new Set(input.operations)];
@@ -2521,19 +2613,22 @@ async function createOrUpdateGrant(
   const grant = existing.rows[0]
     ? await db.query<{ id: string; operations: string[]; scope: GrantScope }>(
         `UPDATE grants SET operations = $2::jsonb, scope = $3::jsonb,
-                           application_origin = $4
+                           application_origin = $4,
+                           notification_criteria = $5::jsonb
          WHERE id = $1 RETURNING id, operations, scope`,
         [
           existing.rows[0].id,
           JSON.stringify(operations),
           JSON.stringify(input.scope),
-          input.applicationOrigin
+          input.applicationOrigin,
+          JSON.stringify(input.notificationCriteria)
         ]
       )
     : await db.query<{ id: string; operations: string[]; scope: GrantScope }>(
         `INSERT INTO grants
-           (id, user_id, application_id, collection_id, operations, scope, application_origin)
-         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)
+           (id, user_id, application_id, collection_id, operations, scope,
+            application_origin, notification_criteria)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8::jsonb)
          RETURNING id, operations, scope`,
         [
           randomUUID(),
@@ -2542,7 +2637,8 @@ async function createOrUpdateGrant(
           input.collectionId,
           JSON.stringify(operations),
           JSON.stringify(input.scope),
-          input.applicationOrigin
+          input.applicationOrigin,
+          JSON.stringify(input.notificationCriteria)
         ]
       );
   if (existing.rows[0]?.encryption) await rotateGrantEncryption(db, existing.rows[0].id);
@@ -2565,7 +2661,7 @@ async function syncHostedNotificationGrant(
     collection_name: string;
     operations: string[];
     scope: GrantScope;
-    notifications: ApplicationNotifications;
+    notification_criteria: NotificationCriterion[];
     created_at: string | Date;
   }>(
     `SELECT g.id, g.application_id, a.name AS application_name,
@@ -2575,7 +2671,7 @@ async function syncHostedNotificationGrant(
             a.icon AS application_icon,
             g.hosted_collection_id AS collection_id,
             hosted.display_name AS collection_name,
-            g.operations, g.scope, a.notifications, g.created_at
+            g.operations, g.scope, g.notification_criteria, g.created_at
      FROM grants g
      JOIN applications a ON a.id = g.application_id
      JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
@@ -2584,7 +2680,7 @@ async function syncHostedNotificationGrant(
   );
   const row = result.rows[0];
   if (!row) return;
-  if (row.notifications.criteria.length === 0) {
+  if (row.notification_criteria.length === 0) {
     await provider.revokeNotificationGrant(row.collection_id, row.id);
     return;
   }
@@ -2599,7 +2695,7 @@ async function syncHostedNotificationGrant(
     application_origin: row.application_origin,
     ...(row.application_icon ? { application_icon: row.application_icon } : {}),
     collection_name: row.collection_name,
-    notification_criteria: row.notifications.criteria,
+    notification_criteria: row.notification_criteria,
     created_at: new Date(row.created_at).toISOString()
   };
   await provider.upsertNotificationGrant(row.collection_id, grant);
@@ -2609,7 +2705,11 @@ async function reconcileApplicationGrants(
   db: DatabasePool,
   relay: RelayHub,
   hostedProvider: HostedProviderClient | undefined,
-  application: { id: string; requirements: ApplicationRequirements }
+  application: {
+    id: string;
+    requirements: ApplicationRequirements;
+    notifications: ApplicationNotifications;
+  }
 ): Promise<void> {
   const desiredScope = scopeForRequirements(application.requirements);
   const requiredContracts = requiredContractsForRequirements(application.requirements);
@@ -2626,11 +2726,12 @@ async function reconcileApplicationGrants(
     template: string | null;
     allowed_types: string[] | null;
     scope: GrantScope;
+    notification_criteria: NotificationCriterion[];
   }>(
     `SELECT g.id, g.user_id, col.connector_id, g.hosted_collection_id, g.hosted_replica_id,
             g.operations, col.contracts AS local_contracts, col.spec_version,
             hosted.contracts AS hosted_contracts, hosted.template,
-            replica.allowed_types, g.scope
+            replica.allowed_types, g.scope, g.notification_criteria
      FROM grants g
      LEFT JOIN collections col ON col.id = g.collection_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
@@ -2640,6 +2741,33 @@ async function reconcileApplicationGrants(
   );
   const changedConnectors = new Set<string>();
   for (const grant of grants.rows) {
+    const retainedCriteria = grant.notification_criteria.filter((authorized) =>
+      application.notifications.criteria.some((declared) =>
+        isDeepStrictEqual(authorized, declared)
+      )
+    );
+    const notificationsChanged = !isDeepStrictEqual(
+      retainedCriteria,
+      grant.notification_criteria
+    );
+    if (notificationsChanged) {
+      await db.query(
+        "UPDATE grants SET notification_criteria = $2::jsonb WHERE id = $1",
+        [grant.id, JSON.stringify(retainedCriteria)]
+      );
+      grant.notification_criteria = retainedCriteria;
+      await audit(
+        db,
+        grant.user_id,
+        "grant.notifications_narrowed",
+        grant.id,
+        {
+          application_id: application.id,
+          criterion_ids: retainedCriteria.map((criterion) => criterion.id)
+        }
+      );
+      if (grant.connector_id) changedConnectors.add(grant.connector_id);
+    }
     if (grant.hosted_replica_id) {
       if (!hostedProvider) {
         throw new Error("Hosted provider unavailable during notification reconciliation.");
@@ -2765,12 +2893,13 @@ async function approveAuthorization(
     application_homepage: string;
     requested_operations: string[];
     requirements: ApplicationRequirements;
+    notifications: ApplicationNotifications;
     relay_protocol: number | null;
     application_public_key: string | null;
     redirect_uri: string;
   }>(
     `SELECT ar.application_id, a.homepage AS application_homepage,
-            ar.requested_operations, a.requirements,
+            ar.requested_operations, a.requirements, a.notifications,
             ar.relay_protocol, ar.application_public_key, ar.redirect_uri
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id
@@ -2834,8 +2963,8 @@ async function approveAuthorization(
   await db.query(
     `INSERT INTO grants
        (id, user_id, application_id, collection_id, operations, scope, encryption,
-        application_origin)
-     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8)`,
+        application_origin, notification_criteria)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, $9::jsonb)`,
     [
       grantId,
       input.userId,
@@ -2844,7 +2973,8 @@ async function approveAuthorization(
       JSON.stringify(input.operations),
       JSON.stringify(scope),
       encryption ? JSON.stringify(encryption) : null,
-      applicationOriginForRedirect(pending.redirect_uri, pending.application_homepage)
+      applicationOriginForRedirect(pending.redirect_uri, pending.application_homepage),
+      JSON.stringify(pending.notifications.criteria)
     ]
   );
   await db.query(
@@ -2888,10 +3018,11 @@ async function approveHostedAuthorization(
       requested_operations: string[];
       requirements: ApplicationRequirements;
       provisions: ApplicationProvisions;
+      notifications: ApplicationNotifications;
     }>(
       `SELECT ar.application_id, a.name AS application_name, a.homepage AS application_homepage,
               ar.redirect_uri, ar.requested_operations,
-              a.requirements, a.provisions
+              a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
@@ -2977,8 +3108,9 @@ async function approveHostedAuthorization(
     await connection.query(
       `INSERT INTO grants
           (id, user_id, application_id, hosted_collection_id, hosted_replica_id,
-          operations, scope, encryption, application_origin)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL, $8)`,
+          operations, scope, encryption, application_origin,
+          notification_criteria)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL, $8, $9::jsonb)`,
       [
         grantId,
         input.userId,
@@ -2987,7 +3119,8 @@ async function approveHostedAuthorization(
         replicaId,
         JSON.stringify(operations),
         JSON.stringify(scope),
-        applicationOrigin
+        applicationOrigin,
+        JSON.stringify(pending.notifications.criteria)
       ]
     );
     await connection.query(

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -139,6 +139,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       hosted_replica_id uuid REFERENCES hosted_replicas(id) ON DELETE SET NULL,
       operations jsonb NOT NULL,
       scope jsonb NOT NULL DEFAULT '{"contracts":[]}'::jsonb,
+      notification_criteria jsonb NOT NULL DEFAULT '[]'::jsonb,
       encryption jsonb,
       application_origin text NOT NULL DEFAULT '',
       created_at timestamptz NOT NULL DEFAULT now(),
@@ -223,12 +224,17 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       id uuid PRIMARY KEY,
       grant_id uuid NOT NULL REFERENCES grants(id) ON DELETE CASCADE,
       installation_id text NOT NULL,
-      endpoint text NOT NULL,
-      endpoint_hash text NOT NULL,
-      p256dh text NOT NULL,
-      auth text NOT NULL,
+      kind text NOT NULL DEFAULT 'web_push',
+      endpoint text,
+      endpoint_hash text,
+      p256dh text,
+      auth text,
+      fcm_project_id text,
+      fcm_token text,
+      fcm_token_hash text,
       expires_at timestamptz,
       disabled_at timestamptz,
+      last_seen_at timestamptz NOT NULL DEFAULT now(),
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now(),
       UNIQUE(grant_id, installation_id),
@@ -267,6 +273,22 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     );
     CREATE INDEX IF NOT EXISTS notification_deliveries_ready_idx
       ON notification_deliveries(status, available_at);
+    CREATE TABLE IF NOT EXISTS notification_webhook_deliveries (
+      id uuid PRIMARY KEY,
+      signal_id uuid NOT NULL UNIQUE REFERENCES notification_signals(id) ON DELETE CASCADE,
+      url text NOT NULL,
+      status text NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'sending', 'retry', 'sent', 'discarded')),
+      attempts integer NOT NULL DEFAULT 0,
+      available_at timestamptz NOT NULL DEFAULT now(),
+      lease_token text,
+      leased_until timestamptz,
+      last_error text,
+      delivered_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS notification_webhook_deliveries_ready_idx
+      ON notification_webhook_deliveries(status, available_at);
   `);
   const authorizationColumns = await db.query<{ column_name: string }>(
     `SELECT column_name FROM information_schema.columns
@@ -313,6 +335,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "grants",
     "scope",
     "ALTER TABLE grants ADD COLUMN scope jsonb NOT NULL DEFAULT '{\"contracts\":[]}'::jsonb"
+  );
+  await ensureColumn(
+    db,
+    "grants",
+    "notification_criteria",
+    "ALTER TABLE grants ADD COLUMN notification_criteria jsonb NOT NULL DEFAULT '[]'::jsonb"
   );
   await ensureColumn(db, "connectors", "relay_public_key", "ALTER TABLE connectors ADD COLUMN relay_public_key text");
   await ensureColumn(
@@ -364,6 +392,43 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "hosted_replicas",
     "purpose",
     "ALTER TABLE hosted_replicas ADD COLUMN purpose text NOT NULL DEFAULT 'mirror'"
+  );
+  await ensureColumn(
+    db,
+    "push_channels",
+    "kind",
+    "ALTER TABLE push_channels ADD COLUMN kind text NOT NULL DEFAULT 'web_push'"
+  );
+  await ensureColumn(
+    db,
+    "push_channels",
+    "fcm_project_id",
+    "ALTER TABLE push_channels ADD COLUMN fcm_project_id text"
+  );
+  await ensureColumn(
+    db,
+    "push_channels",
+    "fcm_token",
+    "ALTER TABLE push_channels ADD COLUMN fcm_token text"
+  );
+  await ensureColumn(
+    db,
+    "push_channels",
+    "fcm_token_hash",
+    "ALTER TABLE push_channels ADD COLUMN fcm_token_hash text"
+  );
+  await ensureColumn(
+    db,
+    "push_channels",
+    "last_seen_at",
+    "ALTER TABLE push_channels ADD COLUMN last_seen_at timestamptz NOT NULL DEFAULT now()"
+  );
+  await ensureNullable(db, "push_channels", "endpoint");
+  await ensureNullable(db, "push_channels", "endpoint_hash");
+  await ensureNullable(db, "push_channels", "p256dh");
+  await ensureNullable(db, "push_channels", "auth");
+  await db.query(
+    "CREATE UNIQUE INDEX IF NOT EXISTS push_channels_fcm_target_idx ON push_channels(grant_id, fcm_token_hash)"
   );
   const grantCollection = await db.query<{ is_nullable: string }>(
     `SELECT is_nullable FROM information_schema.columns

--- a/services/server/src/fcm.test.ts
+++ b/services/server/src/fcm.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { FcmTransport } from "./fcm.js";
+
+const payload = JSON.stringify({
+  type: "mdbase.notification",
+  version: 1,
+  signal_id: "signal_opaque",
+  criterion_id: "task.changed",
+  cursor: "42",
+  presentation: {
+    title: "Tasks changed",
+    body: "Open TaskNotes to refresh.",
+    tag: "task-change"
+  }
+});
+
+describe("FCM transport", () => {
+  it("sends a privacy-minimal cross-platform HTTP v1 message", async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ name: "projects/tasks/messages/1" }),
+      { status: 200 }
+    ));
+    const transport = new FcmTransport({
+      auth: { getAccessToken: async () => "short-lived-access-token" },
+      fetch: fetcher
+    });
+
+    await transport.send({
+      projectId: "tasks-production",
+      token: "device-token"
+    }, payload);
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    const [url, init] = fetcher.mock.calls[0];
+    expect(url).toBe(
+      "https://fcm.googleapis.com/v1/projects/tasks-production/messages:send"
+    );
+    expect(init.headers.authorization).toBe("Bearer short-lived-access-token");
+    const body = JSON.parse(init.body);
+    expect(body.message).toMatchObject({
+      token: "device-token",
+      notification: {
+        title: "Tasks changed",
+        body: "Open TaskNotes to refresh."
+      },
+      data: {
+        type: "mdbase.notification",
+        version: "1",
+        signal_id: "signal_opaque",
+        criterion_id: "task.changed",
+        cursor: "42"
+      },
+      android: {
+        notification: {
+          channel_id: "mdbase-updates",
+          tag: "task-change"
+        }
+      },
+      apns: {
+        payload: {
+          aps: { "thread-id": "task-change" }
+        }
+      }
+    });
+    expect(init.body).not.toContain("path");
+    expect(init.body).not.toContain("frontmatter");
+  });
+
+  it("marks unregistered installation targets as permanent", async () => {
+    const transport = new FcmTransport({
+      auth: { getAccessToken: async () => "token" },
+      fetch: async () => new Response(JSON.stringify({
+        error: {
+          status: "NOT_FOUND",
+          details: [{
+            "@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError",
+            errorCode: "UNREGISTERED"
+          }]
+        }
+      }), { status: 404 })
+    });
+
+    await expect(transport.send({
+      projectId: "tasks-production",
+      token: "expired-token"
+    }, payload)).rejects.toMatchObject({ permanent: true });
+  });
+
+  it("retains retryable provider failures and Retry-After", async () => {
+    const transport = new FcmTransport({
+      auth: { getAccessToken: async () => "token" },
+      fetch: async () => new Response("busy", {
+        status: 503,
+        headers: { "retry-after": "9" }
+      })
+    });
+
+    await expect(transport.send({
+      projectId: "tasks-production",
+      token: "active-token"
+    }, payload)).rejects.toMatchObject({
+      permanent: false,
+      retryAfterMs: 9_000
+    });
+  });
+});

--- a/services/server/src/fcm.ts
+++ b/services/server/src/fcm.ts
@@ -1,0 +1,143 @@
+import { GoogleAuth, type GoogleAuthOptions } from "google-auth-library";
+import {
+  PushDeliveryError,
+  type FcmPushTarget,
+  type FcmPushTransport
+} from "./notifications.js";
+
+const FCM_SCOPE = "https://www.googleapis.com/auth/firebase.messaging";
+
+interface AccessTokenProvider {
+  getAccessToken(): Promise<string | null | undefined>;
+}
+
+interface FcmPayload {
+  type: "mdbase.notification";
+  version: 1;
+  signal_id: string;
+  criterion_id: string;
+  cursor: string;
+  presentation: {
+    title: string;
+    body?: string;
+    tag?: string;
+  };
+}
+
+export interface FcmTransportOptions {
+  credentials?: GoogleAuthOptions["credentials"];
+  auth?: AccessTokenProvider;
+  fetch?: typeof globalThis.fetch;
+}
+
+export class FcmTransport implements FcmPushTransport {
+  private readonly auth: AccessTokenProvider;
+  private readonly fetcher: typeof globalThis.fetch;
+
+  constructor(options: FcmTransportOptions = {}) {
+    this.auth = options.auth ?? new GoogleAuth({
+      scopes: [FCM_SCOPE],
+      ...(options.credentials ? { credentials: options.credentials } : {})
+    });
+    this.fetcher = options.fetch ?? globalThis.fetch;
+  }
+
+  async send(target: FcmPushTarget, serializedPayload: string): Promise<void> {
+    const payload = JSON.parse(serializedPayload) as FcmPayload;
+    const accessToken = await this.auth.getAccessToken();
+    if (!accessToken) {
+      throw new PushDeliveryError("FCM did not issue an access token.");
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    let response: Response;
+    try {
+      response = await this.fetcher(
+        `https://fcm.googleapis.com/v1/projects/${encodeURIComponent(target.projectId)}/messages:send`,
+        {
+          method: "POST",
+          redirect: "error",
+          signal: controller.signal,
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json"
+          },
+          body: JSON.stringify({
+            message: {
+              token: target.token,
+              notification: {
+                title: payload.presentation.title,
+                ...(payload.presentation.body ? { body: payload.presentation.body } : {})
+              },
+              data: {
+                type: payload.type,
+                version: String(payload.version),
+                signal_id: payload.signal_id,
+                criterion_id: payload.criterion_id,
+                cursor: payload.cursor
+              },
+              android: {
+                priority: "high",
+                notification: {
+                  channel_id: "mdbase-updates",
+                  ...(payload.presentation.tag ? { tag: payload.presentation.tag } : {})
+                }
+              },
+              apns: {
+                headers: {
+                  "apns-push-type": "alert",
+                  "apns-priority": "10"
+                },
+                payload: {
+                  aps: {
+                    ...(payload.presentation.tag
+                      ? { "thread-id": payload.presentation.tag }
+                      : {})
+                  }
+                }
+              }
+            }
+          })
+        }
+      );
+    } catch (error) {
+      throw new PushDeliveryError(
+        error instanceof Error ? `FCM request failed: ${error.message}` : "FCM request failed."
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (response.ok) return;
+    const body = await response.text();
+    const code = fcmErrorCode(body);
+    const permanent = code === "UNREGISTERED" || code === "SENDER_ID_MISMATCH";
+    const retryAfterMs = retryAfter(response.headers.get("retry-after"));
+    throw new PushDeliveryError(
+      `FCM returned HTTP ${response.status}${code ? ` (${code})` : ""}.`,
+      permanent,
+      retryAfterMs
+    );
+  }
+}
+
+function fcmErrorCode(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: {
+        status?: string;
+        details?: Array<{ errorCode?: string }>;
+      };
+    };
+    return parsed.error?.details?.find((detail) => detail.errorCode)?.errorCode
+      ?? parsed.error?.status;
+  } catch {
+    return undefined;
+  }
+}
+
+function retryAfter(value: string | null): number | undefined {
+  if (!value) return undefined;
+  if (/^[0-9]+$/.test(value)) return Number(value) * 1_000;
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - Date.now()) : undefined;
+}

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -5,6 +5,8 @@ import { runtimeConfigFromEnv } from "./runtime-config.js";
 import { HostedProviderClient } from "./hosted-provider.js";
 import { createRelayBroker } from "./relay-broker.js";
 import { WebPushTransport } from "./web-push.js";
+import { FcmTransport } from "./fcm.js";
+import { SignedWebhookTransport } from "./webhook.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const runtime = runtimeConfigFromEnv(process.env);
@@ -28,10 +30,24 @@ const { app } = await buildApp({
   trustProxy: runtime.trustProxy,
   allowInsecureManifests: process.env.MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS === "1",
   relayBroker,
-  notifications: runtime.vapid
+  notifications: runtime.vapid || runtime.fcm || runtime.webhookSigning
     ? {
-        publicKey: runtime.vapid.publicKey,
-        transport: new WebPushTransport(runtime.vapid)
+        ...(runtime.vapid ? { publicKey: runtime.vapid.publicKey } : {}),
+        transports: {
+          ...(runtime.vapid
+            ? { webPush: new WebPushTransport(runtime.vapid) }
+            : {}),
+          ...(runtime.fcm
+            ? { fcm: new FcmTransport({
+                ...(runtime.fcm.credentials
+                  ? { credentials: runtime.fcm.credentials }
+                  : {})
+              }) }
+            : {}),
+          ...(runtime.webhookSigning
+            ? { webhook: new SignedWebhookTransport(runtime.webhookSigning) }
+            : {})
+        }
       }
     : undefined
 });

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -54,6 +54,19 @@ const notificationCriterionSchema = z.object({
     tag: z.string().min(1).max(80).optional()
   }).strict()
 }).strict();
+const nativeNotificationDeliverySchema = z.discriminatedUnion("mode", [
+  z.object({
+    mode: z.literal("managed_fcm"),
+    firebase_project_id: z.string()
+      .min(6)
+      .max(63)
+      .regex(/^[a-z][a-z0-9-]*[a-z0-9]$/)
+  }).strict(),
+  z.object({
+    mode: z.literal("webhook"),
+    url: z.url().refine((value) => new URL(value).protocol === "https:", "Webhook URL must use HTTPS.")
+  }).strict()
+]);
 const manifestV2Schema = z.object({
   manifest_version: z.literal(2),
   ...manifestFields,
@@ -61,7 +74,8 @@ const manifestV2Schema = z.object({
     criteria: z.array(notificationCriterionSchema).max(50).refine(
       (criteria) => new Set(criteria.map((criterion) => criterion.id)).size === criteria.length,
       "Notification criterion IDs must be unique."
-    )
+    ),
+    native_delivery: nativeNotificationDeliverySchema.optional()
   }).strict().default({ criteria: [] })
 }).strict();
 const manifestSchema = z.discriminatedUnion("manifest_version", [

--- a/services/server/src/notifications.test.ts
+++ b/services/server/src/notifications.test.ts
@@ -3,7 +3,15 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase, type DatabasePool } from "./db.js";
 import { HostedProviderClient } from "./hosted-provider.js";
-import type { PushSubscriptionTarget, PushTransport } from "./notifications.js";
+import type {
+  FcmPushTarget,
+  FcmPushTransport,
+  NotificationSigningKey,
+  PushSubscriptionTarget,
+  PushTransport,
+  WebhookDeliveryTarget,
+  WebhookDeliveryTransport
+} from "./notifications.js";
 import { tokenHash } from "./security.js";
 
 class RecordingPushTransport implements PushTransport {
@@ -11,6 +19,31 @@ class RecordingPushTransport implements PushTransport {
 
   async send(target: PushSubscriptionTarget, payload: string): Promise<void> {
     this.deliveries.push({ target, payload });
+  }
+}
+
+class RecordingFcmTransport implements FcmPushTransport {
+  readonly deliveries: Array<{ target: FcmPushTarget; payload: string }> = [];
+
+  async send(target: FcmPushTarget, payload: string): Promise<void> {
+    this.deliveries.push({ target, payload });
+  }
+}
+
+class RecordingWebhookTransport implements WebhookDeliveryTransport {
+  readonly deliveries: Array<{ target: WebhookDeliveryTarget; payload: string }> = [];
+
+  async send(target: WebhookDeliveryTarget, payload: string): Promise<void> {
+    this.deliveries.push({ target, payload });
+  }
+
+  publicKeys(): NotificationSigningKey[] {
+    return [{
+      kty: "OKP",
+      crv: "Ed25519",
+      x: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      kid: "connect-test"
+    }];
   }
 }
 
@@ -104,6 +137,61 @@ describe("Web Push notifications", () => {
     });
     expect(undeclared.statusCode).toBe(403);
 
+    await fixture.db.query(
+      `UPDATE applications
+       SET notifications = $2::jsonb
+       WHERE id = (SELECT application_id FROM grants WHERE id = $1)`,
+      [
+        fixture.grantId,
+        JSON.stringify({
+          criteria: [
+            {
+              id: "task.ready",
+              event: { id: "mdbase.record.modified", version: 1 },
+              presentation: { title: "A task changed" }
+            },
+            {
+              id: "private.exfiltrate",
+              event: { id: "mdbase.record.modified", version: 1 },
+              presentation: { title: "Newly declared" }
+            }
+          ]
+        })
+      ]
+    );
+    const silentlyBroadened = await fixture.app.inject({
+      method: "POST",
+      url: "/v1/connectors/notification-signals",
+      headers: { authorization: `Bearer ${fixture.connectorToken}` },
+      payload: {
+        signal_id: "signal_manifest_broadened_012345",
+        grant_id: fixture.grantId,
+        criterion_id: "private.exfiltrate",
+        cursor: "2"
+      }
+    });
+    expect(silentlyBroadened.statusCode).toBe(403);
+    const registration = await fixture.app.inject({
+      method: "POST",
+      url: "/v1/notifications/channels",
+      headers: { authorization: `Bearer ${fixture.applicationToken}` },
+      payload: {
+        installation_id: "installation_broadening_012345",
+        criteria: ["private.exfiltrate"],
+        subscription: {
+          endpoint: "https://push.example/subscription/broadened",
+          keys: {
+            p256dh: "p256dh_012345678901234567890123456789",
+            auth: "auth_0123456789012345"
+          }
+        }
+      }
+    });
+    expect(registration.statusCode).toBe(400);
+    expect(registration.json().error.code).toBe(
+      "notification_reauthorization_required"
+    );
+
     await fixture.db.query("UPDATE grants SET revoked_at = now() WHERE id = $1", [fixture.grantId]);
     const revoked = await fixture.app.inject({
       method: "POST",
@@ -167,11 +255,112 @@ describe("Web Push notifications", () => {
       cursor: "77"
     });
   });
+
+  it("registers a managed FCM installation against the manifest project", async () => {
+    const fixture = await notificationFixture(false, {
+      nativeDelivery: {
+        mode: "managed_fcm",
+        firebase_project_id: "tasks-production"
+      }
+    });
+    const registered = await fixture.app.inject({
+      method: "POST",
+      url: "/v1/notifications/channels",
+      headers: { authorization: `Bearer ${fixture.applicationToken}` },
+      payload: {
+        installation_id: "native_installation_012345",
+        criteria: ["task.ready"],
+        transport: "fcm",
+        token: "fcm_registration_token_012345678901234567890123"
+      }
+    });
+    expect(registered.statusCode, registered.body).toBe(201);
+    expect(registered.json()).toMatchObject({
+      transport: "fcm",
+      criteria: ["task.ready"]
+    });
+
+    const accepted = await fixture.app.inject({
+      method: "POST",
+      url: "/v1/connectors/notification-signals",
+      headers: { authorization: `Bearer ${fixture.connectorToken}` },
+      payload: {
+        signal_id: "managed_fcm_signal_0123456789",
+        grant_id: fixture.grantId,
+        criterion_id: "task.ready",
+        cursor: "88"
+      }
+    });
+    expect(accepted.statusCode, accepted.body).toBe(202);
+    await eventually(() => fixture.fcm.deliveries.length === 1);
+    expect(fixture.fcm.deliveries[0].target).toEqual({
+      projectId: "tasks-production",
+      token: "fcm_registration_token_012345678901234567890123"
+    });
+    expect(JSON.parse(fixture.fcm.deliveries[0].payload)).toMatchObject({
+      signal_id: "managed_fcm_signal_0123456789",
+      cursor: "88"
+    });
+  });
+
+  it("delivers one signed-webhook route without requiring a device channel", async () => {
+    const fixture = await notificationFixture(false, {
+      nativeDelivery: {
+        mode: "webhook",
+        url: "https://hooks.tasks.example/mdbase"
+      }
+    });
+    const accepted = await fixture.app.inject({
+      method: "POST",
+      url: "/v1/connectors/notification-signals",
+      headers: { authorization: `Bearer ${fixture.connectorToken}` },
+      payload: {
+        signal_id: "webhook_signal_012345678901",
+        grant_id: fixture.grantId,
+        criterion_id: "task.ready",
+        cursor: "99"
+      }
+    });
+    expect(accepted.statusCode, accepted.body).toBe(202);
+    expect(accepted.json().deliveries).toBe(1);
+    await eventually(() => fixture.webhook.deliveries.length === 1);
+    const delivery = fixture.webhook.deliveries[0];
+    expect(delivery.target.url).toBe("https://hooks.tasks.example/mdbase");
+    expect(JSON.parse(delivery.payload)).toEqual({
+      type: "mdbase.notification.webhook",
+      version: 1,
+      delivery_id: delivery.target.deliveryId,
+      connection_id: fixture.grantId,
+      notification: {
+        type: "mdbase.notification",
+        version: 1,
+        signal_id: "webhook_signal_012345678901",
+        criterion_id: "task.ready",
+        cursor: "99",
+        presentation: {
+          title: "A task changed",
+          body: "Open Tasks to see the latest update.",
+          tag: "task-change"
+        }
+      }
+    });
+    expect(delivery.payload).not.toContain("path");
+    expect(delivery.payload).not.toContain("frontmatter");
+  });
 });
 
-async function notificationFixture(hosted = false) {
+async function notificationFixture(
+  hosted = false,
+  options: {
+    nativeDelivery?:
+      | { mode: "managed_fcm"; firebase_project_id: string }
+      | { mode: "webhook"; url: string };
+  } = {}
+) {
   const db = await createDatabase("memory");
   const transport = new RecordingPushTransport();
+  const fcm = new RecordingFcmTransport();
+  const webhook = new RecordingWebhookTransport();
   const hostedInternalToken = "hosted_internal_token_012345678901234567890123";
   const built = await buildApp({
     db,
@@ -187,7 +376,7 @@ async function notificationFixture(hosted = false) {
       : {}),
     notifications: {
       publicKey: "public_vapid_key",
-      transport,
+      transports: { webPush: transport, fcm, webhook },
       pollIntervalMs: 10
     }
   });
@@ -236,6 +425,9 @@ async function notificationFixture(hosted = false) {
       "https://tasks.example/",
       JSON.stringify(["https://tasks.example/callback"]),
       JSON.stringify({
+        ...(options.nativeDelivery
+          ? { native_delivery: options.nativeDelivery }
+          : {}),
         criteria: [{
           id: "task.ready",
           event: { id: "mdbase.record.modified", version: 1 },
@@ -251,8 +443,8 @@ async function notificationFixture(hosted = false) {
   await db.query(
     `INSERT INTO grants
        (id, user_id, application_id, ${hosted ? "hosted_collection_id" : "collection_id"},
-        operations, scope, application_origin)
-     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)`,
+        operations, scope, application_origin, notification_criteria)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8::jsonb)`,
     [
       grantId,
       userId,
@@ -260,7 +452,16 @@ async function notificationFixture(hosted = false) {
       collectionId,
       JSON.stringify(["changes", "read"]),
       JSON.stringify({ contracts: [] }),
-      "https://tasks.example"
+      "https://tasks.example",
+      JSON.stringify([{
+        id: "task.ready",
+        event: { id: "mdbase.record.modified", version: 1 },
+        presentation: {
+          title: "A task changed",
+          body: "Open Tasks to see the latest update.",
+          tag: "task-change"
+        }
+      }])
     ]
   );
   await db.query(
@@ -277,6 +478,8 @@ async function notificationFixture(hosted = false) {
     app: built.app,
     db,
     transport,
+    fcm,
+    webhook,
     grantId,
     connectorToken,
     applicationToken,

--- a/services/server/src/notifications.ts
+++ b/services/server/src/notifications.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import type {
+  ApplicationNotifications,
+  NotificationCriterion
+} from "@mdbase/connect-protocol";
 import type { DatabasePool, DatabaseQueryable } from "./db.js";
 
 export interface PushSubscriptionTarget {
@@ -10,12 +14,45 @@ export interface PushSubscriptionTarget {
   };
 }
 
+export interface FcmPushTarget {
+  projectId: string;
+  token: string;
+}
+
 export interface PushTransport {
   send(target: PushSubscriptionTarget, payload: string): Promise<void>;
 }
 
+export interface FcmPushTransport {
+  send(target: FcmPushTarget, payload: string): Promise<void>;
+}
+
+export interface WebhookDeliveryTarget {
+  deliveryId: string;
+  url: string;
+}
+
+export interface NotificationSigningKey extends JsonWebKey {
+  kid: string;
+}
+
+export interface WebhookDeliveryTransport {
+  send(target: WebhookDeliveryTarget, payload: string): Promise<void>;
+  publicKeys(): NotificationSigningKey[];
+}
+
+export interface NotificationTransports {
+  webPush?: PushTransport;
+  fcm?: FcmPushTransport;
+  webhook?: WebhookDeliveryTransport;
+}
+
 export class PushDeliveryError extends Error {
-  constructor(message: string, readonly permanent = false) {
+  constructor(
+    message: string,
+    readonly permanent = false,
+    readonly retryAfterMs?: number
+  ) {
     super(message);
   }
 }
@@ -23,19 +60,43 @@ export class PushDeliveryError extends Error {
 interface DeliveryRow {
   id: string;
   channel_id: string;
-  endpoint: string;
-  p256dh: string;
-  auth: string;
+  kind: "web_push" | "fcm";
+  endpoint: string | null;
+  p256dh: string | null;
+  auth: string | null;
   expires_at: string | null;
+  fcm_project_id: string | null;
+  fcm_token: string | null;
   signal_id: string;
   criterion_id: string;
   cursor: string;
   attempts: number;
-  notifications: {
-    criteria?: Array<{
-      id: string;
-      presentation: { title: string; body?: string; tag?: string };
-    }>;
+  notifications: ApplicationNotifications;
+  notification_criteria: NotificationCriterion[];
+}
+
+interface WebhookDeliveryRow {
+  id: string;
+  url: string;
+  signal_id: string;
+  grant_id: string;
+  criterion_id: string;
+  cursor: string;
+  attempts: number;
+  notifications: ApplicationNotifications;
+  notification_criteria: NotificationCriterion[];
+}
+
+interface NotificationPayload {
+  type: "mdbase.notification";
+  version: 1;
+  signal_id: string;
+  criterion_id: string;
+  cursor: string;
+  presentation: {
+    title: string;
+    body?: string;
+    tag?: string;
   };
 }
 
@@ -52,7 +113,7 @@ export class NotificationService {
 
   constructor(
     private readonly db: DatabasePool,
-    private readonly transport: PushTransport,
+    private readonly transports: NotificationTransports,
     private readonly pollIntervalMs = 1_000,
     private readonly onError: (error: unknown) => void = () => undefined
   ) {}
@@ -73,7 +134,10 @@ export class NotificationService {
     await this.draining;
   }
 
-  async enqueue(input: NotificationSignalInput): Promise<{ duplicate: boolean; deliveries: number }> {
+  async enqueue(input: NotificationSignalInput): Promise<{
+    duplicate: boolean;
+    deliveries: number;
+  }> {
     const connection = await this.db.connect();
     try {
       await connection.query("BEGIN");
@@ -117,6 +181,26 @@ export class NotificationService {
         );
         deliveries += inserted.rowCount ?? inserted.rows.length;
       }
+      const route = await connection.query<{
+        notifications: ApplicationNotifications;
+      }>(
+        `SELECT a.notifications
+         FROM grants g
+         JOIN applications a ON a.id = g.application_id
+         WHERE g.id = $1 AND g.revoked_at IS NULL`,
+        [input.grantId]
+      );
+      const nativeDelivery = route.rows[0]?.notifications.native_delivery;
+      if (nativeDelivery?.mode === "webhook") {
+        const inserted = await connection.query(
+          `INSERT INTO notification_webhook_deliveries (id, signal_id, url)
+           VALUES ($1, $2, $3)
+           ON CONFLICT(signal_id) DO NOTHING
+           RETURNING id`,
+          [randomUUID(), signal.rows[0].id, nativeDelivery.url]
+        );
+        deliveries += inserted.rowCount ?? inserted.rows.length;
+      }
       await connection.query("COMMIT");
       void this.drainOnce().catch(this.onError);
       return { duplicate: false, deliveries };
@@ -137,9 +221,18 @@ export class NotificationService {
   }
 
   private async performDrain(limit: number): Promise<number> {
+    const boundedLimit = Math.max(1, Math.min(limit, 500));
+    const pushes = await this.drainPushes(boundedLimit);
+    const webhooks = await this.drainWebhooks(boundedLimit);
+    return pushes + webhooks;
+  }
+
+  private async drainPushes(limit: number): Promise<number> {
     const ready = await this.db.query<DeliveryRow>(
-      `SELECT nd.id, nd.attempts, pc.id AS channel_id, pc.endpoint, pc.p256dh, pc.auth,
-              pc.expires_at, sig.signal_id, sig.criterion_id, sig.cursor, a.notifications
+      `SELECT nd.id, nd.attempts, pc.id AS channel_id, pc.kind, pc.endpoint,
+              pc.p256dh, pc.auth, pc.expires_at, pc.fcm_project_id, pc.fcm_token,
+              sig.signal_id, sig.criterion_id, sig.cursor, a.notifications,
+              g.notification_criteria
        FROM notification_deliveries nd
        JOIN notification_signals sig ON sig.id = nd.signal_id
        JOIN notification_subscriptions ns ON ns.id = nd.subscription_id
@@ -153,67 +246,122 @@ export class NotificationService {
          AND pc.disabled_at IS NULL AND g.revoked_at IS NULL
        ORDER BY nd.created_at, nd.id
        LIMIT $1`,
-      [Math.max(1, Math.min(limit, 500))]
+      [limit]
     );
     let processed = 0;
     for (const row of ready.rows) {
-      const leaseToken = randomUUID();
-      const claimed = await this.db.query(
-        `UPDATE notification_deliveries
-         SET status = 'sending', lease_token = $2, leased_until = $3, attempts = attempts + 1
-         WHERE id = $1 AND (
-           (status IN ('pending', 'retry') AND available_at <= now())
-           OR (status = 'sending' AND leased_until < now())
-         )
-         RETURNING id`,
-        [row.id, leaseToken, new Date(Date.now() + 30_000).toISOString()]
-      );
-      if (!claimed.rows[0]) continue;
+      const leaseToken = await this.claim("notification_deliveries", row.id);
+      if (!leaseToken) continue;
       processed += 1;
-      const criterion = row.notifications.criteria?.find((candidate) => candidate.id === row.criterion_id);
-      if (!criterion) {
-        await this.finish(row.id, leaseToken, "discarded", "criterion_removed");
+      const payload = notificationPayload(row);
+      if (!payload) {
+        await this.finish(
+          "notification_deliveries",
+          row.id,
+          leaseToken,
+          "criterion_removed"
+        );
+        continue;
+      }
+      try {
+        await this.sendPush(row, JSON.stringify(payload));
+        await this.markSent("notification_deliveries", row.id, leaseToken);
+      } catch (error) {
+        await this.handlePushFailure(row, leaseToken, error);
+      }
+    }
+    return processed;
+  }
+
+  private async drainWebhooks(limit: number): Promise<number> {
+    const ready = await this.db.query<WebhookDeliveryRow>(
+      `SELECT nwd.id, nwd.url, nwd.attempts, sig.signal_id, sig.grant_id,
+              sig.criterion_id, sig.cursor, a.notifications,
+              g.notification_criteria
+       FROM notification_webhook_deliveries nwd
+       JOIN notification_signals sig ON sig.id = nwd.signal_id
+       JOIN grants g ON g.id = sig.grant_id
+       JOIN applications a ON a.id = g.application_id
+       WHERE (
+         (nwd.status IN ('pending', 'retry') AND nwd.available_at <= now())
+         OR (nwd.status = 'sending' AND nwd.leased_until < now())
+       )
+         AND g.revoked_at IS NULL
+       ORDER BY nwd.created_at, nwd.id
+       LIMIT $1`,
+      [limit]
+    );
+    let processed = 0;
+    for (const row of ready.rows) {
+      const leaseToken = await this.claim("notification_webhook_deliveries", row.id);
+      if (!leaseToken) continue;
+      processed += 1;
+      const notification = notificationPayload(row);
+      if (!notification) {
+        await this.finish(
+          "notification_webhook_deliveries",
+          row.id,
+          leaseToken,
+          "criterion_removed"
+        );
+        continue;
+      }
+      const currentRoute = row.notifications.native_delivery;
+      if (
+        currentRoute?.mode !== "webhook"
+        || currentRoute.url !== row.url
+      ) {
+        await this.finish(
+          "notification_webhook_deliveries",
+          row.id,
+          leaseToken,
+          "webhook_route_removed"
+        );
+        continue;
+      }
+      if (!this.transports.webhook) {
+        await this.retry(
+          "notification_webhook_deliveries",
+          row.id,
+          leaseToken,
+          row.attempts + 1,
+          new PushDeliveryError("Signed webhook delivery is not configured.", false, 60 * 60_000)
+        );
         continue;
       }
       const payload = JSON.stringify({
-        type: "mdbase.notification",
+        type: "mdbase.notification.webhook",
         version: 1,
-        signal_id: row.signal_id,
-        criterion_id: row.criterion_id,
-        cursor: row.cursor,
-        presentation: criterion.presentation
+        delivery_id: row.id,
+        connection_id: row.grant_id,
+        notification
       });
       try {
-        await this.transport.send({
-          endpoint: row.endpoint,
-          expirationTime: row.expires_at ? Date.parse(row.expires_at) : null,
-          keys: { p256dh: row.p256dh, auth: row.auth }
-        }, payload);
-        await this.db.query(
-          `UPDATE notification_deliveries
-           SET status = 'sent', delivered_at = now(), lease_token = NULL, leased_until = NULL,
-               last_error = NULL
-           WHERE id = $1 AND lease_token = $2`,
-          [row.id, leaseToken]
+        await this.transports.webhook.send(
+          { deliveryId: row.id, url: row.url },
+          payload
+        );
+        await this.markSent(
+          "notification_webhook_deliveries",
+          row.id,
+          leaseToken
         );
       } catch (error) {
-        const deliveryError = error instanceof PushDeliveryError
-          ? error
-          : new PushDeliveryError(error instanceof Error ? error.message : "Push delivery failed.");
-        if (deliveryError.permanent) {
-          await this.db.query(
-            "UPDATE push_channels SET disabled_at = now(), updated_at = now() WHERE id = $1",
-            [row.channel_id]
+        const deliveryError = asDeliveryError(error, "Webhook delivery failed.");
+        if (deliveryError.permanent || row.attempts + 1 >= 20) {
+          await this.finish(
+            "notification_webhook_deliveries",
+            row.id,
+            leaseToken,
+            deliveryError.message
           );
-          await this.finish(row.id, leaseToken, "discarded", deliveryError.message);
         } else {
-          const delayMs = retryDelayMs(row.attempts + 1);
-          await this.db.query(
-            `UPDATE notification_deliveries
-             SET status = 'retry', available_at = $3, lease_token = NULL, leased_until = NULL,
-                 last_error = $4
-             WHERE id = $1 AND lease_token = $2`,
-            [row.id, leaseToken, new Date(Date.now() + delayMs).toISOString(), deliveryError.message.slice(0, 500)]
+          await this.retry(
+            "notification_webhook_deliveries",
+            row.id,
+            leaseToken,
+            row.attempts + 1,
+            deliveryError
           );
         }
       }
@@ -221,20 +369,153 @@ export class NotificationService {
     return processed;
   }
 
-  private async finish(
+  private async sendPush(row: DeliveryRow, payload: string): Promise<void> {
+    if (row.kind === "fcm") {
+      if (!this.transports.fcm) {
+        throw new PushDeliveryError(
+          "Managed FCM delivery is not configured.",
+          false,
+          60 * 60_000
+        );
+      }
+      if (!row.fcm_project_id || !row.fcm_token) {
+        throw new PushDeliveryError("FCM channel target is incomplete.", true);
+      }
+      const currentRoute = row.notifications.native_delivery;
+      if (
+        currentRoute?.mode !== "managed_fcm"
+        || currentRoute.firebase_project_id !== row.fcm_project_id
+      ) {
+        throw new PushDeliveryError(
+          "The application no longer declares this FCM project.",
+          true
+        );
+      }
+      await this.transports.fcm.send({
+        projectId: row.fcm_project_id,
+        token: row.fcm_token
+      }, payload);
+      return;
+    }
+    if (!this.transports.webPush) {
+      throw new PushDeliveryError(
+        "Web Push delivery is not configured.",
+        false,
+        60 * 60_000
+      );
+    }
+    if (!row.endpoint || !row.p256dh || !row.auth) {
+      throw new PushDeliveryError("Web Push channel target is incomplete.", true);
+    }
+    await this.transports.webPush.send({
+      endpoint: row.endpoint,
+      expirationTime: row.expires_at ? Date.parse(row.expires_at) : null,
+      keys: { p256dh: row.p256dh, auth: row.auth }
+    }, payload);
+  }
+
+  private async handlePushFailure(
+    row: DeliveryRow,
+    leaseToken: string,
+    error: unknown
+  ): Promise<void> {
+    const deliveryError = asDeliveryError(error, "Push delivery failed.");
+    if (deliveryError.permanent) {
+      await this.db.query(
+        "UPDATE push_channels SET disabled_at = now(), updated_at = now() WHERE id = $1",
+        [row.channel_id]
+      );
+      await this.finish(
+        "notification_deliveries",
+        row.id,
+        leaseToken,
+        deliveryError.message
+      );
+    } else {
+      await this.retry(
+        "notification_deliveries",
+        row.id,
+        leaseToken,
+        row.attempts + 1,
+        deliveryError
+      );
+    }
+  }
+
+  private async claim(table: DeliveryTable, id: string): Promise<string | null> {
+    const leaseToken = randomUUID();
+    const claimed = await this.db.query(
+      `UPDATE ${table}
+       SET status = 'sending', lease_token = $2, leased_until = $3,
+           attempts = attempts + 1
+       WHERE id = $1 AND (
+         (status IN ('pending', 'retry') AND available_at <= now())
+         OR (status = 'sending' AND leased_until < now())
+       )
+       RETURNING id`,
+      [id, leaseToken, new Date(Date.now() + 30_000).toISOString()]
+    );
+    return claimed.rows[0] ? leaseToken : null;
+  }
+
+  private async markSent(
+    table: DeliveryTable,
+    id: string,
+    leaseToken: string
+  ): Promise<void> {
+    await this.db.query(
+      `UPDATE ${table}
+       SET status = 'sent', delivered_at = now(), lease_token = NULL,
+           leased_until = NULL, last_error = NULL
+       WHERE id = $1 AND lease_token = $2`,
+      [id, leaseToken]
+    );
+  }
+
+  private async retry(
+    table: DeliveryTable,
     id: string,
     leaseToken: string,
-    status: "discarded",
+    attempt: number,
+    error: PushDeliveryError
+  ): Promise<void> {
+    const delayMs = Math.max(
+      retryDelayMs(attempt),
+      Math.min(error.retryAfterMs ?? 0, 24 * 60 * 60_000)
+    );
+    await this.db.query(
+      `UPDATE ${table}
+       SET status = 'retry', available_at = $3, lease_token = NULL,
+           leased_until = NULL, last_error = $4
+       WHERE id = $1 AND lease_token = $2`,
+      [
+        id,
+        leaseToken,
+        new Date(Date.now() + delayMs).toISOString(),
+        error.message.slice(0, 500)
+      ]
+    );
+  }
+
+  private async finish(
+    table: DeliveryTable,
+    id: string,
+    leaseToken: string,
     error: string
   ): Promise<void> {
     await this.db.query(
-      `UPDATE notification_deliveries
-       SET status = $3, lease_token = NULL, leased_until = NULL, last_error = $4
+      `UPDATE ${table}
+       SET status = 'discarded', lease_token = NULL, leased_until = NULL,
+           last_error = $3
        WHERE id = $1 AND lease_token = $2`,
-      [id, leaseToken, status, error]
+      [id, leaseToken, error.slice(0, 500)]
     );
   }
 }
+
+type DeliveryTable =
+  | "notification_deliveries"
+  | "notification_webhook_deliveries";
 
 export async function activeGrantForToken(
   db: DatabaseQueryable,
@@ -251,6 +532,32 @@ export async function activeGrantForToken(
   return result.rows[0] ?? null;
 }
 
+function notificationPayload(row: {
+  signal_id: string;
+  criterion_id: string;
+  cursor: string;
+  notification_criteria: NotificationCriterion[];
+}): NotificationPayload | null {
+  const criterion = row.notification_criteria.find(
+    (candidate) => candidate.id === row.criterion_id
+  );
+  if (!criterion) return null;
+  return {
+    type: "mdbase.notification",
+    version: 1,
+    signal_id: row.signal_id,
+    criterion_id: row.criterion_id,
+    cursor: row.cursor,
+    presentation: criterion.presentation
+  };
+}
+
+function asDeliveryError(error: unknown, fallback: string): PushDeliveryError {
+  return error instanceof PushDeliveryError
+    ? error
+    : new PushDeliveryError(error instanceof Error ? error.message : fallback);
+}
+
 function retryDelayMs(attempt: number): number {
-  return Math.min(15 * 60_000, 1_000 * (2 ** Math.min(attempt - 1, 10)));
+  return Math.min(60 * 60_000, 1_000 * (2 ** Math.min(attempt - 1, 12)));
 }

--- a/services/server/src/public-network.ts
+++ b/services/server/src/public-network.ts
@@ -1,0 +1,63 @@
+import { lookup } from "node:dns";
+import { BlockList, type LookupFunction } from "node:net";
+
+const blockedAddresses = new BlockList();
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4]
+] as const) {
+  blockedAddresses.addSubnet(network, prefix, "ipv4");
+}
+blockedAddresses.addAddress("::", "ipv6");
+blockedAddresses.addAddress("::1", "ipv6");
+blockedAddresses.addSubnet("fc00::", 7, "ipv6");
+blockedAddresses.addSubnet("fe80::", 10, "ipv6");
+blockedAddresses.addSubnet("ff00::", 8, "ipv6");
+blockedAddresses.addSubnet("2001:db8::", 32, "ipv6");
+
+export const publicHttpsLookup: LookupFunction = (hostname, options, callback) => {
+  lookup(hostname, {
+    all: true,
+    family: options.family,
+    hints: options.hints,
+    order: "verbatim"
+  }, (error, addresses) => {
+    if (error) {
+      callback(error, []);
+      return;
+    }
+    const publicAddresses = addresses.filter(({ address, family }) =>
+      isPublicNetworkAddress(address, family)
+    );
+    if (publicAddresses.length === 0) {
+      callback(
+        Object.assign(new Error("The destination resolved to a non-public address."), {
+          code: "EACCES"
+        }),
+        []
+      );
+      return;
+    }
+    if (options.all) {
+      callback(null, publicAddresses);
+    } else {
+      callback(null, publicAddresses[0].address, publicAddresses[0].family);
+    }
+  });
+};
+
+export function isPublicNetworkAddress(address: string, family: number): boolean {
+  return !blockedAddresses.check(address, family === 4 ? "ipv4" : "ipv6");
+}

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -184,7 +184,7 @@ export class RelayHub {
       operations: string[];
       scope: { contracts: Array<{ id: string; version: number }> };
       encryption: unknown | null;
-      notifications: { criteria?: unknown[] };
+      notification_criteria: unknown[];
       created_at: string;
     }>(
       `SELECT g.id, g.application_id, a.name AS application_name,
@@ -193,7 +193,7 @@ export class RelayHub {
                    ELSE g.application_origin END AS application_origin,
               a.icon AS application_icon,
               c.local_id, c.display_name AS collection_name, g.operations, g.scope,
-              g.encryption, a.notifications, g.created_at
+              g.encryption, g.notification_criteria, g.created_at
        FROM grants g
        JOIN collections c ON c.id = g.collection_id
        JOIN applications a ON a.id = g.application_id
@@ -216,7 +216,7 @@ export class RelayHub {
         application_origin: new URL(grant.application_origin).origin,
         application_icon: grant.application_icon,
         collection_name: grant.collection_name,
-        notification_criteria: grant.notifications.criteria ?? [],
+        notification_criteria: grant.notification_criteria,
         created_at: grant.created_at,
         ...(grant.encryption ? { encryption: grant.encryption } : {})
       }))

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -1,3 +1,4 @@
+import { generateKeyPairSync } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { runtimeConfigFromEnv, validateRuntimeConfig } from "./runtime-config.js";
 
@@ -196,5 +197,33 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_RELAY_NATS_URL: "nats://relay:4222",
       MDBASE_CONNECT_RELAY_NATS_TOKEN: `unsafe ${"x".repeat(40)}`
     })).toThrow(/unsupported characters/);
+  });
+
+  it("loads FCM credentials and a rotatable webhook signing keyring", () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const old = {
+      ...publicKey.export({ format: "jwk" }),
+      kid: "connect-old",
+      alg: "EdDSA",
+      use: "sig"
+    };
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_FCM_ENABLED: "1",
+      MDBASE_CONNECT_FCM_CREDENTIALS_JSON: JSON.stringify({
+        client_email: "sender@example.test"
+      }),
+      MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID: "connect-current",
+      MDBASE_CONNECT_WEBHOOK_SIGNING_PRIVATE_KEY: privateKey.export({
+        format: "pem",
+        type: "pkcs8"
+      }).toString(),
+      MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON: JSON.stringify([old])
+    });
+    expect(value.fcm?.credentials).toMatchObject({
+      client_email: "sender@example.test"
+    });
+    expect(value.webhookSigning?.previousPublicKeys).toEqual([old]);
   });
 });

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -3,6 +3,7 @@ import type { GoogleAuthConfig } from "./google-auth.js";
 import type { HostedProviderConfig } from "./hosted-provider.js";
 import type { RelayBrokerConfig } from "./relay-broker.js";
 import type { VapidConfig } from "./web-push.js";
+import type { WebhookSigningConfig } from "./webhook.js";
 
 export type RegistrationMode = "closed" | "open";
 
@@ -19,6 +20,8 @@ export interface RuntimeConfig {
   trustProxy: boolean;
   relayBroker: RelayBrokerConfig | null;
   vapid: VapidConfig | null;
+  fcm: { credentials?: Record<string, unknown> } | null;
+  webhookSigning: WebhookSigningConfig | null;
 }
 
 export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
@@ -105,6 +108,32 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
       throw new Error("Web Push requires both VAPID public and private keys.");
     }
   }
+  if (config.webhookSigning) {
+    if (!/^[A-Za-z0-9._-]{1,100}$/.test(config.webhookSigning.keyId)) {
+      throw new Error("MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID is invalid.");
+    }
+    if (!config.webhookSigning.privateKeyPem.includes("PRIVATE KEY")) {
+      throw new Error("Webhook signing requires a PEM-encoded Ed25519 private key.");
+    }
+    const keyIds = new Set([config.webhookSigning.keyId]);
+    for (const key of config.webhookSigning.previousPublicKeys ?? []) {
+      if (
+        key.kty !== "OKP"
+        || key.crv !== "Ed25519"
+        || key.alg !== "EdDSA"
+        || typeof key.x !== "string"
+        || !key.x
+        || typeof key.kid !== "string"
+        || !/^[A-Za-z0-9._-]{1,100}$/.test(key.kid)
+      ) {
+        throw new Error("Previous webhook verification keys must be Ed25519 public JWKs.");
+      }
+      if (keyIds.has(key.kid)) {
+        throw new Error("Webhook signing key IDs must be unique.");
+      }
+      keyIds.add(key.kid);
+    }
+  }
   return { ...config, publicUrl: publicUrl.origin, hostedProvider };
 }
 
@@ -138,6 +167,21 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   const vapidPublicKey = env.MDBASE_CONNECT_VAPID_PUBLIC_KEY?.trim() ?? "";
   const vapidPrivateKey = env.MDBASE_CONNECT_VAPID_PRIVATE_KEY?.trim() ?? "";
   const vapidConfigured = Boolean(vapidSubject || vapidPublicKey || vapidPrivateKey);
+  const fcmCredentialsSource = env.MDBASE_CONNECT_FCM_CREDENTIALS_JSON?.trim() ?? "";
+  const fcmEnabled = env.MDBASE_CONNECT_FCM_ENABLED === "1" || Boolean(fcmCredentialsSource);
+  const fcmCredentials = fcmCredentialsSource
+    ? parseJsonObject(fcmCredentialsSource, "MDBASE_CONNECT_FCM_CREDENTIALS_JSON")
+    : undefined;
+  const webhookKeyId = env.MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID?.trim() ?? "";
+  const webhookPrivateKey = env.MDBASE_CONNECT_WEBHOOK_SIGNING_PRIVATE_KEY?.trim() ?? "";
+  const webhookPreviousKeysSource =
+    env.MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON?.trim() ?? "";
+  const webhookPreviousPublicKeys = webhookPreviousKeysSource
+    ? parseWebhookPublicKeys(webhookPreviousKeysSource)
+    : [];
+  const webhookConfigured = Boolean(
+    webhookKeyId || webhookPrivateKey || webhookPreviousKeysSource
+  );
   if (vapidConfigured && !(vapidSubject && vapidPublicKey && vapidPrivateKey)) {
     throw new Error(
       "MDBASE_CONNECT_VAPID_SUBJECT, MDBASE_CONNECT_VAPID_PUBLIC_KEY, and MDBASE_CONNECT_VAPID_PRIVATE_KEY must be configured together."
@@ -146,6 +190,11 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   if ((relayBrokerServers.length > 0) !== Boolean(relayBrokerToken)) {
     throw new Error(
       "MDBASE_CONNECT_RELAY_NATS_URL and MDBASE_CONNECT_RELAY_NATS_TOKEN must be configured together."
+    );
+  }
+  if (webhookConfigured && !(webhookKeyId && webhookPrivateKey)) {
+    throw new Error(
+      "MDBASE_CONNECT_WEBHOOK_SIGNING_KEY_ID and MDBASE_CONNECT_WEBHOOK_SIGNING_PRIVATE_KEY must be configured together."
     );
   }
   return validateRuntimeConfig({
@@ -168,8 +217,48 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
       : null,
     vapid: vapidConfigured
       ? { subject: vapidSubject, publicKey: vapidPublicKey, privateKey: vapidPrivateKey }
+      : null,
+    fcm: fcmEnabled ? { ...(fcmCredentials ? { credentials: fcmCredentials } : {}) } : null,
+    webhookSigning: webhookConfigured
+      ? {
+          keyId: webhookKeyId,
+          privateKeyPem: webhookPrivateKey,
+          previousPublicKeys: webhookPreviousPublicKeys
+        }
       : null
   });
+}
+
+function parseWebhookPublicKeys(
+  value: string
+): NonNullable<WebhookSigningConfig["previousPublicKeys"]> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(
+      "MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON must be valid JSON."
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "MDBASE_CONNECT_WEBHOOK_PREVIOUS_PUBLIC_KEYS_JSON must contain an array."
+    );
+  }
+  return parsed as NonNullable<WebhookSigningConfig["previousPublicKeys"]>;
+}
+
+function parseJsonObject(value: string, name: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`${name} must be valid JSON.`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${name} must contain a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
 }
 
 function commaSeparatedSet(value: string | undefined): Set<string> {

--- a/services/server/src/web-push.ts
+++ b/services/server/src/web-push.ts
@@ -1,12 +1,11 @@
-import { lookup } from "node:dns";
 import { Agent } from "node:https";
-import { BlockList, type LookupFunction } from "node:net";
 import webPush from "web-push";
 import {
   PushDeliveryError,
   type PushSubscriptionTarget,
   type PushTransport
 } from "./notifications.js";
+import { isPublicNetworkAddress, publicHttpsLookup } from "./public-network.js";
 
 export interface VapidConfig {
   subject: string;
@@ -14,36 +13,10 @@ export interface VapidConfig {
   privateKey: string;
 }
 
-const blockedPushAddresses = new BlockList();
-for (const [network, prefix] of [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.0.0.0", 24],
-  ["192.0.2.0", 24],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["198.51.100.0", 24],
-  ["203.0.113.0", 24],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4]
-] as const) {
-  blockedPushAddresses.addSubnet(network, prefix, "ipv4");
-}
-blockedPushAddresses.addAddress("::", "ipv6");
-blockedPushAddresses.addAddress("::1", "ipv6");
-blockedPushAddresses.addSubnet("fc00::", 7, "ipv6");
-blockedPushAddresses.addSubnet("fe80::", 10, "ipv6");
-blockedPushAddresses.addSubnet("ff00::", 8, "ipv6");
-blockedPushAddresses.addSubnet("2001:db8::", 32, "ipv6");
-
 export class WebPushTransport implements PushTransport {
   private readonly agent = new Agent({
     keepAlive: true,
-    lookup: publicPushLookup
+    lookup: publicHttpsLookup
   });
 
   constructor(private readonly config: VapidConfig) {
@@ -76,39 +49,8 @@ export class WebPushTransport implements PushTransport {
   }
 }
 
-const publicPushLookup: LookupFunction = (hostname, options, callback) => {
-  lookup(hostname, {
-    all: true,
-    family: options.family,
-    hints: options.hints,
-    order: "verbatim"
-  }, (error, addresses) => {
-    if (error) {
-      callback(error, []);
-      return;
-    }
-    const publicAddresses = addresses.filter(({ address, family }) =>
-      isPublicPushAddress(address, family)
-    );
-    if (publicAddresses.length === 0) {
-      callback(
-        Object.assign(new Error("The Web Push endpoint resolved to a non-public address."), {
-          code: "EACCES"
-        }),
-        []
-      );
-      return;
-    }
-    if (options.all) {
-      callback(null, publicAddresses);
-    } else {
-      callback(null, publicAddresses[0].address, publicAddresses[0].family);
-    }
-  });
-};
-
 export function isPublicPushAddress(address: string, family: number): boolean {
-  return !blockedPushAddresses.check(address, family === 4 ? "ipv4" : "ipv6");
+  return isPublicNetworkAddress(address, family);
 }
 
 function webPushStatus(error: unknown): number | undefined {

--- a/services/server/src/webhook.test.ts
+++ b/services/server/src/webhook.test.ts
@@ -1,0 +1,114 @@
+import { generateKeyPairSync } from "node:crypto";
+import { verifyNotificationWebhook } from "@mdbase/connect-webhooks";
+import { describe, expect, it } from "vitest";
+import { SignedWebhookTransport } from "./webhook.js";
+
+describe("signed webhook transport", () => {
+  it("publishes the matching Ed25519 verification key", () => {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const transport = new SignedWebhookTransport({
+      keyId: "connect-2026-07",
+      privateKeyPem: privateKey.export({
+        format: "pem",
+        type: "pkcs8"
+      }).toString()
+    });
+
+    expect(transport.publicKeys()).toEqual([
+      expect.objectContaining({
+      kty: "OKP",
+      crv: "Ed25519",
+      kid: "connect-2026-07",
+      alg: "EdDSA",
+      use: "sig"
+      })
+    ]);
+  });
+
+  it("rejects non-Ed25519 signing material", () => {
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048
+    });
+    expect(() => new SignedWebhookTransport({
+      keyId: "wrong-key",
+      privateKeyPem: privateKey.export({
+        format: "pem",
+        type: "pkcs8"
+      }).toString()
+    })).toThrow("Ed25519");
+  });
+
+  it("publishes retained verification keys during rotation", () => {
+    const current = generateKeyPairSync("ed25519");
+    const previous = generateKeyPairSync("ed25519");
+    const previousJwk = {
+      ...previous.publicKey.export({ format: "jwk" }),
+      kid: "connect-previous",
+      alg: "EdDSA",
+      use: "sig"
+    };
+    const transport = new SignedWebhookTransport({
+      keyId: "connect-current",
+      privateKeyPem: current.privateKey.export({
+        format: "pem",
+        type: "pkcs8"
+      }).toString(),
+      previousPublicKeys: [previousJwk]
+    });
+    expect(transport.publicKeys().map((key) => key.kid)).toEqual([
+      "connect-current",
+      "connect-previous"
+    ]);
+  });
+
+  it("signs the exact body with replay-bounded verification headers", async () => {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const captured: Array<{
+      body: string;
+      headers: Record<string, string>;
+    }> = [];
+    const now = Date.parse("2026-07-24T06:00:00Z");
+    const transport = new SignedWebhookTransport({
+      keyId: "connect-2026-07",
+      privateKeyPem: privateKey.export({
+        format: "pem",
+        type: "pkcs8"
+      }).toString()
+    }, {
+      now: () => now,
+      post: async (_url, body, _agent, headers) => {
+        captured.push({ body, headers });
+        return { status: 204 };
+      }
+    });
+    const body = JSON.stringify({
+      type: "mdbase.notification.webhook",
+      version: 1,
+      delivery_id: "01911111-1111-7111-8111-111111111111",
+      connection_id: "01922222-2222-7222-8222-222222222222",
+      notification: {
+        type: "mdbase.notification",
+        version: 1,
+        signal_id: "opaque",
+        criterion_id: "task.changed",
+        cursor: "42",
+        presentation: { title: "Tasks changed" }
+      }
+    });
+
+    await transport.send({
+      deliveryId: "01911111-1111-7111-8111-111111111111",
+      url: "https://hooks.tasks.example/mdbase"
+    }, body);
+
+    expect(verifyNotificationWebhook({
+      body: captured[0].body,
+      headers: captured[0].headers,
+      keys: transport.publicKeys(),
+      now
+    })).toMatchObject({
+      delivery_id: "01911111-1111-7111-8111-111111111111",
+      notification: { cursor: "42" }
+    });
+  });
+});

--- a/services/server/src/webhook.ts
+++ b/services/server/src/webhook.ts
@@ -1,0 +1,157 @@
+import {
+  createPrivateKey,
+  createPublicKey,
+  sign
+} from "node:crypto";
+import { Agent, request } from "node:https";
+import {
+  PushDeliveryError,
+  type NotificationSigningKey,
+  type WebhookDeliveryTarget,
+  type WebhookDeliveryTransport
+} from "./notifications.js";
+import { publicHttpsLookup } from "./public-network.js";
+
+export interface WebhookSigningConfig {
+  keyId: string;
+  privateKeyPem: string;
+  previousPublicKeys?: NotificationSigningKey[];
+}
+
+interface WebhookResponse {
+  status: number;
+  retryAfter?: string;
+}
+
+export interface SignedWebhookTransportOptions {
+  now?: () => number;
+  post?: (
+    url: URL,
+    payload: string,
+    agent: Agent,
+    headers: Record<string, string>
+  ) => Promise<WebhookResponse>;
+}
+
+export class SignedWebhookTransport implements WebhookDeliveryTransport {
+  private readonly privateKey;
+  private readonly publicJwk: NotificationSigningKey;
+  private readonly agent = new Agent({
+    keepAlive: true,
+    lookup: publicHttpsLookup
+  });
+
+  constructor(
+    private readonly config: WebhookSigningConfig,
+    private readonly options: SignedWebhookTransportOptions = {}
+  ) {
+    this.privateKey = createPrivateKey(config.privateKeyPem);
+    if (this.privateKey.asymmetricKeyType !== "ed25519") {
+      throw new Error("Webhook signing key must be an Ed25519 private key.");
+    }
+    for (const key of config.previousPublicKeys ?? []) {
+      const publicKey = createPublicKey({
+        key: key as unknown as import("node:crypto").JsonWebKey,
+        format: "jwk"
+      });
+      if (publicKey.asymmetricKeyType !== "ed25519") {
+        throw new Error("Previous webhook verification keys must use Ed25519.");
+      }
+    }
+    this.publicJwk = {
+      ...createPublicKey(this.privateKey).export({ format: "jwk" }),
+      kid: config.keyId,
+      alg: "EdDSA",
+      use: "sig"
+    } as NotificationSigningKey;
+  }
+
+  publicKey(): NotificationSigningKey {
+    return { ...this.publicJwk };
+  }
+
+  publicKeys(): NotificationSigningKey[] {
+    return [
+      this.publicKey(),
+      ...(this.config.previousPublicKeys ?? []).map((key) => ({ ...key }))
+    ];
+  }
+
+  async send(target: WebhookDeliveryTarget, payload: string): Promise<void> {
+    const url = new URL(target.url);
+    if (
+      url.protocol !== "https:"
+      || url.username
+      || url.password
+      || url.hash
+    ) {
+      throw new PushDeliveryError("Webhook target must be an HTTPS URL.", true);
+    }
+    const timestamp = String(Math.floor((this.options.now?.() ?? Date.now()) / 1_000));
+    const signed = `${target.deliveryId}.${timestamp}.${payload}`;
+    const signature = sign(null, Buffer.from(signed), this.privateKey)
+      .toString("base64url");
+    const response = await (this.options.post ?? postJson)(url, payload, this.agent, {
+      "mdbase-webhook-id": target.deliveryId,
+      "mdbase-webhook-timestamp": timestamp,
+      "mdbase-webhook-key-id": this.config.keyId,
+      "mdbase-webhook-signature": `v1=${signature}`
+    });
+    if (response.status >= 200 && response.status < 300) return;
+    const permanent = response.status >= 300
+      && response.status < 500
+      && ![408, 409, 425, 429].includes(response.status);
+    throw new PushDeliveryError(
+      `Webhook returned HTTP ${response.status}.`,
+      permanent,
+      retryAfter(response.retryAfter)
+    );
+  }
+}
+
+async function postJson(
+  url: URL,
+  payload: string,
+  agent: Agent,
+  headers: Record<string, string>
+): Promise<WebhookResponse> {
+  return new Promise((resolve, reject) => {
+    const outgoing = request(url, {
+      method: "POST",
+      agent,
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(payload),
+        "user-agent": "mdbase-connect-notifications/1",
+        ...headers
+      }
+    }, (response) => {
+      let received = 0;
+      response.on("data", (chunk: Buffer) => {
+        received += chunk.length;
+        if (received > 64 * 1024) response.destroy();
+      });
+      response.on("end", () => resolve({
+        status: response.statusCode ?? 502,
+        ...(typeof response.headers["retry-after"] === "string"
+          ? { retryAfter: response.headers["retry-after"] }
+          : {})
+      }));
+    });
+    outgoing.setTimeout(15_000, () => {
+      outgoing.destroy(new Error("Webhook request timed out."));
+    });
+    outgoing.on("error", (error) => reject(
+      new PushDeliveryError(`Webhook request failed: ${error.message}`)
+    ));
+    outgoing.end(payload);
+  });
+}
+
+function retryAfter(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  if (/^[0-9]+$/.test(value)) return Number(value) * 1_000;
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - Date.now()) : undefined;
+}

--- a/services/server/vitest.config.ts
+++ b/services/server/vitest.config.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from "node:url";
 export default defineConfig({
   resolve: {
     alias: {
-      "@mdbase/connect-sync": fileURLToPath(new URL("../../packages/sync/src/index.ts", import.meta.url))
+      "@mdbase/connect-sync": fileURLToPath(new URL("../../packages/sync/src/index.ts", import.meta.url)),
+      "@mdbase/connect-webhooks": fileURLToPath(new URL("../../packages/webhooks/src/index.ts", import.meta.url))
     }
   },
   test: { include: ["src/**/*.test.ts"] }


### PR DESCRIPTION
Adds manifest v2 native delivery routes, durable FCM and signed webhook delivery, exact grant-time notification criteria, hardened SSRF and signature handling, the public webhook verifier package, authorization UI, and deployment documentation. Validated with the full Rust, TypeScript, relay, sync, provider, package-audit, and local connector suites.