### PR TITLE
Recover from rejected local grants

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -122,6 +122,13 @@ already granted operations and the missing requirements. An
 `missingOperations`, and `requiredOperations` metadata with a `reauthorize`
 recovery action.
 
+When the local connector definitively rejects an encrypted grant, the SDK does
+not bypass that decision through the relay. It classifies the error as requiring
+authorization, removes only the matching stale credential, and emits a `null`
+connection through `onConnectionChange()`. A subsequent
+`requestOperations()` call therefore starts authorization instead of trusting
+the stale cached capability list.
+
 Applications with full collection access can also register and maintain type
 definitions. Type source is returned with a revision token so updates cannot
 silently overwrite a definition changed by another application:

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1251,15 +1251,54 @@ schema:
 
   it("does not bypass an explicit rejection from the local authorization boundary", async () => {
     const fixture = await encryptedConnection();
+    const connectionChanges: Array<ReturnType<typeof fixture.connect.connection>> = [];
+    fixture.connect.onConnectionChange((connection) => connectionChanges.push(connection));
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       error: { code: "direct_operation_rejected", message: "Rejected locally." }
     }), { status: 403, headers: { "content-type": "application/json" } }));
 
-    await expect(fixture.connect.query()).rejects.toEqual(expect.objectContaining({
-      code: "direct_operation_rejected"
+    await expect(fixture.connect.query()).rejects.toMatchObject({
+      code: "direct_operation_rejected",
+      status: 403,
+      requiresAuthorization: true,
+      outcomeUnknown: false,
+      recovery: "reauthorize"
+    });
+    expect(connectionChanges[0]).toEqual(expect.objectContaining({
+      collectionId: fixture.collectionId
     }));
+    expect(connectionChanges.at(-1)).toBeNull();
+    expect(connectionChanges.filter((connection) => connection === null)).toHaveLength(1);
+    expect(fixture.connect.connection()).toBeNull();
+    expect(fixture.storage.getItem(fixture.tokenKey)).toBeNull();
+    await expect(fixture.keyStore.get("grant-key")).resolves.toBeNull();
+    expect(fixture.connect.authorizationCapabilities(["query"])).toMatchObject({
+      authorized: false,
+      sufficient: false,
+      missingOperations: ["query"]
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0][0])).toBe("http://127.0.0.1:28485/v1/operations");
+  });
+
+  it("clears a definitively rejected write without reporting an unknown outcome", async () => {
+    const fixture = await encryptedConnection();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      error: { code: "direct_operation_rejected", message: "Rejected locally." }
+    }), { status: 403, headers: { "content-type": "application/json" } }));
+
+    await expect(fixture.connect.create({
+      path: "rejected.md",
+      frontmatter: {},
+      body: ""
+    })).rejects.toMatchObject({
+      code: "direct_operation_rejected",
+      requiresAuthorization: true,
+      outcomeUnknown: false,
+      recovery: "reauthorize"
+    });
+    expect(fixture.connect.pendingMutation()).toBeNull();
+    expect(fixture.connect.connection()).toBeNull();
   });
 
   it("backs off an unavailable loopback route while keeping relay operations usable", async () => {
@@ -1375,7 +1414,7 @@ schema:
     }));
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0][0])).toBe("http://127.0.0.1:28485/v1/operations");
-    expect(fixture.storage.getItem(tokenKey)).not.toBeNull();
+    expect(fixture.storage.getItem(tokenKey)).toBeNull();
   });
 
   it("rejects loopback overrides that could escape the local machine", () => {
@@ -1408,7 +1447,8 @@ async function encryptedConnection() {
     application_public_key: application.publicKey,
     connector_public_key: connector.publicKey
   };
-  storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+  const tokenKey = `mdbase-connect:token:${serverUrl}:${manifestUrl}`;
+  storage.setItem(tokenKey, JSON.stringify({
     accessToken: "mdb_current",
     refreshToken: "ref_current",
     clientId: "01922222-2222-7222-8222-222222222222",
@@ -1431,6 +1471,8 @@ async function encryptedConnection() {
     manifestUrl,
     collectionId,
     storage,
+    tokenKey,
+    keyStore,
     connect: new MdbaseConnect({
       serverUrl,
       manifestUrl,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1537,6 +1537,9 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       if (attempt.pendingMutation && !attempt.directDeliveryUncertain && !attempt.resumingMutation) {
         this.clearPendingMutation();
       }
+      if (error.code === "direct_operation_rejected" && error.status === 403) {
+        this.invalidateRejectedAuthorization(token);
+      }
       throw error;
     }
     if (attempt.encryptedRequest) {
@@ -1853,6 +1856,17 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     for (const listener of this.connectionListeners) listener(connection);
   }
 
+  private invalidateRejectedAuthorization(rejected: StoredToken): void {
+    const current = parseStored<StoredToken>(this.storage.getItem(this.tokenKey()));
+    if (!current || !sameAuthorization(current, rejected)) return;
+    if (current.keyHandle) void this.keyStore.delete(current.keyHandle);
+    this.storage.removeItem(this.tokenKey());
+    this.clearPendingMutation();
+    this.route = "relay";
+    this.directStatus = this.directAccessMode === "disabled" ? "disabled" : "unavailable";
+    this.emitConnection();
+  }
+
   private currentToken(): StoredToken | null {
     const token = parseStored<StoredToken>(this.storage.getItem(this.tokenKey()));
     if (!token) return null;
@@ -2067,6 +2081,7 @@ function classifyConnectError(code: string, status?: number): Required<Pick<
 >> {
   const authorizationCodes = new Set([
     "authorization_expired",
+    "direct_operation_rejected",
     "encryption_required",
     "insufficient_access",
     "missing_grant_key",
@@ -2136,6 +2151,15 @@ function isMutation(operation: CollectionOperation, input?: unknown): boolean {
 
 function uniqueOperations(operations: CollectionOperation[]): CollectionOperation[] {
   return [...new Set(operations)];
+}
+
+function sameAuthorization(left: StoredToken, right: StoredToken): boolean {
+  if (left.grantId || right.grantId) {
+    return left.grantId === right.grantId
+      && left.keyHandle === right.keyHandle
+      && left.encryption?.key_id === right.encryption?.key_id;
+  }
+  return left.accessToken === right.accessToken;
 }
 
 function throwIfCancelled(signal?: AbortSignal): void {


### PR DESCRIPTION
## What changed

- Classify `direct_operation_rejected` as an authorization failure with `reauthorize` recovery.
- Remove only the matching stale cached grant after a definitive connector 403.
- Preserve the connector as the final authorization boundary: the SDK still does not fall back to relay on 403.
- Emit a null connection so applications can immediately present authorization again.
- Cover reads, writes, pending-mutation safety, key cleanup, capability reset, and expired cloud credentials.

## Root cause

A cached browser grant could outlive the connector's exact local grant. The connector correctly rejected operations, but the SDK treated that 403 as a request error and retained the cached capability list. `requestOperations()` then remained a no-op, trapping applications in a stale connected state.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- Focused `@mdbase/connect` tests and typecheck
