### PR TITLE
Use cloud-only Windows release signing

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.label }}
+    environment: desktop-release
     strategy:
       fail-fast: false
       matrix:
@@ -126,26 +127,94 @@ jobs:
           echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
           echo "APPLE_API_ISSUER=$APPLE_API_ISSUER" >> "$GITHUB_ENV"
 
-      - name: Prepare Windows signing certificate
+      - name: Configure SSL.com eSigner
         if: matrix.platform == 'windows'
         shell: pwsh
         env:
-          WINDOWS_CERTIFICATE_PFX_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_PFX_BASE64 }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_ESIGNER_USERNAME: ${{ secrets.WINDOWS_ESIGNER_USERNAME }}
+          WINDOWS_ESIGNER_PASSWORD: ${{ secrets.WINDOWS_ESIGNER_PASSWORD }}
+          WINDOWS_ESIGNER_TOTP_SECRET: ${{ secrets.WINDOWS_ESIGNER_TOTP_SECRET }}
         run: |
-          if (-not $env:WINDOWS_CERTIFICATE_PFX_BASE64) {
-            throw "WINDOWS_CERTIFICATE_PFX_BASE64 is not configured"
+          foreach ($name in @(
+            "WINDOWS_ESIGNER_USERNAME",
+            "WINDOWS_ESIGNER_PASSWORD",
+            "WINDOWS_ESIGNER_TOTP_SECRET"
+          )) {
+            if (-not (Get-Item "env:$name").Value) {
+              throw "$name is not configured"
+            }
           }
-          if (-not $env:WINDOWS_CERTIFICATE_PASSWORD) {
-            throw "WINDOWS_CERTIFICATE_PASSWORD is not configured"
+
+          $archive = Join-Path $env:RUNNER_TEMP "SSL.COM-eSigner-CKA_1.0.6.zip"
+          $unpacked = Join-Path $env:RUNNER_TEMP "esigner-cka-unpacked"
+          $installDir = Join-Path $env:RUNNER_TEMP "esigner-cka"
+          $masterKey = Join-Path $installDir "master.key"
+          $downloadUrl = "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
+          $expectedSha256 = "e4971440e4ebed94328492cf36e18999554c5c657c856f1cb14a6072c8b1c263"
+
+          Invoke-WebRequest -Uri $downloadUrl -OutFile $archive
+          $actualSha256 = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256) {
+            throw "Unexpected eSigner CKA archive checksum: $actualSha256"
           }
-          $certificatePath = Join-Path $env:RUNNER_TEMP "mdbase-connect-signing.pfx"
-          [IO.File]::WriteAllBytes(
-            $certificatePath,
-            [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_PFX_BASE64)
+
+          Expand-Archive -LiteralPath $archive -DestinationPath $unpacked
+          $installer = Get-ChildItem $unpacked -Recurse -File -Filter "*.exe" |
+            Where-Object { $_.Name -match "eSigner.*CKA" } |
+            Select-Object -First 1
+          if (-not $installer) {
+            throw "eSigner CKA installer is missing from the verified archive"
+          }
+
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          $install = Start-Process `
+            -FilePath $installer.FullName `
+            -ArgumentList @(
+              "/CURRENTUSER",
+              "/VERYSILENT",
+              "/SUPPRESSMSGBOXES",
+              "/DIR=$installDir"
+            ) `
+            -Wait `
+            -PassThru
+          if ($install.ExitCode -ne 0) {
+            throw "eSigner CKA installation failed with exit code $($install.ExitCode)"
+          }
+
+          $cka = Join-Path $installDir "eSignerCKATool.exe"
+          if (-not (Test-Path $cka)) {
+            throw "eSignerCKATool.exe is missing after installation"
+          }
+
+          & $cka config `
+            -mode product `
+            -user $env:WINDOWS_ESIGNER_USERNAME `
+            -pass $env:WINDOWS_ESIGNER_PASSWORD `
+            -totp $env:WINDOWS_ESIGNER_TOTP_SECRET `
+            -key $masterKey `
+            -r
+          if ($LASTEXITCODE -ne 0) {
+            throw "eSigner CKA configuration failed"
+          }
+
+          & $cka unload
+          & $cka load
+          if ($LASTEXITCODE -ne 0) {
+            throw "eSigner CKA certificate loading failed"
+          }
+
+          $certificates = @(
+            Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert |
+              Where-Object { $_.NotAfter -gt (Get-Date) }
           )
-          "WINDOWS_CERTIFICATE_FILE=$certificatePath" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "WINDOWS_CERTIFICATE_PASSWORD=$env:WINDOWS_CERTIFICATE_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Append
+          if ($certificates.Count -ne 1) {
+            throw "Expected exactly one current eSigner code-signing certificate, found $($certificates.Count)"
+          }
+
+          $thumbprint = $certificates[0].Thumbprint
+          $signParams = "/sha1 $thumbprint"
+          "WINDOWS_SIGN_WITH_PARAMS=$signParams" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/apps/desktop/forge.config.cjs
+++ b/apps/desktop/forge.config.cjs
@@ -32,27 +32,17 @@ const macSigning =
       }
     : {};
 
-const windowsSigning =
-  process.platform === "win32" &&
-  process.env.WINDOWS_CERTIFICATE_FILE &&
-  process.env.WINDOWS_CERTIFICATE_PASSWORD
+const windowsSign =
+  process.platform === "win32" && process.env.WINDOWS_SIGN_WITH_PARAMS
     ? {
-        windowsSign: {
-          certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
-          certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD
-        }
+        hashes: ["sha256"],
+        signWithParams: process.env.WINDOWS_SIGN_WITH_PARAMS,
+        timestampServer: "http://ts.ssl.com"
       }
-    : {};
+    : undefined;
 
-const squirrelSigning =
-  process.platform === "win32" &&
-  process.env.WINDOWS_CERTIFICATE_FILE &&
-  process.env.WINDOWS_CERTIFICATE_PASSWORD
-    ? {
-        certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
-        certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD
-      }
-    : {};
+const windowsSigning = windowsSign ? { windowsSign } : {};
+const squirrelSigning = windowsSign ? { windowsSign } : {};
 
 module.exports = {
   packagerConfig: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,13 +25,14 @@
     "scheduler": "^0.27.0"
   },
   "devDependencies": {
-    "@mdbase/connect-ui": "workspace:*",
     "@electron-forge/cli": "^7.11.2",
     "@electron-forge/maker-deb": "^7.11.2",
     "@electron-forge/maker-dmg": "^7.11.2",
     "@electron-forge/maker-rpm": "^7.11.2",
     "@electron-forge/maker-squirrel": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",
+    "@electron/windows-sign": "1.2.2",
+    "@mdbase/connect-ui": "workspace:*",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -41,8 +41,8 @@ downloads. Release automation should receive signing material from the CI
 secret store, never repository files or developer environment files.
 
 The `Desktop Release` workflow builds, verifies, attests, and publishes the
-installers for a version tag. Configure these GitHub Actions secrets before
-creating a tag:
+installers for a version tag. Configure these secrets in the
+`desktop-release` GitHub Actions environment before creating a tag:
 
 - `MACOS_CERTIFICATE_P12_BASE64`: base64-encoded Developer ID Application
   certificate and private key in PKCS#12 format;
@@ -50,9 +50,16 @@ creating a tag:
 - `APPLE_API_KEY_P8_BASE64`: base64-encoded App Store Connect API key;
 - `APPLE_API_KEY_ID` and `APPLE_API_ISSUER`: API key identifiers used for
   notarization;
-- `WINDOWS_CERTIFICATE_PFX_BASE64`: base64-encoded Authenticode certificate and
-  private key in PFX format;
-- `WINDOWS_CERTIFICATE_PASSWORD`: password for that PFX file.
+- `WINDOWS_ESIGNER_USERNAME`: SSL.com account username for the eSigner-enrolled
+  Windows code-signing certificate;
+- `WINDOWS_ESIGNER_PASSWORD`: SSL.com account password;
+- `WINDOWS_ESIGNER_TOTP_SECRET`: automation TOTP secret issued by eSigner.
+
+Windows releases use SSL.com eSigner Cloud Key Adapter on the ephemeral GitHub
+Actions runner. The workflow downloads a pinned CKA release, verifies its
+SHA-256 checksum, loads the cloud-held certificate into the runner certificate
+store, and signs both the application and Squirrel installer through
+`signtool.exe`. Exportable PFX files and physical USB tokens are unsupported.
 
 The tag must exactly match the root and desktop package version:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@electron-forge/maker-zip':
         specifier: ^7.11.2
         version: 7.11.2(supports-color@8.1.1)
+      '@electron/windows-sign':
+        specifier: 1.2.2
+        version: 1.2.2(supports-color@8.1.1)
       '@mdbase/connect-ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
## What changed

- removes exportable PFX and password signing from the desktop release
- configures SSL.com eSigner Cloud Key Adapter on the ephemeral Windows runner
- pins and verifies the CKA installer archive before installation
- routes both Electron Packager and Squirrel signing through `@electron/windows-sign`
- uses one SHA-256 Authenticode signature and SSL.com timestamping
- scopes desktop signing secrets to the `desktop-release` GitHub environment
- documents the three eSigner credentials required by CI

## Why

New public Windows code-signing keys must be hardware- or cloud-HSM-backed. An
exportable PFX is not an appropriate canonical release path, and a physical
token cannot work on GitHub-hosted runners.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- desktop Forge config simulated under `win32` and verified to pass identical
  cloud signing options to Packager and Squirrel
- pinned eSigner CKA archive SHA-256 and installer contents verified
- workflow YAML parsed successfully

The signed release itself remains gated on SSL.com issuing and enrolling the
publisher certificate in eSigner.
