### PR TITLE
Simplify application access requests

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -3,7 +3,11 @@ import "@fontsource/atkinson-hyperlegible/latin-700.css";
 import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
-import { groupApplicationAccess, type ApplicationAccessGroup } from "@mdbase/connect-ui/access";
+import {
+  groupApplicationAccess,
+  groupAuthorizationOperations,
+  type ApplicationAccessGroup
+} from "@mdbase/connect-ui/access";
 import { applyThemePreference, loadThemePreference, saveThemePreference, type ThemePreference } from "@mdbase/connect-ui/theme";
 import "@mdbase/connect-ui/styles.css";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -459,6 +463,10 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
   const setup = selected && request.provisionable_collection_ids.includes(selected.id)
     ? neededProvisions(request.requirements, request.provisions, selected)
     : [];
+  const permissionGroups = useMemo(
+    () => groupAuthorizationOperations(request.requested_operations),
+    [request.requested_operations]
+  );
   useEffect(() => {
     if (!available.some((collection) => collection.id === collectionId)) {
       setCollectionId(available[0]?.id ?? "");
@@ -466,36 +474,83 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
   }, [collectionId, available]);
   return (
     <article className="request-panel">
-      <div className="identity-mark">{initials(request.application_name)}</div>
       <div className="request-identity"><p className="eyebrow">Access request</p><h3>{request.application_name}</h3><code>{host(request.application_homepage)}</code><small>Expires {relativeTime(request.expires_at)}</small>{request.requirements.contracts.length > 0 && <small>{scopeDescription(request.requirements.contracts)}</small>}</div>
-      <div className="request-fields">
-        <label><span>Collection</span><select value={collectionId} disabled={available.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}{request.provisionable_collection_ids.includes(collection.id) ? " · setup required" : ""}</option>)}</select></label>
-        {available.length === 0 && <small>No registered collection supports all requested operations and contracts.</small>}
-        {setup.length > 0 && <small>Allowing access will add {provisionNames(setup)} to this collection.</small>}
-        <fieldset><legend>Requested operations</legend><OperationChoices allowed={request.requested_operations} selected={operations} onChange={setOperations} /></fieldset>
+      <div className="request-decision">
+        <section className="request-section">
+          <div><strong>Collection</strong><small>Choose where {request.application_name} can work.</small></div>
+          <div className="request-section-content">
+            <label><span>Collection on this computer</span><select value={collectionId} disabled={available.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{available.length === 0 && <option value="">No compatible collection</option>}{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}{request.provisionable_collection_ids.includes(collection.id) ? " · setup required" : ""}</option>)}</select></label>
+            {available.length === 0 && <small>No registered collection supports all requested operations and contracts.</small>}
+            {setup.length > 0 && <small>Setup needed: allowing access will add {provisionNames(setup)} to this collection.</small>}
+          </div>
+        </section>
+        <section className="request-section">
+          <div><strong>Permissions</strong><small>{request.requested_operations.length} specific actions across {permissionGroups.length} {permissionGroups.length === 1 ? "category" : "categories"}.</small></div>
+          <RequestPermissionChoices groups={permissionGroups} selected={operations} onChange={setOperations} />
+        </section>
         <NotificationAccess notifications={request.notifications} />
-      </div>
-      <div className="decision-actions">
-        <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
-        <button className="button primary" disabled={busy || !collectionId || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.approveAuthorization({ requestId: request.id, collectionId, operations }); onNotice(`${request.application_name} can now use the selected operations.`); })}>Allow access</button>
+        <footer className="request-footer">
+          <p>{selected
+            ? `${request.application_name} will use ${selected.display_name} on this computer until you revoke access.`
+            : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
+          <div className="decision-actions">
+            <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
+            <button className="button primary" disabled={busy || !collectionId || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.approveAuthorization({ requestId: request.id, collectionId, operations }); onNotice(`${request.application_name} can now use the selected operations.`); })}>Allow {request.application_name}</button>
+          </div>
+        </footer>
       </div>
     </article>
+  );
+}
+
+function RequestPermissionChoices({
+  groups,
+  selected,
+  onChange
+}: {
+  groups: ReturnType<typeof groupAuthorizationOperations>;
+  selected: string[];
+  onChange(value: string[]): void;
+}) {
+  const selectedSet = new Set(selected);
+  const total = groups.reduce((count, group) => count + group.operations.length, 0);
+  function toggle(operation: string, checked: boolean) {
+    onChange(checked
+      ? [...selected, operation]
+      : selected.filter((value) => value !== operation));
+  }
+  return (
+    <details className="request-permission-review">
+      <summary><span><strong>{selected.length} of {total} selected</strong><small>Review or narrow individual actions</small></span><b>Review</b></summary>
+      <div className="request-permission-groups">{groups.map((group) => (
+        <fieldset key={group.id}>
+          <legend>{group.label}</legend>
+          <p>{group.description}</p>
+          <div>{group.operations.map((operation) => (
+            <label key={operation.id}>
+              <input type="checkbox" checked={selectedSet.has(operation.id)} onChange={(event) => toggle(operation.id, event.target.checked)} />
+              <span>{operation.label}</span>
+            </label>
+          ))}</div>
+        </fieldset>
+      ))}</div>
+    </details>
   );
 }
 
 function NotificationAccess({ notifications }: { notifications: ApplicationNotifications }) {
   if (notifications.criteria.length === 0) return null;
   return (
-    <div className="notification-request">
-      <strong>Change notifications</strong>
-      <small>If enabled in the app, these rules run inside the collection and pushes contain no record content.</small>
+    <details className="notification-request">
+      <summary><span><strong>Change notifications</strong><small>{notifications.criteria.length} optional {plural(notifications.criteria.length, "rule", "rules")}; pushes contain no record content.</small></span><b>Details</b></summary>
       <ul>{notifications.criteria.map((criterion) => (
         <li key={criterion.id}>
           <span>{criterion.presentation.title}</span>
           <code>{criterion.event.id} v{criterion.event.version}</code>
         </li>
       ))}</ul>
-    </div>
+      <p>If you enable these in the application, the rules run inside the collection.</p>
+    </details>
   );
 }
 

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -110,23 +110,44 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .empty-state .text-action { margin-left: -7px; }
 
 .request-list { display: grid; margin-top: 10px; }
-.request-panel { display: grid; grid-template-columns: minmax(140px, 0.65fr) minmax(320px, 1.35fr) auto; align-items: center; gap: 20px; padding: 18px 0; border-bottom: 1px solid var(--line); background: var(--paper); }
+.request-panel { display: grid; grid-template-columns: minmax(150px, 0.38fr) minmax(0, 1fr); align-items: start; gap: 32px; padding: 22px 0; border-bottom: 1px solid var(--line); background: var(--paper); }
 .request-panel:first-child { border-top: 1px solid var(--line); }
 .identity-mark { display: none; }
 .request-identity, .grant-identity { display: grid; gap: 3px; }
 .request-identity h3 { margin: 0; font-size: 16px; font-weight: 700; }
 .request-identity code, .grant-identity code, .pairing-wait code, .manual-grant code { overflow: hidden; color: var(--muted); font-size: var(--type-metadata); text-overflow: ellipsis; }
 .request-identity small, .grant-identity small { color: var(--muted); font-size: var(--type-supporting); }
-.request-fields { display: grid; grid-template-columns: minmax(130px, 0.65fr) minmax(190px, 1.35fr); align-items: end; gap: 16px; }
+.request-decision { min-width: 0; border-top: 1px solid var(--line-strong); }
+.request-section { display: grid; grid-template-columns: minmax(130px, 0.38fr) minmax(0, 1fr); gap: 20px; padding: 14px 0; border-bottom: 1px solid var(--line); }
+.request-section > div:first-child { display: grid; align-content: start; gap: 3px; }
+.request-section > div:first-child > strong { font-size: var(--type-body); }
+.request-section > div:first-child > small, .request-section-content > small, .request-permission-review summary small, .notification-request summary small { color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.request-section-content { display: grid; gap: 7px; min-width: 0; }
 label > span, fieldset > legend { color: var(--muted); font-size: var(--type-supporting); font-weight: 700; }
 input, select { width: 100%; min-height: 36px; padding: 0 10px; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font-size: var(--type-body); }
-.request-fields > label, .manual-app label, .manual-grant > label, .pairing-form label { display: grid; gap: 5px; }
-.notification-request { display: grid; grid-column: 1 / -1; grid-template-columns: minmax(130px, 0.65fr) minmax(190px, 1.35fr); gap: 4px 16px; padding: 10px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
-.notification-request > strong { font-size: var(--type-supporting); }
-.notification-request > small { color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
-.notification-request ul { display: grid; grid-column: 2; gap: 4px; margin: 2px 0 0; padding: 0; list-style: none; }
+.request-section-content > label, .manual-app label, .manual-grant > label, .pairing-form label { display: grid; gap: 5px; }
+.request-permission-review, .notification-request { min-width: 0; }
+.request-permission-review > summary, .notification-request > summary { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 36px; cursor: pointer; list-style: none; }
+.request-permission-review > summary::-webkit-details-marker, .notification-request > summary::-webkit-details-marker { display: none; }
+.request-permission-review summary > span, .notification-request summary > span { display: grid; gap: 2px; }
+.request-permission-review summary strong, .notification-request summary strong { font-size: var(--type-supporting); }
+.request-permission-review summary b, .notification-request summary b { font-family: var(--mono); font-size: var(--type-action); font-weight: 500; }
+.request-permission-review summary b::after, .notification-request summary b::after { content: " +"; color: var(--muted); }
+.request-permission-review[open] summary b::after, .notification-request[open] summary b::after { content: " −"; }
+.request-permission-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 18px 24px; padding: 12px 0 2px; }
+.request-permission-groups fieldset > legend { padding: 0; color: var(--ink); }
+.request-permission-groups fieldset > p { margin: 3px 0 8px; color: var(--muted); font-size: var(--type-action); line-height: 1.4; }
+.request-permission-groups fieldset > div { display: grid; gap: 5px; }
+.request-permission-groups label { display: flex; align-items: flex-start; gap: 6px; color: var(--ink); font-size: var(--type-supporting); cursor: pointer; }
+.request-permission-groups input { width: 13px; min-height: 13px; flex: 0 0 auto; margin: 2px 0 0; accent-color: var(--ink); }
+.notification-request { padding: 11px 0; border-bottom: 1px solid var(--line); }
+.notification-request ul { display: grid; gap: 4px; margin: 8px 0 0; padding: 0; list-style: none; }
 .notification-request li { display: flex; justify-content: space-between; gap: 8px; font-size: var(--type-supporting); }
 .notification-request li code { color: var(--muted); font-size: var(--type-action); white-space: nowrap; }
+.notification-request > p { margin: 7px 0 0; color: var(--muted); font-size: var(--type-action); line-height: 1.45; }
+.request-footer { display: flex; align-items: center; justify-content: space-between; gap: 20px; padding-top: 13px; }
+.request-footer > p { max-width: 48ch; margin: 0; color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.request-footer .decision-actions { display: flex; flex: 0 0 auto; }
 fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
 fieldset legend { margin-bottom: 6px; }
 .operation-choices { display: grid; grid-template-columns: repeat(2, minmax(105px, 1fr)); gap: 5px 10px; }
@@ -196,8 +217,7 @@ fieldset legend { margin-bottom: 6px; }
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 22px; padding-top: 15px; border-top: 1px solid var(--line); }
 
 @media (max-width: 1000px) {
-  .request-panel { grid-template-columns: minmax(130px, 0.7fr) minmax(280px, 1.3fr); }
-  .decision-actions { grid-column: 1 / -1; display: flex; justify-content: flex-end; }
+  .request-panel { grid-template-columns: minmax(130px, 0.32fr) minmax(280px, 1fr); }
   .application-grant-group > summary { grid-template-columns: minmax(150px, 1fr) auto auto; }
   .application-grant-group > summary > span:last-of-type { display: none; }
   .grant-row { grid-template-columns: minmax(120px, 0.7fr) minmax(220px, 1.3fr); }
@@ -208,6 +228,10 @@ fieldset legend { margin-bottom: 6px; }
 }
 @media (max-width: 780px) {
   .content { padding-inline: 24px; }
+  .request-panel, .request-section { grid-template-columns: 1fr; }
+  .request-panel { gap: 16px; }
+  .request-section { gap: 8px; }
+  .request-footer { align-items: flex-start; flex-direction: column; }
   .readiness-panel, .pairing-panel { grid-template-columns: 1fr; gap: 24px; }
   .application-grant-group > summary { grid-template-columns: minmax(0, 1fr) auto; gap: 8px 16px; padding: 10px 0; }
   .application-grant-group > summary > span { grid-column: 1; }

--- a/apps/portal/public/theme-bootstrap.js
+++ b/apps/portal/public/theme-bootstrap.js
@@ -1,5 +1,7 @@
 try {
-  const theme = localStorage.getItem("mdbase:theme");
+  const theme = /^\/authorize\/[0-9a-f-]+$/i.test(location.pathname)
+    ? "system"
+    : localStorage.getItem("mdbase:theme");
   if (theme === "light" || theme === "dark") document.documentElement.dataset.theme = theme;
   const dark = theme === "dark" || (theme !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
   document.querySelector('meta[name="theme-color"]')?.setAttribute("content", dark ? "#1c1e24" : "#fcfcfd");

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -3,7 +3,12 @@ import "@fontsource/atkinson-hyperlegible/latin-700.css";
 import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
-import { groupApplicationAccess, type ApplicationAccessGroup } from "@mdbase/connect-ui/access";
+import {
+  authorizationOperationLabel,
+  groupApplicationAccess,
+  groupAuthorizationOperations,
+  type ApplicationAccessGroup
+} from "@mdbase/connect-ui/access";
 import { applyThemePreference, loadThemePreference, saveThemePreference, type ThemePreference } from "@mdbase/connect-ui/theme";
 import "@mdbase/connect-ui/styles.css";
 import React, { useEffect, useMemo, useRef, useState } from "react";
@@ -653,7 +658,7 @@ function PortalGrant({ grant, connectorName, disabled, onChanged, onError }: {
       <b>Review</b>
     </summary>
     <div className="portal-grant-detail">
-      <div><p className="detail-label">Allowed actions</p><div className="permission-options grant-permissions">{orderedOperations.map((operation) => <label key={operation}><input type="checkbox" checked={operations.has(operation)} disabled={inactive} onChange={() => toggle(operation)} /><span>{operationLabel(operation)}</span></label>)}</div></div>
+      <div><p className="detail-label">Allowed actions</p><div className="permission-options grant-permissions">{orderedOperations.map((operation) => <label key={operation}><input type="checkbox" checked={operations.has(operation)} disabled={inactive} onChange={() => toggle(operation)} /><span>{authorizationOperationLabel(operation)}</span></label>)}</div></div>
       <div className="grant-context"><p><span>Scope</span><strong>{grant.scope.contracts.length ? scopeDescription(grant.scope.contracts) : "All record types in this collection."}</strong></p><p><span>Application origin</span><strong className="mono-detail">{grant.application_origin}</strong></p><p><span>Connected</span><strong>{relativeTime(grant.created_at)}</strong></p></div>
       <div className="grant-actions"><button className="button secondary" disabled={inactive || !changed || operations.size === 0} onClick={() => void save()}>Save narrower access</button><button className="quiet-danger" disabled={inactive} onClick={() => void revoke()}>Revoke access</button></div>
     </div>
@@ -807,7 +812,7 @@ function Authorization({ requestId }: { requestId: string }) {
   const [status, setStatus] = useState<"pending" | "approved" | "denied">("pending");
   const [error, setError] = useState("");
   const returning = useRef(false);
-  const deepLink = useMemo(() => `mdbase-connect://authorize?server=${encodeURIComponent(location.origin)}&request=${requestId}`, [requestId]);
+  useSystemTheme();
 
   useEffect(() => {
     api<{ authorization: PendingAuthorization; collections: AvailableCollection[] }>(`/v1/authorization-requests/${requestId}`)
@@ -844,11 +849,11 @@ function Authorization({ requestId }: { requestId: string }) {
   const authorization = request.authorization;
   return (
     <main className="center-page">
-      <PageBrand label="Application request" />
+      <PageBrand label="Application request" themePicker={false} />
       <section className="decision-panel authorization-panel">
         <RequestIdentity request={authorization} large />
         {status === "pending" ? <>
-          <p>Choose the collection and exact permissions this application may use. Local collections remain under their connected computer; hosted collections remain under your mdbase account.</p>
+          <p>{authorization.application_name} is asking to use one collection. Choose where it can work and review what it can do.</p>
           {error && <div className="message error">{error}</div>}
           <ApprovalForm
             request={authorization}
@@ -859,7 +864,6 @@ function Authorization({ requestId }: { requestId: string }) {
               collections: [...current.collections, collection]
             } : current)}
           />
-          <div className="desktop-alternative"><span>Want to review this on the computer instead?</span><a href={deepLink}>Open mdbase connect</a></div>
         </> : status === "approved" ? <><p className="eyebrow outcome-label">Access approved</p><h2>Returning to the application…</h2><p>Your approved collection and permissions will follow you back.</p></> : <><p className="eyebrow outcome-label">Access denied</p><h2>Returning to the application…</h2><p>The application will show that access was not granted.</p></>}
       </section>
     </main>
@@ -916,6 +920,10 @@ function ApprovalForm({
   const [error, setError] = useState("");
   const selected = compatible.find((choice) => choice.collection.id === collectionId)?.collection;
   const setup = selected ? neededProvisions(request, selected) : [];
+  const permissionGroups = useMemo(
+    () => groupAuthorizationOperations(request.requested_operations),
+    [request.requested_operations]
+  );
 
   useEffect(() => {
     if (!compatible.some((choice) => choice.collection.id === collectionId)) {
@@ -980,43 +988,95 @@ function ApprovalForm({
 
   return (
     <div className="approval-form" aria-busy={submitting !== null}>
-      <label className="collection-field" htmlFor={`collection-${request.id}`}>
-        <span>Collection</span>
-        <select id={`collection-${request.id}`} value={collectionId} onChange={(event) => setCollectionId(event.target.value)} disabled={submitting !== null || compatible.length === 0}>
-          {compatible.length === 0 && <option value="">No compatible collection</option>}
-          {choices.map(({ collection, compatibility }) => <option value={collection.id} key={collection.id} disabled={!compatibility.compatible}>{collection.display_name} · {collection.connector_name}{compatibility.compatible ? (neededProvisions(request, collection).length ? " · setup required" : "") : ` · ${compatibility.label}`}</option>)}
-        </select>
-      </label>
-      {unavailable.length > 0 && <div className="collection-compatibility" aria-label="Unavailable collections">
-        <strong>{unavailable.length} {unavailable.length === 1 ? "collection needs attention" : "collections need attention"}</strong>
-        <ul>{unavailable.map(({ collection, compatibility }) => <li key={collection.id}><span>{collection.display_name}</span><small>{compatibility.compatible ? "" : compatibility.detail}</small></li>)}</ul>
-      </div>}
-      {compatible.length === 0 && <div className="authorization-empty-collection">
-        <p className="field-note">No compatible collection is ready.</p>
-        <button
-          className="button secondary"
-          type="button"
-          disabled={submitting !== null}
-          onClick={() => void createCloudCollection()}
-        >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>
-      </div>}
-      {setup.length > 0 && <p className="field-note">Allowing access will add {provisionNames(setup)} to this hosted collection.</p>}
-      <fieldset className="permission-field">
-        <legend>Permissions</legend>
-        <div className="permission-options">{request.requested_operations.map((operation) => (
-          <label key={operation}>
-            <input type="checkbox" checked={operations.has(operation)} onChange={() => toggleOperation(operation)} disabled={submitting !== null} />
-            <span>{operationLabel(operation)}</span>
+      <section className="approval-section">
+        <div className="approval-section-intro">
+          <strong>Collection</strong>
+          <small>Choose where {request.application_name} can work.</small>
+        </div>
+        <div className="approval-section-content">
+          <label className="collection-field" htmlFor={`collection-${request.id}`}>
+            <span>Collection and location</span>
+            <select id={`collection-${request.id}`} value={collectionId} onChange={(event) => setCollectionId(event.target.value)} disabled={submitting !== null || compatible.length === 0}>
+              {compatible.length === 0 && <option value="">No compatible collection</option>}
+              {choices.map(({ collection, compatibility }) => <option value={collection.id} key={collection.id} disabled={!compatibility.compatible}>{collection.display_name} · {collection.connector_name}{compatibility.compatible ? (neededProvisions(request, collection).length ? " · setup required" : "") : ` · ${compatibility.label}`}</option>)}
+            </select>
           </label>
-        ))}</div>
-      </fieldset>
+          {unavailable.length > 0 && <details className="collection-compatibility">
+            <summary>{compatible.length > 0
+              ? `${unavailable.length} other ${unavailable.length === 1 ? "collection is" : "collections are"} unavailable`
+              : `${unavailable.length} ${unavailable.length === 1 ? "collection is" : "collections are"} unavailable`}</summary>
+            <ul>{unavailable.map(({ collection, compatibility }) => <li key={collection.id}><span>{collection.display_name}</span><small>{compatibility.compatible ? "" : compatibility.detail}</small></li>)}</ul>
+          </details>}
+          {compatible.length === 0 && <div className="authorization-empty-collection">
+            <p className="field-note">No compatible collection is ready.</p>
+            <button
+              className="button secondary"
+              type="button"
+              disabled={submitting !== null}
+              onClick={() => void createCloudCollection()}
+            >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>
+          </div>}
+          {setup.length > 0 && <p className="field-note">Setup needed: allowing access will add {provisionNames(setup)} to this hosted collection.</p>}
+        </div>
+      </section>
+      <section className="approval-section">
+        <div className="approval-section-intro">
+          <strong>Permissions</strong>
+          <small>{request.requested_operations.length} specific actions across {permissionGroups.length} {permissionGroups.length === 1 ? "category" : "categories"}.</small>
+        </div>
+        <PermissionChoices
+          groups={permissionGroups}
+          selected={operations}
+          disabled={submitting !== null}
+          onToggle={toggleOperation}
+        />
+      </section>
       <NotificationAccess notifications={request.notifications} />
       {error && <div className="message error compact">{error}</div>}
-      <div className="approval-actions">
-        <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
-        <button className="button primary" type="button" disabled={submitting !== null || !collectionId || operations.size === 0} onClick={() => void decide("approved")}>{submitting === "approved" ? "Approving…" : "Allow access"}</button>
-      </div>
+      <footer className="approval-footer">
+        <p>{selected
+          ? `${request.application_name} will use ${selected.display_name} through ${selected.connector_name}. Access lasts until you revoke it.`
+          : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
+        <div className="approval-actions">
+          <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
+          <button className="button primary" type="button" disabled={submitting !== null || !collectionId || operations.size === 0} onClick={() => void decide("approved")}>{submitting === "approved" ? "Approving…" : `Allow ${request.application_name}`}</button>
+        </div>
+      </footer>
     </div>
+  );
+}
+
+function PermissionChoices({
+  groups,
+  selected,
+  disabled,
+  onToggle
+}: {
+  groups: ReturnType<typeof groupAuthorizationOperations>;
+  selected: ReadonlySet<string>;
+  disabled: boolean;
+  onToggle(operation: string): void;
+}) {
+  const total = groups.reduce((count, group) => count + group.operations.length, 0);
+  return (
+    <details className="permission-review">
+      <summary>
+        <span><strong>{selected.size} of {total} selected</strong><small>Review or narrow individual actions</small></span>
+        <b>Review</b>
+      </summary>
+      <div className="permission-groups">{groups.map((group) => (
+        <fieldset className="permission-group" key={group.id}>
+          <legend>{group.label}</legend>
+          <p>{group.description}</p>
+          <div>{group.operations.map((operation) => (
+            <label key={operation.id}>
+              <input type="checkbox" checked={selected.has(operation.id)} onChange={() => onToggle(operation.id)} disabled={disabled} />
+              <span>{operation.label}</span>
+            </label>
+          ))}</div>
+        </fieldset>
+      ))}</div>
+    </details>
   );
 }
 
@@ -1025,18 +1085,19 @@ function NotificationAccess({ notifications }: {
 }) {
   if (notifications.criteria.length === 0) return null;
   return (
-    <div className="notification-access">
-      <div>
-        <strong>Change notifications</strong>
-        <small>If you turn these on in the app, rules run inside the collection and pushes contain no record content.</small>
-      </div>
+    <details className="notification-access">
+      <summary>
+        <span><strong>Change notifications</strong><small>{notifications.criteria.length} optional {notifications.criteria.length === 1 ? "rule" : "rules"}; pushes contain no record content.</small></span>
+        <b>Details</b>
+      </summary>
       <ul>{notifications.criteria.map((criterion) => (
         <li key={criterion.id}>
           <span>{criterion.presentation.title}</span>
           <code>{criterion.event.id} v{criterion.event.version}</code>
         </li>
       ))}</ul>
-    </div>
+      <p>If you enable these in the application, the rules run inside the collection.</p>
+    </details>
   );
 }
 
@@ -1057,7 +1118,16 @@ function ThemeSelect() {
     saveThemePreference(next);
   }}><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>;
 }
-function PageBrand({ label }: { label: string }) { return <div className="page-brand-row"><div className="page-brand"><Brand /><span>{label}</span></div><ThemeSelect /></div>; }
+function useSystemTheme() {
+  useEffect(() => {
+    applyThemePreference("system");
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const update = () => applyThemePreference("system");
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+}
+function PageBrand({ label, themePicker = true }: { label: string; themePicker?: boolean }) { return <div className="page-brand-row"><div className="page-brand"><Brand /><span>{label}</span></div>{themePicker && <ThemeSelect />}</div>; }
 function Brand({ productLabel = false }: { productLabel?: boolean }) { return <div className="product-brand"><span className="product-brand-dot" aria-hidden="true" /><strong>mdbase</strong>{productLabel && <span className="product-brand-label">connect</span>}</div>; }
 function SectionHeading({ title, note, count }: { title: string; note: string; count?: number }) { return <div className="section-heading"><div><h2>{title}</h2><p>{note}</p></div>{count !== undefined && <span>{count}</span>}</div>; }
 function Empty({ title, text }: { title: string; text: string }) { return <div className="empty"><span className="empty-folder" /><strong>{title}</strong><p>{text}</p></div>; }
@@ -1066,24 +1136,6 @@ function initials(value: string) { return value.split(/\s+/).map((part) => part[
 function message(value: unknown) { return value instanceof Error ? value.message : String(value); }
 function host(value: string) { try { return new URL(value).host; } catch { return value; } }
 function pluralLabel(count: number, singular: string, pluralValue: string) { return `${count} ${count === 1 ? singular : pluralValue}`; }
-function operationLabel(operation: string) {
-  return ({
-    query: "Search and query",
-    list_views: "See saved views",
-    execute_view: "Run saved views",
-    read_view_source: "Inspect saved-view definitions",
-    create_view_source: "Create saved views",
-    list_timers: "List application timers",
-    put_timer: "Create or update timers",
-    cancel_timer: "Cancel timers",
-    reconcile_timers: "Reconcile application timers",
-    update_view_source: "Change saved views",
-    delete_view_source: "Delete saved views",
-    read_type: "Inspect type definitions",
-    create_type: "Create type definitions",
-    update_type: "Change type definitions"
-  } as Record<string, string>)[operation] ?? `${operation[0]?.toUpperCase() ?? ""}${operation.slice(1)}`;
-}
 function neededProvisions(
   request: Pick<PendingAuthorization, "requirements" | "provisions">,
   collection: Pick<AvailableCollection, "contracts">

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -643,10 +643,39 @@ h1 {
 
 .approval-form {
   display: grid;
-  grid-template-columns: minmax(12rem, 0.9fr) minmax(15rem, 1.2fr) auto;
-  align-items: end;
-  gap: 1rem;
   margin-top: 1.1rem;
+  border-top: 1px solid var(--line-strong);
+}
+
+.approval-section {
+  display: grid;
+  grid-template-columns: minmax(8.5rem, 0.38fr) minmax(0, 1fr);
+  gap: 1.6rem;
+  padding: 1.15rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.approval-section-intro {
+  display: grid;
+  align-content: start;
+  gap: 0.2rem;
+}
+
+.approval-section-intro > strong {
+  font-size: 0.78rem;
+}
+
+.approval-section-intro > small,
+.permission-review summary small {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.approval-section-content {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
 }
 
 .collection-field {
@@ -656,7 +685,6 @@ h1 {
 }
 
 .collection-field > span,
-.permission-field legend,
 .auth-panel label span {
   color: var(--ink-muted);
   font-size: 0.72rem;
@@ -675,24 +703,10 @@ select {
   font-size: 0.78rem;
 }
 
-.permission-field {
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.permission-field legend {
-  margin-bottom: 0.4rem;
-  padding: 0;
-}
-
 .permission-options {
   display: flex;
   flex-wrap: wrap;
-  align-content: center;
   gap: 0.45rem 0.8rem;
-  min-height: 2.4rem;
 }
 
 .permission-options label {
@@ -727,31 +741,115 @@ select {
   color: var(--danger);
 }
 
-.approval-form > .message,
-.approval-form > .field-note {
-  grid-column: 1 / -1;
+.permission-review,
+.notification-access,
+.collection-compatibility {
+  min-width: 0;
 }
 
-.notification-access {
-  display: grid;
-  grid-template-columns: minmax(12rem, 0.9fr) minmax(15rem, 1.2fr) auto;
-  grid-column: 1 / -1;
+.permission-review > summary,
+.notification-access > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
-  padding: 0.85rem 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
+  min-height: 2.4rem;
+  cursor: pointer;
+  list-style: none;
 }
 
-.notification-access > div {
+.permission-review > summary::-webkit-details-marker,
+.notification-access > summary::-webkit-details-marker,
+.collection-compatibility > summary::-webkit-details-marker {
+  display: none;
+}
+
+.permission-review > summary > span,
+.notification-access > summary > span {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.15rem;
 }
 
-.notification-access strong {
+.permission-review summary strong,
+.notification-access summary strong {
   font-size: 0.76rem;
 }
 
-.notification-access small {
+.permission-review summary b,
+.notification-access summary b {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  font-weight: 500;
+}
+
+.permission-review summary b::after,
+.notification-access summary b::after {
+  content: " +";
+  color: var(--ink-muted);
+}
+
+.permission-review[open] summary b::after,
+.notification-access[open] summary b::after {
+  content: " −";
+}
+
+.permission-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 1.2rem 1.6rem;
+  padding: 1rem 0 0.2rem;
+}
+
+.permission-group {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.permission-group legend {
+  padding: 0;
+  color: var(--ink);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.permission-group > p {
+  margin: 0.25rem 0 0.6rem;
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+
+.permission-group > div {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.permission-group label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  cursor: pointer;
+}
+
+.permission-group input {
+  width: 0.82rem;
+  height: 0.82rem;
+  flex: 0 0 auto;
+  margin: 0.12rem 0 0;
+  accent-color: var(--accent-dark);
+}
+
+.notification-access {
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.notification-access summary small {
   color: var(--ink-muted);
   font-size: 0.7rem;
   line-height: 1.45;
@@ -759,9 +857,8 @@ select {
 
 .notification-access ul {
   display: grid;
-  grid-column: 2 / -1;
   gap: 0.35rem;
-  margin: 0;
+  margin: 0.8rem 0 0;
   padding: 0;
   list-style: none;
 }
@@ -780,10 +877,38 @@ select {
   white-space: nowrap;
 }
 
+.notification-access > p {
+  margin: 0.65rem 0 0;
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  line-height: 1.45;
+}
+
+.approval-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0 0;
+}
+
+.approval-footer > p {
+  max-width: 48ch;
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.approval-form > .message {
+  margin-bottom: 0;
+}
+
 .field-note {
-  margin: -0.35rem 0 0;
+  margin: 0;
   color: var(--ink-muted);
   font-size: 0.72rem;
+  line-height: 1.45;
 }
 
 .error-copy {
@@ -989,26 +1114,20 @@ select {
 }
 
 .authorization-panel .approval-form {
-  grid-template-columns: 1fr;
   padding-top: 0.25rem;
 }
 
 .collection-compatibility {
-  padding: 0.72rem 0.8rem;
-  border-left: 2px solid var(--warning, #a96f18);
-  background: color-mix(in srgb, var(--paper) 88%, #c99038);
-}
-
-.collection-compatibility > strong {
-  color: var(--ink);
-  font-size: 0.74rem;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
 }
 
 .collection-compatibility ul {
   display: grid;
   gap: 0.55rem;
-  margin: 0.65rem 0 0;
-  padding: 0;
+  margin: 0.65rem 0 0.2rem;
+  padding: 0.65rem 0 0;
+  border-top: 1px solid var(--line);
   list-style: none;
 }
 
@@ -1025,24 +1144,6 @@ select {
 .collection-compatibility li small {
   color: var(--ink-muted);
   line-height: 1.45;
-}
-
-.desktop-alternative {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-top: 1.3rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--line);
-  color: var(--ink-muted);
-  font-size: 0.72rem;
-}
-
-.desktop-alternative a {
-  color: var(--accent-dark);
-  font-family: var(--mono);
-  font-size: 0.66rem;
 }
 
 .outcome-label {
@@ -1151,16 +1252,14 @@ select {
     display: none;
   }
 
-  .approval-form {
+  .approval-section {
     grid-template-columns: 1fr;
+    gap: 0.65rem;
   }
 
-  .notification-access {
-    grid-template-columns: 1fr;
-  }
-
-  .notification-access ul {
-    grid-column: 1;
+  .approval-footer {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .approval-actions {

--- a/apps/portal/theme-bootstrap.test.mjs
+++ b/apps/portal/theme-bootstrap.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = await readFile(new URL("./public/theme-bootstrap.js", import.meta.url), "utf8");
+
+test("authorization requests always start with the system theme", () => {
+  const context = themeContext("/authorize/11111111-1111-4111-8111-111111111111", "dark", false);
+
+  vm.runInNewContext(source, context);
+
+  assert.equal(context.document.documentElement.dataset.theme, undefined);
+  assert.equal(context.themeColor, "#fcfcfd");
+});
+
+test("other portal pages keep the saved theme preference", () => {
+  const context = themeContext("/", "dark", false);
+
+  vm.runInNewContext(source, context);
+
+  assert.equal(context.document.documentElement.dataset.theme, "dark");
+  assert.equal(context.themeColor, "#1c1e24");
+});
+
+function themeContext(pathname, savedTheme, systemDark) {
+  const context = {
+    location: { pathname },
+    localStorage: { getItem: () => savedTheme },
+    matchMedia: () => ({ matches: systemDark }),
+    themeColor: "",
+    document: {
+      documentElement: { dataset: {} },
+      querySelector: () => ({
+        setAttribute: (_name, value) => {
+          context.themeColor = value;
+        }
+      })
+    }
+  };
+  return context;
+}

--- a/packages/ui/access.test.ts
+++ b/packages/ui/access.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { groupApplicationAccess } from "./access.ts";
+import {
+  authorizationOperationLabel,
+  groupApplicationAccess,
+  groupAuthorizationOperations
+} from "./access.ts";
 
 test("groups repeated grants under a stable application identity", () => {
   const groups = groupApplicationAccess([
@@ -24,6 +28,62 @@ test("does not mutate the incoming grant order", () => {
   groupApplicationAccess(grants);
 
   assert.deepEqual(grants.map((item) => item.id), ["newest", "oldest"]);
+});
+
+test("groups requested operations into plain-language permission categories", () => {
+  assert.deepEqual(
+    groupAuthorizationOperations(["read", "query", "create", "delete", "create_view_source"]),
+    [
+      {
+        id: "view",
+        label: "View and find records",
+        description: "Read collection details, records, saved views, and type definitions.",
+        operations: [
+          { id: "read", label: "Read records" },
+          { id: "query", label: "Search and query" }
+        ]
+      },
+      {
+        id: "change",
+        label: "Change records",
+        description: "Create, edit, rename, move, or delete records.",
+        operations: [
+          { id: "create", label: "Create records" },
+          { id: "delete", label: "Delete records" }
+        ]
+      },
+      {
+        id: "manage",
+        label: "Manage collection structure",
+        description: "Create or change saved views and type definitions.",
+        operations: [
+          { id: "create_view_source", label: "Create saved views" }
+        ]
+      }
+    ]
+  );
+});
+
+test("keeps unknown operations visible and readable", () => {
+  assert.deepEqual(groupAuthorizationOperations(["publish_archive"]), [{
+    id: "other",
+    label: "Other permissions",
+    description: "Additional operations declared by this application.",
+    operations: [{ id: "publish_archive", label: "Publish archive" }]
+  }]);
+  assert.equal(authorizationOperationLabel("publish_archive"), "Publish archive");
+});
+
+test("keeps application timers in a distinct permission category", () => {
+  assert.deepEqual(groupAuthorizationOperations(["list_timers", "put_timer"]), [{
+    id: "schedule",
+    label: "Schedule app activity",
+    description: "View and manage timers owned by this application.",
+    operations: [
+      { id: "list_timers", label: "List application timers" },
+      { id: "put_timer", label: "Create or update timers" }
+    ]
+  }]);
 });
 
 function grant(id: string, applicationId: string, collectionName: string, collectionId: string, createdAt: string) {

--- a/packages/ui/access.ts
+++ b/packages/ui/access.ts
@@ -13,6 +13,89 @@ export interface ApplicationAccessGroup<Grant extends ApplicationAccessGrant> {
   grants: Grant[];
 }
 
+export interface AuthorizationOperationGroup {
+  id: string;
+  label: string;
+  description: string;
+  operations: Array<{
+    id: string;
+    label: string;
+  }>;
+}
+
+const authorizationOperationGroups = [
+  {
+    id: "view",
+    label: "View and find records",
+    description: "Read collection details, records, saved views, and type definitions.",
+    operations: [
+      "describe",
+      "changes",
+      "read",
+      "query",
+      "list_views",
+      "execute_view",
+      "read_view_source",
+      "read_type",
+      "validate"
+    ]
+  },
+  {
+    id: "change",
+    label: "Change records",
+    description: "Create, edit, rename, move, or delete records.",
+    operations: ["create", "update", "rename", "delete"]
+  },
+  {
+    id: "manage",
+    label: "Manage collection structure",
+    description: "Create or change saved views and type definitions.",
+    operations: [
+      "create_view_source",
+      "update_view_source",
+      "delete_view_source",
+      "create_type",
+      "update_type"
+    ]
+  },
+  {
+    id: "schedule",
+    label: "Schedule app activity",
+    description: "View and manage timers owned by this application.",
+    operations: [
+      "list_timers",
+      "put_timer",
+      "cancel_timer",
+      "reconcile_timers"
+    ]
+  }
+] as const;
+
+const authorizationOperationLabels: Record<string, string> = {
+  describe: "Describe the collection",
+  changes: "See collection changes",
+  read: "Read records",
+  query: "Search and query",
+  list_views: "See saved views",
+  execute_view: "Run saved views",
+  read_view_source: "Inspect saved-view definitions",
+  validate: "Check collection validity",
+  create: "Create records",
+  update: "Change records",
+  rename: "Rename or move records",
+  delete: "Delete records",
+  create_view_source: "Create saved views",
+  update_view_source: "Change saved views",
+  delete_view_source: "Delete saved views",
+  read_type: "Inspect type definitions",
+  create_type: "Create type definitions",
+  update_type: "Change type definitions",
+  list_timers: "List application timers",
+  put_timer: "Create or update timers",
+  cancel_timer: "Cancel timers",
+  reconcile_timers: "Reconcile application timers"
+};
+
 export function groupApplicationAccess<Grant extends ApplicationAccessGrant>(
   grants: readonly Grant[]
 ): ApplicationAccessGroup<Grant>[] {
@@ -39,6 +122,46 @@ export function groupApplicationAccess<Grant extends ApplicationAccessGrant>(
       grants: [...group.grants].sort(compareGrants)
     }))
     .sort((left, right) => compareText(left.applicationName, right.applicationName));
+}
+
+export function groupAuthorizationOperations(
+  operations: readonly string[]
+): AuthorizationOperationGroup[] {
+  const requested = new Set(operations);
+  const groups: AuthorizationOperationGroup[] = authorizationOperationGroups
+    .map((group) => ({
+      id: group.id,
+      label: group.label,
+      description: group.description,
+      operations: group.operations
+        .filter((operation) => requested.has(operation))
+        .map((operation) => ({
+          id: operation,
+          label: authorizationOperationLabel(operation)
+        }))
+    }))
+    .filter((group) => group.operations.length > 0);
+  const known = new Set<string>(authorizationOperationGroups.flatMap((group) => group.operations));
+  const other = operations.filter((operation) => !known.has(operation));
+
+  if (other.length > 0) {
+    groups.push({
+      id: "other",
+      label: "Other permissions",
+      description: "Additional operations declared by this application.",
+      operations: other.map((operation) => ({
+        id: operation,
+        label: authorizationOperationLabel(operation)
+      }))
+    });
+  }
+
+  return groups;
+}
+
+export function authorizationOperationLabel(operation: string): string {
+  return authorizationOperationLabels[operation]
+    ?? `${operation[0]?.toUpperCase() ?? ""}${operation.slice(1).replaceAll("_", " ")}`;
 }
 
 function compareGrants<Grant extends ApplicationAccessGrant>(left: Grant, right: Grant): number {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1480,12 +1480,12 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     const page = await context.newPage();
     await page.goto(authorizationUrl);
     await expect(page.getByRole("heading", { name: "Hosted SDK E2E" })).toBeVisible();
-    await expect(page.getByText(/Local collections remain under their connected computer/)).toBeVisible();
-    const collection = page.getByLabel("Collection");
+    await expect(page.getByText("Hosted SDK E2E is asking to use one collection. Choose where it can work and review what it can do.")).toBeVisible();
+    const collection = page.getByLabel("Collection and location");
     await expect(collection.locator("option")).toHaveCount(2);
     await collection.selectOption(collectionId);
     await expect(collection.locator("option:checked")).toHaveText("Hosted writing · Hosted by mdbase");
-    await page.getByRole("button", { name: "Allow access" }).click();
+    await page.getByRole("button", { name: "Allow Hosted SDK E2E" }).click();
     const outcome = await Promise.race([
       page.waitForURL(
         (url) => url.origin === callbackOrigin && url.searchParams.has("code")
@@ -1515,7 +1515,7 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, ca
     const page = await context.newPage();
     await page.goto(authorizationUrl);
     await expect(page.getByRole("heading", { name: "TaskNotes Inline E2E" })).toBeVisible();
-    const collection = page.getByLabel("Collection");
+    const collection = page.getByLabel("Collection and location");
     await expect(collection.locator("option")).toHaveCount(1);
     await expect(collection.locator("option:checked")).toHaveText("No compatible collection");
     await expect(collection).toBeDisabled();
@@ -1523,7 +1523,7 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, ca
     await expect(collection.locator("option")).toHaveCount(1);
     await expect(collection.locator("option:checked")).toHaveText("My tasks · mdbase cloud");
     await expect(collection).toBeEnabled();
-    await page.getByRole("button", { name: "Allow access" }).click();
+    await page.getByRole("button", { name: "Allow TaskNotes Inline E2E" }).click();
     await page.waitForURL((url) => url.origin === callbackOrigin && url.searchParams.has("code"));
     return page.url();
   } finally {


### PR DESCRIPTION
## What changed

- Restructured access requests around collection, permissions, notifications, and the final decision across the standalone web form, signed-in portal, and Electron app.
- Grouped exact operations into shared plain-language permission categories with progressive disclosure.
- Collapsed unavailable-collection explanations and notification protocol details until requested.
- Made approval copy name the application and selected collection explicitly.
- Removed the browser-to-desktop handoff from the web request.
- Removed the request-page theme picker and made authorization routes follow the system theme without overwriting the saved portal preference.

## Why

The request flow had accumulated collection compatibility, exact operation, provisioning, notification, and platform-handoff details without a corresponding information-hierarchy pass. On the portal this produced a dense warning and checkbox wall; in Electron it caused the request controls to overlap at normal window widths.

## Impact

The consequential choice stays visible while compatibility reasons, individual scopes, and event identifiers remain available on demand. Portal and desktop now share the same permission vocabulary and responsive decision structure.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm e2e`
- `pnpm e2e:provider`
- Playwright visual and interaction review at the reported portal and Electron widths, in light and dark system themes, with collapsed and expanded details and horizontal-overflow assertions
