### PR TITLE
Fix MCP full collection manifest

### DIFF
--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -25,6 +25,12 @@ describe("mdbase MCP gateway", () => {
       authorization_servers: ["https://mcp.example"],
       scopes_supported: ["mdbase:read", "mdbase:write"]
     });
+    const manifest = await app.inject({ method: "GET", url: "/.well-known/mdbase-app.json" });
+    expect(manifest.statusCode).toBe(200);
+    expect(manifest.json().requirements).toEqual({
+      access: "full_collection",
+      contracts: []
+    });
     const denied = await app.inject({
       method: "POST",
       url: "/mcp",

--- a/services/mcp/src/app.ts
+++ b/services/mcp/src/app.ts
@@ -36,7 +36,7 @@ export async function buildApp(options: BuildOptions) {
     name: "mdbase",
     homepage: config.publicUrl,
     redirect_uris: [`${config.publicUrl}/oauth/connect/callback`],
-    requirements: { contracts: [] },
+    requirements: { access: "full_collection", contracts: [] },
     provisions: { types: [] }
   };
   const gateway = new ConnectGateway(


### PR DESCRIPTION
## What changed

- declare the hosted MCP gateway's application manifest as `full_collection`
- add regression coverage for the published manifest

## Why

Connect now rejects empty contract-scoped manifests. The MCP gateway intentionally exposes collection-wide tools, but its manifest declared an empty contract list without the required explicit access boundary. This caused Claude's OAuth connection flow to fail with `invalid_request` before collection approval.

## Impact

After deployment, Claude and other MCP hosts can authorize the mdbase gateway normally. The approval screen still governs the exact operations granted for each collection.

## Validation

- `pnpm --filter @mdbase/connect-mcp... build`
- `pnpm --filter @mdbase/connect-mcp test`
- `pnpm --filter @mdbase/connect-mcp typecheck`
