### PR TITLE
Enable explicitly unsigned desktop beta previews

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.label }}
     environment: desktop-release
     strategy:
@@ -63,7 +63,11 @@ jobs:
           package_version="$(node -p "require('./package.json').version")"
           desktop_version="$(node -p "require('./apps/desktop/package.json').version")"
           test "$package_version" = "$desktop_version"
-          test "v$package_version" = "$GITHUB_REF_NAME"
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            test "v$package_version" = "$GITHUB_REF_NAME"
+          else
+            echo "Preflighting desktop version $package_version from $GITHUB_REF."
+          fi
           echo "value=$package_version" >> "$GITHUB_OUTPUT"
 
       - id: mdbase_revision
@@ -240,7 +244,7 @@ jobs:
             cosign sign-blob --yes --bundle "$package.sigstore.json" "$package"
             cosign verify-blob \
               --bundle "$package.sigstore.json" \
-              --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/desktop-release.yml@refs/tags/" \
+              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/desktop-release.yml@${GITHUB_REF}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "$package"
           done

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -31,11 +31,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: macOS signed and notarized
+          - label: macOS desktop
             os: macos-15
             artifact: desktop-macos
             platform: macos
-          - label: Windows Store and unsigned previews
+          - label: Windows desktop
             os: windows-2025
             artifact: desktop-windows
             platform: windows
@@ -96,7 +96,7 @@ jobs:
         if: matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install --yes fakeroot rpm
 
-      - name: Import Apple signing identity
+      - name: Configure Apple release mode
         if: matrix.platform == 'macos'
         shell: bash
         env:
@@ -106,11 +106,23 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
-          test -n "$MACOS_CERTIFICATE_P12_BASE64"
-          test -n "$MACOS_CERTIFICATE_PASSWORD"
-          test -n "$APPLE_API_KEY_P8_BASE64"
-          test -n "$APPLE_API_KEY_ID"
-          test -n "$APPLE_API_ISSUER"
+          if [ -z "$MACOS_CERTIFICATE_P12_BASE64" ] \
+            && [ -z "$APPLE_API_KEY_P8_BASE64" ] \
+            && [ -z "$APPLE_API_KEY_ID" ] \
+            && [ -z "$APPLE_API_ISSUER" ]; then
+            echo "MACOS_RELEASE_MODE=unsigned" >> "$GITHUB_ENV"
+            echo "Apple signing material is absent; publishing an explicitly unsigned beta preview."
+            exit 0
+          fi
+
+          if [ -z "$MACOS_CERTIFICATE_P12_BASE64" ] \
+            || [ -z "$MACOS_CERTIFICATE_PASSWORD" ] \
+            || [ -z "$APPLE_API_KEY_P8_BASE64" ] \
+            || [ -z "$APPLE_API_KEY_ID" ] \
+            || [ -z "$APPLE_API_ISSUER" ]; then
+            echo "Apple signing is partially configured; provide every certificate and API-key value or remove the signing material." >&2
+            exit 1
+          fi
 
           certificate_path="$RUNNER_TEMP/mdbase-connect-signing.p12"
           keychain_path="$RUNNER_TEMP/mdbase-connect.keychain-db"
@@ -139,11 +151,27 @@ jobs:
           echo "APPLE_API_KEY=$api_key_path" >> "$GITHUB_ENV"
           echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
           echo "APPLE_API_ISSUER=$APPLE_API_ISSUER" >> "$GITHUB_ENV"
+          echo "MACOS_RELEASE_MODE=signed" >> "$GITHUB_ENV"
 
-      - name: Configure Microsoft Store package identity
+      - name: Configure Windows release mode
         if: matrix.platform == 'windows'
         shell: pwsh
         run: |
+          $identityValues = @(
+            $env:WINDOWS_STORE_IDENTITY_NAME,
+            $env:WINDOWS_STORE_PUBLISHER,
+            $env:WINDOWS_STORE_PUBLISHER_DISPLAY_NAME
+          )
+          $configured = @($identityValues | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count
+          if ($configured -eq 0) {
+            "WINDOWS_STORE_MODE=preview" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            Write-Output "Partner Center identity is absent; publishing explicitly unsigned beta previews."
+            exit 0
+          }
+          if ($configured -ne $identityValues.Count) {
+            throw "Microsoft Store identity is partially configured; provide all three Partner Center values or remove them."
+          }
+
           $build = [int]$env:GITHUB_RUN_NUMBER
           if ($build -gt 65535) {
             throw "GitHub run number exceeds the Microsoft Store version field limit"
@@ -153,6 +181,7 @@ jobs:
             -Publisher $env:WINDOWS_STORE_PUBLISHER `
             -PublisherDisplayName $env:WINDOWS_STORE_PUBLISHER_DISPLAY_NAME `
             -PackageVersion "1.0.$build.0"
+          "WINDOWS_STORE_MODE=store" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
@@ -160,28 +189,42 @@ jobs:
       - run: pnpm test
       - run: pnpm --filter @mdbase/connect-desktop make
 
-      - name: Verify macOS signature and notarization
+      - name: Verify macOS release mode
         if: matrix.platform == 'macos'
         shell: bash
         run: |
           app_path="$(find apps/desktop/out -type d -name 'mdbase connect.app' -print -quit)"
           test -n "$app_path"
-          codesign --verify --deep --strict --verbose=2 "$app_path"
-          spctl --assess --type execute --verbose=4 "$app_path"
-          xcrun stapler validate "$app_path"
           dmg_path="$(find apps/desktop/out/make -type f -name '*.dmg' -print -quit)"
           test -n "$dmg_path"
+          if [ "$MACOS_RELEASE_MODE" = "signed" ]; then
+            codesign --verify --deep --strict --verbose=2 "$app_path"
+            spctl --assess --type execute --verbose=4 "$app_path"
+            xcrun stapler validate "$app_path"
+          else
+            if codesign -dv "$app_path" 2>&1 | grep -q "Authority=Developer ID Application"; then
+              echo "Unsigned preview unexpectedly has a Developer ID signature." >&2
+              exit 1
+            fi
+            echo "Verified that the macOS beta preview has no Developer ID signature."
+          fi
 
       - name: Verify Windows packages
         if: matrix.platform == 'windows'
         shell: pwsh
         run: |
-          ./scripts/verify-windows-packages.ps1 `
-            -OutPath "apps/desktop/out" `
-            -IdentityName $env:WINDOWS_STORE_IDENTITY_NAME `
-            -Publisher $env:WINDOWS_STORE_PUBLISHER `
-            -PublisherDisplayName $env:WINDOWS_STORE_PUBLISHER_DISPLAY_NAME `
-            -PackageVersion $env:WINDOWS_STORE_PACKAGE_VERSION
+          if ($env:WINDOWS_STORE_MODE -eq "store") {
+            ./scripts/verify-windows-packages.ps1 `
+              -OutPath "apps/desktop/out" `
+              -IdentityName $env:WINDOWS_STORE_IDENTITY_NAME `
+              -Publisher $env:WINDOWS_STORE_PUBLISHER `
+              -PublisherDisplayName $env:WINDOWS_STORE_PUBLISHER_DISPLAY_NAME `
+              -PackageVersion $env:WINDOWS_STORE_PACKAGE_VERSION
+          } else {
+            ./scripts/verify-windows-packages.ps1 `
+              -OutPath "apps/desktop/out" `
+              -PreviewOnly
+          }
 
       - name: Install cosign
         if: matrix.platform == 'linux'
@@ -203,7 +246,7 @@ jobs:
           done
 
       - name: Stage Microsoft Store submission
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && env.WINDOWS_STORE_MODE == 'store'
         shell: bash
         run: |
           mkdir -p store-artifacts
@@ -227,6 +270,16 @@ jobs:
             cp "$portable" \
               "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-windows-x64-UNSIGNED-portable.zip"
             cp docs/windows-unsigned-preview.txt release-artifacts/
+          elif [ "${{ matrix.platform }}" = "macos" ] && [ "$MACOS_RELEASE_MODE" = "unsigned" ]; then
+            dmg="$(find apps/desktop/out/make -type f -name '*.dmg' -print -quit)"
+            portable="$(find apps/desktop/out/make -type f -name '*.zip' -print -quit)"
+            test -n "$dmg"
+            test -n "$portable"
+            cp "$dmg" \
+              "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-macos-x64-UNSIGNED.dmg"
+            cp "$portable" \
+              "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-macos-x64-UNSIGNED.zip"
+            cp docs/macos-unsigned-preview.txt release-artifacts/
           else
             find apps/desktop/out/make -type f \
               \( -name '*.dmg' -o -name '*.zip' -o -name '*.deb' -o -name '*.rpm' \
@@ -247,7 +300,7 @@ jobs:
           subject-path: mdbase-connect/release-artifacts/*
 
       - name: Attest Microsoft Store submission
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && env.WINDOWS_STORE_MODE == 'store'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: mdbase-connect/store-artifacts/*
@@ -260,7 +313,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Microsoft Store submission
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && env.WINDOWS_STORE_MODE == 'store'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-store-submission
@@ -288,7 +341,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --generate-notes \
-            --notes "Windows files containing **UNSIGNED** are optional preview builds and will show Unknown Publisher/SmartScreen warnings. Install from Microsoft Store for the trusted, Store-signed Windows release." \
+            --notes "Files containing **UNSIGNED** are preview builds, not trusted platform releases. Windows will show Unknown Publisher or SmartScreen warnings. macOS will require a manual Privacy & Security override and has not been notarized. Checksums and GitHub attestations establish build provenance but do not replace platform signing." \
             --prerelease \
             --title "mdbase connect $GITHUB_REF_NAME"
 

--- a/docs/macos-unsigned-preview.txt
+++ b/docs/macos-unsigned-preview.txt
@@ -1,0 +1,13 @@
+mdbase connect — UNSIGNED and UNNOTARIZED macOS preview
+
+This GitHub download does not have an Apple Developer ID signature and has not
+been submitted to Apple's notarization service. macOS will block its first
+launch by default.
+
+Only proceed if you understand this limitation and have verified the download's
+checksum and GitHub build-provenance attestation. After attempting to open the
+app, macOS permits a one-time override under System Settings > Privacy &
+Security > Open Anyway.
+
+The trusted macOS channel is deferred until the mdbase company and Apple
+Developer Program publisher account are available.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -42,9 +42,15 @@ canonical Windows installation channel. Windows will show Unknown Publisher or
 SmartScreen warnings for them. Checksums and GitHub artifact attestations prove
 which workflow produced the files, but do not provide Authenticode trust.
 
+Before company-backed publisher accounts are available, beta releases may also
+contain macOS DMG and ZIP files whose names contain `UNSIGNED`. They are neither
+Developer ID signed nor notarized and require a manual Gatekeeper override.
+Their bundled warning, checksums, and GitHub attestations describe the exact
+trust boundary.
+
 The `Desktop Release` workflow builds, verifies, attests, and publishes the
-installers for a version tag. Configure these secrets in the
-`desktop-release` GitHub Actions environment before creating a tag:
+installers for a version tag. To enable trusted macOS output, configure these
+secrets in the `desktop-release` GitHub Actions environment:
 
 - `MACOS_CERTIFICATE_P12_BASE64`: base64-encoded Developer ID Application
   certificate and private key in PKCS#12 format;
@@ -54,14 +60,16 @@ installers for a version tag. Configure these secrets in the
   notarization.
 
 Reserve `mdbase connect` in Partner Center, then copy the following non-secret
-values from **Product identity** into variables on the same GitHub environment:
+values from **Product identity** into variables on the same GitHub environment
+to additionally build a Store-submission package:
 
 - `WINDOWS_STORE_IDENTITY_NAME`: the exact package Identity/Name;
 - `WINDOWS_STORE_PUBLISHER`: the exact package Identity/Publisher;
 - `WINDOWS_STORE_PUBLISHER_DISPLAY_NAME`: the exact publisher display name.
 
-The Windows job creates a Store-submission AppX whose manifest is checked
-against those values. The workflow uses `1.0.<GitHub run number>.0` as the
+When those values are present, the Windows job creates a Store-submission AppX
+whose manifest is checked against them. The workflow uses
+`1.0.<GitHub run number>.0` as the
 monotonically increasing Store package version; the fourth component remains
 zero as required by the Store. The AppX is retained as the
 `windows-store-submission` Actions artifact and is deliberately excluded from
@@ -76,12 +84,14 @@ git tag -a v0.1.0-beta.1 -m "mdbase connect 0.1.0-beta.1"
 git push origin v0.1.0-beta.1
 ```
 
-The workflow refuses to publish when Apple signing material or Partner Center
-identity values are absent, macOS notarization or signature verification fails,
-or the Store package identity is wrong. It also verifies that the Windows
-GitHub preview executables are unsigned before labeling and publishing them.
-Linux packages receive keyless Sigstore bundles, checksums, and GitHub artifact
-attestations.
+When platform publisher configuration is wholly absent, the workflow publishes
+only explicitly labelled preview artifacts for that platform. Partially
+configured Apple signing material or Partner Center identity values fail the
+build. Fully configured trusted paths remain fail-closed when macOS
+notarization, signature verification, or Store package identity checks fail.
+The workflow also verifies that GitHub preview executables are unsigned before
+labeling and publishing them. Linux packages receive keyless Sigstore bundles,
+checksums, and GitHub artifact attestations.
 
 Before publishing a version, record the exact `mdbase-rs` revision, run the
 local and oracle end-to-end suites, retain checksums for every artifact, verify

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -77,6 +77,17 @@ the GitHub release. Upload it to the matching Partner Center submission. The
 Store replaces its build-time development signature with Microsoft's
 certificate after certification.
 
+Before creating a release tag, run the workflow manually from the commit that
+will be tagged:
+
+```bash
+gh workflow run desktop-release.yml --ref main
+```
+
+This preflight builds, verifies, signs where configured, attests, and uploads
+all platform artifacts without creating a GitHub release. Require the macOS,
+Windows, Linux, and Windows Store smoke-test jobs to pass before tagging.
+
 The tag must exactly match the root and desktop package version:
 
 ```bash

--- a/docs/windows-unsigned-preview.txt
+++ b/docs/windows-unsigned-preview.txt
@@ -4,6 +4,7 @@ This GitHub download is intentionally not Authenticode-signed. Windows will
 identify its publisher as unknown and Microsoft Defender SmartScreen may warn
 or block it.
 
-For the trusted Windows release, install mdbase connect from Microsoft Store.
-Checksums and GitHub artifact attestations can verify this preview's integrity
-and build provenance, but they do not remove Windows publisher warnings.
+The trusted Microsoft Store channel is deferred until the mdbase publisher
+account is available. Checksums and GitHub artifact attestations can verify this
+preview's integrity and build provenance, but they do not remove Windows
+publisher warnings.

--- a/scripts/verify-windows-packages.ps1
+++ b/scripts/verify-windows-packages.ps1
@@ -3,16 +3,14 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$OutPath,
 
-  [Parameter(Mandatory = $true)]
+  [switch]$PreviewOnly,
+
   [string]$IdentityName,
 
-  [Parameter(Mandatory = $true)]
   [string]$Publisher,
 
-  [Parameter(Mandatory = $true)]
   [string]$PublisherDisplayName,
 
-  [Parameter(Mandatory = $true)]
   [string]$PackageVersion
 )
 
@@ -50,18 +48,41 @@ $portable = Get-SinglePackageFile `
   -Files @(
     Get-ChildItem (Join-Path $OutPath "make") -Recurse -File -Filter "*.zip"
   )
-$storePackage = Get-SinglePackageFile `
-  -Description "Microsoft Store AppX package" `
-  -Files @(
-    Get-ChildItem (Join-Path $OutPath "make") -Recurse -File -Filter "*.appx"
-  )
-
 foreach ($file in @($application, $installer)) {
   $signature = Get-AuthenticodeSignature $file.FullName
   if ($signature.Status -ne "NotSigned") {
     throw "Expected unsigned GitHub preview executable, got $($signature.Status): $($file.FullName)"
   }
 }
+
+if ($PreviewOnly) {
+  $storePackages = @(
+    Get-ChildItem (Join-Path $OutPath "make") -Recurse -File -Filter "*.appx"
+  )
+  if ($storePackages.Count -ne 0) {
+    throw "Preview-only build unexpectedly produced a Microsoft Store AppX package"
+  }
+  Write-Output "Verified unsigned setup preview: $($installer.FullName)"
+  Write-Output "Verified unsigned portable preview: $($portable.FullName)"
+  exit 0
+}
+
+foreach ($value in @{
+  IdentityName = $IdentityName
+  Publisher = $Publisher
+  PublisherDisplayName = $PublisherDisplayName
+  PackageVersion = $PackageVersion
+}.GetEnumerator()) {
+  if ([string]::IsNullOrWhiteSpace([string]$value.Value)) {
+    throw "$($value.Key) is required when verifying a Microsoft Store package"
+  }
+}
+
+$storePackage = Get-SinglePackageFile `
+  -Description "Microsoft Store AppX package" `
+  -Files @(
+    Get-ChildItem (Join-Path $OutPath "make") -Recurse -File -Filter "*.appx"
+  )
 
 function Find-WindowsSdkTool {
   param(


### PR DESCRIPTION
## Summary

- publish clearly labelled unsigned macOS and Windows beta previews when platform publisher credentials are absent
- keep partially configured and fully configured signing paths fail-closed
- add a manual, non-publishing desktop release preflight before tagging
- retain Linux Sigstore bundles, checksums, and GitHub attestations

## Validation

- workflow YAML parses successfully
- release changes passed Node, server, hosted-provider, and Windows Store packaging checks on PR #47 before being cleanly split onto current main
- the current main manifest fix remains intact

PR #47 is superseded because its protocol-v1 changes were independently merged in PR #48.