### PR TITLE
Fix Linux desktop packaging

### DIFF
--- a/apps/desktop/forge.config.cjs
+++ b/apps/desktop/forge.config.cjs
@@ -8,13 +8,27 @@ const agent = path.resolve(
 );
 const macIcon = path.resolve(__dirname, "assets/app-icon.icns");
 const windowsIcon = path.resolve(__dirname, "assets/app-icon.ico");
+const linuxIcon = path.resolve(__dirname, "assets/app-icon.png");
 const windowsStoreAssets = path.resolve(__dirname, "assets/appx");
 const platformIcon =
   process.platform === "darwin"
     ? macIcon
     : process.platform === "win32"
       ? windowsIcon
-      : path.resolve(__dirname, "assets/app-icon.png");
+      : linuxIcon;
+
+const linuxMakerOptions = {
+  name: "mdbase-connect",
+  productName: "mdbase connect",
+  genericName: "mdbase connector",
+  description: "Connect applications to authorized mdbase collections.",
+  productDescription:
+    "Connect applications to authorized local and hosted mdbase collections.",
+  bin: "mdbase-connect",
+  homepage: "https://mdbase.dev",
+  icon: linuxIcon,
+  categories: ["Utility"]
+};
 
 const macSigning =
   process.platform === "darwin" &&
@@ -91,8 +105,19 @@ const platformMakers =
           }
         ]
       : [
-          { name: "@electron-forge/maker-deb" },
-          { name: "@electron-forge/maker-rpm" }
+          {
+            name: "@electron-forge/maker-deb",
+            config: { options: linuxMakerOptions }
+          },
+          {
+            name: "@electron-forge/maker-rpm",
+            config: {
+              options: {
+                ...linuxMakerOptions,
+                license: "MIT"
+              }
+            }
+          }
         ];
 
 module.exports = {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,6 +38,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "electron": "^43.1.1",
+    "lodash": "^4.18.1",
     "playwright-core": "^1.61.1",
     "typescript": "^7.0.2",
     "vite": "^8.1.5"

--- a/apps/desktop/test/forge-config.test.mjs
+++ b/apps/desktop/test/forge-config.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+
+test(
+  "Linux makers target the packaged executable",
+  { skip: process.platform !== "linux" },
+  () => {
+    const config = require("../forge.config.cjs");
+    const makers = new Map(config.makers.map((maker) => [maker.name, maker]));
+
+    assert.equal(config.packagerConfig.executableName, "mdbase-connect");
+
+    for (const name of [
+      "@electron-forge/maker-deb",
+      "@electron-forge/maker-rpm"
+    ]) {
+      const options = makers.get(name)?.config?.options;
+      assert.equal(options?.name, "mdbase-connect");
+      assert.equal(options?.bin, "mdbase-connect");
+    }
+
+    assert.equal(
+      makers.get("@electron-forge/maker-rpm")?.config?.options?.license,
+      "MIT"
+    );
+  }
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       electron:
         specifier: ^43.1.1
         version: 43.1.1(supports-color@8.1.1)
+      lodash:
+        specifier: ^4.18.1
+        version: 4.18.1
       playwright-core:
         specifier: ^1.61.1
         version: 1.61.1
@@ -6234,8 +6237,7 @@ snapshots:
   lodash.merge@4.6.2:
     optional: true
 
-  lodash@4.18.1:
-    optional: true
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:


### PR DESCRIPTION
## What changed

- declare `lodash` as an explicit desktop build dependency
- update the pnpm lockfile so it is no longer treated as optional
- give the DEB and RPM makers explicit package and executable names
- cover the Linux maker contract with a regression test

## Why

The full desktop preflight successfully built Windows plus both macOS
architectures, but Electron Forge rejected the Linux DEB/RPM makers. Their
optional installer packages load `lodash`; pnpm's hoisted workspace install had
classified that shared package as optional and omitted it, causing Forge to
report both makers as unsupported. After resolving that dependency, the makers
also inherited the scoped workspace package name (`@mdbase/connect-desktop`) as
their binary path instead of the packaged executable (`mdbase-connect`).

## Impact

Clean Linux installs now materialize the dependency required by
`electron-installer-debian` and `electron-installer-redhat`, allowing the DEB/RPM
packaging stage to run with valid package metadata and the correct executable.

## Validation

- clean pnpm dependency reconstruction
- `electron-installer-debian` and `electron-installer-redhat` load successfully
- both Forge makers report supported on Linux
- Linux maker regression test verifies package and executable names
- `pnpm --filter @mdbase/connect-desktop test`
- `pnpm --filter @mdbase/connect-desktop typecheck`
- `git diff --check`

Full preflight context:
https://github.com/mdbase-dev/mdbase-connect/actions/runs/30152255779
