### PR TITLE
Publish the Connect SDK documentation boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ on a user's local or mdbase-hosted [mdbase](https://mdbase.dev) collections.
 Local collection folders are never exposed directly to the internet; hosted
 collections keep their authoritative Markdown on mdbase with optional mirrors.
 
+Build an application with the task-oriented
+[Connect SDK guide](https://mdbase.dev/sdk/), or start with the
+[five-minute quickstart](https://mdbase.dev/sdk/quickstart/).
+
 Applications bundle declarations that can include portable type provisions.
 When a selected collection is missing a required contract, its local or hosted
 authority installs the declared type during approval, verifies the resulting

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,6 +1,6 @@
 # Encryption architecture
 
-Status: encrypted relay implemented; hosted encryption remains a design
+Status: encrypted relay and standard hosted encryption implemented
 
 ## Purpose
 
@@ -43,6 +43,14 @@ implementations and exercises tampering, replay, scope, pause, revocation, and
 downgrade behavior. Connector identity material currently lives in a mode-0600
 agent state file. Moving it into platform-protected storage, verifying first
 contact, and auditing logs remain public-release gates.
+
+The hosted provider encrypts canonical records, retained versions, change
+payloads, mutation receipts, and collection resources with AES-256-GCM under a
+random per-collection data key. It wraps that key with the provider deployment
+master key and authenticates ciphertext identity as associated data. PostgreSQL
+retains the wrapped key, ciphertext, and the explicit metadata listed below.
+Key-service integration, online key rotation, and restore drills remain release
+operations work; private/zero-knowledge hosting is not implemented.
 
 Local Markdown files are also plaintext from mdbase's perspective. Operating
 system full-disk encryption, encrypted home directories, and device access
@@ -226,43 +234,53 @@ provider while the collection key is available to that provider.
 
 ### Infrastructure encryption
 
-Managed-database volume encryption and encrypted backups form the minimum
-baseline. Their keys are controlled separately from database credentials and
-follow documented rotation and recovery procedures.
+Managed-database volume encryption and encrypted backups form the deployment
+baseline. They complement, but do not replace, the application-level collection
+encryption below. Deployment verification and restore drills are release gates.
 
 ### Collection envelope encryption
 
-Each hosted collection receives a random data-encryption key. A key-encryption
-key held by a managed key service wraps that collection key. PostgreSQL stores
-the wrapped collection key and encrypted content; the key service controls
-unwrapping and records its use.
+Each hosted collection receives a random 256-bit data-encryption key. A
+deployment master key supplied to the Rust provider wraps that collection key.
+PostgreSQL stores the wrapped collection key and encrypted content. Provider
+startup verifies the supplied master key against an authenticated database key
+check and refuses a mismatched key.
 
-Each canonical document and retained version is authenticated with its
-collection ID, record ID, revision, and format version. Nonces are unique per
-key and record version. Key rotation creates a new key version and re-encrypts
-content incrementally while old versions remain readable during the migration.
+AES-256-GCM envelopes carry a random 96-bit nonce. Associated data binds each
+envelope to its purpose and identity: collection resources to the collection;
+record documents and versions to collection, record, and sequence; changes to
+collection, sequence, and side; and receipts to replica and mutation. Moving
+ciphertext to another identity therefore fails authentication.
 
-The provider unwraps a collection key only while serving authorized work and
-keeps plaintext and unwrapped keys out of logs, crash reports, and durable
-caches. Memory clearing has platform limits, so operational isolation and
-short-lived provider processes remain part of the protection.
+The provider decrypts records to evaluate authorized operations through
+`mdbase-rs`. Plaintext and unwrapped keys must stay out of logs, crash reports,
+and durable caches. Memory clearing has platform limits, so operational
+isolation remains part of the protection.
+
+The current provider does not support live master-key or collection-key
+rotation. Backup restoration must use the original provider master key. A
+versioned key-service integration, rotation procedure, and restore drill remain
+release operations work.
 
 ### Hosted metadata
 
-The hosted design records which metadata remains visible. A practical first
-version can leave tenant, collection, record ID, revision, sequence, size,
-deletion state, and contract-routing metadata in plaintext. Paths can be
-encrypted while a keyed path token enforces uniqueness.
+The implemented schema leaves collection and replica identifiers, record IDs,
+revisions, sequences, sizes, deletion state, matched type labels, quotas, and
+contract-routing metadata in plaintext. Record paths live inside encrypted
+record payloads; an HMAC-SHA-256 path token supports equality lookup and
+uniqueness without storing the record path itself. Resource paths such as
+`mdbase.yaml` and type-definition paths are visible.
 
-Frontmatter values, bodies, query source, validation results, and retained
-document versions should remain encrypted at rest. Plaintext JSONB copies or
-search indexes would weaken the database-dump protection. The first hosted
-provider can decrypt scoped candidate records and evaluate queries through
-`mdbase-rs`; later indexes need their own documented leakage analysis.
+Frontmatter values, bodies, retained document versions, change images, and
+mutation receipts are encrypted at rest. The provider decrypts scoped candidate
+records and evaluates queries through `mdbase-rs`; it does not maintain
+plaintext frontmatter JSONB or search indexes. Any future index needs its own
+documented leakage analysis.
 
 The encryption design and the hosted storage interface in
-[Hosted collections and sync](./sync.md) must be developed together. Revisions,
-version retention, transaction boundaries, and exports all cross this boundary.
+[Hosted collections and sync](./sync.md) are implemented together. Revisions,
+version retention, transaction boundaries, snapshots, and exports all cross
+this boundary.
 
 ## Private hosted collections
 
@@ -349,9 +367,9 @@ Keys have distinct lifecycles:
   the computer is revoked;
 - per-grant application keys are created during authorization, rotated on
   reauthorization or policy change, and discarded on disconnect or revocation;
-- standard hosted collection keys are generated by the provider, wrapped by a
-  managed key service, versioned, backed up through the wrapped form, and
-  destroyed according to collection deletion policy;
+- standard hosted collection keys are generated by the provider and wrapped by
+  its deployment master key. Versioned rotation and a formally exercised key
+  destruction procedure remain to be implemented;
 - private hosted collection keys are generated and wrapped on user devices,
   shared only with approved device/application keys, and covered by an explicit
   recovery procedure.
@@ -361,28 +379,30 @@ and decrypted recovery material never enter audit events.
 
 ## Implementation state and remaining sequence
 
-### Implemented: relay protocol and fixtures
+### Implemented: relay and standard hosted protection
 
 - protocol 1 request, response, grant-binding, and schema definitions;
 - Rust connector identity, derivation, authenticated encryption, durable replay
   state, exact local policy enforcement, and encrypted responses;
 - browser non-extractable keys, atomic counters, encrypted operations, binding
   refresh, and fail-closed behavior;
-- opaque relay routing and cross-runtime end-to-end coverage.
+- opaque relay routing and cross-runtime end-to-end coverage;
+- per-collection hosted data keys wrapped by a deployment master key;
+- authenticated encryption for hosted documents, resources, retained versions,
+  change images, and mutation receipts;
+- keyed record-path lookup without plaintext record paths in PostgreSQL; and
+- ciphertext tamper, wrong-key, two-provider race, sync, and operation tests.
 
-### Next: release security work
+### Next: release security and key operations
 
 - platform-protected connector identity and native application key storage;
 - first-contact connector identity verification or key transparency;
 - browser restart and multi-tab integration tests using real IndexedDB;
-- independent protocol review and systematic log, trace, and crash-path audit.
-
-### Then: hosted envelope encryption
-
-- integrate collection-key wrapping with the hosted Rust provider;
-- encrypt current documents, versions, paths where selected, and backups;
-- document visible metadata and query-index leakage;
-- implement rotation, restore, export, deletion, and key-service outage paths.
+- independent protocol review and systematic log, trace, and crash-path audit;
+- move hosted key wrapping to a versioned managed-key boundary;
+- implement and exercise rotation, restore, deletion, and key-service outage
+  procedures; and
+- verify managed volume and backup encryption in the production environment.
 
 ### Later: private hosted prototype
 
@@ -416,10 +436,11 @@ The relay-only encryption milestone is complete when:
 ## Decisions still open
 
 - first-contact authentication against an actively malicious control plane;
-- key rotation intervals and message limits;
+- relay key rotation intervals and message limits;
 - visible relay metadata, including whether operation names remain visible;
-- plaintext metadata and query-index leakage for standard hosted collections;
-- key-service availability and disaster-recovery procedure;
+- any future plaintext metadata or query-index leakage for standard hosted
+  collections;
+- hosted key-service availability, rotation, and disaster-recovery procedure;
 - private-hosted recovery and contract-scoped key distribution.
 
 The relay guarantee can be implemented independently of hosted sync. Hosted

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -1,6 +1,6 @@
-# MVP acceptance path
+# Release acceptance path
 
-The MVP is complete when a user can:
+The original local-collection MVP is complete when a user can:
 
 1. Install mdbase connect and launch it automatically at login.
 2. Create a v0.3 collection or register an existing one.
@@ -26,6 +26,14 @@ The MVP is complete when a user can:
     tampering, or plaintext fallback.
 
 The TaskNotes reference app proves that an independent frontend can follow a
-configurable domain contract. Hosted collections, file mirroring, a developer
-portal, an app marketplace, multi-user sharing, billing, and fine-grained field
-permissions remain outside this milestone.
+configurable domain contract.
+
+The current private beta extends that milestone with hosted collections,
+offline SDK replicas, and receive-only or writable filesystem mirrors. These
+paths preserve the same manifest, grant, contract, operation, revision, and
+notification model across local and hosted authorities.
+
+The public developer portal is now maintained at
+[`mdbase.dev/sdk`](https://mdbase.dev/sdk/). An app marketplace, multi-user
+sharing, billing, attachments, private/zero-knowledge hosting, and
+fine-grained field permissions remain outside the first release.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -2,6 +2,15 @@
 
 Browser SDK for dynamically discovered mdbase connect applications.
 
+The complete developer guide covers
+[setup](https://mdbase.dev/sdk/quickstart/),
+[manifests and contracts](https://mdbase.dev/sdk/manifest/),
+[authorization](https://mdbase.dev/sdk/authorization/),
+[operations](https://mdbase.dev/sdk/operations/),
+[routing](https://mdbase.dev/sdk/routing/),
+[offline sync](https://mdbase.dev/sdk/offline-sync/), and
+[testing](https://mdbase.dev/sdk/testing/).
+
 ```ts
 const connect = new MdbaseConnect({
   serverUrl: "https://connect.mdbase.dev",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/mdbase-dev/mdbase-connect.git",
     "directory": "packages/client"
   },
-  "homepage": "https://mdbase.dev",
+  "homepage": "https://mdbase.dev/sdk/",
   "sideEffects": false,
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- link the repository and npm package to the task-oriented SDK guide
- update the release acceptance path for hosted collections and mirrors
- reconcile the encryption architecture with the implemented Rust hosted provider

## Verification

- pnpm typecheck
- cargo test -p mdbase-connect-hosted-provider crypto
- git diff --check
