### PR TITLE
Add multi-collection connection architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ deployment, DNS, and verification checklist, and
 The hosted MCP endpoint is `https://mcp.mdbase.dev/mcp`; users add that URL as
 a remote/custom connector and authorize their first collection through mdbase
 connect. The `add_connection` tool creates a short-lived approval link for each
-additional collection. See [`docs/mcp-gateway.md`](docs/mcp-gateway.md) for the
+additional collection, and `reconnect_collection` renews one existing
+connection with its collection preselected. See
+[`docs/mcp-gateway.md`](docs/mcp-gateway.md) for the
 trust boundary, development workflow, tools, and production checklist.
 
 ## Security status

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -96,6 +96,7 @@ interface PendingAuthorization {
   application_homepage: string;
   application_icon?: string;
   requested_operations: string[];
+  collection_hint?: string;
   requirements: ApplicationRequirements;
   provisions: ApplicationProvisions;
   notifications: ApplicationNotifications;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -461,7 +461,11 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
     ),
     [collections, request.compatible_collection_ids, request.provisionable_collection_ids]
   );
-  const [collectionId, setCollectionId] = useState(available[0]?.id ?? "");
+  const [collectionId, setCollectionId] = useState(
+    available.some((collection) => collection.id === request.collection_hint)
+      ? request.collection_hint!
+      : available[0]?.id ?? ""
+  );
   const [operations, setOperations] = useState(request.requested_operations);
   const selected = available.find((collection) => collection.id === collectionId);
   const setup = selected && request.provisionable_collection_ids.includes(selected.id)

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -85,6 +85,7 @@ export interface HostedCollection {
 export interface PendingAuthorization {
   id: string;
   requested_operations: string[];
+  collection_hint?: string | null;
   expires_at: string;
   application_id: string;
   application_name: string;

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -919,7 +919,11 @@ function ApprovalForm({
     () => choices.filter((choice) => !choice.compatibility.compatible),
     [choices]
   );
-  const [collectionId, setCollectionId] = useState(compatible[0]?.collection.id ?? "");
+  const [collectionId, setCollectionId] = useState(
+    compatible.some((choice) => choice.collection.id === request.collection_hint)
+      ? request.collection_hint!
+      : compatible[0]?.collection.id ?? ""
+  );
   const [operations, setOperations] = useState(() => new Set(request.requested_operations));
   const [submitting, setSubmitting] = useState<"approved" | "denied" | "creating" | null>(null);
   const [error, setError] = useState("");

--- a/apps/tasknotes/src/main.tsx
+++ b/apps/tasknotes/src/main.tsx
@@ -9,8 +9,12 @@ const requestedOperations = ["describe", "changes", "read", "query", "create", "
 
 function App() {
   const connect = useMemo(() => new MdbaseConnect<TaskFrontmatter>({ serverUrl }), []);
-  const tasknotes = useMemo(() => new TasknotesCollection(connect), [connect]);
-  const [connection, setConnection] = useState(() => connect.connection());
+  const [bound, setBound] = useState(() => {
+    const first = connect.connections()[0];
+    return first ? connect.connection(first.collectionId) : null;
+  });
+  const tasknotes = useMemo(() => bound ? new TasknotesCollection(bound) : null, [bound]);
+  const connection = bound?.info() ?? null;
   const connected = connection !== null;
   const [tasks, setTasks] = useState<TaskSummary[]>([]);
   const [title, setTitle] = useState("");
@@ -19,12 +23,17 @@ function App() {
   const [error, setError] = useState<string>();
   const loadGeneration = useRef(0);
 
-  useEffect(() => connect.onConnectionChange(setConnection), [connect]);
+  useEffect(() => connect.onConnectionsChange((connections) => {
+    const current = bound && connect.connection(bound.collectionId);
+    if (current) setBound(current);
+    else setBound(connections[0] ? connect.connection(connections[0].collectionId) : null);
+  }), [bound, connect]);
 
   const load = useCallback(async () => {
     const generation = ++loadGeneration.current;
     setLoading(true);
     try {
+      if (!tasknotes) return;
       const next = await tasknotes.list();
       if (generation === loadGeneration.current) {
         setTasks(next);
@@ -41,21 +50,22 @@ function App() {
     const callback = new URL(location.href);
     if (!callback.searchParams.has("code")) return;
     connect.completeAuthorization()
-      .then(() => {
+      .then(({ connection }) => {
         history.replaceState({}, "", callback.pathname);
-        setConnection(connect.connection());
+        setBound(connection);
       })
       .catch((caught) => setError(message(caught)));
   }, [connect]);
 
   useEffect(() => {
     if (!connected) return;
-    void connect.checkDirectAccess();
+    if (!bound) return;
+    void bound.checkDirectAccess();
     void load();
     const controller = new AbortController();
     void (async () => {
       try {
-        for await (const event of connect.watch({ signal: controller.signal })) {
+        for await (const event of bound.watch({ signal: controller.signal })) {
           if (event.type.startsWith("mdbase.record.") || event.type === "mdbase.type.changed") {
             await load();
           }
@@ -65,7 +75,7 @@ function App() {
       }
     })();
     return () => controller.abort();
-  }, [connect, connected, load]);
+  }, [bound, connected, load]);
 
   async function addTask(event: React.FormEvent) {
     event.preventDefault();
@@ -73,6 +83,7 @@ function App() {
     if (!nextTitle || saving) return;
     setSaving(true);
     try {
+      if (!tasknotes) return;
       await tasknotes.create({ title: nextTitle });
       setTitle("");
       await load();
@@ -88,6 +99,7 @@ function App() {
       ? { ...item, completed: !item.completed }
       : item));
     try {
+      if (!tasknotes) return;
       await tasknotes.setCompleted(task.path, !task.completed);
       await load();
     } catch (caught) {
@@ -102,7 +114,7 @@ function App() {
         <p className="wordmark">TaskNotes</p>
         <h1>Your tasks, wherever you need them.</h1>
         <p>Use this app with a TaskNotes collection on your computer.</p>
-        <button className="primary" onClick={() => void connect.authorize([...requestedOperations])}>
+        <button className="primary" onClick={() => void connect.authorize({ operations: [...requestedOperations] })}>
           Connect a collection
         </button>
         {error && <p className="error" role="alert">{error}</p>}
@@ -117,7 +129,7 @@ function App() {
         <p className="connection">{connection?.route === "direct" ? "Connected directly" : "Connected through mdbase"}</p>
         {connection?.directAccess === "permission_required" && (
           <div className="direct-option">
-            <button className="direct-access" aria-describedby="direct-access-hint" onClick={() => void connect.requestDirectAccess()}>
+            <button className="direct-access" aria-describedby="direct-access-hint" onClick={() => void bound?.requestDirectAccess()}>
               Connect directly
             </button>
             <span id="direct-access-hint">Let TaskNotes reach mdbase on this computer.</span>
@@ -125,8 +137,8 @@ function App() {
         )}
       </div>
       <button className="quiet" onClick={() => {
-        connect.disconnect();
-        setConnection(null);
+        bound?.forget();
+        setBound(null);
         setTasks([]);
       }}>Disconnect</button>
     </header>

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -20,8 +20,9 @@ use tempfile::NamedTempFile;
 use thiserror::Error;
 use uuid::Uuid;
 
-const COLLECTION_NAMESPACE: Uuid = Uuid::from_u128(0x72972de3_d05a_4db7_82f5_c9ce02f0fb1d);
 const ENCRYPTED_REPLAY_WINDOW: u64 = 1024;
+const CONNECT_EXTENSION: &str = "x-mdbase-connect";
+const CONNECT_COLLECTION_ID: &str = "collection_id";
 
 #[derive(Debug, Error)]
 pub enum ConnectError {
@@ -365,16 +366,34 @@ impl CollectionRegistry {
 
         let provider = Arc::new(FilesystemProvider::open(&path)?);
 
+        let id = ensure_collection_id(&path)?;
         let metadata = read_collection_metadata(&path)?;
         let path_string = path.to_string_lossy().to_string();
-        let id = Uuid::new_v5(&COLLECTION_NAMESPACE, path_string.as_bytes());
         let display_name = collection_display_name(&metadata, &path);
         let description = normalized_optional(metadata.description);
+
+        let existing_path = self
+            .connection()?
+            .query_row(
+                "SELECT path FROM collections WHERE id = ?1",
+                [id.to_string()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(existing_path) = existing_path.as_deref() {
+            if existing_path != path_string && Path::new(existing_path).exists() {
+                return Err(ConnectError::CollectionOpen(format!(
+                    "Collection identity {id} is already registered at {existing_path}. \
+                     Give copied collections a new {CONNECT_EXTENSION}.{CONNECT_COLLECTION_ID}."
+                )));
+            }
+        }
 
         self.connection()?.execute(
             "INSERT INTO collections (id, path, display_name, description, spec_version, enabled)
              VALUES (?1, ?2, ?3, ?4, ?5, 1)
-             ON CONFLICT(path) DO UPDATE SET
+             ON CONFLICT(id) DO UPDATE SET
+               path = excluded.path,
                display_name = excluded.display_name,
                description = excluded.description,
                spec_version = excluded.spec_version,
@@ -1859,6 +1878,54 @@ struct CollectionMetadata {
     description: Option<String>,
 }
 
+fn ensure_collection_id(root: &Path) -> Result<Uuid, ConnectError> {
+    let config_path = root.join("mdbase.yaml");
+    let source = fs::read_to_string(&config_path)?;
+    let mut config: serde_yaml::Value = serde_yaml::from_str(&source)?;
+    let mapping = config.as_mapping_mut().ok_or_else(|| {
+        ConnectError::CollectionOpen("mdbase.yaml must contain a YAML mapping.".to_string())
+    })?;
+    let extension_key = serde_yaml::Value::String(CONNECT_EXTENSION.to_string());
+    let collection_id_key = serde_yaml::Value::String(CONNECT_COLLECTION_ID.to_string());
+
+    if let Some(value) = mapping
+        .get(&extension_key)
+        .and_then(serde_yaml::Value::as_mapping)
+        .and_then(|extension| extension.get(&collection_id_key))
+    {
+        let value = value.as_str().ok_or_else(|| {
+            ConnectError::CollectionOpen(format!(
+                "{CONNECT_EXTENSION}.{CONNECT_COLLECTION_ID} must be a UUID string."
+            ))
+        })?;
+        return Uuid::parse_str(value).map_err(|_| {
+            ConnectError::CollectionOpen(format!(
+                "{CONNECT_EXTENSION}.{CONNECT_COLLECTION_ID} must be a valid UUID."
+            ))
+        });
+    }
+
+    let id = Uuid::new_v4();
+    let extension = mapping
+        .entry(extension_key)
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    let extension = extension.as_mapping_mut().ok_or_else(|| {
+        ConnectError::CollectionOpen(format!("{CONNECT_EXTENSION} must be a YAML mapping."))
+    })?;
+    extension.insert(collection_id_key, serde_yaml::Value::String(id.to_string()));
+
+    let serialized = serde_yaml::to_string(&config)?;
+    let permissions = fs::metadata(&config_path)?.permissions();
+    let mut temporary = NamedTempFile::new_in(root)?;
+    temporary.as_file().set_permissions(permissions)?;
+    temporary.write_all(serialized.as_bytes())?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(&config_path)
+        .map_err(|error| ConnectError::Io(error.error))?;
+    Ok(id)
+}
+
 fn read_collection_metadata(root: &Path) -> Result<CollectionMetadata, ConnectError> {
     let source = fs::read_to_string(root.join("mdbase.yaml"))?;
     Ok(serde_yaml::from_str(&source)?)
@@ -2130,6 +2197,55 @@ mod tests {
             "unregistering must not delete collection files"
         );
         assert!(registry.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn collection_identity_survives_a_folder_move() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let original = collection_parent.path().join("notes");
+        let moved = collection_parent.path().join("archive");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+
+        let created = registry.create(&original, Some("Notes")).unwrap();
+        let config: serde_yaml::Value =
+            serde_yaml::from_str(&fs::read_to_string(original.join("mdbase.yaml")).unwrap())
+                .unwrap();
+        assert_eq!(
+            config[CONNECT_EXTENSION][CONNECT_COLLECTION_ID],
+            created.id.to_string()
+        );
+
+        fs::rename(&original, &moved).unwrap();
+        let registered_after_move = registry.add(&moved).unwrap();
+
+        assert_eq!(registered_after_move.id, created.id);
+        assert_eq!(
+            Path::new(&registered_after_move.path),
+            moved.canonicalize().unwrap()
+        );
+        assert_eq!(registry.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn copied_collection_identity_is_rejected_while_the_original_is_registered() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let original = collection_parent.path().join("notes");
+        let copy = collection_parent.path().join("notes-copy");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+
+        let created = registry.create(&original, Some("Notes")).unwrap();
+        fs::create_dir_all(&copy).unwrap();
+        fs::copy(original.join("mdbase.yaml"), copy.join("mdbase.yaml")).unwrap();
+        fs::create_dir_all(copy.join("_types")).unwrap();
+
+        assert!(matches!(
+            registry.add(&copy),
+            Err(ConnectError::CollectionOpen(message))
+                if message.contains(&created.id.to_string())
+                    && message.contains(CONNECT_COLLECTION_ID)
+        ));
     }
 
     #[test]

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -578,6 +578,8 @@ pub struct PendingAuthorization {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub application_icon: Option<String>,
     pub requested_operations: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection_hint: Option<Uuid>,
     #[serde(default)]
     pub requirements: ApplicationRequirements,
     #[serde(default)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,30 @@ The connector is the authority for local data and policy. The server routes a
 request only when its access token and grant allow the operation. The connector
 checks its local policy copy again before it opens a collection.
 
+## Collection identity and application selection
+
+A local collection gets a random durable UUID the first time the connector
+registers it. The connector stores it in the collection's portable
+`mdbase.yaml` extension:
+
+```yaml
+x-mdbase-connect:
+  collection_id: 019...
+```
+
+The identity follows the folder when it is moved or renamed; absolute paths are
+never identities and never leave the connector. If a copied folder presents
+the same ID while the original remains registered, the connector rejects the
+copy and asks the user to establish a distinct identity instead of silently
+aliasing two authorities.
+
+The browser SDK is multi-collection by default. `MdbaseConnect` manages the
+saved authorization set and `MdbaseConnection` is permanently bound to one
+collection. Client applications should put the stable server collection ID,
+not the mutable display name, in a bookmarkable URL parameter such as
+`?collection=<id>`. Authorization may carry that ID as a preselection hint, but
+the approval UI still requires an explicit compatible user choice.
+
 ## Components
 
 - `mdbase-rs` owns collection loading, validation, querying, mutation,

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -44,6 +44,11 @@ minutes. Following it repeats steps 3–5 and adds one independently approved
 collection to the same set. Every tool call still requires the opaque
 `connection_id`; there is no implicit cross-collection query or write.
 
+`reconnect_collection` creates the same kind of single-use link for an existing
+connection. It passes that connection's collection ID as an advisory hint, so
+the approval screen opens on the expected collection without bypassing the
+user's choice or compatibility checks.
+
 Revoking or narrowing the application grant in mdbase connect remains the final
 authorization control. The local connector independently enforces its cached
 exact grant before opening a local collection.
@@ -52,7 +57,8 @@ exact grant before opening a local collection.
 
 Read access provides:
 
-- `list_connections`, `add_connection`, and `describe_collection`;
+- `list_connections`, `add_connection`, `reconnect_collection`, and
+  `describe_collection`;
 - `list_changes`, `query_records`, `read_record`, and `validate_collection`;
 - `read_type`.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -79,7 +79,7 @@ Declare a `timer.fired` criterion, request the timer operations, and reconcile
 the desired namespace whenever application state changes:
 
 ```ts
-await connect.reconcileTimers({
+await connection.reconcileTimers({
   namespace: "task-reminders",
   criterion_id: "task.reminder",
   timers: [{
@@ -108,7 +108,7 @@ criteria or an explicit subset:
 import { MdbaseConnect } from "@mdbase/connect";
 
 const worker = await navigator.serviceWorker.register("/service-worker.js");
-await connect.registerNotifications({
+await connection.registerNotifications({
   serviceWorker: worker,
   criteria: ["task.changed"]
 });
@@ -145,7 +145,7 @@ sender identity permission to send messages to that project. The app obtains
 an FCM registration token and registers it after a user explicitly opts in:
 
 ```ts
-await connect.registerNativeNotifications({
+await connection.registerNativeNotifications({
   token: await nativeMessaging.getToken(),
   criteria: ["task.reminder"]
 });

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -12,25 +12,29 @@ The complete developer guide covers
 [testing](https://mdbase.dev/sdk/testing/).
 
 ```ts
-const connect = new MdbaseConnect({
+const mdbase = new MdbaseConnect({
   serverUrl: "https://connect.mdbase.dev",
   manifest: new URL(".well-known/mdbase-app.json", location.href).href,
   redirectUri: "https://workouts.example/auth/mdbase/callback"
 });
 
-await connect.authorize(["describe", "changes", "read", "query", "update"]);
+await mdbase.authorize({
+  operations: ["describe", "changes", "read", "query", "update"],
+  returnTo: location.pathname + location.search
+});
 
 // On the callback route:
-await connect.completeAuthorization();
-const description = await connect.describe();
-const workouts = await connect.query({ types: ["workout"] });
-await connect.update({
+const { connection, returnTo } =
+  await mdbase.completeAuthorization(location.href);
+const description = await connection.describe();
+const workouts = await connection.query({ types: ["workout"] });
+await connection.update({
   path: "workouts/monday.md",
   patch: { completed: true },
   if_revision: workouts.result.results[0].revision
 });
 
-const preview = await connect.preflightRename({
+const preview = await connection.preflightRename({
   from: "workouts/monday.md",
   to: "archive/monday.md",
   update_refs: true,
@@ -39,7 +43,7 @@ const preview = await connect.preflightRename({
 console.log(preview.result.references_affected);
 
 const controller = new AbortController();
-await connect.renameWithProgress({
+await connection.renameWithProgress({
   from: "workouts/monday.md",
   to: "archive/monday.md",
   update_refs: true,
@@ -52,10 +56,20 @@ await connect.renameWithProgress({
   }
 });
 
-for await (const change of connect.watch()) {
+for await (const change of connection.watch()) {
   console.log(change.type, change.payload.path);
 }
 ```
+
+`MdbaseConnect` is an application-level manager. It can retain several
+independently authorized collections; call `connections()` to list them and
+`connection(collectionId)` to obtain a client permanently bound to one. Pass
+that `MdbaseConnection` into repositories and feature code.
+
+For bookmarkable static applications, store the stable ID in a query parameter
+such as `?collection=<id>`. Treat an explicit ID as authoritative and show the
+chooser or reconnect that exact ID when it is unavailable. Collection names
+are display text and may change.
 
 Bundled v1 application manifests can declare runtime notification criteria.
 Register a service worker from a user gesture to receive standards-based Web
@@ -63,7 +77,7 @@ Push while the app is closed:
 
 ```ts
 const worker = await navigator.serviceWorker.register("/service-worker.js");
-await connect.registerNotifications({
+await connection.registerNotifications({
   serviceWorker: worker,
   criteria: ["workout.reminder"]
 });
@@ -92,7 +106,7 @@ Native shells can use one FCM token for Android and iOS when the declaration
 declares `notifications.native_delivery.mode` as `managed_fcm`:
 
 ```ts
-await connect.registerNativeNotifications({
+await connection.registerNativeNotifications({
   token: await nativeMessaging.getToken(),
   criteria: ["workout.reminder"]
 });
@@ -117,10 +131,10 @@ waiting for an operation to fail:
 
 ```ts
 const required = ["read", "query", "update"] as const;
-const capabilities = connect.authorizationCapabilities([...required]);
+const capabilities = connection.authorizationCapabilities([...required]);
 if (!capabilities.sufficient) {
   console.log("Needs", capabilities.missingOperations);
-  await connect.requestOperations([...required]);
+  await connection.requestOperations([...required]);
 }
 ```
 
@@ -135,7 +149,7 @@ Applications that declare a `timer.fired` notification criterion can keep
 one-shot reminders at the collection authority:
 
 ```ts
-await connect.reconcileTimers({
+await connection.reconcileTimers({
   namespace: "workout-reminders",
   criterion_id: "workout.reminder",
   timers: [{
@@ -162,7 +176,7 @@ definitions. Type source is returned with a revision token so updates cannot
 silently overwrite a definition changed by another application:
 
 ```ts
-const created = await connect.createType({
+const created = await connection.createType({
   document: `---
 kind: mdbase.type
 name: workout
@@ -175,8 +189,8 @@ schema:
 `
 });
 
-const current = await connect.readType({ name: "workout" });
-await connect.updateType({
+const current = await connection.readType({ name: "workout" });
+await connection.updateType({
   path: current.result.path,
   document: current.result.document.replace("version: 1", "version: 2"),
   if_revision: current.result.revision
@@ -189,13 +203,13 @@ Contract-scoped applications cannot manage collection-wide type definitions.
 For a local collection, ask for same-computer access from a user gesture:
 
 ```ts
-const status = await connect.checkDirectAccess();
+const status = await connection.checkDirectAccess();
 if (status === "permission_required") {
-  directButton.onclick = () => connect.requestDirectAccess();
+  directButton.onclick = () => connection.requestDirectAccess();
 }
 
-connect.onConnectionChange((connection) => {
-  console.log(connection?.route); // "direct", "relay", or "hosted"
+connection.onConnectionChange((info) => {
+  console.log(info?.route); // "direct", "relay", or "hosted"
 });
 ```
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -19,6 +19,8 @@ import type {
 
 afterEach(() => vi.restoreAllMocks());
 
+const TEST_COLLECTION_ID = "00000000-0000-0000-0000-000000000002";
+
 describe("PKCE", () => {
   it("creates an OAuth S256 verifier and challenge", async () => {
     const pair = await createPkce();
@@ -495,7 +497,7 @@ describe("mobile notifications", () => {
     ]
   };
   const manifestSource = `bundle:${manifest.id}`;
-  const tokenKey = `mdbase-connect:token:${serverUrl}:${manifestSource}`;
+  const tokenKey = storedTokenKey(serverUrl, manifestSource, TEST_COLLECTION_ID);
 
   it("registers the selected criteria atomically for one browser installation", async () => {
     const storage = new MemoryStorage();
@@ -545,12 +547,13 @@ describe("mobile notifications", () => {
       }
       throw new Error(`Unexpected request: ${url}`);
     });
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     const registration = await connect.registerNotifications({
       serviceWorker,
@@ -598,12 +601,13 @@ describe("mobile notifications", () => {
         notifications: { criteria: [{ id: "task.ready" }] }
       }
     }));
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     await expect(connect.registerNotifications({
       serviceWorker: {
@@ -688,12 +692,13 @@ describe("mobile notifications", () => {
         throw new Error(`Unexpected request: ${url}`);
       }
     );
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest,
       redirectUri: "dev.tasknotes.app://auth/mdbase/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     const registration = await connect.registerNativeNotifications({
       token: "fcm_registration_token_012345678901234567890123",
@@ -721,19 +726,31 @@ describe("mobile notifications", () => {
   it("keeps a native channel recoverable when authorization is unavailable during opt-out", async () => {
     const storage = new MemoryStorage();
     const registrationKey =
-      `mdbase-connect:notifications:${serverUrl}:${manifestSource}:fcm`;
+      `mdbase-connect:${serverUrl}:${manifestSource}:notifications:${TEST_COLLECTION_ID}:fcm`;
+    storage.setItem(tokenKey, JSON.stringify({
+      accessToken: "expired",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      collectionId: TEST_COLLECTION_ID,
+      collectionName: "TaskNotes",
+      operations: ["query"],
+      scope: { contracts: [] },
+      expiresAt: Date.now() + 60_000,
+      savedAt: Date.now()
+    }));
     storage.setItem(registrationKey, JSON.stringify({
       channelId: "00000000-0000-0000-0000-000000000004",
       installationId: "native-installation-0001",
       transport: "fcm",
       criteria: ["task.ready"]
     }));
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest,
       redirectUri: "dev.tasknotes.app://auth/mdbase/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
+    storage.removeItem(tokenKey);
 
     await expect(connect.unregisterNativeNotifications()).rejects.toMatchObject({
       code: "not_authorized"
@@ -786,12 +803,7 @@ describe("long mutation progress", () => {
   };
 
   it("reports authoritative phases and estimates without repeating a supplied preflight", async () => {
-    const connect = new MdbaseConnect({
-      serverUrl: "https://connect.example",
-      manifest: "https://tasks.example/manifest.json",
-      redirectUri: "https://tasks.example/callback",
-      storage: new MemoryStorage()
-    });
+    const connect = progressConnection();
     const preflight = vi.spyOn(connect, "preflightRename");
     vi.spyOn(connect, "rename").mockResolvedValue({
       valid: true,
@@ -833,12 +845,7 @@ describe("long mutation progress", () => {
   });
 
   it("cancels between preflight and apply without dispatching the mutation", async () => {
-    const connect = new MdbaseConnect({
-      serverUrl: "https://connect.example",
-      manifest: "https://tasks.example/manifest.json",
-      redirectUri: "https://tasks.example/callback",
-      storage: new MemoryStorage()
-    });
+    const connect = progressConnection();
     const rename = vi.spyOn(connect, "rename");
     const controller = new AbortController();
     const states: string[] = [];
@@ -861,12 +868,7 @@ describe("long mutation progress", () => {
   });
 
   it("rejects a reused preflight for a different mutation", async () => {
-    const connect = new MdbaseConnect({
-      serverUrl: "https://connect.example",
-      manifest: "https://tasks.example/manifest.json",
-      redirectUri: "https://tasks.example/callback",
-      storage: new MemoryStorage()
-    });
+    const connect = progressConnection();
     const rename = vi.spyOn(connect, "rename");
 
     await expect(connect.renameWithProgress(
@@ -877,12 +879,7 @@ describe("long mutation progress", () => {
   });
 
   it("does not estimate reference updates for a rename-only move", async () => {
-    const connect = new MdbaseConnect({
-      serverUrl: "https://connect.example",
-      manifest: "https://tasks.example/manifest.json",
-      redirectUri: "https://tasks.example/callback",
-      storage: new MemoryStorage()
-    });
+    const connect = progressConnection();
     vi.spyOn(connect, "rename").mockResolvedValue({
       valid: true,
       diagnostics: [],
@@ -910,11 +907,143 @@ describe("long mutation progress", () => {
 });
 
 describe("authorization renewal", () => {
+  it("keeps independent collection-bound connections and forgets only the selected one", () => {
+    const storage = new MemoryStorage();
+    const serverUrl = "https://connect.example";
+    const manifestUrl = "https://tasks.example/manifest.json";
+    const secondId = "00000000-0000-0000-0000-000000000003";
+    for (const [collectionId, collectionName] of [
+      [TEST_COLLECTION_ID, "Home tasks"],
+      [secondId, "Studio tasks"]
+    ]) {
+      storage.setItem(storedTokenKey(serverUrl, manifestUrl, collectionId), JSON.stringify({
+        accessToken: `token-${collectionId}`,
+        clientId: "00000000-0000-0000-0000-000000000001",
+        collectionId,
+        collectionName,
+        operations: ["query"],
+        scope: { contracts: [] },
+        expiresAt: Date.now() + 60_000,
+        savedAt: Date.now()
+      }));
+    }
+    storage.setItem(
+      `mdbase-connect:${serverUrl}:${manifestUrl}:connections`,
+      JSON.stringify([secondId, TEST_COLLECTION_ID])
+    );
+    const manager = new MdbaseConnect({
+      serverUrl,
+      manifest: manifestUrl,
+      redirectUri: "https://tasks.example/callback",
+      storage
+    });
+
+    expect(manager.connections().map(({ displayName }) => displayName)).toEqual([
+      "Home tasks",
+      "Studio tasks"
+    ]);
+    manager.connection(TEST_COLLECTION_ID)!.forget();
+    expect(manager.connection(TEST_COLLECTION_ID)).toBeNull();
+    expect(manager.connection(secondId)?.displayName).toBe("Studio tasks");
+  });
+
+  it("passes an exact collection hint and return location through authorization", async () => {
+    const storage = new MemoryStorage();
+    const navigate = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      application: {
+        id: "00000000-0000-0000-0000-000000000001",
+        name: "Tasks",
+        homepage: "https://tasks.example/"
+      }
+    }));
+    const manager = new MdbaseConnect({
+      serverUrl: "https://connect.example",
+      manifest: {
+        manifest_version: 1,
+        id: "dev.tasks",
+        name: "Tasks",
+        homepage: "https://tasks.example/",
+        redirect_uris: ["https://tasks.example/callback"]
+      },
+      redirectUri: "https://tasks.example/callback",
+      storage,
+      relayEncryption: "disabled",
+      navigate
+    });
+
+    void manager.authorize({
+      operations: ["query"],
+      collectionId: TEST_COLLECTION_ID,
+      returnTo: "/today?filter=open"
+    });
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+
+    const authorization = new URL(navigate.mock.calls[0][0]);
+    expect(authorization.searchParams.get("collection_hint")).toBe(TEST_COLLECTION_ID);
+    const state = authorization.searchParams.get("state")!;
+    expect(JSON.parse(storage.getItem(
+      `mdbase-connect:https://connect.example:bundle:dev.tasks:pending:${state}`
+    )!)).toMatchObject({
+      collectionId: TEST_COLLECTION_ID,
+      returnTo: "/today?filter=open"
+    });
+  });
+
+  it("cleans up a denied authorization without disturbing saved connections", async () => {
+    const storage = new MemoryStorage();
+    const serverUrl = "https://connect.example";
+    const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
+    const pendingKey = `mdbase-connect:${serverUrl}:${manifestUrl}:pending:denied-state`;
+    storage.setItem(pendingKey, JSON.stringify({
+      verifier: "pkce-verifier",
+      state: "denied-state",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      redirectUri: "https://tasks.example/callback",
+      relayEncryption: "disabled",
+      returnTo: "/today"
+    }));
+    storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      accessToken: "mdb_saved",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      collectionId: TEST_COLLECTION_ID,
+      collectionName: "Saved tasks",
+      operations: ["query"],
+      scope: { contracts: [] },
+      expiresAt: Date.now() + 60_000,
+      savedAt: Date.now()
+    }));
+    storage.setItem(
+      `mdbase-connect:${serverUrl}:${manifestUrl}:connections`,
+      JSON.stringify([TEST_COLLECTION_ID])
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const manager = new MdbaseConnect({
+      serverUrl,
+      manifest: manifestUrl,
+      redirectUri: "https://tasks.example/callback",
+      storage,
+      relayEncryption: "disabled"
+    });
+
+    await expect(manager.completeAuthorization(
+      "https://tasks.example/callback?error=access_denied&error_description=Not%20now&state=denied-state"
+    )).rejects.toMatchObject({
+      code: "access_denied",
+      message: "Not now",
+      details: { returnTo: "/today" }
+    });
+
+    expect(storage.getItem(pendingKey)).toBeNull();
+    expect(manager.connection(TEST_COLLECTION_ID)?.displayName).toBe("Saved tasks");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("coalesces concurrent authorization completion into one code exchange", async () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    storage.setItem(`mdbase-connect:pending:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    storage.setItem(`mdbase-connect:${serverUrl}:${manifestUrl}:pending:callback-state`, JSON.stringify({
       verifier: "pkce-verifier",
       state: "callback-state",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -926,7 +1055,8 @@ describe("authorization renewal", () => {
       refresh_token: "ref_authorized",
       expires_in: 3600,
       refresh_expires_in: 2_592_000,
-      collection_id: "00000000-0000-0000-0000-000000000002",
+      collection_id: TEST_COLLECTION_ID,
+      collection_name: "Tasks",
       operations: ["query"],
       scope: { contracts: [] }
     }), { status: 200, headers: { "content-type": "application/json" } }));
@@ -945,8 +1075,9 @@ describe("authorization renewal", () => {
     ]);
 
     expect(first).toEqual(second);
-    expect(first).toMatchObject({
-      collectionId: "00000000-0000-0000-0000-000000000002",
+    expect(first.connection.info()).toMatchObject({
+      collectionId: TEST_COLLECTION_ID,
+      displayName: "Tasks",
       operations: ["query"]
     });
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -957,7 +1088,7 @@ describe("authorization renewal", () => {
     const navigate = vi.fn();
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
       accessToken: "mdb_current",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -984,7 +1115,7 @@ describe("authorization renewal", () => {
             }
           })
     );
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "dev.tasknotes.app://auth/mdbase/callback",
@@ -992,6 +1123,7 @@ describe("authorization renewal", () => {
       relayEncryption: "disabled",
       navigate
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     expect(connect.authorizationCapabilities(["read", "update", "update"])).toEqual({
       authorized: true,
@@ -1013,7 +1145,7 @@ describe("authorization renewal", () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
       accessToken: "mdb_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
@@ -1021,12 +1153,13 @@ describe("authorization renewal", () => {
       scope: { contracts: [] },
       expiresAt: Date.now() + 60_000
     }));
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     await expect(connect.read({ path: "Notes/example.md" })).rejects.toMatchObject({
       code: "insufficient_access",
@@ -1070,7 +1203,7 @@ describe("authorization renewal", () => {
       navigate
     });
 
-    void connect.authorize(["query"]);
+    void connect.authorize({ operations: ["query"] });
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
     expect(new URL(navigate.mock.calls[0][0]).searchParams.get("redirect_uri"))
       .toBe("dev.tasknotes.app://auth/mdbase/callback");
@@ -1081,7 +1214,7 @@ describe("authorization renewal", () => {
     const serverUrl = "https://connect.example";
     const providerUrl = "https://provider.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
       accessToken: "mdb_control",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1100,12 +1233,13 @@ describe("authorization renewal", () => {
       ok: true,
       result: { valid: true, result: { results: [] }, diagnostics: [] }
     }), { status: 200, headers: { "content-type": "application/json" } }));
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     expect((await connect.query()).valid).toBe(true);
     expect(String(fetchMock.mock.calls[0][0])).toBe(
@@ -1120,7 +1254,7 @@ describe("authorization renewal", () => {
     const serverUrl = "https://connect.example";
     const providerUrl = "https://provider.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
       accessToken: "mdb_control",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1147,12 +1281,13 @@ describe("authorization renewal", () => {
       snapshot_id: "00000000-0000-0000-0000-000000000005",
       resources: { revision: "one", spec_version: "0.3.0", types: [], contracts: [] }
     }), { status: 200, headers: { "content-type": "application/json" } }));
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
 
     const hosted = connect.hostedSync();
     expect(hosted).toEqual(expect.objectContaining({
@@ -1172,7 +1307,7 @@ describe("authorization renewal", () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    storage.setItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`, JSON.stringify({
+    storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
       accessToken: "mdb_expired",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1197,12 +1332,13 @@ describe("authorization renewal", () => {
         result: { valid: true, result: { results: [] }, diagnostics: [] }
       }), { status: 200, headers: { "content-type": "application/json" } }));
 
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
     const result = await connect.query();
 
     expect(result.valid).toBe(true);
@@ -1210,7 +1346,7 @@ describe("authorization renewal", () => {
     expect(String(fetchMock.mock.calls[0][0])).toBe(`${serverUrl}/oauth/token`);
     expect((fetchMock.mock.calls[1][1]?.headers as Record<string, string>).authorization)
       .toBe("Bearer mdb_renewed");
-    expect(JSON.parse(storage.getItem(`mdbase-connect:token:${serverUrl}:${manifestUrl}`)!))
+    expect(JSON.parse(storage.getItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID))!))
       .toEqual(expect.objectContaining({ accessToken: "mdb_renewed", refreshToken: "ref_rotated" }));
   });
 
@@ -1218,7 +1354,7 @@ describe("authorization renewal", () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
-    const tokenKey = `mdbase-connect:token:${serverUrl}:${manifestUrl}`;
+    const tokenKey = storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID);
     const baseToken = {
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
@@ -1249,12 +1385,13 @@ describe("authorization renewal", () => {
         result: { valid: true, result: { results: [] }, diagnostics: [] }
       }), { status: 200, headers: { "content-type": "application/json" } }));
 
-    const connect = new MdbaseConnect({
+    const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
       storage
     });
+    const connect = manager.connection(TEST_COLLECTION_ID)!;
     const result = await connect.query();
 
     expect(result.valid).toBe(true);
@@ -1384,7 +1521,7 @@ schema:
 
   it("does not bypass an explicit rejection from the local authorization boundary", async () => {
     const fixture = await encryptedConnection();
-    const connectionChanges: Array<ReturnType<typeof fixture.connect.connection>> = [];
+    const connectionChanges: Array<ReturnType<typeof fixture.connect.info>> = [];
     fixture.connect.onConnectionChange((connection) => connectionChanges.push(connection));
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       error: { code: "direct_operation_rejected", message: "Rejected locally." }
@@ -1402,7 +1539,7 @@ schema:
     }));
     expect(connectionChanges.at(-1)).toBeNull();
     expect(connectionChanges.filter((connection) => connection === null)).toHaveLength(1);
-    expect(fixture.connect.connection()).toBeNull();
+    expect(fixture.connect.info()).toBeNull();
     expect(fixture.storage.getItem(fixture.tokenKey)).toBeNull();
     await expect(fixture.keyStore.get("grant-key")).resolves.toBeNull();
     expect(fixture.connect.authorizationCapabilities(["query"])).toMatchObject({
@@ -1431,7 +1568,7 @@ schema:
       recovery: "reauthorize"
     });
     expect(fixture.connect.pendingMutation()).toBeNull();
-    expect(fixture.connect.connection()).toBeNull();
+    expect(fixture.connect.info()).toBeNull();
   });
 
   it("backs off an unavailable loopback route while keeping relay operations usable", async () => {
@@ -1466,7 +1603,7 @@ schema:
   it("renews a stale binding after an uncertain direct read without reporting an unknown write", async () => {
     const fixture = await encryptedConnection();
     const token = JSON.parse(fixture.storage.getItem(
-      `mdbase-connect:token:${fixture.serverUrl}:${fixture.manifestUrl}`
+      storedTokenKey(fixture.serverUrl, fixture.manifestUrl, fixture.collectionId)
     )!);
     const fetchMock = vi.spyOn(globalThis, "fetch")
       .mockRejectedValueOnce(new TypeError("loopback response was lost"))
@@ -1518,7 +1655,7 @@ schema:
   it("lets a user re-enable direct access after disabling it", async () => {
     const fixture = await encryptedConnection();
     fixture.connect.disableDirectAccess();
-    expect(fixture.connect.connection()?.directAccess).toBe("disabled");
+    expect(fixture.connect.info()?.directAccess).toBe("disabled");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       service: "mdbase-connect",
       loopback_protocol_version: 1,
@@ -1526,12 +1663,12 @@ schema:
     }), { status: 200, headers: { "content-type": "application/json" } }));
 
     await expect(fixture.connect.requestDirectAccess()).resolves.toBe("available");
-    expect(fixture.connect.connection()?.directAccess).toBe("available");
+    expect(fixture.connect.info()?.directAccess).toBe("available");
   });
 
   it("keeps direct grant proof usable after every cloud credential expires", async () => {
     const fixture = await encryptedConnection();
-    const tokenKey = `mdbase-connect:token:${fixture.serverUrl}:${fixture.manifestUrl}`;
+    const tokenKey = storedTokenKey(fixture.serverUrl, fixture.manifestUrl, fixture.collectionId);
     const token = JSON.parse(fixture.storage.getItem(tokenKey)!);
     fixture.storage.setItem(tokenKey, JSON.stringify({
       ...token,
@@ -1580,12 +1717,13 @@ async function encryptedConnection() {
     application_public_key: application.publicKey,
     connector_public_key: connector.publicKey
   };
-  const tokenKey = `mdbase-connect:token:${serverUrl}:${manifestUrl}`;
+  const tokenKey = storedTokenKey(serverUrl, manifestUrl, collectionId);
   storage.setItem(tokenKey, JSON.stringify({
     accessToken: "mdb_current",
     refreshToken: "ref_current",
     clientId: "01922222-2222-7222-8222-222222222222",
     collectionId,
+    collectionName: "Encrypted notes",
     operations: [
       "describe", "changes", "read", "query", "list_views", "execute_view", "validate", "create", "update", "delete", "rename",
       "read_type", "create_type", "update_type"
@@ -1596,9 +1734,17 @@ async function encryptedConnection() {
     grantId: "01911111-1111-7111-8111-111111111111",
     encryption,
     applicationOrigin: "https://tasks.example",
-    keyHandle: "grant-key"
+    keyHandle: "grant-key",
+    savedAt: Date.now()
   }));
   storage.setItem("mdbase-connect:direct:https://tasks.example", "enabled");
+  const manager = new MdbaseConnect({
+    serverUrl,
+    manifest: manifestUrl,
+    redirectUri: "https://tasks.example/callback",
+    storage,
+    keyStore
+  });
   return {
     serverUrl,
     manifestUrl,
@@ -1606,14 +1752,44 @@ async function encryptedConnection() {
     storage,
     tokenKey,
     keyStore,
-    connect: new MdbaseConnect({
-      serverUrl,
-      manifest: manifestUrl,
-      redirectUri: "https://tasks.example/callback",
-      storage,
-      keyStore
-    })
+    connect: manager.connection(collectionId)!
   };
+}
+
+function progressConnection() {
+  const serverUrl = "https://connect.example";
+  const manifest = "https://tasks.example/manifest.json";
+  const storage = new MemoryStorage();
+  storage.setItem(storedTokenKey(serverUrl, manifest, TEST_COLLECTION_ID), JSON.stringify({
+    accessToken: "progress",
+    clientId: "00000000-0000-0000-0000-000000000001",
+    collectionId: TEST_COLLECTION_ID,
+    collectionName: "Tasks",
+    operations: ["rename", "delete"],
+    scope: { contracts: [] },
+    expiresAt: Date.now() + 60_000,
+    grantId: "00000000-0000-0000-0000-000000000003",
+    encryption: {
+      protocol_version: 1,
+      suite: "P256-HKDF-SHA256-AES256GCM",
+      key_id: "progress-key",
+      scope_epoch: 1,
+      connector_id: "00000000-0000-0000-0000-000000000004",
+      collection_id: TEST_COLLECTION_ID,
+      application_public_key: "04".padEnd(130, "1"),
+      connector_public_key: "04".padEnd(130, "2")
+    },
+    keyHandle: "progress-key",
+    savedAt: Date.now()
+  }));
+  const manager = new MdbaseConnect({
+    serverUrl,
+    manifest,
+    redirectUri: "https://tasks.example/callback",
+    storage,
+    keyStore: new MemoryGrantKeyStore()
+  });
+  return manager.connection(TEST_COLLECTION_ID)!;
 }
 
 class MemoryStorage implements Storage {
@@ -1631,4 +1807,12 @@ function jsonResponse(value: unknown, status = 200): Response {
     status,
     headers: { "content-type": "application/json" }
   });
+}
+
+function storedTokenKey(
+  serverUrl: string,
+  manifestSource: string,
+  collectionId: string,
+): string {
+  return `mdbase-connect:${serverUrl}:${manifestSource}:token:${collectionId}`;
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -118,12 +118,31 @@ export type DirectAccessStatus =
   | "unavailable"
   | "denied";
 
-export interface MdbaseConnection {
+export interface MdbaseConnectionInfo {
   collectionId: string;
+  displayName: string;
   operations: CollectionOperation[];
   scope: GrantScope;
   route: MdbaseConnectionRoute;
   directAccess: DirectAccessStatus;
+}
+
+export interface MdbaseAuthorizeOptions {
+  operations?: CollectionOperation[];
+  /** Preselect this collection without bypassing the user's approval. */
+  collectionId?: string;
+  /** App-local location to restore after the authorization callback. */
+  returnTo?: string;
+}
+
+export interface MdbaseConnectionAuthorizeOptions {
+  operations?: CollectionOperation[];
+  returnTo?: string;
+}
+
+export interface MdbaseAuthorizationResult<Frontmatter extends JsonObject = JsonObject> {
+  connection: MdbaseConnection<Frontmatter>;
+  returnTo?: string;
 }
 
 export interface MdbaseDesiredTimer {
@@ -773,6 +792,8 @@ interface StoredAuthorization {
   clientId: string;
   redirectUri: string;
   relayEncryption: "required" | "disabled";
+  collectionId?: string;
+  returnTo?: string;
   keyHandle?: string;
   applicationPublicKey?: string;
 }
@@ -782,6 +803,7 @@ interface StoredToken {
   refreshToken?: string;
   clientId: string;
   collectionId: string;
+  collectionName: string;
   operations: CollectionOperation[];
   scope: GrantScope;
   expiresAt: number;
@@ -790,6 +812,7 @@ interface StoredToken {
   encryption?: GrantEncryption;
   applicationOrigin?: string;
   keyHandle?: string;
+  savedAt: number;
   hosted?: {
     providerUrl: string;
     replicaId: string;
@@ -817,29 +840,62 @@ interface OperationAttempt {
 const DEFAULT_OPERATIONS: CollectionOperation[] = ["describe", "changes", "read", "query"];
 
 export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
-  private readonly serverUrl: string;
-  private readonly manifest: MdbaseAppManifest | string;
-  private readonly manifestSource: string;
-  private readonly redirectUri: string;
-  private readonly storage: Storage;
-  private readonly relayEncryption: "required" | "disabled";
-  private readonly keyStore: GrantKeyStore;
-  private readonly directAccessMode: "auto" | "disabled";
-  private readonly loopbackUrl: string;
-  private readonly navigate?: (url: string) => void | Promise<void>;
+  private readonly internals: MdbaseConnectInternals<Frontmatter>;
+
+  constructor(options: MdbaseConnectOptions) {
+    this.internals = new MdbaseConnectInternals(options);
+  }
+
+  register(): Promise<Application> {
+    return this.internals.register();
+  }
+
+  authorize(options: MdbaseAuthorizeOptions = {}): Promise<never> {
+    return this.internals.authorize(options);
+  }
+
+  completeAuthorization(
+    callbackUrl = defaultCallbackUrl()
+  ): Promise<MdbaseAuthorizationResult<Frontmatter>> {
+    return this.internals.completeAuthorization(callbackUrl);
+  }
+
+  connections(): MdbaseConnectionInfo[] {
+    return this.internals.connections();
+  }
+
+  connection(collectionId: string): MdbaseConnection<Frontmatter> | null {
+    return this.internals.connection(collectionId);
+  }
+
+  onConnectionsChange(
+    listener: (connections: MdbaseConnectionInfo[]) => void
+  ): () => void {
+    return this.internals.onConnectionsChange(listener);
+  }
+
+  forgetAll(): void {
+    for (const connection of this.connections()) {
+      this.connection(connection.collectionId)?.forget();
+    }
+  }
+}
+
+class MdbaseConnectInternals<Frontmatter extends JsonObject> {
+  readonly serverUrl: string;
+  readonly manifest: MdbaseAppManifest | string;
+  readonly manifestSource: string;
+  readonly redirectUri: string;
+  readonly storage: Storage;
+  readonly relayEncryption: "required" | "disabled";
+  readonly keyStore: GrantKeyStore;
+  readonly directAccessMode: "auto" | "disabled";
+  readonly loopbackUrl: string;
+  readonly navigate?: (url: string) => void | Promise<void>;
   private application: Application | null = null;
-  private authorizationCompletionPromise: Promise<{
-    collectionId: string;
-    operations: CollectionOperation[];
-    scope: GrantScope;
-  }> | null = null;
-  private refreshPromise: Promise<StoredToken> | null = null;
-  private readonly collectionClient: MdbaseCollectionClient<Frontmatter>;
-  private directStatus: DirectAccessStatus;
-  private route: MdbaseConnectionRoute = "relay";
-  private directFailures = 0;
-  private directRetryAt = 0;
-  private readonly connectionListeners = new Set<(connection: MdbaseConnection | null) => void>();
+  private readonly completionPromises = new Map<string, Promise<MdbaseAuthorizationResult<Frontmatter>>>();
+  private readonly connectionCache = new Map<string, MdbaseConnection<Frontmatter>>();
+  private readonly listeners = new Set<(connections: MdbaseConnectionInfo[]) => void>();
 
   constructor(options: MdbaseConnectOptions) {
     this.serverUrl = stripTrailingSlash(options.serverUrl);
@@ -855,11 +911,14 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     this.loopbackUrl = canonicalLoopbackUrl(
       options.loopbackUrl ?? `http://127.0.0.1:${DEFAULT_LOOPBACK_PORT}`
     );
-    this.directStatus = this.directAccessMode === "disabled" ? "disabled" : "unavailable";
     this.navigate = options.navigate;
-    this.collectionClient = new MdbaseCollectionClient({
-      operation: (operation, input, requestOptions) => this.performOperation(operation, input, requestOptions)
-    });
+    if (typeof window !== "undefined" && this.storage === window.localStorage) {
+      window.addEventListener("storage", (event) => {
+        if (event.storageArea !== this.storage || !event.key?.startsWith(this.storagePrefix())) return;
+        this.connectionCache.get(collectionIdFromTokenKey(event.key))?.notifyStorageChanged();
+        this.emitConnections();
+      });
+    }
   }
 
   async register(): Promise<Application> {
@@ -908,17 +967,13 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     }
   }
 
-  async authorize(operations: CollectionOperation[] = DEFAULT_OPERATIONS): Promise<never> {
+  async authorize(options: MdbaseAuthorizeOptions = {}): Promise<never> {
     if (typeof location === "undefined" && !this.navigate) {
       throw new MdbaseConnectError(
         "browser_required",
         "Authorization navigation requires a browser environment."
       );
     }
-    const replaced = parseStored<StoredAuthorization>(this.storage.getItem(this.pendingKey()));
-    if (replaced?.keyHandle) await this.keyStore.delete(replaced.keyHandle);
-    this.storage.removeItem(this.pendingKey());
-    this.clearPendingMutation();
     const application = await this.register();
     const { verifier, challenge } = await createPkce();
     const state = randomBase64Url(24);
@@ -932,17 +987,25 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       clientId: application.id,
       redirectUri: this.redirectUri,
       relayEncryption: this.relayEncryption,
+      collectionId: options.collectionId,
+      returnTo: options.returnTo,
       keyHandle,
       applicationPublicKey: grantKey?.publicKey
     };
-    this.storage.setItem(this.pendingKey(), JSON.stringify(pending));
+    this.storage.setItem(this.pendingKey(state), JSON.stringify(pending));
     const authorize = new URL(`${this.serverUrl}/oauth/authorize`);
     authorize.searchParams.set("client_id", application.id);
     authorize.searchParams.set("redirect_uri", this.redirectUri);
     authorize.searchParams.set("code_challenge", challenge);
     authorize.searchParams.set("code_challenge_method", "S256");
     authorize.searchParams.set("state", state);
-    authorize.searchParams.set("operations", [...new Set(operations)].join(","));
+    authorize.searchParams.set(
+      "operations",
+      uniqueOperations(options.operations ?? DEFAULT_OPERATIONS).join(",")
+    );
+    if (options.collectionId) {
+      authorize.searchParams.set("collection_hint", options.collectionId);
+    }
     if (grantKey) {
       authorize.searchParams.set("relay_protocol", "1");
       authorize.searchParams.set("application_public_key", grantKey.publicKey);
@@ -952,66 +1015,46 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     return new Promise<never>(() => undefined);
   }
 
-  authorizationCapabilities(
-    requiredOperations: CollectionOperation[] = DEFAULT_OPERATIONS
-  ): MdbaseAuthorizationCapabilities {
-    const connection = this.connection();
-    const grantedOperations = connection?.operations ?? [];
-    const missingOperations = uniqueOperations(requiredOperations)
-      .filter((operation) => !grantedOperations.includes(operation));
-    return {
-      authorized: connection !== null,
-      sufficient: connection !== null && missingOperations.length === 0,
-      ...(connection ? { collectionId: connection.collectionId } : {}),
-      grantedOperations: [...grantedOperations],
-      missingOperations
-    };
-  }
-
-  hasOperations(requiredOperations: CollectionOperation[]): boolean {
-    return this.authorizationCapabilities(requiredOperations).sufficient;
-  }
-
-  /**
-   * Request only the additional capabilities an app needs while retaining the
-   * exact operations already present on a replacement grant.
-   */
-  async requestOperations(requiredOperations: CollectionOperation[]): Promise<void> {
-    const capabilities = this.authorizationCapabilities(requiredOperations);
-    if (capabilities.sufficient) return;
-    await this.authorize(uniqueOperations([
-      ...capabilities.grantedOperations,
-      ...capabilities.missingOperations
-    ]));
-  }
-
-  completeAuthorization(callbackUrl = defaultCallbackUrl()): Promise<{
-    collectionId: string;
-    operations: CollectionOperation[];
-    scope: GrantScope;
-  }> {
-    if (this.authorizationCompletionPromise) return this.authorizationCompletionPromise;
-    const completion = this.performAuthorizationCompletion(callbackUrl);
+  completeAuthorization(callbackUrl: string): Promise<MdbaseAuthorizationResult<Frontmatter>> {
+    const state = new URL(callbackUrl).searchParams.get("state");
+    if (!state) {
+      return Promise.reject(new MdbaseConnectError(
+        "invalid_callback",
+        "Authorization callback is missing its state."
+      ));
+    }
+    const existing = this.completionPromises.get(state);
+    if (existing) return existing;
+    const completion = this.performAuthorizationCompletion(callbackUrl, state);
     const shared = completion.finally(() => {
-      if (this.authorizationCompletionPromise === shared) {
-        this.authorizationCompletionPromise = null;
-      }
+      if (this.completionPromises.get(state) === shared) this.completionPromises.delete(state);
     });
-    this.authorizationCompletionPromise = shared;
+    this.completionPromises.set(state, shared);
     return shared;
   }
 
-  private async performAuthorizationCompletion(callbackUrl: string): Promise<{
-    collectionId: string;
-    operations: CollectionOperation[];
-    scope: GrantScope;
-  }> {
+  private async performAuthorizationCompletion(
+    callbackUrl: string,
+    state: string
+  ): Promise<MdbaseAuthorizationResult<Frontmatter>> {
     const callback = new URL(callbackUrl);
     const code = callback.searchParams.get("code");
-    const state = callback.searchParams.get("state");
-    const pending = parseStored<StoredAuthorization>(this.storage.getItem(this.pendingKey()));
-    if (!code || !state || !pending || state !== pending.state) {
+    const pendingKey = this.pendingKey(state);
+    const pending = parseStored<StoredAuthorization>(this.storage.getItem(pendingKey));
+    if (!pending || state !== pending.state) {
       throw new MdbaseConnectError("invalid_callback", "Authorization callback is missing or does not match this browser session.");
+    }
+    if (callback.searchParams.has("error")) {
+      if (pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
+      this.storage.removeItem(pendingKey);
+      throw new MdbaseConnectError(
+        callback.searchParams.get("error") ?? "access_denied",
+        callback.searchParams.get("error_description") ?? "Collection access was not approved.",
+        { details: pending.returnTo ? { returnTo: pending.returnTo } : undefined }
+      );
+    }
+    if (!code) {
+      throw new MdbaseConnectError("invalid_callback", "Authorization callback is missing its code.");
     }
     const response = await fetch(`${this.serverUrl}/oauth/token`, {
       method: "POST",
@@ -1032,7 +1075,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       || body.encryption.application_public_key !== pending.applicationPublicKey
     )) {
       if (pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
-      this.storage.removeItem(this.pendingKey());
+      this.storage.removeItem(pendingKey);
       throw new MdbaseConnectError(
         "encryption_required",
         "Authorization did not establish the required encrypted relay grant."
@@ -1044,27 +1087,276 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       pending.clientId,
       body.hosted ? undefined : pending.keyHandle
     );
-    this.storage.removeItem(this.pendingKey());
-    return { collectionId: token.collectionId, operations: token.operations, scope: token.scope };
+    if (pending.collectionId && pending.collectionId !== token.collectionId) {
+      this.removeToken(token.collectionId, token.keyHandle);
+      this.storage.removeItem(pendingKey);
+      throw new MdbaseConnectError(
+        "collection_mismatch",
+        "The approved collection does not match the collection requested by this link."
+      );
+    }
+    this.storage.removeItem(pendingKey);
+    return {
+      connection: this.connection(token.collectionId)!,
+      ...(pending.returnTo ? { returnTo: pending.returnTo } : {})
+    };
   }
 
-  connection(): MdbaseConnection | null {
+  connections(): MdbaseConnectionInfo[] {
+    const connections: MdbaseConnectionInfo[] = [];
+    for (const collectionId of this.connectionIds()) {
+      const info = this.connection(collectionId)?.info();
+      if (info) connections.push(info);
+    }
+    return connections.sort((left, right) =>
+      left.displayName.localeCompare(right.displayName) || left.collectionId.localeCompare(right.collectionId)
+    );
+  }
+
+  connection(collectionId: string): MdbaseConnection<Frontmatter> | null {
+    if (!this.storage.getItem(this.tokenKey(collectionId))) return null;
+    let connection = this.connectionCache.get(collectionId);
+    if (!connection) {
+      connection = new MdbaseConnection(this, collectionId);
+      this.connectionCache.set(collectionId, connection);
+    }
+    return connection.info() ? connection : null;
+  }
+
+  onConnectionsChange(listener: (connections: MdbaseConnectionInfo[]) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.connections());
+    return () => this.listeners.delete(listener);
+  }
+
+  storeTokenResponse(body: any, clientId: string, keyHandle?: string): StoredToken {
+    const collectionId = body.collection_id;
+    if (typeof collectionId !== "string") {
+      throw new MdbaseConnectError("invalid_token_response", "Authorization returned no collection ID.");
+    }
+    const previous = parseStored<StoredToken>(this.storage.getItem(this.tokenKey(collectionId)));
+    if (previous?.keyHandle && previous.keyHandle !== keyHandle) void this.keyStore.delete(previous.keyHandle);
+    const token: StoredToken = {
+      accessToken: body.access_token,
+      refreshToken: body.refresh_token,
+      clientId,
+      collectionId,
+      collectionName: body.collection_name ?? `Collection ${collectionId.slice(0, 8)}`,
+      operations: body.operations,
+      scope: body.scope ?? { contracts: [] },
+      expiresAt: Date.now() + body.expires_in * 1_000,
+      refreshExpiresAt: body.refresh_expires_in
+        ? Date.now() + body.refresh_expires_in * 1_000
+        : undefined,
+      grantId: body.grant_id,
+      encryption: body.encryption ?? undefined,
+      applicationOrigin: body.application_origin ?? this.defaultApplicationOrigin(),
+      keyHandle,
+      savedAt: Date.now(),
+      hosted: body.hosted ? {
+        providerUrl: body.hosted.provider_url,
+        replicaId: body.hosted.replica_id,
+        accessToken: body.hosted.access_token
+      } : undefined
+    };
+    this.storage.setItem(this.tokenKey(collectionId), JSON.stringify(token));
+    this.addConnectionId(collectionId);
+    this.connectionCache.delete(collectionId);
+    this.emitConnections();
+    return token;
+  }
+
+  removeToken(collectionId: string, keyHandle?: string): void {
+    if (keyHandle) void this.keyStore.delete(keyHandle);
+    this.storage.removeItem(this.tokenKey(collectionId));
+    this.storage.removeItem(this.pendingMutationKey(collectionId));
+    for (const transport of ["web_push", "fcm"] as const) {
+      this.storage.removeItem(this.notificationKey(collectionId, transport));
+    }
+    this.storage.setItem(
+      this.connectionsKey(),
+      JSON.stringify(this.connectionIds().filter((id) => id !== collectionId))
+    );
+    this.connectionCache.delete(collectionId);
+    this.emitConnections();
+  }
+
+  tokenKey(collectionId: string): string {
+    return `${this.storagePrefix()}:token:${collectionId}`;
+  }
+
+  pendingMutationKey(collectionId: string): string {
+    return `${this.storagePrefix()}:pending-mutation:${collectionId}`;
+  }
+
+  notificationKey(collectionId: string, transport: "web_push" | "fcm" = "web_push"): string {
+    return `${this.storagePrefix()}:notifications:${collectionId}:${transport}`;
+  }
+
+  directPreferenceKey(): string {
+    return `mdbase-connect:direct:${this.defaultApplicationOrigin()}`;
+  }
+
+  defaultApplicationOrigin(): string {
+    const redirect = new URL(this.redirectUri);
+    if (["http:", "https:"].includes(redirect.protocol)) return redirect.origin;
+    if (typeof location !== "undefined") return location.origin;
+    if (this.manifest && typeof this.manifest !== "string") {
+      return new URL(this.manifest.homepage).origin;
+    }
+    try {
+      return new URL(this.manifestSource).origin;
+    } catch {
+      return "";
+    }
+  }
+
+  private pendingKey(state: string): string {
+    return `${this.storagePrefix()}:pending:${state}`;
+  }
+
+  private storagePrefix(): string {
+    return `mdbase-connect:${this.serverUrl}:${this.manifestSource}`;
+  }
+
+  private connectionsKey(): string {
+    return `${this.storagePrefix()}:connections`;
+  }
+
+  private connectionIds(): string[] {
+    return parseStored<string[]>(this.storage.getItem(this.connectionsKey())) ?? [];
+  }
+
+  private addConnectionId(collectionId: string): void {
+    this.storage.setItem(
+      this.connectionsKey(),
+      JSON.stringify([...new Set([...this.connectionIds(), collectionId])])
+    );
+  }
+
+  private emitConnections(): void {
+    const connections = this.connections();
+    for (const listener of this.listeners) listener(connections);
+  }
+}
+
+function collectionIdFromTokenKey(key: string): string {
+  const marker = ":token:";
+  const index = key.lastIndexOf(marker);
+  return index < 0 ? "" : key.slice(index + marker.length);
+}
+
+export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
+  private readonly serverUrl: string;
+  private readonly storage: Storage;
+  private readonly keyStore: GrantKeyStore;
+  private readonly directAccessMode: "auto" | "disabled";
+  private readonly loopbackUrl: string;
+  private refreshPromise: Promise<StoredToken> | null = null;
+  private readonly collectionClient: MdbaseCollectionClient<Frontmatter>;
+  private directStatus: DirectAccessStatus;
+  private currentRoute: MdbaseConnectionRoute = "relay";
+  private directFailures = 0;
+  private directRetryAt = 0;
+  private readonly connectionListeners = new Set<(connection: MdbaseConnectionInfo | null) => void>();
+
+  constructor(
+    private readonly internals: MdbaseConnectInternals<Frontmatter>,
+    readonly collectionId: string
+  ) {
+    this.serverUrl = internals.serverUrl;
+    this.storage = internals.storage;
+    this.keyStore = internals.keyStore;
+    this.directAccessMode = internals.directAccessMode;
+    this.loopbackUrl = internals.loopbackUrl;
+    this.directStatus = this.directAccessMode === "disabled" ? "disabled" : "unavailable";
+    this.collectionClient = new MdbaseCollectionClient({
+      operation: (operation, input, requestOptions) => this.performOperation(operation, input, requestOptions)
+    });
+  }
+
+  get displayName(): string {
+    return this.currentToken()?.collectionName ?? `Collection ${this.collectionId.slice(0, 8)}`;
+  }
+
+  get operations(): CollectionOperation[] {
+    return [...(this.currentToken()?.operations ?? [])];
+  }
+
+  get scope(): GrantScope {
+    return this.currentToken()?.scope ?? { contracts: [] };
+  }
+
+  get directAccess(): DirectAccessStatus {
+    return this.currentToken()?.hosted ? "disabled" : this.directStatus;
+  }
+
+  get route(): MdbaseConnectionRoute {
+    return this.currentToken()?.hosted ? "hosted" : this.currentRoute;
+  }
+
+  register(): Promise<Application> {
+    return this.internals.register();
+  }
+
+  info(): MdbaseConnectionInfo | null {
     const token = this.currentToken();
-    return token
-      ? {
-          collectionId: token.collectionId,
-          operations: token.operations,
-          scope: token.scope,
-          route: token.hosted ? "hosted" : this.route,
-          directAccess: token.hosted ? "disabled" : this.directStatus
-        }
-      : null;
+    return token ? {
+      collectionId: token.collectionId,
+      displayName: token.collectionName,
+      operations: [...token.operations],
+      scope: token.scope,
+      route: token.hosted ? "hosted" : this.currentRoute,
+      directAccess: token.hosted ? "disabled" : this.directStatus
+    } : null;
   }
 
-  onConnectionChange(listener: (connection: MdbaseConnection | null) => void): () => void {
+  authorizationCapabilities(
+    requiredOperations: CollectionOperation[] = DEFAULT_OPERATIONS
+  ): MdbaseAuthorizationCapabilities {
+    const grantedOperations = this.operations;
+    const missingOperations = uniqueOperations(requiredOperations)
+      .filter((operation) => !grantedOperations.includes(operation));
+    return {
+      authorized: this.info() !== null,
+      sufficient: this.info() !== null && missingOperations.length === 0,
+      collectionId: this.collectionId,
+      grantedOperations,
+      missingOperations
+    };
+  }
+
+  hasOperations(requiredOperations: CollectionOperation[]): boolean {
+    return this.authorizationCapabilities(requiredOperations).sufficient;
+  }
+
+  authorize(options: MdbaseConnectionAuthorizeOptions = {}): Promise<never> {
+    return this.internals.authorize({ ...options, collectionId: this.collectionId });
+  }
+
+  async requestOperations(
+    requiredOperations: CollectionOperation[],
+    options: Pick<MdbaseConnectionAuthorizeOptions, "returnTo"> = {}
+  ): Promise<void> {
+    const capabilities = this.authorizationCapabilities(requiredOperations);
+    if (capabilities.sufficient) return;
+    await this.authorize({
+      ...options,
+      operations: uniqueOperations([
+        ...capabilities.grantedOperations,
+        ...capabilities.missingOperations
+      ])
+    });
+  }
+
+  onConnectionChange(listener: (connection: MdbaseConnectionInfo | null) => void): () => void {
     this.connectionListeners.add(listener);
-    listener(this.connection());
+    listener(this.info());
     return () => this.connectionListeners.delete(listener);
+  }
+
+  notifyStorageChanged(): void {
+    this.emitConnection();
   }
 
   async checkDirectAccess(): Promise<DirectAccessStatus> {
@@ -1360,15 +1652,9 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     await subscription?.unsubscribe();
   }
 
-  disconnect(): void {
-    const handles = new Set([
-      this.currentToken()?.keyHandle,
-      parseStored<StoredAuthorization>(this.storage.getItem(this.pendingKey()))?.keyHandle
-    ].filter((handle): handle is string => Boolean(handle)));
-    for (const handle of handles) void this.keyStore.delete(handle);
-    this.storage.removeItem(this.tokenKey());
-    this.storage.removeItem(this.pendingKey());
-    this.clearPendingMutation();
+  forget(): void {
+    const token = this.currentToken();
+    this.internals.removeToken(this.collectionId, token?.keyHandle);
     this.setRoute("relay");
     this.emitConnection();
   }
@@ -1970,24 +2256,22 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   }
 
   private setRoute(route: MdbaseConnectionRoute): void {
-    if (this.route !== route) {
-      this.route = route;
+    if (this.currentRoute !== route) {
+      this.currentRoute = route;
       this.emitConnection();
     }
   }
 
   private emitConnection(): void {
-    const connection = this.connection();
+    const connection = this.info();
     for (const listener of this.connectionListeners) listener(connection);
   }
 
   private invalidateRejectedAuthorization(rejected: StoredToken): void {
     const current = parseStored<StoredToken>(this.storage.getItem(this.tokenKey()));
     if (!current || !sameAuthorization(current, rejected)) return;
-    if (current.keyHandle) void this.keyStore.delete(current.keyHandle);
-    this.storage.removeItem(this.tokenKey());
-    this.clearPendingMutation();
-    this.route = "relay";
+    this.internals.removeToken(this.collectionId, current.keyHandle);
+    this.currentRoute = "relay";
     this.directStatus = this.directAccessMode === "disabled" ? "disabled" : "unavailable";
     this.emitConnection();
   }
@@ -2002,8 +2286,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
       // encrypted local grant usable while the connector still recognizes it; relay
       // use will require reauthorization, and revocation remains enforced locally.
       if (this.directCapable(token)) return token;
-      if (token.keyHandle) void this.keyStore.delete(token.keyHandle);
-      this.storage.removeItem(this.tokenKey());
+      this.internals.removeToken(this.collectionId, token.keyHandle);
       return null;
     }
     return token;
@@ -2020,8 +2303,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
           "Direct access is still available on this computer, but using the relay requires reconnecting this application."
         );
       }
-      if (token.keyHandle) void this.keyStore.delete(token.keyHandle);
-      this.storage.removeItem(this.tokenKey());
+      this.internals.removeToken(this.collectionId, token.keyHandle);
       return null;
     }
     return this.refreshAuthorization();
@@ -2063,8 +2345,7 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
         return latest;
       }
       if (!this.directCapable(current)) {
-        if (current.keyHandle) void this.keyStore.delete(current.keyHandle);
-        this.storage.removeItem(this.tokenKey());
+        this.internals.removeToken(this.collectionId, current.keyHandle);
       }
       throw apiError(body, "authorization_expired", "Reconnect this application to continue.", response.status);
     }
@@ -2072,29 +2353,14 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   }
 
   private storeTokenResponse(body: any, clientId: string, keyHandle?: string): StoredToken {
-    const token: StoredToken = {
-      accessToken: body.access_token,
-      refreshToken: body.refresh_token,
-      clientId,
-      collectionId: body.collection_id,
-      operations: body.operations,
-      scope: body.scope ?? { contracts: [] },
-      expiresAt: Date.now() + body.expires_in * 1_000,
-      refreshExpiresAt: body.refresh_expires_in
-        ? Date.now() + body.refresh_expires_in * 1_000
-        : undefined,
-      grantId: body.grant_id,
-      encryption: body.encryption ?? undefined,
-      applicationOrigin: body.application_origin ?? this.defaultApplicationOrigin(),
-      keyHandle,
-      hosted: body.hosted ? {
-        providerUrl: body.hosted.provider_url,
-        replicaId: body.hosted.replica_id,
-        accessToken: body.hosted.access_token
-      } : undefined
-    };
-    this.storage.setItem(this.tokenKey(), JSON.stringify(token));
-    this.route = token.hosted ? "hosted" : "relay";
+    if (body.collection_id !== this.collectionId) {
+      throw new MdbaseConnectError(
+        "collection_mismatch",
+        "The refreshed authorization belongs to a different collection."
+      );
+    }
+    const token = this.internals.storeTokenResponse(body, clientId, keyHandle);
+    this.currentRoute = token.hosted ? "hosted" : "relay";
     this.directStatus = token.hosted || this.directAccessMode === "disabled"
       ? "disabled"
       : "unavailable";
@@ -2102,11 +2368,11 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     return token;
   }
 
-  private pendingKey() { return `mdbase-connect:pending:${this.serverUrl}:${this.manifestSource}`; }
-  private tokenKey() { return `mdbase-connect:token:${this.serverUrl}:${this.manifestSource}`; }
+  private tokenKey() {
+    return this.internals.tokenKey(this.collectionId);
+  }
   private notificationKey(transport: "web_push" | "fcm" = "web_push") {
-    const base = `mdbase-connect:notifications:${this.serverUrl}:${this.manifestSource}`;
-    return transport === "web_push" ? base : `${base}:${transport}`;
+    return this.internals.notificationKey(this.collectionId, transport);
   }
   private async deleteNotificationChannel(
     channelId: string,
@@ -2130,27 +2396,13 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     }
   }
   private pendingMutationKey() {
-    return `mdbase-connect:pending-mutation:${this.serverUrl}:${this.manifestSource}`;
+    return this.internals.pendingMutationKey(this.collectionId);
   }
   private clearPendingMutation(): void {
     this.storage.removeItem(this.pendingMutationKey());
   }
   private directPreferenceKey() {
-    return `mdbase-connect:direct:${this.defaultApplicationOrigin()}`;
-  }
-
-  private defaultApplicationOrigin(): string {
-    const redirect = new URL(this.redirectUri);
-    if (["http:", "https:"].includes(redirect.protocol)) return redirect.origin;
-    if (typeof location !== "undefined") return location.origin;
-    if (this.manifest && typeof this.manifest !== "string") {
-      return new URL(this.manifest.homepage).origin;
-    }
-    try {
-      return new URL(this.manifestSource).origin;
-    } catch {
-      return "";
-    }
+    return this.internals.directPreferenceKey();
   }
 }
 

--- a/packages/pickle/src/index.ts
+++ b/packages/pickle/src/index.ts
@@ -6,7 +6,7 @@ import type {
   RecordResult,
   RecordSummary
 } from "@mdbase/connect-protocol";
-import type { MdbaseConnect, QueryResult } from "@mdbase/connect";
+import type { MdbaseConnection, QueryResult } from "@mdbase/connect";
 
 export {
   PICKLE_ACK_RESPONSE_TYPE_DOCUMENT,
@@ -117,11 +117,11 @@ export interface RespondOptions {
 export interface PickleClient {
   describe(): Promise<CollectionDescription>;
   queryAll(
-    input: Parameters<MdbaseConnect<PickleFrontmatter>["queryAll"]>[0]
+    input: Parameters<MdbaseConnection<PickleFrontmatter>["queryAll"]>[0]
   ): Promise<QueryResult<PickleFrontmatter>>;
   create(
-    input: Parameters<MdbaseConnect<PickleFrontmatter>["create"]>[0]
-  ): ReturnType<MdbaseConnect<PickleFrontmatter>["create"]>;
+    input: Parameters<MdbaseConnection<PickleFrontmatter>["create"]>[0]
+  ): ReturnType<MdbaseConnection<PickleFrontmatter>["create"]>;
 }
 
 export function resolvePickleContract(

--- a/packages/tasknotes/src/index.ts
+++ b/packages/tasknotes/src/index.ts
@@ -5,7 +5,7 @@ import type {
   RecordResult,
   SyncCollectionResources
 } from "@mdbase/connect-protocol";
-import type { MdbaseConnect, QueryResult } from "@mdbase/connect";
+import type { MdbaseConnection, QueryResult } from "@mdbase/connect";
 import type { OfflineReplica } from "@mdbase/connect-sync";
 
 export const TASKNOTES_TASK_CONTRACT = "tasknotes.task";
@@ -79,7 +79,7 @@ function resolveContract(
 export class TasknotesCollection {
   private contract: TasknotesContract | null = null;
 
-  constructor(private readonly connect: MdbaseConnect<TaskFrontmatter>) {}
+  constructor(private readonly connect: MdbaseConnection<TaskFrontmatter>) {}
 
   async describe(): Promise<TasknotesContract> {
     this.contract ??= resolveTasknotesContract(await this.connect.describe());

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -250,11 +250,13 @@ secret: connector scope test
   const accessToken = refreshed.body.access_token;
   relayContext.binding.encryption = refreshed.body.encryption;
   const sdkStorage = new MemoryStorage();
-  sdkStorage.setItem(`mdbase-connect:token:${serverUrl}:bundle:${manifest.applicationManifest.id}`, JSON.stringify({
+  const sdkStoragePrefix = `mdbase-connect:${serverUrl}:bundle:${manifest.applicationManifest.id}`;
+  sdkStorage.setItem(`${sdkStoragePrefix}:token:${collection.id}`, JSON.stringify({
     accessToken,
     refreshToken: refreshed.body.refresh_token,
     clientId: appId,
     collectionId: collection.id,
+    collectionName: collection.name,
     operations: refreshed.body.operations,
     scope: refreshed.body.scope,
     // Direct access remains usable while the cloud access token needs renewal.
@@ -263,8 +265,10 @@ secret: connector scope test
     grantId: refreshed.body.grant_id,
     encryption: refreshed.body.encryption,
     applicationOrigin: refreshed.body.application_origin,
-    keyHandle: "e2e-grant"
+    keyHandle: "e2e-grant",
+    savedAt: Date.now()
   }));
+  sdkStorage.setItem(`${sdkStoragePrefix}:connections`, JSON.stringify([collection.id]));
   const sdk = new MdbaseConnect({
     serverUrl,
     manifest: manifest.applicationManifest,
@@ -281,13 +285,17 @@ secret: connector scope test
     return browserFetch(input, { ...init, headers });
   };
   try {
-    if (await sdk.requestDirectAccess() !== "available") {
+    const connection = sdk.connection(collection.id);
+    if (!connection) {
+      throw new Error("Browser SDK did not restore the saved collection connection");
+    }
+    if (await connection.requestDirectAccess() !== "available") {
       throw new Error("Browser SDK did not discover the direct connector");
     }
-    const sdkQuery = await sdk.query({ limit: 1_100 });
+    const sdkQuery = await connection.query({ limit: 1_100 });
     if (!sdkQuery.valid
         || sdkQuery.result.results.length !== 1_000
-        || sdk.connection()?.route !== "direct") {
+        || connection.route !== "direct") {
       throw new Error("Browser SDK did not complete the 1,000-record query directly");
     }
   } finally {
@@ -363,6 +371,7 @@ secret: connector scope test
         refreshToken: browserToken.body.refresh_token,
         clientId: browserAppId,
         collectionId: browserToken.body.collection_id,
+        collectionName: browserToken.body.collection_name,
         operations: browserToken.body.operations,
         scope: browserToken.body.scope,
         // Exercise genuine cloud-independent access, not merely deferred renewal.
@@ -371,7 +380,8 @@ secret: connector scope test
         grantId: browserToken.body.grant_id,
         encryption: browserToken.body.encryption,
         applicationOrigin: browserToken.body.application_origin,
-        keyHandle: "browser-e2e-grant"
+        keyHandle: "browser-e2e-grant",
+        savedAt: Date.now()
       }
     });
     if (browserResult.status !== "available"
@@ -763,8 +773,15 @@ async function openApplicationServer(name, contracts, access) {
   globalThis.directHarness = {
     publicKey: key.publicKey,
     async exercise(config) {
-      const tokenKey = \`mdbase-connect:token:\${config.serverUrl}:bundle:\${config.manifest.id}\`;
-      localStorage.setItem(tokenKey, JSON.stringify(config.token));
+      const storagePrefix = \`mdbase-connect:\${config.serverUrl}:bundle:\${config.manifest.id}\`;
+      localStorage.setItem(
+        \`\${storagePrefix}:token:\${config.token.collectionId}\`,
+        JSON.stringify(config.token)
+      );
+      localStorage.setItem(
+        \`\${storagePrefix}:connections\`,
+        JSON.stringify([config.token.collectionId])
+      );
       const connect = new MdbaseConnect({
         serverUrl: config.serverUrl,
         manifest: config.manifest,
@@ -772,27 +789,29 @@ async function openApplicationServer(name, contracts, access) {
         keyStore,
         loopbackUrl: config.loopbackUrl
       });
-      const status = await connect.requestDirectAccess();
-      const description = await connect.describe();
-      const created = await connect.create({
+      const connection = connect.connection(config.token.collectionId);
+      if (!connection) throw new Error("Saved browser connection was not restored");
+      const status = await connection.requestDirectAccess();
+      const description = await connection.describe();
+      const created = await connection.create({
         path: "browser/direct.md",
         frontmatter: { type: "task", title: "Real browser direct", status: "open" },
         body: "Created in Chromium."
       });
       const revision = created.result.revision;
-      const read = await connect.read({ path: "browser/direct.md" });
-      const updated = await connect.update({
+      const read = await connection.read({ path: "browser/direct.md" });
+      const updated = await connection.update({
         path: "browser/direct.md",
         patch: { status: "done" },
         if_revision: revision
       });
-      const readUpdated = await connect.read({ path: "browser/direct.md" });
-      const renamed = await connect.rename({
+      const readUpdated = await connection.read({ path: "browser/direct.md" });
+      const renamed = await connection.rename({
         from: "browser/direct.md",
         to: "browser/renamed.md"
       });
-      const query = await connect.query({ limit: 1_100 });
-      const validated = await connect.validate();
+      const query = await connection.query({ limit: 1_100 });
+      const validated = await connection.validate();
       const typeDocument = \`---
 kind: mdbase.type
 name: browsernote
@@ -806,23 +825,23 @@ schema:
       title: { type: string }
 ---
 \`;
-      const createdType = await connect.createType({ document: typeDocument });
-      const readType = await connect.readType({ name: "browsernote" });
-      const updatedType = await connect.updateType({
+      const createdType = await connection.createType({ document: typeDocument });
+      const readType = await connection.readType({ name: "browsernote" });
+      const updatedType = await connection.updateType({
         name: "browsernote",
         document: typeDocument.replace("Browser note", "Updated browser note"),
         if_revision: readType.result.revision
       });
-      const views = await connect.listViews();
-      const executedView = await connect.executeView({
+      const views = await connection.listViews();
+      const executedView = await connection.executeView({
         path: "TaskNotes/Views/tasks.base",
         view: "open-tasks"
       });
-      const changed = await connect.changes({ after: description.change_cursor });
-      const deleted = await connect.delete({ path: "browser/renamed.md" });
+      const changed = await connection.changes({ after: description.change_cursor });
+      const deleted = await connection.delete({ path: "browser/renamed.md" });
       return {
         status,
-        route: connect.connection()?.route,
+        route: connection.route,
         records: query.result.results.length,
         read: read.result.body.includes("Created in Chromium"),
         updated: updated.valid && readUpdated.result.frontmatter.status === "done",

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -540,17 +540,19 @@ try {
       storage: inlineStorage,
       keyStore: new MemoryGrantKeyStore()
     });
-    void inlineSdk.authorize(["describe", "read", "query", "create", "update"]);
+    void inlineSdk.authorize({
+      operations: ["describe", "read", "query", "create", "update"]
+    });
     await waitFor(() => inlineAuthorizationUrl, "SDK did not start inline hosted authorization");
     const inlineCallback = await authorizeHostedApplicationByCreating(
       inlineAuthorizationUrl,
       emptyCookie,
       inlineManifest.origin
     );
-    await inlineSdk.completeAuthorization(inlineCallback);
+    const { connection: inlineConnection } = await inlineSdk.completeAuthorization(inlineCallback);
     const inlineToken = inlineStorage.token();
     assert.equal(inlineToken.hosted.providerUrl, provider.url);
-    const inlineDescription = await inlineSdk.describe();
+    const inlineDescription = await inlineConnection.describe();
     assert.equal(inlineDescription.contracts[0]?.id, "tasknotes.task");
   } finally {
     await new Promise((resolveClose) => inlineManifest.server.close(resolveClose));
@@ -579,10 +581,12 @@ try {
     storage,
     keyStore: new MemoryGrantKeyStore()
   });
-  void hostedSdk.authorize([
-    "describe", "changes", "read", "query", "list_views", "execute_view",
-    "create", "update", "delete", "rename", "create_type"
-  ]);
+  void hostedSdk.authorize({
+    operations: [
+      "describe", "changes", "read", "query", "list_views", "execute_view",
+      "create", "update", "delete", "rename", "create_type"
+    ]
+  });
   await waitFor(() => authorizationUrl, "SDK did not start hosted authorization");
   const callbackUrl = await authorizeHostedApplication(
     authorizationUrl,
@@ -590,7 +594,7 @@ try {
     genericCollectionId,
     manifest.origin
   );
-  await hostedSdk.completeAuthorization(callbackUrl);
+  const { connection: hostedConnection } = await hostedSdk.completeAuthorization(callbackUrl);
   const storedHostedToken = storage.token();
   assert.equal(storedHostedToken.hosted.providerUrl, provider.url);
   assert.equal(storedHostedToken.encryption, undefined);
@@ -634,30 +638,30 @@ try {
     headers.set("origin", manifest.origin);
     return originalFetch(input, { ...init, headers });
   };
-  const description = await hostedSdk.describe();
+  const description = await hostedConnection.describe();
   assert.equal(description.display_name, "Hosted writing");
   assert.deepEqual(description.contracts, []);
-  const sdkCreated = await hostedSdk.create({
+  const sdkCreated = await hostedConnection.create({
     path: "Draft.md",
     frontmatter: { title: "Created through hosted SDK" },
     body: "Generic mdbase Markdown."
   });
   assert.equal(sdkCreated.valid, true);
   assert.deepEqual(sdkCreated.result.types, []);
-  const sdkUpdated = await hostedSdk.update({
+  const sdkUpdated = await hostedConnection.update({
     path: "Draft.md",
     fields: { title: "Updated through hosted SDK" },
     if_revision: sdkCreated.result.revision
   });
   assert.equal(sdkUpdated.valid, true);
-  const sdkRenamed = await hostedSdk.rename({
+  const sdkRenamed = await hostedConnection.rename({
     from: "Draft.md",
     to: "Writing/Draft.md",
     if_revision: sdkUpdated.result.revision
   });
   assert.equal(sdkRenamed.valid, true);
-  assert.equal((await hostedSdk.query()).result.results[0].path, "Writing/Draft.md");
-  const viewType = await hostedSdk.createType({
+  assert.equal((await hostedConnection.query()).result.results[0].path, "Writing/Draft.md");
+  const viewType = await hostedConnection.createType({
     document: `---
 kind: mdbase.type
 name: view
@@ -673,7 +677,7 @@ schema:
 `
   });
   assert.equal(viewType.valid, true);
-  const viewRecord = await hostedSdk.create({
+  const viewRecord = await hostedConnection.create({
     path: "Views/writing.md",
     frontmatter: {
       type: "view",
@@ -695,14 +699,14 @@ schema:
     }
   });
   assert.equal(viewRecord.valid, true);
-  const listedViews = await hostedSdk.listViews();
+  const listedViews = await hostedConnection.listViews();
   assert.equal(listedViews.valid, true);
   assert.equal(listedViews.result.views[0].views[0].id, "all");
   assert.deepEqual(listedViews.result.views[0].views[0].properties[1], {
     key: "display_title",
     label: "Display title"
   });
-  const executedView = await hostedSdk.executeView({
+  const executedView = await hostedConnection.executeView({
     path: "Views/writing.md",
     view: "all"
   });
@@ -715,15 +719,15 @@ schema:
     executedView.result.results[0].values.display_title,
     "Updated through hosted SDK!"
   );
-  assert.equal((await hostedSdk.delete({
+  assert.equal((await hostedConnection.delete({
     path: "Views/writing.md",
     if_revision: viewRecord.result.revision
   })).valid, true);
-  assert.equal((await hostedSdk.delete({
+  assert.equal((await hostedConnection.delete({
     path: "Writing/Draft.md",
     if_revision: sdkRenamed.result.revision
   })).valid, true);
-  const hostedSync = hostedSdk.hostedSync();
+  const hostedSync = hostedConnection.hostedSync();
   assert.ok(hostedSync);
   const offline = new OfflineReplica(hostedSync.transport, store(hostedSync.replicaId));
   await offline.initialize();
@@ -1844,7 +1848,7 @@ function memoryStorage() {
     setItem(key, value) { values.set(key, String(value)); },
     token() {
       const value = [...values.entries()]
-        .find(([key]) => key.startsWith("mdbase-connect:token:"))?.[1];
+        .find(([key]) => key.includes(":token:"))?.[1];
       assert.ok(value, "SDK did not persist a hosted token");
       return JSON.parse(value);
     }

--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -156,6 +156,14 @@ describe("mdbase MCP gateway", () => {
       "First collection",
       "Second collection"
     ]);
+    const reconnectUrl = await oauth.createConnectionTicket(context!, connections[0].id);
+    const reconnect = await app.inject({
+      method: "GET",
+      url: `${new URL(reconnectUrl).pathname}${new URL(reconnectUrl).search}`
+    });
+    expect(reconnect.statusCode).toBe(302);
+    expect(new URL(reconnect.headers.location!).searchParams.get("collection_hint"))
+      .toBe(connections[0].collection_id);
 
     const stored = await db.query<{ credentials_ciphertext: string }>(
       "SELECT credentials_ciphertext FROM mcp_connections"
@@ -171,6 +179,7 @@ describe("mdbase MCP gateway", () => {
     await client.connect(transport);
     const tools = await client.listTools();
     expect(tools.tools.map((tool) => tool.name)).toContain("add_connection");
+    expect(tools.tools.map((tool) => tool.name)).toContain("reconnect_collection");
     expect(tools.tools.map((tool) => tool.name)).toContain("create_record");
     const listed = await client.callTool({ name: "list_connections", arguments: {} });
     expect((listed.structuredContent as any).connections).toHaveLength(2);

--- a/services/mcp/src/db.ts
+++ b/services/mcp/src/db.ts
@@ -137,9 +137,13 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       token_hash text NOT NULL UNIQUE,
       connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
       scopes jsonb NOT NULL,
+      collection_hint uuid,
       expires_at timestamptz NOT NULL,
       used_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now()
     );
   `);
+  await db.query(
+    "ALTER TABLE mcp_connection_tickets ADD COLUMN IF NOT EXISTS collection_hint uuid"
+  );
 }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -35,6 +35,21 @@ export function createMcpServer(
     });
   });
 
+  server.registerTool("reconnect_collection", {
+    title: "Reconnect an mdbase collection",
+    description: "Create a short-lived browser link that preselects one existing collection so the user can renew or broaden its approval.",
+    inputSchema: { connection_id: connectionId },
+    annotations: { readOnlyHint: false, openWorldHint: true }
+  }, async ({ connection_id }) => {
+    const authorizationUrl = await oauth.createConnectionTicket(context, connection_id);
+    return toolResult({
+      authorization_url: authorizationUrl,
+      connection_id,
+      expires_in: 600,
+      instruction: "Ask the user to open this link and review the preselected collection approval, then call list_connections again."
+    });
+  });
+
   server.registerTool("describe_collection", {
     title: "Describe an mdbase collection",
     description: "Return collection metadata, supported operations, types and contracts.",

--- a/services/mcp/src/oauth.ts
+++ b/services/mcp/src/oauth.ts
@@ -126,7 +126,7 @@ export class OAuthService {
         new Date(Date.now() + 10 * 60_000)
       ]
     );
-    return this.beginUpstream("initial", setId, scopes, requestId);
+    return this.beginUpstream("initial", setId, scopes, requestId, null);
   }
 
   async completeUpstream(input: { state?: string; code?: string; error?: string }): Promise<{
@@ -300,13 +300,35 @@ export class OAuthService {
     };
   }
 
-  async createConnectionTicket(context: McpAuthContext): Promise<string> {
+  async createConnectionTicket(
+    context: McpAuthContext,
+    connectionId?: string
+  ): Promise<string> {
+    let collectionHint: string | null = null;
+    if (connectionId) {
+      const selected = await this.db.query<{ collection_id: string }>(
+        `SELECT collection_id FROM mcp_connections
+         WHERE id = $1 AND connection_set_id = $2`,
+        [connectionId, context.connectionSetId]
+      );
+      if (!selected.rows[0]) {
+        throw new OAuthError("invalid_request", "That collection connection is unavailable.");
+      }
+      collectionHint = selected.rows[0].collection_id;
+    }
     const token = randomToken("add");
     await this.db.query(
       `INSERT INTO mcp_connection_tickets
-         (id, token_hash, connection_set_id, scopes, expires_at)
-       VALUES ($1, $2, $3, $4::jsonb, $5)`,
-      [randomUUID(), tokenHash(token), context.connectionSetId, JSON.stringify(context.scopes), new Date(Date.now() + 10 * 60_000)]
+         (id, token_hash, connection_set_id, scopes, collection_hint, expires_at)
+       VALUES ($1, $2, $3, $4::jsonb, $5, $6)`,
+      [
+        randomUUID(),
+        tokenHash(token),
+        context.connectionSetId,
+        JSON.stringify(context.scopes),
+        collectionHint,
+        new Date(Date.now() + 10 * 60_000)
+      ]
     );
     return `${this.publicUrl}/connections/new?ticket=${encodeURIComponent(token)}`;
   }
@@ -316,22 +338,30 @@ export class OAuthService {
       id: string;
       connection_set_id: string;
       scopes: McpScope[];
+      collection_hint: string | null;
     }>(
       `UPDATE mcp_connection_tickets SET used_at = now()
        WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now()
-       RETURNING id, connection_set_id, scopes`,
+       RETURNING id, connection_set_id, scopes, collection_hint`,
       [tokenHash(token)]
     );
     const ticket = result.rows[0];
     if (!ticket) throw new OAuthError("invalid_request", "This add-collection link is invalid or expired.");
-    return this.beginUpstream("additional", ticket.connection_set_id, ticket.scopes, null);
+    return this.beginUpstream(
+      "additional",
+      ticket.connection_set_id,
+      ticket.scopes,
+      null,
+      ticket.collection_hint
+    );
   }
 
   private async beginUpstream(
     kind: "initial" | "additional",
     connectionSetId: string,
     scopes: McpScope[],
-    authorizationRequestId: string | null
+    authorizationRequestId: string | null,
+    collectionHint: string | null
   ): Promise<string> {
     const application = await this.gateway.registerApplication();
     const state = randomToken("state");
@@ -362,6 +392,7 @@ export class OAuthService {
     authorize.searchParams.set("code_challenge_method", "S256");
     authorize.searchParams.set("state", state);
     authorize.searchParams.set("operations", operationsForScopes(scopes).join(","));
+    if (collectionHint) authorize.searchParams.set("collection_hint", collectionHint);
     authorize.searchParams.set("relay_protocol", "1");
     authorize.searchParams.set("application_public_key", key.publicKey);
     return authorize.href;

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -313,7 +313,7 @@ describe("mdbase connect server", () => {
     const state = "test-state";
     const authorize = await app.inject({
       method: "GET",
-      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&state=${state}&operations=read,query`,
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&state=${state}&operations=read,query&collection_hint=${collectionId}`,
       headers: { cookie }
     });
     expect(authorize.statusCode).toBe(302);
@@ -326,6 +326,7 @@ describe("mdbase connect server", () => {
     });
     expect(pending.statusCode).toBe(200);
     expect(pending.json().authorization.application_name).toBe("Workout Tracker");
+    expect(pending.json().authorization.collection_hint).toBe(collectionId);
     expect(pending.json().collections).toContainEqual(expect.objectContaining({
       display_name: "Legacy workouts",
       spec_version: "0.2.0"
@@ -350,6 +351,7 @@ describe("mdbase connect server", () => {
     });
     expect(localControl.statusCode).toBe(200);
     expect(localControl.json().pending_authorizations[0].application_name).toBe("Workout Tracker");
+    expect(localControl.json().pending_authorizations[0].collection_hint).toBe(localCollectionId);
     expect(localControl.json().pending_authorizations[0].requirements).toEqual({
       contracts: [{ id: "workout.record", version: 1 }]
     });

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -1005,7 +1005,7 @@ export async function buildApp(options: BuildOptions) {
       [user.id]
     );
     const pendingAuthorizations = await options.db.query(
-      `SELECT ar.id, ar.requested_operations, ar.expires_at,
+      `SELECT ar.id, ar.requested_operations, ar.collection_hint, ar.expires_at,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
               a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar
@@ -1182,13 +1182,16 @@ export async function buildApp(options: BuildOptions) {
     const pendingAuthorizations = await options.db.query(
       `SELECT ar.id, ar.application_id, a.name AS application_name,
               a.homepage AS application_homepage, a.icon AS application_icon,
-              ar.requested_operations, ar.expires_at, a.requirements, a.provisions, a.notifications
+              ar.requested_operations, hinted.local_id AS collection_hint,
+              ar.expires_at, a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
+       LEFT JOIN collections hinted
+         ON hinted.id = ar.collection_hint AND hinted.connector_id = $2
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
          AND ar.expires_at > now()
        ORDER BY ar.expires_at`,
-      [connector.user_id]
+      [connector.user_id, connector.id]
     );
     return {
       configured: true,
@@ -1838,6 +1841,7 @@ export async function buildApp(options: BuildOptions) {
       code_challenge_method: z.literal("S256"),
       state: z.string().max(500).optional(),
       operations: z.string().default("read,query"),
+      collection_hint: z.uuid().optional(),
       relay_protocol: z.coerce.number().int().optional(),
       application_public_key: z.string().min(80).max(200).optional()
     }).parse(request.query);
@@ -1875,8 +1879,8 @@ export async function buildApp(options: BuildOptions) {
     await options.db.query(
       `INSERT INTO authorization_requests
          (id, user_id, application_id, redirect_uri, state, code_challenge,
-          requested_operations, relay_protocol, application_public_key, expires_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, now() + interval '10 minutes')`,
+          requested_operations, collection_hint, relay_protocol, application_public_key, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, now() + interval '10 minutes')`,
       [
         authorizationId,
         user.id,
@@ -1885,6 +1889,7 @@ export async function buildApp(options: BuildOptions) {
         query.state ?? null,
         query.code_challenge,
         JSON.stringify(requestedOperations),
+        query.collection_hint ?? null,
         query.relay_protocol ?? null,
         query.application_public_key ?? null
       ]
@@ -1897,7 +1902,7 @@ export async function buildApp(options: BuildOptions) {
     if (!user) return;
     const { requestId } = z.object({ requestId: z.uuid() }).parse(request.params);
     const authorization = await options.db.query(
-      `SELECT ar.id, ar.requested_operations, ar.expires_at,
+      `SELECT ar.id, ar.requested_operations, ar.collection_hint, ar.expires_at,
               a.id AS application_id, a.name AS application_name, a.homepage, a.icon,
               a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar JOIN applications a ON a.id = ar.application_id

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -154,6 +154,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       state text,
       code_challenge text NOT NULL,
       requested_operations jsonb NOT NULL,
+      collection_hint uuid,
       relay_protocol integer,
       application_public_key text,
       expires_at timestamptz NOT NULL,
@@ -364,6 +365,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   );
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
+  await ensureColumn(db, "authorization_requests", "collection_hint", "ALTER TABLE authorization_requests ADD COLUMN collection_hint uuid");
   await ensureColumn(db, "hosted_collections", "provider_url", "ALTER TABLE hosted_collections ADD COLUMN provider_url text");
   await ensureColumn(
     db,


### PR DESCRIPTION
Makes MdbaseConnect an app-level manager, introduces collection-bound connections, adds durable collection UUIDs and OAuth collection hints, updates MCP reconnect behavior, and revises SDK and Connect docs. This is intentionally a breaking pre-public API change without compatibility shims or a v2 namespace. Verified with full TypeScript and Rust suites, clippy, package audit, and direct, relay, sync, and hosted-provider E2E paths.