### PR TITLE
Make TaskNotes follow canonical mdbase task types

### DIFF
--- a/apps/tasknotes/package.json
+++ b/apps/tasknotes/package.json
@@ -7,7 +7,7 @@
     "manifest": "node scripts/write-manifest.mjs",
     "build": "pnpm manifest && vite build",
     "dev": "pnpm manifest && vite",
-    "test": "node --test",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
@@ -21,6 +21,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "typescript": "^7.0.2",
-    "vite": "^8.1.5"
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/tasknotes/src/main.tsx
+++ b/apps/tasknotes/src/main.tsx
@@ -1,7 +1,20 @@
 import { StrictMode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { MdbaseConnect, MdbaseConnectError } from "@mdbase/connect";
-import { TasknotesCollection, type TaskFrontmatter, type TaskSummary } from "@mdbase/tasknotes";
+import { MdbaseConnect, MdbaseConnectError, type JsonObject } from "@mdbase/connect";
+import {
+  TasknotesCollection,
+  type TaskFieldDefinition,
+  type TaskFrontmatter,
+  type TasknotesContract,
+  type TaskSummary
+} from "@mdbase/tasknotes";
+import {
+  editableTaskFields,
+  missingRequiredFields,
+  requiredCreateFields,
+  taskFieldPatch,
+  taskFieldValue
+} from "./taskFields";
 import "./styles.css";
 
 const serverUrl = import.meta.env.VITE_CONNECT_SERVER_URL ?? "http://127.0.0.1:8787";
@@ -24,8 +37,12 @@ function App() {
   const tasknotes = useMemo(() => bound ? new TasknotesCollection(bound) : null, [bound]);
   const connection = bound?.info() ?? null;
   const connected = connection !== null;
+  const [contract, setContract] = useState<TasknotesContract>();
   const [tasks, setTasks] = useState<TaskSummary[]>([]);
   const [title, setTitle] = useState("");
+  const [creationValues, setCreationValues] = useState<Record<string, string | boolean>>({});
+  const [expandedPath, setExpandedPath] = useState<string>();
+  const [busyPath, setBusyPath] = useState<string>();
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
@@ -42,8 +59,10 @@ function App() {
     setLoading(true);
     try {
       if (!tasknotes) return;
+      const activeContract = await tasknotes.describe();
       const next = await tasknotes.list();
       if (generation === loadGeneration.current) {
+        setContract(activeContract);
         setTasks(next);
         setError(undefined);
       }
@@ -76,7 +95,7 @@ function App() {
       try {
         for await (const event of bound.watch({ signal: controller.signal })) {
           if (event.type === "mdbase.type.changed") {
-            await tasknotes.refreshContract();
+            setContract(await tasknotes.refreshContract());
             await load();
           } else if (event.type.startsWith("mdbase.record.")) {
             await load();
@@ -93,11 +112,21 @@ function App() {
     event.preventDefault();
     const nextTitle = title.trim();
     if (!nextTitle || saving) return;
+    const createFields = contract ? requiredCreateFields(contract) : [];
+    const missing = missingRequiredFields(createFields, creationValues);
+    if (missing.length > 0) {
+      setError(`Complete the required ${missing.join(", ")} field${missing.length === 1 ? "" : "s"}.`);
+      return;
+    }
     setSaving(true);
     try {
       if (!tasknotes) return;
-      await tasknotes.create({ title: nextTitle });
+      await tasknotes.create({
+        title: nextTitle,
+        fields: taskFieldPatch(createFields, creationValues)
+      });
       setTitle("");
+      setCreationValues({});
       await load();
     } catch (caught) {
       setError(message(caught));
@@ -112,11 +141,54 @@ function App() {
       : item));
     try {
       if (!tasknotes) return;
+      setBusyPath(task.path);
       await tasknotes.setCompleted(task.path, !task.completed);
       await load();
     } catch (caught) {
       setError(message(caught));
       await load();
+    } finally {
+      setBusyPath(undefined);
+    }
+  }
+
+  async function updateStatus(task: TaskSummary, status: string) {
+    if (!tasknotes || task.status === status) return;
+    setBusyPath(task.path);
+    try {
+      await tasknotes.setStatus(task.path, status);
+      await load();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusyPath(undefined);
+    }
+  }
+
+  async function updatePriority(task: TaskSummary, priority: string) {
+    if (!tasknotes || task.priority === priority) return;
+    setBusyPath(task.path);
+    try {
+      await tasknotes.setPriority(task.path, priority);
+      await load();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusyPath(undefined);
+    }
+  }
+
+  async function saveFields(task: TaskSummary, fields: JsonObject) {
+    if (!tasknotes) return;
+    setBusyPath(task.path);
+    try {
+      await tasknotes.updateFields(task.path, fields);
+      setExpandedPath(undefined);
+      await load();
+    } catch (caught) {
+      setError(message(caught));
+    } finally {
+      setBusyPath(undefined);
     }
   }
 
@@ -151,6 +223,7 @@ function App() {
       <button className="quiet" onClick={() => {
         bound?.forget();
         setBound(null);
+        setContract(undefined);
         setTasks([]);
       }}>Disconnect</button>
     </header>
@@ -158,15 +231,33 @@ function App() {
     <section aria-labelledby="tasks-heading">
       <h1 id="tasks-heading">Tasks</h1>
       <form className="quick-add" onSubmit={addTask}>
-        <label className="sr-only" htmlFor="new-task">New task</label>
-        <input
-          id="new-task"
-          value={title}
-          onChange={(event) => setTitle(event.target.value)}
-          placeholder="Add a task"
-          autoComplete="off"
-        />
-        <button disabled={!title.trim() || saving}>{saving ? "Adding" : "Add"}</button>
+        <div className="quick-add-title">
+          <label className="sr-only" htmlFor="new-task">New task</label>
+          <input
+            id="new-task"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Add a task"
+            autoComplete="off"
+          />
+          <button disabled={!title.trim() || saving}>{saving ? "Adding" : "Add"}</button>
+        </div>
+        {contract && requiredCreateFields(contract).length > 0 && (
+          <div className="quick-add-required" aria-label="Required task details">
+            {requiredCreateFields(contract).map((field, index) => (
+              <TaskFieldControl
+                key={field.key}
+                id={`create-field-${index}`}
+                field={field}
+                value={creationValues[field.key] ?? (field.kind === "boolean" ? false : "")}
+                onChange={(value) => setCreationValues((current) => ({
+                  ...current,
+                  [field.key]: value
+                }))}
+              />
+            ))}
+          </div>
+        )}
       </form>
 
       {error && <p className="error" role="alert">{error}</p>}
@@ -175,18 +266,200 @@ function App() {
       </div> : tasks.length === 0 ? <p className="empty">No tasks yet. Add the first one above.</p> :
         <ul className="task-list">
           {tasks.map((task) => <li key={task.path}>
-            <label>
-              <input
-                type="checkbox"
-                checked={task.completed}
-                onChange={() => void toggle(task)}
-              />
-              <span className={task.completed ? "completed" : ""}>{task.title}</span>
-            </label>
+            <div className="task-row">
+              <label className="task-check">
+                <input
+                  type="checkbox"
+                  checked={task.completed}
+                  disabled={busyPath === task.path}
+                  onChange={() => void toggle(task)}
+                />
+                <span className={task.completed ? "completed" : ""}>{task.title}</span>
+              </label>
+              {contract && <div className="task-controls">
+                <label>
+                  <span className="sr-only">Status for {task.title}</span>
+                  <select
+                    value={task.status ?? contract.configuration.status.default ?? ""}
+                    disabled={busyPath === task.path}
+                    onChange={(event) => void updateStatus(task, event.target.value)}
+                  >
+                    {contract.statuses.map((status) => (
+                      <option key={status.value} value={status.value}>{status.label}</option>
+                    ))}
+                  </select>
+                </label>
+                {contract.priorities.length > 0 && <label>
+                  <span className="sr-only">Priority for {task.title}</span>
+                  <select
+                    value={task.priority ?? contract.configuration.priority?.default ?? ""}
+                    disabled={busyPath === task.path}
+                    onChange={(event) => void updatePriority(task, event.target.value)}
+                  >
+                    {contract.priorities.map((priority) => (
+                      <option key={priority.value} value={priority.value}>{priority.label}</option>
+                    ))}
+                  </select>
+                </label>}
+                {editableTaskFields(contract).length > 0 && <button
+                  type="button"
+                  className="details-button"
+                  aria-expanded={expandedPath === task.path}
+                  aria-controls={`task-details-${safeId(task.path)}`}
+                  onClick={() => setExpandedPath((current) =>
+                    current === task.path ? undefined : task.path
+                  )}
+                >
+                  {expandedPath === task.path ? "Close" : "Details"}
+                </button>}
+              </div>}
+            </div>
+            {contract && expandedPath === task.path && <TaskEditor
+              id={`task-details-${safeId(task.path)}`}
+              task={task}
+              contract={contract}
+              saving={busyPath === task.path}
+              onSave={(fields) => saveFields(task, fields)}
+            />}
           </li>)}
         </ul>}
     </section>
   </main>;
+}
+
+function TaskEditor({
+  id,
+  task,
+  contract,
+  saving,
+  onSave
+}: {
+  id: string;
+  task: TaskSummary;
+  contract: TasknotesContract;
+  saving: boolean;
+  onSave: (fields: JsonObject) => Promise<void>;
+}) {
+  const fields = useMemo(() => editableTaskFields(contract), [contract]);
+  const initialValues = useCallback(
+    () => Object.fromEntries(
+      fields.map((field) => [field.key, taskFieldValue(task.frontmatter, field)])
+    ),
+    [fields, task.frontmatter]
+  );
+  const [values, setValues] = useState<Record<string, string | boolean>>(initialValues);
+  const [validationError, setValidationError] = useState<string>();
+
+  useEffect(() => {
+    setValues(initialValues());
+    setValidationError(undefined);
+  }, [initialValues]);
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault();
+    const missing = missingRequiredFields(
+      fields.filter((field) => field.required),
+      values
+    );
+    if (missing.length > 0) {
+      setValidationError(
+        `Complete ${missing.join(", ")} before saving.`
+      );
+      return;
+    }
+    try {
+      await onSave(taskFieldPatch(fields, values));
+      setValidationError(undefined);
+    } catch (caught) {
+      setValidationError(message(caught));
+    }
+  }
+
+  const preserved = contract.fields.filter(
+    (field) => field.kind === "unsupported" && !field.readOnly
+  ).length;
+
+  return <form id={id} className="task-editor" onSubmit={(event) => void submit(event)}>
+    <div className="field-grid">
+      {fields.map((field, index) => <TaskFieldControl
+        key={field.key}
+        id={`${id}-field-${index}`}
+        field={field}
+        value={values[field.key] ?? (field.kind === "boolean" ? false : "")}
+        onChange={(value) => setValues((current) => ({ ...current, [field.key]: value }))}
+      />)}
+    </div>
+    {preserved > 0 && <p className="preservation-note">
+      {preserved} advanced field{preserved === 1 ? " is" : "s are"} preserved without changes.
+    </p>}
+    {validationError && <p className="field-error" role="alert">{validationError}</p>}
+    <div className="editor-actions">
+      <button type="submit" disabled={saving}>{saving ? "Saving" : "Save details"}</button>
+    </div>
+  </form>;
+}
+
+function TaskFieldControl({
+  id,
+  field,
+  value,
+  onChange
+}: {
+  id: string;
+  field: TaskFieldDefinition;
+  value: string | boolean;
+  onChange: (value: string | boolean) => void;
+}) {
+  const descriptionId = field.description ? `${id}-description` : undefined;
+  if (field.kind === "boolean") {
+    return <label className="field-control boolean-field" htmlFor={id}>
+      <input
+        id={id}
+        type="checkbox"
+        checked={value === true}
+        aria-describedby={descriptionId}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span>{field.label}{field.required && <b aria-hidden="true"> *</b>}</span>
+      {field.description && <small id={descriptionId}>{field.description}</small>}
+    </label>;
+  }
+
+  return <label className="field-control" htmlFor={id}>
+    <span>{field.label}{field.required && <b aria-hidden="true"> *</b>}</span>
+    {field.kind === "enum" ? <select
+      id={id}
+      value={String(value)}
+      required={field.required}
+      aria-describedby={descriptionId}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {!field.required && <option value="">None</option>}
+      {field.enumValues?.map((option) => (
+        <option key={option} value={option}>{option}</option>
+      ))}
+    </select> : <input
+      id={id}
+      type={
+        field.kind === "number" || field.kind === "integer"
+          ? "number"
+          : field.kind === "date"
+            ? "date"
+            : "text"
+      }
+      step={field.kind === "integer" ? "1" : field.kind === "number" ? "any" : undefined}
+      value={String(value)}
+      required={field.required}
+      aria-describedby={descriptionId}
+      placeholder={field.kind === "list" ? "Comma-separated values" : undefined}
+      onChange={(event) => onChange(event.target.value)}
+    />}
+    {field.description && <small id={descriptionId}>{field.description}</small>}
+  </label>;
+}
+
+function safeId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, "-");
 }
 
 function message(error: unknown): string {

--- a/apps/tasknotes/src/main.tsx
+++ b/apps/tasknotes/src/main.tsx
@@ -5,7 +5,15 @@ import { TasknotesCollection, type TaskFrontmatter, type TaskSummary } from "@md
 import "./styles.css";
 
 const serverUrl = import.meta.env.VITE_CONNECT_SERVER_URL ?? "http://127.0.0.1:8787";
-const requestedOperations = ["describe", "changes", "read", "query", "create", "update"] as const;
+const requestedOperations = [
+  "describe",
+  "changes",
+  "read",
+  "query",
+  "create",
+  "update",
+  "rename"
+] as const;
 
 function App() {
   const connect = useMemo(() => new MdbaseConnect<TaskFrontmatter>({ serverUrl }), []);

--- a/apps/tasknotes/src/main.tsx
+++ b/apps/tasknotes/src/main.tsx
@@ -60,13 +60,17 @@ function App() {
   useEffect(() => {
     if (!connected) return;
     if (!bound) return;
+    if (!tasknotes) return;
     void bound.checkDirectAccess();
     void load();
     const controller = new AbortController();
     void (async () => {
       try {
         for await (const event of bound.watch({ signal: controller.signal })) {
-          if (event.type.startsWith("mdbase.record.") || event.type === "mdbase.type.changed") {
+          if (event.type === "mdbase.type.changed") {
+            await tasknotes.refreshContract();
+            await load();
+          } else if (event.type.startsWith("mdbase.record.")) {
             await load();
           }
         }

--- a/apps/tasknotes/src/styles.css
+++ b/apps/tasknotes/src/styles.css
@@ -7,9 +7,12 @@
 
 * { box-sizing: border-box; }
 body { margin: 0; min-width: 320px; min-height: 100vh; }
-button, input { font: inherit; }
+button, input, select { font: inherit; }
 button { cursor: pointer; }
-button:focus-visible, input:focus-visible { outline: 2px solid oklch(0.59 0.16 255); outline-offset: 2px; }
+button:focus-visible, input:focus-visible, select:focus-visible {
+  outline: 2px solid oklch(0.59 0.16 255);
+  outline-offset: 2px;
+}
 
 .welcome {
   min-height: 100vh;
@@ -47,8 +50,14 @@ header .wordmark { margin: 0 0 5px; }
 .direct-option span { font-size: 11px; color: oklch(0.59 0.018 225); }
 section h1 { margin: 0 0 22px; font-size: 25px; line-height: 1.2; letter-spacing: -0.025em; }
 
-.quick-add { display: flex; gap: 8px; padding-bottom: 24px; border-bottom: 1px solid oklch(0.9 0.007 225); }
-.quick-add input {
+.quick-add {
+  display: grid;
+  gap: 14px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid oklch(0.9 0.007 225);
+}
+.quick-add-title { display: flex; gap: 8px; }
+.quick-add-title input {
   flex: 1;
   min-width: 0;
   height: 40px;
@@ -58,16 +67,110 @@ section h1 { margin: 0 0 22px; font-size: 25px; line-height: 1.2; letter-spacing
   color: inherit;
   background: oklch(0.997 0.002 220);
 }
-.quick-add input::placeholder { color: oklch(0.65 0.012 225); }
+.quick-add-title input::placeholder { color: oklch(0.65 0.012 225); }
+.quick-add-required {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 14px 0 2px;
+}
 
 .task-list { list-style: none; margin: 0; padding: 6px 0 0; }
 .task-list li { border-bottom: 1px solid oklch(0.925 0.006 225); }
-.task-list label { display: flex; align-items: center; gap: 12px; min-height: 52px; cursor: pointer; }
-.task-list input { width: 17px; height: 17px; margin: 0; accent-color: oklch(0.52 0.15 255); }
-.task-list span { line-height: 1.4; }
+.task-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  min-height: 62px;
+}
+.task-check {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  cursor: pointer;
+}
+.task-check input {
+  width: 17px;
+  height: 17px;
+  margin: 0;
+  accent-color: oklch(0.52 0.15 255);
+}
+.task-check span { min-width: 0; overflow-wrap: anywhere; line-height: 1.4; }
+.task-controls { display: flex; align-items: center; gap: 6px; }
+.task-controls select {
+  max-width: 116px;
+  height: 30px;
+  border: 1px solid oklch(0.88 0.008 225);
+  border-radius: 4px;
+  padding: 0 24px 0 8px;
+  color: oklch(0.42 0.014 235);
+  background: oklch(0.992 0.003 220);
+  font-size: 12px;
+}
+.details-button {
+  min-height: 30px;
+  padding-inline: 8px;
+  color: oklch(0.5 0.018 225);
+  background: transparent;
+  border-color: transparent;
+  font-size: 12px;
+}
 .completed { color: oklch(0.6 0.012 225); text-decoration: line-through; text-decoration-thickness: 1px; }
 .empty { margin: 34px 0; color: oklch(0.56 0.018 225); }
 .error { margin: 18px 0; color: oklch(0.49 0.16 28); font-size: 14px; line-height: 1.45; }
+
+.task-editor {
+  padding: 18px 0 22px 29px;
+  border-top: 1px solid oklch(0.94 0.005 225);
+}
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 18px;
+}
+.field-control {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  color: oklch(0.4 0.014 235);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.field-control > span { font-weight: 600; }
+.field-control b { color: oklch(0.5 0.13 28); }
+.field-control input:not([type="checkbox"]), .field-control select {
+  width: 100%;
+  height: 36px;
+  border: 1px solid oklch(0.86 0.009 225);
+  border-radius: 4px;
+  padding: 0 9px;
+  color: oklch(0.28 0.013 235);
+  background: oklch(0.997 0.002 220);
+}
+.field-control small { color: oklch(0.57 0.015 225); line-height: 1.4; }
+.boolean-field {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  min-height: 36px;
+}
+.boolean-field input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: oklch(0.52 0.15 255);
+}
+.boolean-field small { grid-column: 2; }
+.preservation-note, .field-error {
+  margin: 14px 0 0;
+  color: oklch(0.57 0.015 225);
+  font-size: 11px;
+  line-height: 1.45;
+}
+.field-error { color: oklch(0.49 0.16 28); }
+.editor-actions { display: flex; justify-content: flex-end; margin-top: 16px; }
+.editor-actions button { min-height: 34px; }
 
 .loading { padding-top: 12px; }
 .loading span { display: block; width: 72%; height: 13px; margin: 19px 0; border-radius: 3px; background: oklch(0.93 0.006 225); }
@@ -82,6 +185,10 @@ section h1 { margin: 0 0 22px; font-size: 25px; line-height: 1.2; letter-spacing
   .shell { width: min(100% - 28px, 720px); padding-top: 20px; }
   header { min-height: 104px; }
   .direct-option span { display: none; }
+  .quick-add-required, .field-grid { grid-template-columns: 1fr; }
+  .task-row { grid-template-columns: 1fr; gap: 10px; padding: 14px 0; }
+  .task-controls { padding-left: 29px; flex-wrap: wrap; }
+  .task-editor { padding-left: 29px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/tasknotes/src/taskFields.test.ts
+++ b/apps/tasknotes/src/taskFields.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { TasknotesContract } from "@mdbase/tasknotes";
+import {
+  editableTaskFields,
+  missingRequiredFields,
+  requiredCreateFields,
+  taskFieldPatch,
+  taskFieldValue
+} from "./taskFields";
+
+const fields = [
+  {
+    key: "due_on",
+    role: "due",
+    label: "Due",
+    kind: "date",
+    required: false,
+    readOnly: false,
+    schema: {}
+  },
+  {
+    key: "estimate",
+    label: "Effort",
+    kind: "integer",
+    required: true,
+    readOnly: false,
+    schema: {}
+  },
+  {
+    key: "reviewed",
+    label: "Reviewed",
+    kind: "boolean",
+    required: false,
+    readOnly: false,
+    schema: {}
+  },
+  {
+    key: "labels",
+    label: "Labels",
+    kind: "list",
+    itemKind: "text",
+    required: false,
+    readOnly: false,
+    schema: {}
+  },
+  {
+    key: "time_entries",
+    role: "timeEntries",
+    label: "Time entries",
+    kind: "list",
+    itemKind: "unsupported",
+    required: false,
+    readOnly: false,
+    schema: {}
+  }
+] satisfies TasknotesContract["fields"];
+
+const contract = { fields } as TasknotesContract;
+
+describe("TaskNotes schema field forms", () => {
+  it("selects safe custom and common core fields", () => {
+    expect(editableTaskFields(contract).map((field) => field.key)).toEqual([
+      "due_on",
+      "estimate",
+      "reviewed",
+      "labels"
+    ]);
+    expect(requiredCreateFields(contract).map((field) => field.key)).toEqual(["estimate"]);
+  });
+
+  it("reads and serializes supported schema values", () => {
+    expect(taskFieldValue({ labels: ["work", "home"] }, fields[3])).toBe("work, home");
+    expect(taskFieldPatch(fields.slice(0, 4), {
+      due_on: "",
+      estimate: "45",
+      reviewed: true,
+      labels: "work, home"
+    })).toEqual({
+      due_on: null,
+      estimate: 45,
+      reviewed: true,
+      labels: ["work", "home"]
+    });
+  });
+
+  it("validates required and numeric values before sending a patch", () => {
+    expect(missingRequiredFields([fields[1]], { estimate: "" })).toEqual(["Effort"]);
+    expect(() => taskFieldPatch([fields[1]], { estimate: "4.5" }))
+      .toThrow("Effort must be a valid integer.");
+  });
+});

--- a/apps/tasknotes/src/taskFields.ts
+++ b/apps/tasknotes/src/taskFields.ts
@@ -1,0 +1,112 @@
+import type {
+  TaskFieldDefinition,
+  TaskFrontmatter,
+  TasknotesContract
+} from "@mdbase/tasknotes";
+import type { JsonObject } from "@mdbase/connect";
+
+const EDITABLE_CORE_ROLES = new Set([
+  "due",
+  "scheduled",
+  "contexts",
+  "projects",
+  "timeEstimate",
+  "tags",
+  "recurrence",
+  "recurrenceAnchor"
+]);
+
+const INTERNAL_FIELDS = new Set(["id", "type", "types"]);
+
+export function editableTaskFields(contract: TasknotesContract): TaskFieldDefinition[] {
+  return contract.fields.filter((field) => {
+    if (field.readOnly || field.kind === "unsupported" || INTERNAL_FIELDS.has(field.key)) {
+      return false;
+    }
+    if (field.kind === "list" && field.itemKind !== "text" && field.itemKind !== "enum") {
+      return false;
+    }
+    return field.role ? EDITABLE_CORE_ROLES.has(field.role) : true;
+  });
+}
+
+export function requiredCreateFields(contract: TasknotesContract): TaskFieldDefinition[] {
+  return editableTaskFields(contract).filter(
+    (field) => field.required && field.defaultValue === undefined
+  );
+}
+
+export function taskFieldValue(
+  frontmatter: TaskFrontmatter,
+  field: TaskFieldDefinition
+): string | boolean {
+  const value = getPath(frontmatter, field.key);
+  if (field.kind === "boolean") return value === true;
+  if (field.kind === "list") {
+    return Array.isArray(value)
+      ? value.filter((item) => typeof item === "string").join(", ")
+      : "";
+  }
+  return typeof value === "string" || typeof value === "number" ? String(value) : "";
+}
+
+export function taskFieldPatch(
+  fields: readonly TaskFieldDefinition[],
+  values: Record<string, string | boolean>
+): JsonObject {
+  const patch: JsonObject = {};
+  for (const field of fields) {
+    const value = values[field.key];
+    if (field.kind === "boolean") {
+      patch[field.key] = value === true;
+      continue;
+    }
+    const text = typeof value === "string" ? value.trim() : "";
+    if (!text) {
+      patch[field.key] = null;
+      continue;
+    }
+    if (field.kind === "number" || field.kind === "integer") {
+      const number = Number(text);
+      if (!Number.isFinite(number) || (field.kind === "integer" && !Number.isInteger(number))) {
+        throw new Error(`${field.label} must be a valid ${field.kind}.`);
+      }
+      patch[field.key] = number;
+      continue;
+    }
+    if (field.kind === "list") {
+      patch[field.key] = text
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean);
+      continue;
+    }
+    patch[field.key] = text;
+  }
+  return patch;
+}
+
+export function missingRequiredFields(
+  fields: readonly TaskFieldDefinition[],
+  values: Record<string, string | boolean>
+): string[] {
+  return fields
+    .filter((field) => {
+      const value = values[field.key];
+      return field.kind === "boolean" ? false : !String(value ?? "").trim();
+    })
+    .map((field) => field.label);
+}
+
+function getPath(value: JsonObject, path: string): unknown {
+  let current: unknown = value;
+  for (const segment of path.split(".")) {
+    if (!isObject(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -75,3 +75,20 @@ perf report
 `samply record` or `cargo flamegraph` can replace `perf record`. Keep latency
 JSON beside a CPU profile so changes can be compared at both the request and
 function level.
+
+## TaskNotes contract adapter
+
+Profile canonical contract parsing and task normalization with a synthetic
+10,000-task collection:
+
+```bash
+pnpm --filter @mdbase/tasknotes run profile
+node --cpu-prof --cpu-prof-dir=/tmp/tasknotes-profile \
+  packages/tasknotes/scripts/profile.mjs
+```
+
+The workload uses a renamed task type, mapped core fields, custom status and
+priority vocabularies, recurrence fields, and two schema-defined custom fields.
+It reports mean contract-resolution and per-task normalization time without
+printing task content. Build `@mdbase/tasknotes` before invoking the CPU-profile
+command directly.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "pnpm -r typecheck"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1"
+    "@playwright/test": "^1.61.1",
+    "tslib": "^2.8.1"
   }
 }

--- a/packages/tasknotes/README.md
+++ b/packages/tasknotes/README.md
@@ -3,7 +3,14 @@
 Portable TaskNotes task semantics for mdbase connect clients. The adapter reads
 the collection's `tasknotes.task` contract, follows its field-role mapping, and
 performs revision-safe generic mdbase operations. It does not assume fixed
-frontmatter property names.
+frontmatter property names or a fixed task type name.
+
+The resolved contract includes JSON Schema field definitions, status and
+priority vocabularies, collection path policy, capabilities, and all declared
+TaskNotes field roles. `TasknotesCollection.refreshContract()` invalidates the
+cached description after a type change. Creation applies declared defaults,
+while completion uses `@tasknotes/model` for completed dates, recurrence, and
+time-tracking effects. Unknown and unsupported frontmatter remains untouched.
 
 `TasknotesOfflineCollection` provides the same contract-aware create, list, and
 completion operations over an `@mdbase/connect-sync` offline replica. Local

--- a/packages/tasknotes/package.json
+++ b/packages/tasknotes/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@mdbase/connect": "workspace:*",
     "@mdbase/connect-protocol": "workspace:*",
-    "@mdbase/connect-sync": "workspace:*"
+    "@mdbase/connect-sync": "workspace:*",
+    "@tasknotes/model": "0.3.0-rc.1"
   },
   "devDependencies": {
     "typescript": "^7.0.2",

--- a/packages/tasknotes/package.json
+++ b/packages/tasknotes/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
+    "profile": "pnpm build && node scripts/profile.mjs",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/tasknotes/scripts/profile.mjs
+++ b/packages/tasknotes/scripts/profile.mjs
@@ -1,0 +1,151 @@
+import { performance } from "node:perf_hooks";
+import {
+  resolveTasknotesContract,
+  TasknotesCollection
+} from "../dist/index.js";
+
+const contractIterations = positiveInteger(
+  process.env.TASKNOTES_PROFILE_CONTRACT_ITERATIONS,
+  50_000
+);
+const taskCount = positiveInteger(process.env.TASKNOTES_PROFILE_TASKS, 10_000);
+const listIterations = positiveInteger(
+  process.env.TASKNOTES_PROFILE_LIST_ITERATIONS,
+  20
+);
+
+const roles = {
+  title: "summary",
+  status: "state",
+  priority: "urgency",
+  due: "due_on",
+  scheduled: "start_on",
+  completedDate: "finished_on",
+  dateModified: "updated_at",
+  contexts: "areas",
+  projects: "goals",
+  timeEstimate: "estimate",
+  recurrence: "repeat",
+  completeInstances: "completed_runs",
+  skippedInstances: "skipped_runs",
+  timeEntries: "sessions"
+};
+
+const properties = {
+  summary: { type: "string" },
+  state: { enum: ["open", "doing", "done"] },
+  urgency: { enum: ["low", "normal", "high"] },
+  due_on: { type: "string", format: "date" },
+  start_on: { type: "string", format: "date" },
+  finished_on: { type: "string", format: "date" },
+  updated_at: { type: "string", format: "date-time" },
+  areas: { type: "array", items: { type: "string" } },
+  goals: { type: "array", items: { type: "string" } },
+  estimate: { type: "integer" },
+  repeat: { type: "string" },
+  completed_runs: { type: "array", items: { type: "string" } },
+  skipped_runs: { type: "array", items: { type: "string" } },
+  sessions: { type: "array", items: { type: "object" } },
+  reviewed: { type: "boolean" },
+  client: { type: "string" }
+};
+
+const description = {
+  protocol_version: 1,
+  collection_id: "profile",
+  display_name: "TaskNotes profile",
+  spec_version: "0.3.0",
+  operations: ["describe", "query"],
+  change_cursor: 0,
+  types: [{
+    name: "custom-task",
+    schema: { type: "object", properties },
+    collection: {
+      path: { folder: "Tasks", template: "{{title}}-{{id}}" }
+    },
+    extensions: {}
+  }],
+  contracts: [{
+    id: "tasknotes.task",
+    version: 1,
+    type_name: "custom-task",
+    extension: "x-tasknotes",
+    configuration: {
+      contract: "tasknotes.task",
+      version: 1,
+      field_roles: roles,
+      status: {
+        values: ["open", "doing", "done"],
+        completed_values: ["done"],
+        default: "open",
+        definitions: [
+          { value: "open", label: "Ready", order: 1 },
+          { value: "doing", label: "In progress", order: 2 },
+          { value: "done", label: "Done", is_completed: true, order: 3 }
+        ]
+      },
+      priority: {
+        values: ["low", "normal", "high"],
+        default: "normal"
+      }
+    }
+  }]
+};
+
+const records = Array.from({ length: taskCount }, (_, index) => ({
+  path: `Tasks/${index}.md`,
+  frontmatter: {
+    summary: `Task ${index}`,
+    state: index % 2 ? "open" : "done",
+    urgency: "normal",
+    due_on: "2026-08-01",
+    estimate: index % 120,
+    reviewed: index % 3 === 0,
+    client: "Example"
+  },
+  types: ["custom-task"]
+}));
+
+let started = performance.now();
+for (let index = 0; index < contractIterations; index += 1) {
+  resolveTasknotesContract(description);
+}
+const contractMilliseconds = performance.now() - started;
+
+const connection = {
+  describe: async () => description,
+  query: async () => ({
+    valid: true,
+    diagnostics: [],
+    result: { results: records }
+  })
+};
+const collection = new TasknotesCollection(connection);
+started = performance.now();
+for (let index = 0; index < listIterations; index += 1) await collection.list();
+const listMilliseconds = performance.now() - started;
+
+console.log(JSON.stringify({
+  contract: {
+    iterations: contractIterations,
+    total_ms: round(contractMilliseconds),
+    mean_us: round(contractMilliseconds * 1_000 / contractIterations)
+  },
+  normalization: {
+    tasks: taskCount * listIterations,
+    total_ms: round(listMilliseconds),
+    mean_us_per_task: round(listMilliseconds * 1_000 / (taskCount * listIterations))
+  },
+  memory: {
+    heap_used_mb: round(process.memoryUsage().heapUsed / 1024 / 1024)
+  }
+}, null, 2));
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function round(value) {
+  return Number(value.toFixed(3));
+}

--- a/packages/tasknotes/src/contract.ts
+++ b/packages/tasknotes/src/contract.ts
@@ -1,0 +1,420 @@
+import type {
+  CollectionContractDescriptor,
+  CollectionDescription,
+  CollectionTypeDescriptor,
+  JsonObject,
+  SyncCollectionResources
+} from "@mdbase/connect-protocol";
+import {
+  ALL_FIELD_ROLES,
+  buildSpecFieldMapping
+} from "@tasknotes/model/config";
+import {
+  DEFAULT_FIELD_MAPPING,
+  DEFAULT_PRIORITIES,
+  DEFAULT_STATUSES
+} from "@tasknotes/model/defaults";
+import type {
+  FieldMapping,
+  FieldRole,
+  PriorityConfig,
+  SpecFieldMapping,
+  StatusConfig
+} from "@tasknotes/model/types";
+
+export const TASKNOTES_TASK_CONTRACT = "tasknotes.task";
+
+export interface TasknotesContractConfiguration extends JsonObject {
+  contract: typeof TASKNOTES_TASK_CONTRACT;
+  version: number;
+  field_roles: Record<string, string>;
+  status: JsonObject & {
+    values?: string[];
+    completed_values: string[];
+    skipped_values?: string[];
+    default?: string;
+    definitions?: JsonObject[];
+  };
+  priority?: JsonObject & {
+    values?: string[];
+    default?: string;
+    definitions?: JsonObject[];
+  };
+  title?: JsonObject & {
+    storage?: "filename" | "frontmatter";
+    filename_format?: string;
+    custom_filename_template?: string;
+  };
+  recurrence?: JsonObject;
+  occurrences?: JsonObject;
+  links?: JsonObject;
+  archive?: JsonObject;
+  time_tracking?: JsonObject;
+  templating?: JsonObject;
+  profiles?: string[];
+  capabilities?: string[];
+}
+
+export type TaskFieldKind =
+  | "text"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "date"
+  | "datetime"
+  | "list"
+  | "enum"
+  | "unsupported";
+
+export interface TaskFieldDefinition {
+  key: string;
+  role?: string;
+  label: string;
+  description?: string;
+  kind: TaskFieldKind;
+  required: boolean;
+  readOnly: boolean;
+  enumValues?: string[];
+  defaultValue?: unknown;
+  itemKind?: Exclude<TaskFieldKind, "list">;
+  schema: JsonObject;
+}
+
+export interface TasknotesContract {
+  descriptor: CollectionContractDescriptor;
+  configuration: TasknotesContractConfiguration;
+  typeName: string;
+  type: CollectionTypeDescriptor;
+  schema: JsonObject;
+  fields: TaskFieldDefinition[];
+  fieldMapping: FieldMapping;
+  specFieldMapping: SpecFieldMapping;
+  statuses: StatusConfig[];
+  priorities: PriorityConfig[];
+  pathFolder?: string;
+  pathTemplate?: string;
+  pathRuntime?: string;
+  titleStorage: "filename" | "frontmatter";
+  profiles: string[];
+  capabilities: string[];
+}
+
+export function resolveTasknotesContract(description: CollectionDescription): TasknotesContract {
+  return resolveContract(description.types, description.contracts);
+}
+
+export function resolveTasknotesSyncContract(resources: SyncCollectionResources): TasknotesContract {
+  return resolveContract(resources.types, resources.contracts);
+}
+
+function resolveContract(
+  types: CollectionDescription["types"],
+  contracts: CollectionDescription["contracts"]
+): TasknotesContract {
+  const descriptor = contracts.find((contract) => contract.id === TASKNOTES_TASK_CONTRACT);
+  if (!descriptor) {
+    throw new TasknotesContractError("TaskNotes task contract is not available in this collection.");
+  }
+  const configuration = parseConfiguration(descriptor.configuration);
+  const type = types.find((candidate) => candidate.name === descriptor.type_name);
+  if (!type) {
+    throw new TasknotesContractError(
+      `TaskNotes contract refers to missing type "${descriptor.type_name}".`
+    );
+  }
+
+  const schema = schemaValue(type.schema);
+  const properties = asObject(schema.properties) ?? {};
+  const collection = asObject(type.collection);
+  const path = asObject(collection?.path);
+  const display = asObject(collection?.display);
+  const inferredMapping = buildSpecFieldMapping(
+    properties,
+    stringValue(display?.name_field)
+  );
+  const specFieldMapping = applyDeclaredRoles(
+    inferredMapping,
+    configuration.field_roles,
+    configuration.status.completed_values
+  );
+  const fieldMapping = tasknotesFieldMapping(configuration.field_roles, specFieldMapping);
+  const statuses = statusDefinitions(configuration, properties, specFieldMapping);
+  const priorities = priorityDefinitions(configuration, properties, specFieldMapping);
+
+  return {
+    descriptor,
+    configuration,
+    typeName: descriptor.type_name,
+    type,
+    schema,
+    fields: schemaFields(properties, schema, configuration.field_roles),
+    fieldMapping,
+    specFieldMapping,
+    statuses,
+    priorities,
+    pathFolder: stringValue(path?.folder),
+    pathTemplate: stringValue(path?.template) ?? stringValue(path?.pattern),
+    pathRuntime: stringValue(path?.runtime),
+    titleStorage: configuration.title?.storage === "filename" ? "filename" : "frontmatter",
+    profiles: stringArray(configuration.profiles),
+    capabilities: stringArray(configuration.capabilities)
+  };
+}
+
+function parseConfiguration(value: JsonObject): TasknotesContractConfiguration {
+  const roles = asObject(value.field_roles);
+  const status = asObject(value.status);
+  const completedValues = status?.completed_values;
+  if (
+    value.contract !== TASKNOTES_TASK_CONTRACT
+    || typeof value.version !== "number"
+    || !roles
+    || !status
+    || !Array.isArray(completedValues)
+    || completedValues.length === 0
+    || !completedValues.every((item) => typeof item === "string" && item.length > 0)
+    || !Object.values(roles).every(
+      (field) => typeof field === "string" && validFieldPath(field)
+    )
+    || (
+      status.default !== undefined
+      && (typeof status.default !== "string" || status.default.length === 0)
+    )
+  ) {
+    throw new TasknotesContractError("The TaskNotes task contract is malformed.");
+  }
+  return value as TasknotesContractConfiguration;
+}
+
+function applyDeclaredRoles(
+  inferred: SpecFieldMapping,
+  roles: Record<string, string>,
+  completedStatuses: string[]
+): SpecFieldMapping {
+  const roleToField: SpecFieldMapping["roleToField"] = { ...inferred.roleToField };
+  for (const role of ALL_FIELD_ROLES) {
+    const declared = roles[role];
+    if (declared) roleToField[role as keyof typeof roleToField] = declared;
+  }
+  const fieldToRole: Record<string, FieldRole> = {};
+  for (const role of ALL_FIELD_ROLES) {
+    fieldToRole[roleToField[role as keyof typeof roleToField]] = role;
+  }
+  return {
+    roleToField,
+    fieldToRole,
+    displayNameKey: roleToField.title,
+    completedStatuses: [...completedStatuses]
+  };
+}
+
+function tasknotesFieldMapping(
+  roles: Record<string, string>,
+  spec: SpecFieldMapping
+): FieldMapping {
+  const mapping = { ...DEFAULT_FIELD_MAPPING };
+  for (const key of Object.keys(mapping) as Array<keyof FieldMapping>) {
+    const declared = roles[key];
+    if (declared) mapping[key] = declared;
+  }
+  for (const role of ALL_FIELD_ROLES) {
+    if (role in mapping) {
+      mapping[role as keyof FieldMapping] =
+        spec.roleToField[role as keyof typeof spec.roleToField];
+    }
+  }
+  return mapping;
+}
+
+function statusDefinitions(
+  configuration: TasknotesContractConfiguration,
+  properties: JsonObject,
+  mapping: SpecFieldMapping
+): StatusConfig[] {
+  const policy = configuration.status;
+  const schema = asObject(properties[mapping.roleToField.status]);
+  const values = firstStrings(policy.values, schema?.enum, [
+    policy.default,
+    ...policy.completed_values,
+    ...stringArray(policy.skipped_values)
+  ]);
+  const definitions = definitionMap(policy.definitions);
+  const completed = new Set(policy.completed_values);
+  const skipped = new Set(stringArray(policy.skipped_values));
+  return values.map((value, index) => {
+    const definition = definitions.get(value);
+    const fallback = DEFAULT_STATUSES.find((status) => status.value === value);
+    return {
+      id: stringValue(definition?.id) ?? fallback?.id ?? value,
+      value,
+      label: stringValue(definition?.label) ?? fallback?.label ?? humanize(value),
+      color: stringValue(definition?.color) ?? fallback?.color ?? "",
+      ...(stringValue(definition?.icon) ? { icon: stringValue(definition?.icon) } : {}),
+      isCompleted: booleanValue(definition?.is_completed) ?? completed.has(value),
+      isSkipped: booleanValue(definition?.is_skipped) ?? skipped.has(value),
+      excludeFromCycle:
+        booleanValue(definition?.exclude_from_cycle) ?? fallback?.excludeFromCycle ?? false,
+      ...(stringValue(definition?.next_status)
+        ? { nextStatus: stringValue(definition?.next_status) }
+        : {}),
+      order: numberValue(definition?.order) ?? fallback?.order ?? index,
+      autoArchive:
+        booleanValue(definition?.auto_archive) ?? fallback?.autoArchive ?? false,
+      autoArchiveDelay:
+        numberValue(definition?.auto_archive_delay_minutes)
+        ?? fallback?.autoArchiveDelay
+        ?? 0
+    };
+  }).sort((left, right) => left.order - right.order);
+}
+
+function priorityDefinitions(
+  configuration: TasknotesContractConfiguration,
+  properties: JsonObject,
+  mapping: SpecFieldMapping
+): PriorityConfig[] {
+  const policy = configuration.priority;
+  const schema = asObject(properties[mapping.roleToField.priority]);
+  const values = firstStrings(policy?.values, schema?.enum, [policy?.default]);
+  const definitions = definitionMap(policy?.definitions);
+  return values.map((value, index) => {
+    const definition = definitions.get(value);
+    const fallback = DEFAULT_PRIORITIES.find((priority) => priority.value === value);
+    return {
+      id: stringValue(definition?.id) ?? fallback?.id ?? value,
+      value,
+      label: stringValue(definition?.label) ?? fallback?.label ?? humanize(value),
+      color: stringValue(definition?.color) ?? fallback?.color ?? "",
+      ...(stringValue(definition?.icon) ? { icon: stringValue(definition?.icon) } : {}),
+      weight: numberValue(definition?.weight) ?? fallback?.weight ?? index
+    };
+  }).sort((left, right) => left.weight - right.weight);
+}
+
+function schemaFields(
+  properties: JsonObject,
+  schema: JsonObject,
+  roles: Record<string, string>
+): TaskFieldDefinition[] {
+  const required = new Set(stringArray(schema.required));
+  const fieldRoles = new Map(Object.entries(roles).map(([role, field]) => [field, role]));
+  return Object.entries(properties).map(([key, rawSchema]) => {
+    const original = asObject(rawSchema) ?? {};
+    const resolved = preferredSchema(original);
+    const enumValues = stringArray(resolved.enum);
+    const kind = fieldKind(resolved, enumValues);
+    const defaultValue = resolved.default;
+    return {
+      key,
+      ...(fieldRoles.get(key) ? { role: fieldRoles.get(key) } : {}),
+      label: stringValue(resolved.title) ?? humanize(fieldRoles.get(key) ?? key),
+      ...(stringValue(resolved.description)
+        ? { description: stringValue(resolved.description) }
+        : {}),
+      kind,
+      required: required.has(key),
+      readOnly: resolved.readOnly === true,
+      ...(enumValues.length > 0 ? { enumValues } : {}),
+      ...(defaultValue !== undefined ? { defaultValue } : {}),
+      ...(kind === "list"
+        ? { itemKind: listItemKind(resolved.items) }
+        : {}),
+      schema: original
+    };
+  });
+}
+
+function listItemKind(value: unknown): Exclude<TaskFieldKind, "list"> {
+  const kind = fieldKind(preferredSchema(asObject(value) ?? {}), []);
+  return kind === "list" ? "unsupported" : kind;
+}
+
+function preferredSchema(schema: JsonObject): JsonObject {
+  const variants = Array.isArray(schema.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema.oneOf)
+      ? schema.oneOf
+      : [];
+  return variants
+    .map(asObject)
+    .find((candidate) => candidate && candidate.type !== "null")
+    ?? schema;
+}
+
+function fieldKind(schema: JsonObject, enumValues: string[]): TaskFieldKind {
+  if (enumValues.length > 0) return "enum";
+  if (schema.format === "date") return "date";
+  if (schema.format === "date-time") return "datetime";
+  if (schema.type === "string") return "text";
+  if (schema.type === "number") return "number";
+  if (schema.type === "integer") return "integer";
+  if (schema.type === "boolean") return "boolean";
+  if (schema.type === "array") return "list";
+  return "unsupported";
+}
+
+function schemaValue(schema: JsonObject): JsonObject {
+  return asObject(schema.value) ?? schema;
+}
+
+function definitionMap(value: unknown): Map<string, JsonObject> {
+  const definitions = new Map<string, JsonObject>();
+  if (!Array.isArray(value)) return definitions;
+  for (const entry of value) {
+    const definition = asObject(entry);
+    const key = stringValue(definition?.value);
+    if (definition && key) definitions.set(key, definition);
+  }
+  return definitions;
+}
+
+function firstStrings(...candidates: unknown[]): string[] {
+  for (const candidate of candidates) {
+    const values = stringArray(candidate);
+    if (values.length > 0) return [...new Set(values)];
+  }
+  return [];
+}
+
+function validFieldPath(value: string): boolean {
+  return value.split(".").every(
+    (part) =>
+      part.length > 0
+      && part !== "__proto__"
+      && part !== "prototype"
+      && part !== "constructor"
+  );
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function asObject(value: unknown): JsonObject | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.length > 0)
+    : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export class TasknotesContractError extends Error {}

--- a/packages/tasknotes/src/index.test.ts
+++ b/packages/tasknotes/src/index.test.ts
@@ -18,8 +18,21 @@ const description = {
   change_cursor: 0,
   types: [{
     name: "task",
-    schema: { type: "object" },
-    collection: { path: { folder: "inbox" } },
+    schema: {
+      type: "object",
+      required: ["name", "state"],
+      properties: {
+        name: { type: "string", title: "Task name" },
+        state: { enum: ["open", "closed"] },
+        urgency: { enum: ["low", "high"] },
+        estimate: { type: "number", title: "Effort" },
+        reviewed: { type: "boolean" }
+      }
+    },
+    collection: {
+      display: { name_field: "name" },
+      path: { folder: "inbox", template: "{{title}}-{{id}}" }
+    },
     extensions: {}
   }],
   contracts: [{
@@ -30,15 +43,45 @@ const description = {
     configuration: {
       contract: "tasknotes.task",
       version: 1,
-      field_roles: { title: "name", status: "state" },
-      status: { completed_values: ["closed"], default: "open" }
+      field_roles: {
+        title: "name",
+        status: "state",
+        priority: "urgency",
+        timeEstimate: "estimate"
+      },
+      status: {
+        values: ["open", "closed"],
+        completed_values: ["closed"],
+        default: "open",
+        definitions: [
+          { value: "open", label: "Ready", order: 1 },
+          { value: "closed", label: "Finished", is_completed: true, order: 2 }
+        ]
+      },
+      priority: {
+        values: ["low", "high"],
+        default: "low",
+        definitions: [
+          { value: "low", label: "Low", weight: 1 },
+          { value: "high", label: "High", weight: 10 }
+        ]
+      }
     }
   }]
 };
 
 describe("TaskNotes contract adapter", () => {
   it("uses declared field roles for create and completion", async () => {
-    expect(resolveTasknotesContract(description).pathFolder).toBe("inbox");
+    const contract = resolveTasknotesContract(description);
+    expect(contract.pathFolder).toBe("inbox");
+    expect(contract.pathTemplate).toBe("{{title}}-{{id}}");
+    expect(contract.fieldMapping.priority).toBe("urgency");
+    expect(contract.statuses.map((status) => status.label)).toEqual(["Ready", "Finished"]);
+    expect(contract.priorities.map((priority) => priority.value)).toEqual(["low", "high"]);
+    expect(contract.fields).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: "estimate", role: "timeEstimate", kind: "number" }),
+      expect.objectContaining({ key: "reviewed", kind: "boolean" })
+    ]));
     const connect = {
       describe: vi.fn().mockResolvedValue(description),
       query: vi.fn().mockResolvedValue({ valid: true, diagnostics: [], result: { results: [] } }),
@@ -62,7 +105,7 @@ describe("TaskNotes contract adapter", () => {
 
     await tasks.create({ title: "Write docs" });
     expect(connect.create).toHaveBeenCalledWith(expect.objectContaining({
-      path: "inbox/write-docs.md",
+      path: undefined,
       frontmatter: { name: "Write docs", state: "open" }
     }));
 
@@ -72,6 +115,79 @@ describe("TaskNotes contract adapter", () => {
       patch: { state: "closed" },
       if_revision: "one"
     });
+  });
+
+  it("refreshes its cached contract after a type change", async () => {
+    const renamed = {
+      ...description,
+      types: [{
+        ...description.types[0],
+        schema: {
+          ...description.types[0].schema,
+          properties: {
+            ...description.types[0].schema.properties,
+            summary: { type: "string" },
+            phase: { enum: ["queued", "finished"] }
+          }
+        }
+      }],
+      contracts: [{
+        ...description.contracts[0],
+        configuration: {
+          ...description.contracts[0].configuration,
+          field_roles: {
+            ...description.contracts[0].configuration.field_roles,
+            title: "summary",
+            status: "phase"
+          },
+          status: {
+            values: ["queued", "finished"],
+            completed_values: ["finished"],
+            default: "queued"
+          }
+        }
+      }]
+    };
+    const connect = {
+      describe: vi.fn()
+        .mockResolvedValueOnce(description)
+        .mockResolvedValueOnce(renamed),
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          valid: true,
+          diagnostics: [],
+          result: {
+            results: [{
+              path: "inbox/one.md",
+              frontmatter: { name: "Before", state: "open" },
+              types: ["task"]
+            }]
+          }
+        })
+        .mockResolvedValueOnce({
+          valid: true,
+          diagnostics: [],
+          result: {
+            results: [{
+              path: "inbox/one.md",
+              frontmatter: { summary: "After", phase: "finished" },
+              types: ["task"]
+            }]
+          }
+        })
+    } as any;
+    const tasks = new TasknotesCollection(connect);
+
+    expect((await tasks.list())[0]).toEqual(expect.objectContaining({
+      title: "Before",
+      completed: false
+    }));
+    await tasks.refreshContract();
+    expect((await tasks.list())[0]).toEqual(expect.objectContaining({
+      title: "After",
+      completed: true
+    }));
+    expect(connect.describe).toHaveBeenCalledTimes(2);
   });
 
   it("rejects empty titles and unsafe contract field paths", async () => {

--- a/packages/tasknotes/src/index.test.ts
+++ b/packages/tasknotes/src/index.test.ts
@@ -26,7 +26,17 @@ const description = {
         state: { enum: ["open", "closed"] },
         urgency: { enum: ["low", "high"] },
         estimate: { type: "number", title: "Effort" },
-        reviewed: { type: "boolean" }
+        deadline: { type: "string", format: "date" },
+        start_on: { type: "string", format: "date" },
+        areas: { type: "array", items: { type: "string" } },
+        goals: { type: "array", items: { type: "string" } },
+        repeat: { type: "string" },
+        completed_runs: { type: "array", items: { type: "string", format: "date" } },
+        skipped_runs: { type: "array", items: { type: "string", format: "date" } },
+        finished_on: { type: "string", format: "date" },
+        updated_at: { type: "string", format: "date-time" },
+        sessions: { type: "array", items: { type: "object" } },
+        reviewed: { type: "boolean", default: false }
       }
     },
     collection: {
@@ -47,7 +57,17 @@ const description = {
         title: "name",
         status: "state",
         priority: "urgency",
-        timeEstimate: "estimate"
+        timeEstimate: "estimate",
+        due: "deadline",
+        scheduled: "start_on",
+        contexts: "areas",
+        projects: "goals",
+        recurrence: "repeat",
+        completeInstances: "completed_runs",
+        skippedInstances: "skipped_runs",
+        completedDate: "finished_on",
+        dateModified: "updated_at",
+        timeEntries: "sessions"
       },
       status: {
         values: ["open", "closed"],
@@ -106,15 +126,23 @@ describe("TaskNotes contract adapter", () => {
     await tasks.create({ title: "Write docs" });
     expect(connect.create).toHaveBeenCalledWith(expect.objectContaining({
       path: undefined,
-      frontmatter: { name: "Write docs", state: "open" }
+      frontmatter: expect.objectContaining({
+        name: "Write docs",
+        state: "open",
+        urgency: "low"
+      })
     }));
 
     await tasks.setCompleted("inbox/write-docs.md", true);
-    expect(connect.update).toHaveBeenCalledWith({
+    expect(connect.update).toHaveBeenCalledWith(expect.objectContaining({
       path: "inbox/write-docs.md",
-      patch: { state: "closed" },
+      patch: expect.objectContaining({
+        state: "closed",
+        finished_on: expect.any(String),
+        updated_at: expect.any(String)
+      }),
       if_revision: "one"
-    });
+    }));
   });
 
   it("refreshes its cached contract after a type change", async () => {
@@ -188,6 +216,236 @@ describe("TaskNotes contract adapter", () => {
       completed: true
     }));
     expect(connect.describe).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalizes mapped core roles and schema-defined custom fields", async () => {
+    const connect = {
+      describe: vi.fn().mockResolvedValue(description),
+      query: vi.fn().mockResolvedValue({
+        valid: true,
+        diagnostics: [],
+        result: {
+          results: [{
+            path: "inbox/mapped.md",
+            frontmatter: {
+              name: "Mapped task",
+              state: "open",
+              urgency: "high",
+              deadline: "2026-08-01",
+              start_on: "2026-07-30",
+              estimate: 45,
+              areas: ["home"],
+              goals: ["[[Launch]]"],
+              reviewed: true
+            },
+            types: ["task"]
+          }]
+        }
+      })
+    } as any;
+
+    const task = (await new TasknotesCollection(connect).list())[0];
+    expect(task).toEqual(expect.objectContaining({
+      title: "Mapped task",
+      status: "open",
+      priority: "high",
+      due: "2026-08-01",
+      scheduled: "2026-07-30",
+      timeEstimate: 45,
+      contexts: ["home"],
+      projects: ["[[Launch]]"],
+      customProperties: { reviewed: true }
+    }));
+  });
+
+  it("uses model-planned completion, stops active tracking, and archives immediately", async () => {
+    const semanticDescription = {
+      ...description,
+      contracts: [{
+        ...description.contracts[0],
+        configuration: {
+          ...description.contracts[0].configuration,
+          status: {
+            ...description.contracts[0].configuration.status,
+            definitions: [
+              { value: "open", label: "Ready", order: 1 },
+              {
+                value: "closed",
+                label: "Finished",
+                is_completed: true,
+                auto_archive: true,
+                auto_archive_delay_minutes: 0,
+                order: 2
+              }
+            ]
+          },
+          time_tracking: { auto_stop_on_complete: true },
+          archive: {
+            tags_field: "tags",
+            archived_tag: "archived",
+            move_on_archive: true,
+            folder: "Archive"
+          }
+        }
+      }]
+    };
+    const connect = {
+      describe: vi.fn().mockResolvedValue(semanticDescription),
+      read: vi.fn()
+        .mockResolvedValueOnce({
+          valid: true,
+          diagnostics: [],
+          result: {
+            path: "inbox/tracked.md",
+            frontmatter: {
+              name: "Tracked",
+              state: "open",
+              tags: ["work"],
+              sessions: [{ startTime: "2026-07-25T12:00:00.000Z" }]
+            },
+            types: ["task"],
+            revision: "one"
+          }
+        }),
+      update: vi.fn().mockImplementation(async ({ patch }) => ({
+        valid: true,
+        diagnostics: [],
+        result: {
+          path: "inbox/tracked.md",
+          frontmatter: patch,
+          types: ["task"],
+          revision: "two"
+        }
+      })),
+      rename: vi.fn().mockResolvedValue({
+        valid: true,
+        diagnostics: [],
+        result: { from: "inbox/tracked.md", to: "Archive/tracked.md", revision: "three" }
+      })
+    } as any;
+
+    await new TasknotesCollection(connect).setCompleted("inbox/tracked.md", true);
+
+    expect(connect.update).toHaveBeenCalledWith(expect.objectContaining({
+      path: "inbox/tracked.md",
+      patch: expect.objectContaining({
+        state: "closed",
+        finished_on: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        updated_at: expect.any(String),
+        tags: ["work", "archived"],
+        sessions: [expect.objectContaining({
+          startTime: "2026-07-25T12:00:00.000Z",
+          endTime: expect.any(String)
+        })]
+      })
+    }));
+    expect(connect.rename).toHaveBeenCalledWith({
+      from: "inbox/tracked.md",
+      to: "Archive/tracked.md",
+      if_revision: "two",
+      update_refs: false
+    });
+  });
+
+  it("advances recurring tasks through the shared TaskNotes operation planner", async () => {
+    const connect = {
+      describe: vi.fn().mockResolvedValue(description),
+      read: vi.fn().mockResolvedValue({
+        valid: true,
+        diagnostics: [],
+        result: {
+          path: "inbox/daily.md",
+          frontmatter: {
+            name: "Daily",
+            state: "open",
+            start_on: "2026-07-26",
+            deadline: "2026-07-27",
+            repeat: "DTSTART:20260726;FREQ=DAILY",
+            completed_runs: [],
+            skipped_runs: []
+          },
+          types: ["task"],
+          revision: "one"
+        }
+      }),
+      update: vi.fn().mockImplementation(async ({ patch }) => ({
+        valid: true,
+        diagnostics: [],
+        result: {
+          path: "inbox/daily.md",
+          frontmatter: patch,
+          types: ["task"],
+          revision: "two"
+        }
+      }))
+    } as any;
+
+    await new TasknotesCollection(connect).setCompleted("inbox/daily.md", true);
+    const patch = connect.update.mock.calls[0][0].patch;
+    expect(patch).toEqual(expect.objectContaining({
+      repeat: expect.any(String),
+      completed_runs: expect.arrayContaining([expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)]),
+      start_on: expect.any(String),
+      deadline: expect.any(String),
+      updated_at: expect.any(String)
+    }));
+    expect(patch).not.toHaveProperty("state");
+    expect(patch).not.toHaveProperty("finished_on");
+  });
+
+  it("preserves siblings when updating a nested mapped field", async () => {
+    const nested = {
+      ...description,
+      contracts: [{
+        ...description.contracts[0],
+        configuration: {
+          ...description.contracts[0].configuration,
+          field_roles: {
+            ...description.contracts[0].configuration.field_roles,
+            status: "workflow.state",
+            completedDate: "workflow.completed"
+          }
+        }
+      }]
+    };
+    const connect = {
+      describe: vi.fn().mockResolvedValue(nested),
+      read: vi.fn().mockResolvedValue({
+        valid: true,
+        diagnostics: [],
+        result: {
+          path: "inbox/nested.md",
+          frontmatter: {
+            name: "Nested",
+            workflow: { state: "open", owner: "Callum" }
+          },
+          types: ["task"],
+          revision: "one"
+        }
+      }),
+      update: vi.fn().mockImplementation(async ({ patch }) => ({
+        valid: true,
+        diagnostics: [],
+        result: {
+          path: "inbox/nested.md",
+          frontmatter: patch,
+          types: ["task"],
+          revision: "two"
+        }
+      }))
+    } as any;
+
+    await new TasknotesCollection(connect).setCompleted("inbox/nested.md", true);
+    expect(connect.update).toHaveBeenCalledWith(expect.objectContaining({
+      patch: {
+        workflow: expect.objectContaining({
+          state: "closed",
+          owner: "Callum",
+          completed: expect.any(String)
+        }),
+        updated_at: expect.any(String)
+      }
+    }));
   });
 
   it("rejects empty titles and unsafe contract field paths", async () => {

--- a/packages/tasknotes/src/index.ts
+++ b/packages/tasknotes/src/index.ts
@@ -5,6 +5,17 @@ import type {
 import type { MdbaseConnection, QueryResult } from "@mdbase/connect";
 import type { OfflineReplica } from "@mdbase/connect-sync";
 import {
+  denormalizeSpecFrontmatter,
+  normalizeSpecFrontmatter
+} from "@tasknotes/model/config";
+import { getCurrentDateString } from "@tasknotes/model/date";
+import { mapTaskFromFrontmatter } from "@tasknotes/model/mapping";
+import {
+  buildSpecCompleteTaskUpdate,
+  buildSpecStopTimeTrackingUpdate
+} from "@tasknotes/model/operations";
+import type { TaskInfo, UserMappedField } from "@tasknotes/model/types";
+import {
   resolveTasknotesContract,
   TasknotesContractError,
   type TasknotesContract
@@ -28,13 +39,13 @@ export interface TaskFrontmatter extends JsonObject {
   status?: string;
 }
 
-export interface TaskSummary {
+export type TaskSummary = Partial<TaskInfo> & {
   path: string;
   title: string;
   status?: string;
   completed: boolean;
   frontmatter: TaskFrontmatter;
-}
+};
 
 export interface CreateTaskInput {
   title: string;
@@ -72,11 +83,18 @@ export class TasknotesCollection {
 
   async create(input: CreateTaskInput): Promise<RecordResult<TaskFrontmatter>> {
     const contract = await this.describe();
-    const fields: JsonObject = { ...(input.fields ?? {}) };
+    const fields = createFields(contract, input.fields);
     setField(fields, roleField(contract, "title", "title"), taskTitle(input.title));
     const defaultStatus = contract.configuration.status.default;
     if (defaultStatus && getField(fields, roleField(contract, "status", "status")) === undefined) {
       setField(fields, roleField(contract, "status", "status"), defaultStatus);
+    }
+    const defaultPriority = contract.configuration.priority?.default;
+    if (
+      defaultPriority
+      && getField(fields, roleField(contract, "priority", "priority")) === undefined
+    ) {
+      setField(fields, roleField(contract, "priority", "priority"), defaultPriority);
     }
     const response = await this.connect.create({
       type: contract.typeName,
@@ -92,21 +110,102 @@ export class TasknotesCollection {
     const contract = await this.describe();
     const read = await this.connect.read({ path });
     assertValid(read);
-    const status = completed
-      ? contract.configuration.status.completed_values[0]
-      : incompleteStatus(contract);
-    if (!status) {
-      throw new TasknotesContractError("The TaskNotes contract does not define a status for this change.");
-    }
-    const fields: JsonObject = {};
-    setField(fields, roleField(contract, "status", "status"), status);
+    const fields = completionPatch(
+      read.result.raw_frontmatter ?? read.result.frontmatter,
+      contract,
+      completed,
+      path
+    );
     const updated = await this.connect.update({
       path,
       patch: fields,
       if_revision: read.result.revision
     });
     assertValid(updated);
+    await this.moveArchivedTask(path, updated.result.revision, contract, completed);
     return updated.result;
+  }
+
+  async setStatus(path: string, status: string): Promise<RecordResult<TaskFrontmatter>> {
+    const contract = await this.describe();
+    const definition = contract.statuses.find((candidate) => candidate.value === status);
+    if (!definition) {
+      throw new TasknotesContractError(`Unknown TaskNotes status "${status}".`);
+    }
+    if (definition.isCompleted) return this.setCompleted(path, true);
+    const read = await this.connect.read({ path });
+    assertValid(read);
+    const raw = read.result.raw_frontmatter ?? read.result.frontmatter;
+    const patch: JsonObject = {};
+    setPatchField(patch, raw, roleField(contract, "status", "status"), status);
+    setPatchField(
+      patch,
+      raw,
+      roleField(contract, "completedDate", "completedDate"),
+      null
+    );
+    const updated = await this.connect.update({
+      path,
+      patch,
+      if_revision: read.result.revision
+    });
+    assertValid(updated);
+    return updated.result;
+  }
+
+  async setPriority(path: string, priority: string): Promise<RecordResult<TaskFrontmatter>> {
+    const contract = await this.describe();
+    if (!contract.priorities.some((candidate) => candidate.value === priority)) {
+      throw new TasknotesContractError(`Unknown TaskNotes priority "${priority}".`);
+    }
+    return this.updateFields(path, {
+      [roleField(contract, "priority", "priority")]: priority
+    });
+  }
+
+  async updateFields(
+    path: string,
+    fields: JsonObject
+  ): Promise<RecordResult<TaskFrontmatter>> {
+    const read = await this.connect.read({ path });
+    assertValid(read);
+    const raw = read.result.raw_frontmatter ?? read.result.frontmatter;
+    const patch: JsonObject = {};
+    for (const [field, value] of Object.entries(fields)) {
+      setPatchField(patch, raw, field, value);
+    }
+    const updated = await this.connect.update({
+      path,
+      patch,
+      if_revision: read.result.revision
+    });
+    assertValid(updated);
+    return updated.result;
+  }
+
+  private async moveArchivedTask(
+    path: string,
+    revision: string,
+    contract: TasknotesContract,
+    completed: boolean
+  ): Promise<void> {
+    if (!completed || contract.configuration.archive?.move_on_archive !== true) return;
+    const status = completedStatus(contract);
+    if (!status?.autoArchive || status.autoArchiveDelay > 0) return;
+    const folder = stringValue(contract.configuration.archive.folder)?.replace(
+      /^\/+|\/+$/g,
+      ""
+    );
+    if (!folder || folder.includes("{{")) return;
+    const filename = path.split("/").at(-1);
+    if (!filename || path === `${folder}/${filename}`) return;
+    const renamed = await this.connect.rename({
+      from: path,
+      to: `${folder}/${filename}`,
+      if_revision: revision,
+      update_refs: false
+    });
+    assertValid(renamed);
   }
 }
 
@@ -124,11 +223,18 @@ export class TasknotesOfflineCollection {
   }
 
   async create(input: CreateTaskInput): Promise<string> {
-    const fields: JsonObject = { ...(input.fields ?? {}) };
+    const fields = createFields(this.contract, input.fields);
     setField(fields, roleField(this.contract, "title", "title"), taskTitle(input.title));
     const defaultStatus = this.contract.configuration.status.default;
     if (defaultStatus && getField(fields, roleField(this.contract, "status", "status")) === undefined) {
       setField(fields, roleField(this.contract, "status", "status"), defaultStatus);
+    }
+    const defaultPriority = this.contract.configuration.priority?.default;
+    if (
+      defaultPriority
+      && getField(fields, roleField(this.contract, "priority", "priority")) === undefined
+    ) {
+      setField(fields, roleField(this.contract, "priority", "priority"), defaultPriority);
     }
     const record = await this.replica.queueCreate({
       path: input.path ?? defaultTaskPath(input.title, this.contract) ?? `tasks/${crypto.randomUUID()}.md`,
@@ -142,12 +248,7 @@ export class TasknotesOfflineCollection {
   async setCompleted(recordId: string, completed: boolean): Promise<void> {
     const record = (await this.replica.records()).find((candidate) => candidate.record_id === recordId);
     if (!record) throw new TasknotesContractError("Task is not available in the offline cache.");
-    const status = completed
-      ? this.contract.configuration.status.completed_values[0]
-      : incompleteStatus(this.contract);
-    if (!status) throw new TasknotesContractError("The TaskNotes contract does not define a status for this change.");
-    const patch: JsonObject = {};
-    setField(patch, roleField(this.contract, "status", "status"), status);
+    const patch = completionPatch(record.frontmatter, this.contract, completed, record.path);
     await this.replica.queueUpdate({ recordId, patch });
   }
 
@@ -157,13 +258,33 @@ export class TasknotesOfflineCollection {
 }
 
 function normalizeTask(path: string, frontmatter: TaskFrontmatter, contract: TasknotesContract): TaskSummary {
-  const title = getField(frontmatter, roleField(contract, "title", "title"));
-  const status = getField(frontmatter, roleField(contract, "status", "status"));
-  return {
+  const modelFrontmatter: Record<string, unknown> = { ...frontmatter };
+  for (const field of Object.values(contract.fieldMapping)) {
+    const value = getField(frontmatter, field);
+    if (value !== undefined) modelFrontmatter[field] = value;
+  }
+  const task = mapTaskFromFrontmatter(
+    contract.fieldMapping,
+    modelFrontmatter,
     path,
-    title: typeof title === "string" && title.length > 0 ? title : path,
+    contract.titleStorage === "filename",
+    userFields(contract),
+    contract.statuses,
+    contract.priorities
+  );
+  const title = getField(frontmatter, roleField(contract, "title", "title"));
+  const status = task.status
+    ?? getField(frontmatter, roleField(contract, "status", "status"));
+  return {
+    ...task,
+    path,
+    title:
+      task.title
+      ?? (typeof title === "string" && title.length > 0 ? title : path),
     status: typeof status === "string" ? status : undefined,
-    completed: typeof status === "string" && contract.configuration.status.completed_values.includes(status),
+    completed:
+      typeof status === "string"
+      && contract.configuration.status.completed_values.includes(status),
     frontmatter
   };
 }
@@ -178,10 +299,131 @@ function taskTitle(value: string): string {
   return title;
 }
 
+function createFields(
+  contract: TasknotesContract,
+  provided: JsonObject | undefined
+): JsonObject {
+  const fields: JsonObject = {};
+  for (const field of contract.fields) {
+    if (field.defaultValue !== undefined && !field.readOnly) {
+      setField(fields, field.key, cloneJson(field.defaultValue));
+    }
+  }
+  for (const [key, value] of Object.entries(provided ?? {})) fields[key] = cloneJson(value);
+  return fields;
+}
+
+function completionPatch(
+  raw: TaskFrontmatter,
+  contract: TasknotesContract,
+  completed: boolean,
+  path: string
+): JsonObject {
+  const status = completed ? completedStatus(contract)?.value : incompleteStatus(contract);
+  if (!status) {
+    throw new TasknotesContractError(
+      "The TaskNotes contract does not define a status for this change."
+    );
+  }
+
+  if (!completed) {
+    const patch: JsonObject = {};
+    setPatchField(patch, raw, roleField(contract, "status", "status"), status);
+    setPatchField(
+      patch,
+      raw,
+      roleField(contract, "completedDate", "completedDate"),
+      null
+    );
+    return patch;
+  }
+
+  const currentTimestamp = new Date().toISOString();
+  const normalized = normalizeSpecFrontmatter(
+    mappedFrontmatter(raw, contract),
+    contract.specFieldMapping
+  );
+  const plan = buildSpecCompleteTaskUpdate({
+    frontmatter: normalized,
+    targetDate: getCurrentDateString(),
+    completedStatus: status,
+    currentTimestamp,
+    path
+  });
+  const roleFields: Record<string, unknown> = { ...plan.fields };
+
+  if (contract.configuration.time_tracking?.auto_stop_on_complete === true) {
+    const stopped = buildSpecStopTimeTrackingUpdate({
+      frontmatter: { ...normalized, ...roleFields },
+      currentTimestamp,
+      path
+    });
+    if (stopped.changed) Object.assign(roleFields, stopped.fields);
+  }
+
+  const patch = roleFieldsPatch(raw, contract, roleFields);
+  const definition = completedStatus(contract);
+  if (definition?.autoArchive && definition.autoArchiveDelay <= 0) {
+    applyArchiveTag(patch, raw, contract);
+  }
+  return patch;
+}
+
+function mappedFrontmatter(
+  raw: TaskFrontmatter,
+  contract: TasknotesContract
+): Record<string, unknown> {
+  const mapped: Record<string, unknown> = { ...raw };
+  for (const field of Object.values(contract.specFieldMapping.roleToField)) {
+    const value = getField(raw, field);
+    if (value !== undefined) mapped[field] = value;
+  }
+  return mapped;
+}
+
+function roleFieldsPatch(
+  raw: TaskFrontmatter,
+  contract: TasknotesContract,
+  fields: Record<string, unknown>
+): JsonObject {
+  const denormalized = denormalizeSpecFrontmatter(fields, contract.specFieldMapping);
+  const patch: JsonObject = {};
+  for (const [field, value] of Object.entries(denormalized)) {
+    setPatchField(patch, raw, field, value ?? null);
+  }
+  return patch;
+}
+
+function applyArchiveTag(
+  patch: JsonObject,
+  raw: TaskFrontmatter,
+  contract: TasknotesContract
+): void {
+  const archive = contract.configuration.archive;
+  const tag = stringValue(archive?.archived_tag);
+  if (!tag) return;
+  const tagsField = stringValue(archive?.tags_field)
+    ?? contract.specFieldMapping.roleToField.tags;
+  const existing = getField(raw, tagsField);
+  const tags = Array.isArray(existing)
+    ? existing.filter((value): value is string => typeof value === "string")
+    : typeof existing === "string"
+      ? existing.split(",").map((value) => value.trim()).filter(Boolean)
+      : [];
+  if (!tags.includes(tag)) tags.push(tag);
+  setPatchField(patch, raw, tagsField, tags);
+}
+
+function completedStatus(contract: TasknotesContract) {
+  return contract.statuses.find((status) => status.isCompleted);
+}
+
 function incompleteStatus(contract: TasknotesContract): string | undefined {
   const candidate = contract.configuration.status.default;
   if (candidate && !contract.configuration.status.completed_values.includes(candidate)) return candidate;
-  return undefined;
+  return contract.statuses.find(
+    (status) => !status.isCompleted && !status.isSkipped
+  )?.value;
 }
 
 function defaultTaskPath(title: string, contract: TasknotesContract): string | undefined {
@@ -221,6 +463,69 @@ function setField(value: JsonObject, path: string, fieldValue: unknown): void {
   current[segments.at(-1)!] = fieldValue;
 }
 
+function setPatchField(
+  patch: JsonObject,
+  currentValue: JsonObject,
+  path: string,
+  fieldValue: unknown
+): void {
+  const segments = path.split(".");
+  const first = segments[0];
+  if (segments.length === 1) {
+    patch[first] = cloneJson(fieldValue);
+    return;
+  }
+  const existing = asObject(patch[first]) ?? asObject(currentValue[first]);
+  const root = existing ? cloneJson(existing) as JsonObject : {};
+  let current = root;
+  for (const segment of segments.slice(1, -1)) {
+    const child = asObject(current[segment]);
+    const next = child ? cloneJson(child) as JsonObject : {};
+    current[segment] = next;
+    current = next;
+  }
+  const last = segments.at(-1)!;
+  if (fieldValue === null) delete current[last];
+  else current[last] = cloneJson(fieldValue);
+  patch[first] = root;
+}
+
+function userFields(contract: TasknotesContract): UserMappedField[] {
+  return contract.fields
+    .filter((field) => !field.role && field.kind !== "unsupported")
+    .map((field) => ({
+      id: field.key,
+      displayName: field.label,
+      key: field.key,
+      type:
+        field.kind === "number" || field.kind === "integer"
+          ? "number"
+          : field.kind === "date" || field.kind === "datetime"
+            ? "date"
+            : field.kind === "boolean"
+              ? "boolean"
+              : field.kind === "list"
+                ? "list"
+                : "text",
+      ...(isUserFieldDefault(field.defaultValue)
+        ? { defaultValue: cloneJson(field.defaultValue) as UserMappedField["defaultValue"] }
+        : {})
+    }));
+}
+
+function isUserFieldDefault(
+  value: unknown
+): value is string | number | boolean | string[] {
+  return typeof value === "string"
+    || typeof value === "number"
+    || typeof value === "boolean"
+    || (Array.isArray(value) && value.every((item) => typeof item === "string"));
+}
+
+function cloneJson<T>(value: T): T {
+  return value === undefined ? value : structuredClone(value);
+}
+
 function assertValid(value: { valid: boolean; diagnostics: Array<{ message: string }> }): void {
   if (value.valid) return;
   throw new TasknotesContractError(value.diagnostics[0]?.message ?? "Task operation failed.");
@@ -230,4 +535,8 @@ function asObject(value: unknown): JsonObject | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as JsonObject
     : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }

--- a/packages/tasknotes/src/index.ts
+++ b/packages/tasknotes/src/index.ts
@@ -1,38 +1,31 @@
 import type {
-  CollectionContractDescriptor,
-  CollectionDescription,
   JsonObject,
-  RecordResult,
-  SyncCollectionResources
+  RecordResult
 } from "@mdbase/connect-protocol";
 import type { MdbaseConnection, QueryResult } from "@mdbase/connect";
 import type { OfflineReplica } from "@mdbase/connect-sync";
+import {
+  resolveTasknotesContract,
+  TasknotesContractError,
+  type TasknotesContract
+} from "./contract.js";
 
-export const TASKNOTES_TASK_CONTRACT = "tasknotes.task";
+export {
+  resolveTasknotesContract,
+  resolveTasknotesSyncContract,
+  TASKNOTES_TASK_CONTRACT,
+  TasknotesContractError
+} from "./contract.js";
+export type {
+  TaskFieldDefinition,
+  TaskFieldKind,
+  TasknotesContract,
+  TasknotesContractConfiguration
+} from "./contract.js";
 
 export interface TaskFrontmatter extends JsonObject {
   title?: string;
   status?: string;
-}
-
-export interface TasknotesContractConfiguration extends JsonObject {
-  contract: typeof TASKNOTES_TASK_CONTRACT;
-  version: number;
-  field_roles: Record<string, string>;
-  status: {
-    completed_values: string[];
-    default?: string;
-  };
-  priority?: { default?: string };
-  archive?: { tags_field?: string; archived_tag?: string };
-}
-
-export interface TasknotesContract {
-  descriptor: CollectionContractDescriptor;
-  configuration: TasknotesContractConfiguration;
-  typeName: string;
-  pathFolder?: string;
-  pathPattern?: string;
 }
 
 export interface TaskSummary {
@@ -50,32 +43,6 @@ export interface CreateTaskInput {
   body?: string;
 }
 
-export function resolveTasknotesContract(description: CollectionDescription): TasknotesContract {
-  return resolveContract(description.types, description.contracts);
-}
-
-export function resolveTasknotesSyncContract(resources: SyncCollectionResources): TasknotesContract {
-  return resolveContract(resources.types, resources.contracts);
-}
-
-function resolveContract(
-  types: CollectionDescription["types"],
-  contracts: CollectionDescription["contracts"]
-): TasknotesContract {
-  const descriptor = contracts.find((contract) => contract.id === TASKNOTES_TASK_CONTRACT);
-  if (!descriptor) throw new TasknotesContractError("TaskNotes task contract is not available in this collection.");
-  const configuration = parseConfiguration(descriptor.configuration);
-  const type = types.find((candidate) => candidate.name === descriptor.type_name);
-  const path = asObject(type?.collection?.path);
-  return {
-    descriptor,
-    configuration,
-    typeName: descriptor.type_name,
-    pathFolder: stringValue(path?.folder),
-    pathPattern: stringValue(path?.pattern)
-  };
-}
-
 export class TasknotesCollection {
   private contract: TasknotesContract | null = null;
 
@@ -84,6 +51,15 @@ export class TasknotesCollection {
   async describe(): Promise<TasknotesContract> {
     this.contract ??= resolveTasknotesContract(await this.connect.describe());
     return this.contract;
+  }
+
+  invalidateContract(): void {
+    this.contract = null;
+  }
+
+  async refreshContract(): Promise<TasknotesContract> {
+    this.invalidateContract();
+    return this.describe();
   }
 
   async list(): Promise<TaskSummary[]> {
@@ -180,26 +156,6 @@ export class TasknotesOfflineCollection {
   }
 }
 
-export class TasknotesContractError extends Error {}
-
-function parseConfiguration(value: JsonObject): TasknotesContractConfiguration {
-  const roles = asObject(value.field_roles);
-  const status = asObject(value.status);
-  const completedValues = status?.completed_values;
-  if (value.contract !== TASKNOTES_TASK_CONTRACT
-      || typeof value.version !== "number"
-      || !roles
-      || !status
-      || !Array.isArray(completedValues)
-      || completedValues.length === 0
-      || !completedValues.every((item) => typeof item === "string" && item.length > 0)
-      || !Object.values(roles).every((field) => typeof field === "string" && validFieldPath(field))
-      || (status.default !== undefined && (typeof status.default !== "string" || status.default.length === 0))) {
-    throw new TasknotesContractError("The TaskNotes task contract is malformed.");
-  }
-  return value as TasknotesContractConfiguration;
-}
-
 function normalizeTask(path: string, frontmatter: TaskFrontmatter, contract: TasknotesContract): TaskSummary {
   const title = getField(frontmatter, roleField(contract, "title", "title"));
   const status = getField(frontmatter, roleField(contract, "status", "status"));
@@ -222,10 +178,6 @@ function taskTitle(value: string): string {
   return title;
 }
 
-function validFieldPath(value: string): boolean {
-  return value.split(".").every((part) => part.length > 0 && part !== "__proto__" && part !== "prototype" && part !== "constructor");
-}
-
 function incompleteStatus(contract: TasknotesContract): string | undefined {
   const candidate = contract.configuration.status.default;
   if (candidate && !contract.configuration.status.completed_values.includes(candidate)) return candidate;
@@ -233,7 +185,7 @@ function incompleteStatus(contract: TasknotesContract): string | undefined {
 }
 
 function defaultTaskPath(title: string, contract: TasknotesContract): string | undefined {
-  if (contract.pathPattern) return undefined;
+  if (contract.pathTemplate || contract.pathRuntime) return undefined;
   const filename = slug(title) || "task";
   const folder = contract.pathFolder?.replace(/^\/+|\/+$/g, "") ?? "tasks";
   return `${folder}/${filename}.md`;
@@ -278,8 +230,4 @@ function asObject(value: unknown): JsonObject | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as JsonObject
     : undefined;
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       '@mdbase/connect-sync':
         specifier: workspace:*
         version: link:../sync
+      '@tasknotes/model':
+        specifier: 0.3.0-rc.1
+        version: 0.3.0-rc.1
     devDependencies:
       typescript:
         specifier: ^7.0.2
@@ -408,6 +411,9 @@ importers:
         version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
+
+  '@callumalpass/mdbase-runtime@0.1.0-rc.1':
+    resolution: {integrity: sha512-I+sLSUZWvq2F57ehWsfgFM5ZIbDiCkf7ROyE7EzAV/M1lkFqihFjkkH0FSr/2RzleiT84UEadZuQD1D8NdJKFA==}
 
   '@electron-forge/cli@7.11.2':
     resolution: {integrity: sha512-c+C4ndLfHbxwZuCn9G8iT9wD/woLdaVkoSVjAIbj+0nJhi8UmiVsz/+Gxlj4cvhMRTzBMBxudstLU7RocMikfg==}
@@ -1013,6 +1019,9 @@ packages:
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
+
+  '@tasknotes/model@0.3.0-rc.1':
+    resolution: {integrity: sha512-XFNfUL+DFDgyOZRfaN9909fLhaUGLmgDYmjApYYOHXOxDmvr4x/c3T8XrNLyr5hk3q4fIkGJNljO4r0Ck4GBKg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -3202,6 +3211,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -3822,10 +3834,20 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@callumalpass/mdbase-runtime@0.1.0-rc.1':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      semver: 7.8.5
+      yaml: 2.9.0
 
   '@electron-forge/cli@7.11.2(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@8.1.1)':
     dependencies:
@@ -4636,6 +4658,13 @@ snapshots:
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tasknotes/model@0.3.0-rc.1':
+    dependencies:
+      '@callumalpass/mdbase-runtime': 0.1.0-rc.1
+      rrule: 2.8.1
+      yaml: 2.9.0
+      zod: 3.25.76
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -6851,6 +6880,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
+
   run-async@2.4.1:
     optional: true
 
@@ -7178,8 +7211,7 @@ snapshots:
   tslib@1.14.1:
     optional: true
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.23.1:
     dependencies:
@@ -7455,5 +7487,7 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
 
   apps/desktop:
     dependencies:
@@ -153,6 +156,9 @@ importers:
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/client:
     dependencies:


### PR DESCRIPTION
## Summary

- resolve the canonical `tasknotes.task` contract from arbitrary task type names and refresh it when type resources change
- delegate template/runtime paths to mdbase authority and use `@tasknotes/model` for field mapping, completion, recurrence, completed dates, time tracking, and archive effects
- expose every core field role plus JSON Schema required/default/enum/type metadata
- render contract-defined status/priority controls and generated editors for safe custom scalar/list fields while preserving unsupported or nested data
- add contract/normalization profiling and focused adapter/UI tests

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace` (59 passed)
- `pnpm build`
- `pnpm test` (all workspace suites passed)
- `pnpm typecheck`
- `pnpm e2e` (real Rust agent, OAuth, relay, direct loopback, Chromium SDK, 1,000 records)
- `pnpm e2e:sync` (hosted/offline TaskNotes vertical slice)
- `pnpm package:audit`
- live TaskNotes UI at 1440×1000 and 390×844: no console errors or overflow; visible keyboard focus; FCP 200 ms locally
- `pnpm --filter @mdbase/tasknotes run profile`: 23.584 µs/contract resolution; 2.074 µs/task across 200,000 tasks; 44.4 MB heap

## Impact

The TaskNotes type file is now the app's canonical runtime contract. Renames, field-role mappings, path rules, schema changes, status/priority vocabularies, defaults, and supported custom fields are reflected without parallel hard-coded app semantics.