### PR TITLE
Add hosted-to-local authority transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ and revocation.
 PostgreSQL 18. It includes a real Chromium portal flow, direct OAuth SDK
 operations, encrypted-at-rest checks, two provider instances racing one write,
 pinned snapshots, writable filesystem mirroring, durable retry receipts,
+an exact hosted-to-local authority handoff through the real CLI and portal,
+authority fencing, proof rejection, completion retry, cancellation recovery,
 compaction, restart recovery, logical backup restoration into a fresh database,
-credential rotation, quotas, ciphertext tamper detection, and a private
-mutation flowing through the hosted runtime into an opaque notification
-callback.
+credential rotation, quotas, ciphertext tamper detection, and a private mutation
+flowing through the hosted runtime into an opaque notification callback.
 `pnpm e2e:provider:stress` repeats the path with 10,000 records and enforces the
 documented latency budgets.
 

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -78,8 +78,26 @@ export interface HostedCollection {
   provider_url: string;
   spec_version: string;
   contracts: ContractRequirement[];
+  authority_state: "active" | "transferring" | "transferred";
+  authority_epoch: number;
+  transferred_collection_id: string | null;
   created_at: string;
   replicas: HostedReplica[];
+}
+
+export interface AuthorityTransfer {
+  id: string;
+  collection_id: string;
+  replica_id: string;
+  state: "requested" | "approved" | "prepared" | "completed" | "cancelled" | "expired";
+  final_head: number | null;
+  authority_epoch: number | null;
+  manifest_digest: string | null;
+  expires_at: string;
+  verification_uri: string;
+  local_collection_id?: string;
+  collection_name?: string;
+  mirror_name?: string;
 }
 
 export interface PendingAuthorization {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -21,6 +21,7 @@ import { createRoot } from "react-dom/client";
 import {
   api,
   ApiError,
+  type AuthorityTransfer as AuthorityTransferData,
   type AvailableCollection,
   type ContractRequirement,
   type DashboardData,
@@ -36,10 +37,12 @@ const allOperations = ["describe", "changes", "read", "query", "list_views", "ex
 function Portal() {
   const pairingId = location.pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
   const mirrorPairingId = location.pathname.match(/^\/mirror\/([0-9a-f-]+)$/i)?.[1];
+  const authorityTransferId = location.pathname.match(/^\/transfer\/([0-9a-f-]+)$/i)?.[1];
   const authorizationId = location.pathname.match(/^\/authorize\/([0-9a-f-]+)$/i)?.[1];
   if (location.pathname === "/login") return <Login />;
   if (pairingId) return <Pairing pairingId={pairingId} />;
   if (mirrorPairingId) return <MirrorPairing pairingId={mirrorPairingId} />;
+  if (authorityTransferId) return <AuthorityTransfer transferId={authorityTransferId} />;
   if (authorizationId) return <Authorization requestId={authorizationId} />;
   return <Dashboard />;
 }
@@ -307,7 +310,9 @@ function Dashboard() {
                   collections={[
                     ...data.collections.filter((collection) => collection.enabled)
                       .map((collection) => ({ ...collection, kind: "local" as const })),
-                    ...data.hosted_collections.map((collection) => ({
+                    ...data.hosted_collections
+                      .filter((collection) => collection.authority_state === "active")
+                      .map((collection) => ({
                       ...collection,
                       kind: "hosted" as const,
                       connector_name: "Hosted by mdbase"
@@ -412,6 +417,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
   const [panel, setPanel] = useState<"mirror" | "rename" | null>(null);
   const [name, setName] = useState(collection.display_name);
   const [busy, setBusy] = useState(false);
+  const isActive = collection.authority_state === "active";
   const activeReplicas = collection.replicas.filter((replica) => !replica.revoked_at);
   useEffect(() => { if (panel !== "rename") setName(collection.display_name); }, [collection.display_name, panel]);
 
@@ -451,10 +457,26 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
 
   return <article className="hosted-row">
     <div className="hosted-summary">
-      <div><strong>{collection.display_name}</strong><small>mdbase · authoritative on mdbase · created {relativeTime(collection.created_at)}</small></div>
-      <span className="availability online"><i />Hosted</span>
+      <div><strong>{collection.display_name}</strong><small>
+        {collection.authority_state === "transferred"
+          ? `mdbase · moved to a computer · authority epoch ${collection.authority_epoch}`
+          : collection.authority_state === "transferring"
+            ? "mdbase · authority transfer in progress"
+            : `mdbase · authoritative on mdbase · created ${relativeTime(collection.created_at)}`}
+      </small></div>
+      <span className={`availability ${isActive ? "online" : "idle"}`}><i />
+        {collection.authority_state === "transferred"
+          ? "Moved"
+          : collection.authority_state === "transferring"
+            ? "Moving"
+            : "Hosted"}
+      </span>
       <span className="replica-count">{activeReplicas.length} {activeReplicas.length === 1 ? "mirror" : "mirrors"}</span>
-      <div className="computer-actions"><button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Sync folder</button><button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button><button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button></div>
+      <div className="computer-actions">
+        {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Sync folder</button>}
+        {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button>}
+        <button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button>
+      </div>
     </div>
     {panel === "rename" && <form className="hosted-detail hosted-rename" onSubmit={(event) => void rename(event)}>
       <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
@@ -803,6 +825,135 @@ function MirrorPairing({ pairingId }: { pairingId: string }) {
               <a className="button primary link-button" href="/">Open your collections</a>
             </div>
           </>}
+        </>}
+      </section>
+    </main>
+  );
+}
+
+function AuthorityTransfer({ transferId }: { transferId: string }) {
+  const [transfer, setTransfer] = useState<AuthorityTransferData | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function refresh() {
+    try {
+      const result = await api<{ transfer: AuthorityTransferData }>(
+        `/v1/authority-transfers/${transferId}`
+      );
+      setTransfer(result.transfer);
+      setError("");
+    } catch (reason) {
+      if (reason instanceof ApiError && reason.status === 401) {
+        location.href = `/login?return_to=${encodeURIComponent(location.href)}`;
+      } else {
+        setError(message(reason));
+      }
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 2_000);
+    return () => window.clearInterval(timer);
+  }, [transferId]);
+
+  async function approve() {
+    setBusy(true);
+    try {
+      const result = await api<{ transfer: AuthorityTransferData }>(
+        `/v1/authority-transfers/${transferId}/approve`,
+        { method: "POST", body: "{}" }
+      );
+      setTransfer(result.transfer);
+      setError("");
+    } catch (reason) {
+      setError(message(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function cancel() {
+    setBusy(true);
+    try {
+      await api(`/v1/authority-transfers/${transferId}`, { method: "DELETE" });
+      await refresh();
+    } catch (reason) {
+      setError(message(reason));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!transfer) return <Loading error={error} />;
+  const collectionName = transfer.collection_name ?? "This collection";
+  const mirrorName = transfer.mirror_name ?? "the selected computer";
+  const waiting = transfer.state === "approved" || transfer.state === "prepared";
+  const inactive = transfer.state === "cancelled" || transfer.state === "expired";
+  return (
+    <main className="center-page">
+      <PageBrand label="Authority transfer" />
+      <section className="decision-panel authority-decision">
+        {transfer.state === "completed" ? <>
+          <p className="eyebrow outcome-label">Transfer complete</p>
+          <h1>{collectionName} now lives on your computer.</h1>
+          <p>
+            The folder on {mirrorName} is the source of truth. Hosted access has stopped
+            and previous application connections were revoked.
+          </p>
+          <div className="transfer-status" role="status">
+            <span className="status-dot connected" aria-hidden="true" />
+            <span>Local authority, epoch {transfer.authority_epoch}</span>
+          </div>
+          <a className="button primary link-button" href="/">Return to your account</a>
+        </> : inactive ? <>
+          <p className="eyebrow">Transfer ended</p>
+          <h1>Hosted authority was kept.</h1>
+          <p>
+            {collectionName} remains hosted. No source-of-truth change was completed.
+          </p>
+          {error && <div className="message error" role="alert">{error}</div>}
+          <a className="button primary link-button" href="/">Return to your account</a>
+        </> : waiting ? <>
+          <p className="eyebrow outcome-label">Transfer approved</p>
+          <h1>Return to {mirrorName}.</h1>
+          <p>
+            The command is checking the final hosted sequence, registering the folder
+            with mdbase connect, and activating local authority.
+          </p>
+          <div className="transfer-status" role="status">
+            <span className="status-dot paused" aria-hidden="true" />
+            <span>{transfer.state === "prepared" ? "Hosted writes are paused" : "Waiting for the computer"}</span>
+          </div>
+          {error && <div className="message error" role="alert">{error}</div>}
+          <div className="decision-actions">
+            <button className="quiet-danger" disabled={busy} onClick={() => void cancel()}>
+              Cancel transfer
+            </button>
+          </div>
+        </> : <>
+          <p className="eyebrow">Move source of truth</p>
+          <h1>Make {mirrorName} authoritative?</h1>
+          <p>
+            {collectionName} will stop being hosted and become a computer-owned collection.
+            This changes where every future edit is accepted.
+          </p>
+          <dl className="transfer-consequences">
+            <div><dt>Folder</dt><dd>The synchronized Markdown folder becomes the source of truth.</dd></div>
+            <div><dt>Hosted service</dt><dd>Writes pause during verification, then hosted access is retired.</dd></div>
+            <div><dt>Applications</dt><dd>Existing access is revoked. Connect applications again to use the local collection.</dd></div>
+            <div><dt>Recovery</dt><dd>If verification fails or this request expires, hosted writes resume.</dd></div>
+          </dl>
+          {error && <div className="message error" role="alert">{error}</div>}
+          <div className="decision-actions">
+            <button className="button secondary" disabled={busy} onClick={() => void cancel()}>
+              Keep it hosted
+            </button>
+            <button className="button primary" disabled={busy} onClick={() => void approve()}>
+              {busy ? "Approving…" : "Move authority"}
+            </button>
+          </div>
         </>}
       </section>
     </main>

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -1032,6 +1032,45 @@ select {
   line-height: 1.5;
 }
 
+.authority-decision {
+  width: min(36rem, 100%);
+}
+
+.transfer-consequences {
+  margin: 1.5rem 0 0;
+  border-top: 1px solid var(--line-strong);
+}
+
+.transfer-consequences > div {
+  display: grid;
+  grid-template-columns: 7.5rem 1fr;
+  gap: 1.2rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.transfer-consequences dt {
+  color: var(--ink-muted);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+}
+
+.transfer-consequences dd {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.transfer-status {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 1.5rem;
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+}
+
 .auth-panel .button {
   margin-top: 1.5rem;
 }
@@ -1209,6 +1248,11 @@ select {
   .inline-create,
   .mirror-form {
     grid-template-columns: 1fr;
+  }
+
+  .transfer-consequences > div {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
   }
 
   .copy-row,

--- a/crates/connect-hosted-provider/migrations/0008_authority_transfer.sql
+++ b/crates/connect-hosted-provider/migrations/0008_authority_transfer.sql
@@ -1,0 +1,31 @@
+ALTER TABLE hosted_provider_collections
+  DROP CONSTRAINT IF EXISTS hosted_provider_collections_state_check;
+
+ALTER TABLE hosted_provider_collections
+  ADD CONSTRAINT hosted_provider_collections_state_check
+  CHECK (state IN ('active', 'importing', 'transferring', 'transferred', 'deleting'));
+
+CREATE TABLE IF NOT EXISTS hosted_provider_authority_transfers (
+  id uuid PRIMARY KEY,
+  collection_id uuid NOT NULL
+    REFERENCES hosted_provider_collections(id) ON DELETE CASCADE,
+  replica_id uuid NOT NULL
+    REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
+  final_head bigint NOT NULL CHECK (final_head >= 0),
+  next_authority_epoch bigint NOT NULL CHECK (next_authority_epoch > 1),
+  manifest_digest text NOT NULL CHECK (manifest_digest ~ '^[a-f0-9]{64}$'),
+  state text NOT NULL DEFAULT 'prepared'
+    CHECK (state IN ('prepared', 'completed', 'aborted')),
+  expires_at timestamptz NOT NULL,
+  prepared_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  aborted_at timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS hosted_provider_authority_transfer_active_idx
+  ON hosted_provider_authority_transfers(collection_id)
+  WHERE state = 'prepared';
+
+CREATE INDEX IF NOT EXISTS hosted_provider_authority_transfer_expiry_idx
+  ON hosted_provider_authority_transfers(expires_at)
+  WHERE state = 'prepared';

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -28,7 +28,10 @@ use uuid::Uuid;
 
 use crate::{
     error::{ApiError, ApiResult},
-    provider::{validate_limit, HostedProvider, RegisterReplica, UpdateApplicationReplica},
+    provider::{
+        validate_limit, HostedProvider, PrepareAuthorityTransfer, RegisterReplica,
+        UpdateApplicationReplica,
+    },
 };
 
 // Leave room for the mutation envelope, frontmatter, and JSON escaping around
@@ -101,6 +104,11 @@ struct ProvisionTypesRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct CompleteAuthorityTransferRequest {
+    manifest_digest: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct SnapshotQuery {
     snapshot_id: Uuid,
     page: Option<String>,
@@ -138,6 +146,14 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/internal/v1/collections/{collection_id}/types/provision",
             post(provision_types),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/authority-transfers",
+            post(prepare_authority_transfer),
+        )
+        .route(
+            "/internal/v1/authority-transfers/{transfer_id}",
+            post(complete_authority_transfer).delete(abort_authority_transfer),
         )
         .route(
             "/internal/v1/collections/{collection_id}/notification-grants/{grant_id}",
@@ -384,6 +400,50 @@ async fn compact_collection(
         .compact_through(collection_id, input.through)
         .await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+async fn prepare_authority_transfer(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<PrepareAuthorityTransfer>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let transfer = state
+        .provider
+        .prepare_authority_transfer(collection_id, input)
+        .await?;
+    Ok(Json(serde_json::to_value(transfer).map_err(|error| {
+        ApiError::internal(format!("Authority transfer could not serialize: {error}"))
+    })?))
+}
+
+async fn complete_authority_transfer(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(transfer_id): Path<Uuid>,
+    Json(input): Json<CompleteAuthorityTransferRequest>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let transfer = state
+        .provider
+        .complete_authority_transfer(transfer_id, &input.manifest_digest)
+        .await?;
+    Ok(Json(serde_json::to_value(transfer).map_err(|error| {
+        ApiError::internal(format!("Authority transfer could not serialize: {error}"))
+    })?))
+}
+
+async fn abort_authority_transfer(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(transfer_id): Path<Uuid>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let transfer = state.provider.abort_authority_transfer(transfer_id).await?;
+    Ok(Json(serde_json::to_value(transfer).map_err(|error| {
+        ApiError::internal(format!("Authority transfer could not serialize: {error}"))
+    })?))
 }
 
 async fn open_session(

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -10,4 +10,7 @@ pub use crypto::ProviderCrypto;
 pub use error::{ApiError, ApiResult};
 pub use http::{app, AppState};
 pub use notifications::{HostedNotificationConfig, HostedNotificationRuntime};
-pub use provider::{HostedProvider, ProviderLimits, RegisterReplica};
+pub use provider::{
+    HostedProvider, PrepareAuthorityTransfer, ProviderAuthorityTransfer, ProviderLimits,
+    RegisterReplica,
+};

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -145,6 +145,16 @@ async fn maintain_history(provider: HostedProvider, retain_changes: u64, period:
             }
             Err(error) => tracing::error!(%error, "hosted history maintenance failed"),
         }
+        match provider.recover_expired_authority_transfers().await {
+            Ok(0) => {}
+            Ok(transfers) => {
+                tracing::warn!(
+                    transfers,
+                    "restored hosted authority after expired transfers"
+                )
+            }
+            Err(error) => tracing::error!(%error, "authority transfer recovery failed"),
+        }
     }
 }
 

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -16,7 +16,10 @@ use mdbase_connect_protocol::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
-use sqlx::{postgres::PgPoolOptions, PgPool, Postgres, Row, Transaction};
+use sqlx::{
+    postgres::{PgPoolOptions, PgRow},
+    PgPool, Postgres, Row, Transaction,
+};
 use subtle::ConstantTimeEq;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -119,6 +122,26 @@ pub struct ProviderReplicaStatus {
     pub acknowledged_sequence: u64,
     pub last_seen_at: Option<DateTime<Utc>>,
     pub token_expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PrepareAuthorityTransfer {
+    pub transfer_id: Uuid,
+    pub replica_id: Uuid,
+    #[serde(default = "default_authority_transfer_ttl")]
+    pub ttl_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderAuthorityTransfer {
+    pub id: Uuid,
+    pub collection_id: Uuid,
+    pub replica_id: Uuid,
+    pub final_head: u64,
+    pub authority_epoch: u64,
+    pub manifest_digest: String,
+    pub state: String,
+    pub expires_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone)]
@@ -566,6 +589,322 @@ impl HostedProvider {
             .collect()
     }
 
+    pub async fn prepare_authority_transfer(
+        &self,
+        collection_id: Uuid,
+        input: PrepareAuthorityTransfer,
+    ) -> ApiResult<ProviderAuthorityTransfer> {
+        if !(60..=60 * 60).contains(&input.ttl_seconds) {
+            return Err(ApiError::bad_request(
+                "invalid_authority_transfer_ttl",
+                "Authority transfer preparation must expire between one minute and one hour.",
+            ));
+        }
+        let mut transaction = self.pool.begin().await?;
+        recover_expired_authority_transfers_in(&mut transaction).await?;
+        let collection = sqlx::query(
+            r#"SELECT state, authority_epoch, head, wrapped_data_key
+               FROM hosted_provider_collections
+               WHERE id = $1
+               FOR UPDATE"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        if let Some(existing) = sqlx::query(
+            r#"SELECT id, collection_id, replica_id, final_head, next_authority_epoch,
+                      manifest_digest, state, expires_at
+               FROM hosted_provider_authority_transfers
+               WHERE id = $1"#,
+        )
+        .bind(input.transfer_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        {
+            if existing.get::<Uuid, _>("collection_id") != collection_id
+                || existing.get::<Uuid, _>("replica_id") != input.replica_id
+            {
+                return Err(ApiError::conflict(
+                    "authority_transfer_conflict",
+                    "Authority transfer already exists for another collection or mirror.",
+                ));
+            }
+            let result = provider_authority_transfer(&existing)?;
+            transaction.commit().await?;
+            return Ok(result);
+        }
+        if collection.get::<String, _>("state") != "active" {
+            return Err(ApiError::conflict(
+                "authority_transfer_unavailable",
+                "The hosted collection is not available for authority transfer.",
+            ));
+        }
+        let replica = sqlx::query(
+            r#"SELECT purpose, mode, allowed_types, revoked_at
+               FROM hosted_provider_replicas
+               WHERE id = $1 AND collection_id = $2
+               FOR UPDATE"#,
+        )
+        .bind(input.replica_id)
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found("replica_not_found", "The promotion mirror was not found.")
+        })?;
+        let eligible = replica.get::<String, _>("purpose") == "mirror"
+            && replica.get::<String, _>("mode") == "read_write"
+            && replica.get::<Vec<String>, _>("allowed_types").is_empty()
+            && replica
+                .get::<Option<DateTime<Utc>>, _>("revoked_at")
+                .is_none();
+        if !eligible {
+            return Err(ApiError::conflict(
+                "promotion_mirror_ineligible",
+                "Authority can move only to an active, two-way, full collection mirror.",
+            ));
+        }
+        let head = number(collection.get::<i64, _>("head"), "collection head")?;
+        let current_epoch = number(
+            collection.get::<i64, _>("authority_epoch"),
+            "authority epoch",
+        )?;
+        let next_epoch = current_epoch
+            .checked_add(1)
+            .ok_or_else(|| ApiError::internal("The collection authority epoch is exhausted."))?;
+        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let resources =
+            load_resource_documents(&mut transaction, &self.crypto, &data_key, collection_id)
+                .await?;
+        let records =
+            load_records(&mut transaction, &self.crypto, &data_key, collection_id).await?;
+        let manifest_digest = authority_manifest_digest(resources, records);
+        let expires_at = Utc::now()
+            + chrono::Duration::seconds(to_i64(input.ttl_seconds, "authority transfer lifetime")?);
+        sqlx::query(
+            r#"INSERT INTO hosted_provider_authority_transfers
+                 (id, collection_id, replica_id, final_head, next_authority_epoch,
+                  manifest_digest, expires_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)"#,
+        )
+        .bind(input.transfer_id)
+        .bind(collection_id)
+        .bind(input.replica_id)
+        .bind(to_i64(head, "collection head")?)
+        .bind(to_i64(next_epoch, "authority epoch")?)
+        .bind(&manifest_digest)
+        .bind(expires_at)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| match error {
+            sqlx::Error::Database(ref database) if database.is_unique_violation() => {
+                ApiError::conflict(
+                    "authority_transfer_in_progress",
+                    "Another authority transfer is already in progress.",
+                )
+            }
+            other => other.into(),
+        })?;
+        sqlx::query(
+            "UPDATE hosted_provider_collections SET state = 'transferring', updated_at = now() WHERE id = $1",
+        )
+        .bind(collection_id)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(ProviderAuthorityTransfer {
+            id: input.transfer_id,
+            collection_id,
+            replica_id: input.replica_id,
+            final_head: head,
+            authority_epoch: next_epoch,
+            manifest_digest,
+            state: "prepared".to_string(),
+            expires_at,
+        })
+    }
+
+    pub async fn complete_authority_transfer(
+        &self,
+        transfer_id: Uuid,
+        manifest_digest: &str,
+    ) -> ApiResult<ProviderAuthorityTransfer> {
+        let mut transaction = self.pool.begin().await?;
+        let row = sqlx::query(
+            r#"SELECT transfer.id, transfer.collection_id, transfer.replica_id,
+                      transfer.final_head, transfer.next_authority_epoch,
+                      transfer.manifest_digest, transfer.state, transfer.expires_at,
+                      collection.state AS collection_state,
+                      replica.acknowledged_sequence
+               FROM hosted_provider_authority_transfers transfer
+               JOIN hosted_provider_collections collection
+                 ON collection.id = transfer.collection_id
+               JOIN hosted_provider_replicas replica
+                 ON replica.id = transfer.replica_id
+               WHERE transfer.id = $1
+               FOR UPDATE OF transfer, collection, replica"#,
+        )
+        .bind(transfer_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "authority_transfer_not_found",
+                "Authority transfer was not found.",
+            )
+        })?;
+        let transfer = provider_authority_transfer(&row)?;
+        if transfer.state == "completed" {
+            transaction.commit().await?;
+            return Ok(transfer);
+        }
+        if transfer.state != "prepared" {
+            return Err(ApiError::conflict(
+                "authority_transfer_inactive",
+                "Authority transfer is no longer active.",
+            ));
+        }
+        if transfer.expires_at <= Utc::now() {
+            sqlx::query(
+                "UPDATE hosted_provider_authority_transfers SET state = 'aborted', aborted_at = now() WHERE id = $1",
+            )
+            .bind(transfer_id)
+            .execute(&mut *transaction)
+            .await?;
+            sqlx::query(
+                "UPDATE hosted_provider_collections SET state = 'active', updated_at = now() WHERE id = $1 AND state = 'transferring'",
+            )
+            .bind(transfer.collection_id)
+            .execute(&mut *transaction)
+            .await?;
+            transaction.commit().await?;
+            return Err(ApiError::conflict(
+                "authority_transfer_expired",
+                "Authority transfer expired and hosted writes were restored.",
+            ));
+        }
+        if row.get::<String, _>("collection_state") != "transferring" {
+            return Err(ApiError::conflict(
+                "authority_transfer_inactive",
+                "The hosted collection is no longer fenced for this transfer.",
+            ));
+        }
+        if !constant_time_text_equal(&transfer.manifest_digest, manifest_digest) {
+            return Err(ApiError::conflict(
+                "authority_manifest_mismatch",
+                "The local folder does not exactly match the fenced hosted collection.",
+            ));
+        }
+        let acknowledged = number(
+            row.get::<i64, _>("acknowledged_sequence"),
+            "replica acknowledged sequence",
+        )?;
+        if acknowledged < transfer.final_head {
+            return Err(ApiError::conflict(
+                "promotion_mirror_behind",
+                "The local mirror has not acknowledged the final hosted sequence.",
+            ));
+        }
+        sqlx::query(
+            r#"UPDATE hosted_provider_collections
+               SET state = 'transferred', authority_epoch = $2, updated_at = now()
+               WHERE id = $1 AND state = 'transferring'"#,
+        )
+        .bind(transfer.collection_id)
+        .bind(to_i64(transfer.authority_epoch, "authority epoch")?)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"UPDATE hosted_provider_authority_transfers
+               SET state = 'completed', completed_at = now()
+               WHERE id = $1"#,
+        )
+        .bind(transfer_id)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "UPDATE hosted_provider_replicas SET revoked_at = COALESCE(revoked_at, now()) WHERE collection_id = $1",
+        )
+        .bind(transfer.collection_id)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query("DELETE FROM hosted_provider_snapshot_leases WHERE collection_id = $1")
+            .bind(transfer.collection_id)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await?;
+        self.working_sets
+            .lock()
+            .await
+            .remove(&transfer.collection_id);
+        Ok(ProviderAuthorityTransfer {
+            state: "completed".to_string(),
+            ..transfer
+        })
+    }
+
+    pub async fn abort_authority_transfer(
+        &self,
+        transfer_id: Uuid,
+    ) -> ApiResult<ProviderAuthorityTransfer> {
+        let mut transaction = self.pool.begin().await?;
+        let row = sqlx::query(
+            r#"SELECT id, collection_id, replica_id, final_head, next_authority_epoch,
+                      manifest_digest, state, expires_at
+               FROM hosted_provider_authority_transfers
+               WHERE id = $1
+               FOR UPDATE"#,
+        )
+        .bind(transfer_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "authority_transfer_not_found",
+                "Authority transfer was not found.",
+            )
+        })?;
+        let transfer = provider_authority_transfer(&row)?;
+        if transfer.state == "completed" {
+            return Err(ApiError::conflict(
+                "authority_transfer_completed",
+                "Completed authority transfer cannot be cancelled.",
+            ));
+        }
+        if transfer.state == "prepared" {
+            sqlx::query(
+                "UPDATE hosted_provider_authority_transfers SET state = 'aborted', aborted_at = now() WHERE id = $1",
+            )
+            .bind(transfer_id)
+            .execute(&mut *transaction)
+            .await?;
+            sqlx::query(
+                "UPDATE hosted_provider_collections SET state = 'active', updated_at = now() WHERE id = $1 AND state = 'transferring'",
+            )
+            .bind(transfer.collection_id)
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+        Ok(ProviderAuthorityTransfer {
+            state: "aborted".to_string(),
+            ..transfer
+        })
+    }
+
+    pub async fn recover_expired_authority_transfers(&self) -> ApiResult<usize> {
+        let mut transaction = self.pool.begin().await?;
+        let recovered = recover_expired_authority_transfers_in(&mut transaction).await?;
+        transaction.commit().await?;
+        Ok(recovered)
+    }
+
     pub async fn rotate_replica_token(
         &self,
         replica_id: Uuid,
@@ -793,9 +1132,23 @@ impl HostedProvider {
             .await?;
         let row = sqlx::query(
             r#"SELECT head, retained_after, resource_revision, wrapped_data_key, resources_ciphertext
-               FROM hosted_provider_collections WHERE id = $1 AND state = 'active'"#,
+               FROM hosted_provider_collections collection
+               WHERE id = $1 AND (
+                 state = 'active'
+                 OR (
+                   state = 'transferring'
+                   AND EXISTS (
+                     SELECT 1 FROM hosted_provider_authority_transfers transfer
+                     WHERE transfer.collection_id = collection.id
+                       AND transfer.replica_id = $2
+                       AND transfer.state = 'prepared'
+                       AND transfer.expires_at > now()
+                   )
+                 )
+               )"#,
         )
         .bind(collection_id)
+        .bind(replica.id)
         .fetch_optional(&self.pool)
         .await?
         .ok_or_else(|| {
@@ -872,7 +1225,20 @@ impl HostedProvider {
                FROM hosted_provider_snapshot_leases lease
                JOIN hosted_provider_collections collection ON collection.id = lease.collection_id
                WHERE lease.id = $1 AND lease.collection_id = $2 AND lease.replica_id = $3
-                 AND expires_at > now()"#,
+                 AND lease.expires_at > now()
+                 AND (
+                   collection.state = 'active'
+                   OR (
+                     collection.state = 'transferring'
+                     AND EXISTS (
+                       SELECT 1 FROM hosted_provider_authority_transfers transfer
+                       WHERE transfer.collection_id = collection.id
+                         AND transfer.replica_id = $3
+                         AND transfer.state = 'prepared'
+                         AND transfer.expires_at > now()
+                     )
+                   )
+                 )"#,
         )
         .bind(snapshot_id)
         .bind(collection_id)
@@ -940,6 +1306,18 @@ impl HostedProvider {
                 Ok(payload.record)
             })
             .collect::<ApiResult<Vec<_>>>()?;
+        if next_page.is_none() {
+            sqlx::query(
+                r#"UPDATE hosted_provider_replicas
+                   SET acknowledged_sequence = GREATEST(acknowledged_sequence, $2),
+                       last_seen_at = now()
+                   WHERE id = $1"#,
+            )
+            .bind(replica.id)
+            .bind(to_i64(cursor, "snapshot cursor")?)
+            .execute(&self.pool)
+            .await?;
+        }
         Ok(SyncSnapshotPage {
             protocol_version: SYNC_PROTOCOL_VERSION,
             snapshot_id,
@@ -962,9 +1340,24 @@ impl HostedProvider {
             .authenticate_for_sync(collection_id, token, "changes", request_origin)
             .await?;
         let collection = sqlx::query(
-            "SELECT head, retained_after, wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
+            r#"SELECT head, retained_after, wrapped_data_key
+               FROM hosted_provider_collections collection
+               WHERE id = $1 AND (
+                 state = 'active'
+                 OR (
+                   state = 'transferring'
+                   AND EXISTS (
+                     SELECT 1 FROM hosted_provider_authority_transfers transfer
+                     WHERE transfer.collection_id = collection.id
+                       AND transfer.replica_id = $2
+                       AND transfer.state = 'prepared'
+                       AND transfer.expires_at > now()
+                   )
+                 )
+               )"#,
         )
         .bind(collection_id)
+        .bind(replica.id)
         .fetch_optional(&self.pool)
         .await?
         .ok_or_else(|| {
@@ -3528,6 +3921,97 @@ fn validate_operations(operations: &[String], mode: SyncReplicaMode) -> ApiResul
     Ok(())
 }
 
+fn default_authority_transfer_ttl() -> u64 {
+    15 * 60
+}
+
+fn provider_authority_transfer(row: &PgRow) -> ApiResult<ProviderAuthorityTransfer> {
+    Ok(ProviderAuthorityTransfer {
+        id: row.get("id"),
+        collection_id: row.get("collection_id"),
+        replica_id: row.get("replica_id"),
+        final_head: number(row.get::<i64, _>("final_head"), "collection head")?,
+        authority_epoch: number(row.get::<i64, _>("next_authority_epoch"), "authority epoch")?,
+        manifest_digest: row.get("manifest_digest"),
+        state: row.get("state"),
+        expires_at: row.get("expires_at"),
+    })
+}
+
+async fn recover_expired_authority_transfers_in(
+    transaction: &mut Transaction<'_, Postgres>,
+) -> ApiResult<usize> {
+    let expired = sqlx::query(
+        r#"UPDATE hosted_provider_authority_transfers
+           SET state = 'aborted', aborted_at = now()
+           WHERE state = 'prepared' AND expires_at <= now()
+           RETURNING collection_id"#,
+    )
+    .fetch_all(&mut **transaction)
+    .await?;
+    for row in &expired {
+        sqlx::query(
+            r#"UPDATE hosted_provider_collections
+               SET state = 'active', updated_at = now()
+               WHERE id = $1 AND state = 'transferring'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM hosted_provider_authority_transfers
+                   WHERE collection_id = $1 AND state = 'prepared'
+                 )"#,
+        )
+        .bind(row.get::<Uuid, _>("collection_id"))
+        .execute(&mut **transaction)
+        .await?;
+    }
+    Ok(expired.len())
+}
+
+fn authority_manifest_digest(
+    resources: Vec<(String, String)>,
+    records: BTreeMap<Uuid, PersistedRecord>,
+) -> String {
+    let mut entries = BTreeMap::<(String, String), String>::new();
+    for (path, document) in resources {
+        entries.insert(
+            ("resource".to_string(), path),
+            sha256_hex(document.as_bytes()),
+        );
+    }
+    for persisted in records.into_values() {
+        entries.insert(
+            ("record".to_string(), persisted.record.path),
+            persisted.record.revision,
+        );
+    }
+    authority_manifest_digest_from_hashes(entries)
+}
+
+fn authority_manifest_digest_from_hashes(entries: BTreeMap<(String, String), String>) -> String {
+    let mut manifest = Sha256::new();
+    manifest.update(b"mdbase-authority-manifest-v1\n");
+    for ((kind, path), document_hash) in entries {
+        manifest.update(kind.as_bytes());
+        manifest.update(b"\0");
+        manifest.update(path.as_bytes());
+        manifest.update(b"\0");
+        manifest.update(document_hash.as_bytes());
+        manifest.update(b"\n");
+    }
+    hex_digest(&manifest.finalize())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    hex_digest(&Sha256::digest(value))
+}
+
+fn hex_digest(value: &[u8]) -> String {
+    value.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn constant_time_text_equal(expected: &str, candidate: &str) -> bool {
+    expected.len() == candidate.len() && bool::from(expected.as_bytes().ct_eq(candidate.as_bytes()))
+}
+
 fn token_hash(token: &str) -> Vec<u8> {
     Sha256::digest(token.as_bytes()).to_vec()
 }
@@ -3574,6 +4058,24 @@ pub fn validate_limit(limit: Option<u32>) -> ApiResult<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn authority_manifest_matches_the_node_promotion_fixture() {
+        let entries = BTreeMap::from([
+            (
+                ("record".to_string(), "tasks/a.md".to_string()),
+                "00".repeat(32),
+            ),
+            (
+                ("resource".to_string(), "mdbase.yaml".to_string()),
+                "ff".repeat(32),
+            ),
+        ]);
+        assert_eq!(
+            authority_manifest_digest_from_hashes(entries),
+            "c3a6c98f15ed143bf4b9642e32c9f4c775ca8ad4978a42a4dbd69f79f6fc5e0f"
+        );
+    }
 
     #[test]
     fn deleted_record_events_use_the_portable_types_field() {

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,8 +1,9 @@
 # Hosted collections and sync
 
-Status: production provider and filesystem-mirror path implemented for private
-preview; writable initialization can import existing Markdown, while atomic
-control-plane import and authority transfer remain later administration features
+Status: production provider, filesystem mirrors, and hosted-to-local authority
+transfer are implemented for private preview. Writable initialization can import
+existing Markdown; atomic local-to-hosted import remains a later administration
+feature.
 
 ## Purpose
 
@@ -168,10 +169,30 @@ the source revisions still match the import manifest. Concurrent filesystem
 edits restart the affected upload page. An interrupted import leaves the local
 collection authoritative and available.
 
-Moving back to local authority uses the reverse explicit transfer: download and
-verify a complete snapshot, stop cloud writes at a final sequence, promote the
-local collection, and create a new authority epoch. Authority transfer is a
-product action rather than a background merge between two writers.
+Moving back to local authority is implemented as an explicit, browser-confirmed
+handoff from a full writable mirror:
+
+1. `mdbase-mirror promote <directory>` synchronizes the mirror and creates a
+   short-lived transfer request using its renewal credential.
+2. The owner reviews the destination folder and consequences in the Connect
+   portal. Approval freezes hosted writes at a final sequence and assigns the
+   next authority epoch.
+3. Only the promotion mirror may continue reading while frozen. It pulls through
+   the final sequence and proves an exact manifest of collection resources and
+   record revisions. Unmanaged Markdown, queued writes, or conflicts stop the
+   transfer before cutover.
+4. The CLI gives the directory the hosted collection's stable ID and registers
+   it with the local agent as a disabled candidate.
+5. After both the hosted proof and local registration exist, the control plane
+   atomically activates the local collection in the new epoch, retires the
+   hosted authority, and revokes old application grants, tokens, and replicas.
+
+The command is resumable after local materialization. Cancellation or expiry
+before completion restores hosted writes. The hosted copy remains retained as a
+retired recovery copy until the owner explicitly deletes it, but it cannot
+resume writing in the old epoch. Applications must authorize the new local
+authority explicitly. This is a product action, not a background merge between
+two writers.
 
 ## Replication data model
 
@@ -514,6 +535,16 @@ Markdown records and type definitions.
 - resolve echo suppression, path conflicts, deletions, and interrupted writes;
 - isolate record conflicts so independent Markdown keeps synchronizing;
 - add explicitly authorized config and type-resource editing.
+
+### 6. Hosted-to-local authority handoff
+
+- require an exact, converged full writable mirror and browser confirmation;
+- freeze provider writes at a final sequence and verify a cross-language
+  manifest proof;
+- register the materialized folder as a local candidate before activating it;
+- advance the authority epoch and revoke every old hosted capability;
+- make completion retry-safe and restore hosted writes on cancellation or
+  pre-cutover expiry.
 
 Multi-user collaboration can build on the same authority and log after
 single-user replication is reliable. Peer-to-peer and multi-authority merging

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -28,12 +28,23 @@ mdbase-mirror connect ./tasks --server https://connect.mdbase.dev \
 mdbase-mirror sync ./tasks
 mdbase-mirror status ./tasks
 mdbase-mirror resolve ./tasks <record-id> --use local
+
+# Move authority from mdbase cloud to this computer
+mdbase-mirror promote ./tasks
 ```
 
 `connect` creates a short-lived browser approval request. The resulting
 collection-scoped access and renewal credentials are stored in the device's
 owner-only application-state directory, never inside the mirrored folder.
 Access tokens renew automatically until the mirror is revoked.
+
+`promote` requires a converged, full writable mirror and a running local
+`mdbase-connect` agent. It opens a browser confirmation, freezes hosted writes
+at a final sequence, proves that the directory is exact, and registers the
+folder locally under the collection's stable ID. Completion advances the
+authority epoch and revokes the old hosted replicas and application grants.
+Before cutover, cancellation or expiry restores hosted writes. If the command
+is interrupted after local registration, run it again to resume completion.
 
 The lower-level `init` command remains available for automation and migration.
 It reads a pre-provisioned token from a hidden prompt or

--- a/packages/sync/src/cli.ts
+++ b/packages/sync/src/cli.ts
@@ -12,9 +12,17 @@ import {
   type MirrorStatus
 } from "./node.js";
 import {
+  clearAuthorityPromotionCheckpoint,
   loadMirrorProfile,
+  loadAuthorityPromotionCheckpoint,
+  readCollectionConfiguration,
+  restoreCollectionConfiguration,
+  retireMirrorAfterPromotion,
   saveMirrorProfile,
+  saveAuthorityPromotionCheckpoint,
+  setHostedCollectionIdentity,
   updateMirrorCredentials,
+  type AuthorityPromotionCheckpoint,
   type StoredMirrorProfile
 } from "./device.js";
 
@@ -31,6 +39,7 @@ const parsed = parseArgs({
     name: { type: "string" },
     json: { type: "boolean", default: false },
     use: { type: "string" },
+    "connect-cli": { type: "string", default: "mdbase-connect" },
     help: { type: "boolean", short: "h" }
   }
 });
@@ -41,7 +50,10 @@ if (parsed.values.help || parsed.positionals.length === 0) {
 }
 
 const [command, directoryValue] = parsed.positionals;
-if (!directoryValue || !["connect", "init", "sync", "watch", "status", "resolve"].includes(command)) {
+if (
+  !directoryValue
+  || !["connect", "init", "sync", "watch", "status", "resolve", "promote"].includes(command)
+) {
   usage();
   process.exit(1);
 }
@@ -82,6 +94,8 @@ try {
     await initialSync(root);
     const configuration = await currentProfile(root);
     printStatus(await mirrorFor(root, configuration).status());
+  } else if (command === "promote") {
+    await promote(root);
   } else if (command === "resolve") {
     const recordId = parsed.positionals[2];
     const resolution = parsed.values.use;
@@ -223,6 +237,33 @@ interface MirrorExchangeResponse {
   sync_url: string;
 }
 
+interface AuthorityTransfer {
+  id: string;
+  collection_id: string;
+  replica_id: string;
+  state: "requested" | "approved" | "prepared" | "completed" | "cancelled" | "expired";
+  final_head: number | null;
+  authority_epoch: number | null;
+  manifest_digest: string | null;
+  expires_at: string;
+  verification_uri: string;
+  local_collection_id?: string;
+}
+
+interface AuthorityTransferResponse {
+  transfer: AuthorityTransfer;
+  verification_uri?: string;
+  expires_in?: number;
+}
+
+interface AuthorityTransferCompletion {
+  status: "completed" | "waiting_for_connector";
+  collection_id?: string;
+  local_collection_id?: string;
+  authority_epoch?: number;
+  message?: string;
+}
+
 async function connect(root: string): Promise<void> {
   await mkdir(root, { recursive: true });
   const controlUrl = canonicalProviderUrl(required(parsed.values.server, "--server"));
@@ -278,6 +319,252 @@ async function connect(root: string): Promise<void> {
   throw new Error("Browser approval expired. Run the connect command again.");
 }
 
+async function promote(root: string): Promise<void> {
+  const unfinished = await loadAuthorityPromotionCheckpoint(root);
+  // A committed provider has already revoked the mirror access token. Resume
+  // from the durable proof without attempting ordinary token renewal.
+  const stored = unfinished ? await loadMirrorProfile(root) : await currentProfile(root);
+  if (
+    stored.profile.mode !== "read_write"
+    || !stored.profile.control_url
+    || !stored.profile.enrollment_id
+    || !stored.credentials.refresh_token
+  ) {
+    throw new Error(
+      "Authority can move only from a browser-paired, two-way full collection mirror."
+    );
+  }
+  const controlUrl = canonicalProviderUrl(stored.profile.control_url);
+  const authentication = { authorization: `Bearer ${stored.credentials.refresh_token}` };
+  if (unfinished) {
+    if (unfinished.collection_id !== stored.profile.collection_id) {
+      throw new Error("The saved authority promotion belongs to another hosted collection.");
+    }
+    process.stdout.write("Resuming the materialized authority handoff.\n");
+    await setHostedCollectionIdentity(root, unfinished.collection_id);
+    await registerPromotedCollection(root, unfinished.collection_id);
+    await completePromotion(root, controlUrl, authentication, unfinished);
+    return;
+  }
+
+  await initialSync(root);
+  const requested = await jsonRequest<AuthorityTransferResponse>(
+    `${controlUrl}/v1/mirror-pairing-requests/${encodeURIComponent(stored.profile.enrollment_id)}/authority-transfers`,
+    {
+      method: "POST",
+      headers: { ...authentication, "content-type": "application/json" },
+      body: "{}"
+    }
+  );
+  const verificationUri = requested.verification_uri ?? requested.transfer.verification_uri;
+  process.stdout.write(
+    `Confirm moving the source of truth to this computer:\n${verificationUri}\n`
+  );
+  if (!parsed.values["no-open"]) openBrowser(verificationUri);
+  const deadline = new Date(requested.transfer.expires_at).getTime();
+  let prepared = requested.transfer;
+  while (prepared.state !== "prepared" && Date.now() < deadline) {
+    const response = await fetch(
+      `${controlUrl}/v1/authority-transfers/${encodeURIComponent(prepared.id)}/prepare`,
+      { method: "POST", headers: { ...authentication, "content-type": "application/json" }, body: "{}" }
+    );
+    if (response.status === 202) {
+      await delay(1_500);
+      continue;
+    }
+    prepared = (await responseJson<AuthorityTransferResponse>(response)).transfer;
+  }
+  if (
+    prepared.state !== "prepared"
+    || prepared.final_head === null
+    || prepared.authority_epoch === null
+    || !prepared.manifest_digest
+  ) {
+    throw new Error("Authority transfer approval expired. Run the promote command again.");
+  }
+
+  let localRegistered = false;
+  let checkpoint: Omit<AuthorityPromotionCheckpoint, "version"> | null = null;
+  try {
+    const configuration = await currentProfile(root);
+    const mirror = mirrorFor(root, configuration);
+    await mirror.sync();
+    const manifest = await mirror.authorityPromotionManifest();
+    if (
+      manifest.cursor !== prepared.final_head
+      || manifest.digest !== prepared.manifest_digest
+    ) {
+      throw new Error(
+        "The local folder does not exactly match the fenced hosted collection."
+      );
+    }
+    const originalConfiguration = await readCollectionConfiguration(root);
+    checkpoint = {
+      transfer_id: prepared.id,
+      collection_id: prepared.collection_id,
+      manifest_digest: prepared.manifest_digest,
+      authority_epoch: prepared.authority_epoch,
+      expires_at: prepared.expires_at,
+      original_configuration: originalConfiguration
+    };
+    await saveAuthorityPromotionCheckpoint(root, checkpoint);
+    await setHostedCollectionIdentity(root, prepared.collection_id);
+    const added = await runConnectCli(["collection", "add", root]);
+    const registeredId = collectionIdFromControlResult(added);
+    if (registeredId !== prepared.collection_id) {
+      throw new Error("The local agent registered a different collection identity.");
+    }
+    localRegistered = true;
+    await runConnectCli(["collection", "validate", prepared.collection_id]);
+  } catch (error) {
+    if (localRegistered) {
+      await runConnectCli(["collection", "remove", prepared.collection_id]).catch(() => undefined);
+    }
+    const saved = await loadAuthorityPromotionCheckpoint(root);
+    if (saved?.transfer_id === prepared.id) {
+      await restoreCollectionConfiguration(root, saved.original_configuration).catch(() => undefined);
+      await clearAuthorityPromotionCheckpoint(root).catch(() => undefined);
+    }
+    await fetch(
+      `${controlUrl}/v1/authority-transfers/${encodeURIComponent(prepared.id)}`,
+      { method: "DELETE", headers: authentication }
+    ).catch(() => undefined);
+    throw error;
+  }
+
+  if (!checkpoint) throw new Error("Authority promotion checkpoint was not created.");
+  process.stdout.write("Local collection registered. Waiting for this computer to publish it.\n");
+  await completePromotion(root, controlUrl, authentication, checkpoint);
+}
+
+async function registerPromotedCollection(root: string, collectionId: string): Promise<void> {
+  const added = await runConnectCli(["collection", "add", root]);
+  const registeredId = collectionIdFromControlResult(added);
+  if (registeredId !== collectionId) {
+    throw new Error("The local agent registered a different collection identity.");
+  }
+  await runConnectCli(["collection", "validate", collectionId]);
+}
+
+async function completePromotion(
+  root: string,
+  controlUrl: string,
+  authentication: { authorization: string },
+  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">
+): Promise<void> {
+  const deadline = new Date(checkpoint.expires_at).getTime();
+  let attempted = false;
+  while (!attempted || Date.now() < deadline) {
+    attempted = true;
+    let response: Response;
+    try {
+      response = await fetch(
+        `${controlUrl}/v1/authority-transfers/${encodeURIComponent(checkpoint.transfer_id)}/complete`,
+        {
+          method: "POST",
+          headers: { ...authentication, "content-type": "application/json" },
+          body: JSON.stringify({ manifest_digest: checkpoint.manifest_digest })
+        }
+      );
+    } catch {
+      if (Date.now() >= deadline) break;
+      await delay(2_000);
+      continue;
+    }
+    if (response.status === 202) {
+      if (Date.now() >= deadline) break;
+      await delay(2_000);
+      continue;
+    }
+    let completed: AuthorityTransferCompletion;
+    try {
+      completed = await responseJson<AuthorityTransferCompletion>(response);
+    } catch (error) {
+      if (
+        error instanceof ApiRequestError
+        && error.status === 409
+        && ["authority_transfer_expired", "authority_transfer_inactive"].includes(error.code)
+      ) {
+        await rollbackMaterializedPromotion(root, checkpoint);
+      }
+      throw error;
+    }
+    if (
+      completed.status !== "completed"
+      || completed.collection_id !== checkpoint.collection_id
+      || completed.authority_epoch !== checkpoint.authority_epoch
+    ) {
+      if (Date.now() >= deadline) break;
+      await delay(2_000);
+      continue;
+    }
+    await retireMirrorAfterPromotion(root, {
+      collection_id: checkpoint.collection_id,
+      authority_epoch: completed.authority_epoch
+    });
+    process.stdout.write(
+      `Authority moved to ${root}. Hosted writes are retired at epoch ${completed.authority_epoch}.\n`
+    );
+    return;
+  }
+  throw new Error(
+    "The local collection is ready, but activation did not finish. "
+    + "Leave the folder and local agent running, then run promote again."
+  );
+}
+
+async function rollbackMaterializedPromotion(
+  root: string,
+  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">
+): Promise<void> {
+  await runConnectCli(["collection", "remove", checkpoint.collection_id]);
+  await restoreCollectionConfiguration(root, checkpoint.original_configuration);
+  await clearAuthorityPromotionCheckpoint(root);
+}
+
+async function runConnectCli(args: string[]): Promise<unknown> {
+  const executable = parsed.values["connect-cli"] ?? "mdbase-connect";
+  const output = await new Promise<{ stdout: string; stderr: string; code: number | null }>(
+    (resolveRun, rejectRun) => {
+      const child = spawn(executable, ["--compact", ...args], {
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.on("error", rejectRun);
+      child.on("close", (code) => resolveRun({ stdout, stderr, code }));
+    }
+  );
+  interface LocalControlResponse {
+    ok?: boolean;
+    result?: unknown;
+    error?: { message?: string };
+  }
+  let response: LocalControlResponse | null = null;
+  try {
+    response = JSON.parse(output.stdout) as LocalControlResponse;
+  } catch {
+    // The exit status and stderr below provide the actionable error.
+  }
+  if (output.code !== 0 || !response?.ok) {
+    throw new Error(
+      response?.error?.message
+      ?? (output.stderr.trim() || "The local mdbase connect agent rejected the collection.")
+    );
+  }
+  return response.result;
+}
+
+function collectionIdFromControlResult(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const id = (result as Record<string, unknown>).id;
+  return typeof id === "string" ? id : null;
+}
+
 async function mirrorEnrollmentRequest<Result>(
   controlUrl: string,
   enrollmentId: string,
@@ -297,10 +584,24 @@ async function jsonRequest<Result>(url: string, init: RequestInit): Promise<Resu
 async function responseJson<Result>(response: Response): Promise<Result> {
   const value = await response.json().catch(() => null);
   if (!response.ok) {
-    const error = value as { error?: { message?: string } } | null;
-    throw new Error(error?.error?.message ?? `Request failed with status ${response.status}.`);
+    const error = value as { error?: { code?: string; message?: string } } | null;
+    throw new ApiRequestError(
+      response.status,
+      error?.error?.code ?? "request_failed",
+      error?.error?.message ?? `Request failed with status ${response.status}.`
+    );
   }
   return value as Result;
+}
+
+class ApiRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+  }
 }
 
 function openBrowser(url: string): void {
@@ -414,9 +715,11 @@ function usage(): void {
   mdbase-mirror watch <directory> [--interval <milliseconds>]
   mdbase-mirror status <directory> [--json]
   mdbase-mirror resolve <directory> <record-id> --use <local|remote>
+  mdbase-mirror promote <directory> [--no-open] [--connect-cli <path>]
 
 The connect command opens a browser for collection approval and keeps credentials
 in device-local storage. The manual init command remains available for self-hosted
 automation and reads MDBASE_CONNECT_REPLICA_TOKEN when set.
+The promote command moves authority from a hosted collection to this computer.
 `);
 }

--- a/packages/sync/src/device.test.ts
+++ b/packages/sync/src/device.test.ts
@@ -3,13 +3,113 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  loadAuthorityPromotionCheckpoint,
   loadMirrorProfile,
   mirrorProfileDirectory,
-  saveMirrorProfile
+  restoreCollectionConfiguration,
+  retireMirrorAfterPromotion,
+  saveAuthorityPromotionCheckpoint,
+  saveMirrorProfile,
+  setHostedCollectionIdentity
 } from "./device.js";
 import { NodeMirrorStateStore, type MirrorState } from "./node.js";
 
 describe("device-local mirror storage", () => {
+  it("sets the hosted identity atomically and can restore the original collection config", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    const collectionId = crypto.randomUUID();
+    const original = "spec_version: 0.3.0\nname: Promoted\n";
+    try {
+      await writeFile(join(root, "mdbase.yaml"), original);
+      const saved = await setHostedCollectionIdentity(root, collectionId);
+      expect(saved).toBe(original);
+      expect(await readFile(join(root, "mdbase.yaml"), "utf8")).toContain(
+        `collection_id: ${collectionId}`
+      );
+      await setHostedCollectionIdentity(root, collectionId);
+      await expect(setHostedCollectionIdentity(root, crypto.randomUUID()))
+        .rejects.toMatchObject({ code: "collection_identity_conflict" });
+      await restoreCollectionConfiguration(root, saved);
+      expect(await readFile(join(root, "mdbase.yaml"), "utf8")).toBe(original);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retires mirror secrets and leaves only a non-secret authority receipt", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+    const collectionId = crypto.randomUUID();
+    try {
+      await saveMirrorProfile(
+        root,
+        {
+          version: 1,
+          provider_url: "https://sync.example",
+          control_url: "https://connect.example",
+          collection_id: collectionId,
+          replica_id: crypto.randomUUID(),
+          mode: "read_write"
+        },
+        { access_token: "access-secret", refresh_token: "refresh-secret" },
+        stateRoot
+      );
+      await new NodeMirrorStateStore(root, stateRoot).write({
+        protocol_version: 1,
+        replica_id: crypto.randomUUID(),
+        scope_epoch: 1,
+        cursor: 3,
+        records: {},
+        conflicts: {}
+      });
+      const directory = await mirrorProfileDirectory(root, stateRoot);
+      await retireMirrorAfterPromotion(
+        root,
+        { collection_id: collectionId, authority_epoch: 2 },
+        stateRoot
+      );
+      await expect(readFile(join(directory, "credentials.json"), "utf8"))
+        .rejects.toMatchObject({ code: "ENOENT" });
+      await expect(readFile(join(directory, "profile.json"), "utf8"))
+        .rejects.toMatchObject({ code: "ENOENT" });
+      await expect(readFile(join(directory, "mirror-state.json"), "utf8"))
+        .rejects.toMatchObject({ code: "ENOENT" });
+      const receipt = JSON.parse(await readFile(join(directory, "authority.json"), "utf8"));
+      expect(receipt).toMatchObject({
+        version: 1,
+        collection_id: collectionId,
+        authority_epoch: 2
+      });
+      expect(JSON.stringify(receipt)).not.toContain("secret");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("persists the proof needed to resume after the hosted provider commits", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+    const checkpoint = {
+      transfer_id: crypto.randomUUID(),
+      collection_id: crypto.randomUUID(),
+      manifest_digest: "a".repeat(64),
+      authority_epoch: 2,
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      original_configuration: "spec_version: 0.3.0\n"
+    };
+    try {
+      await saveAuthorityPromotionCheckpoint(root, checkpoint, stateRoot);
+      expect(await loadAuthorityPromotionCheckpoint(root, stateRoot)).toEqual({
+        version: 1,
+        ...checkpoint
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps credentials and replica state outside the synchronized folder", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
     const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));

--- a/packages/sync/src/device.ts
+++ b/packages/sync/src/device.ts
@@ -1,6 +1,17 @@
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, realpath, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  realpath,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile
+} from "node:fs/promises";
 import { join } from "node:path";
+import { isMap, parseDocument } from "yaml";
 import {
   mirrorDeviceDirectory,
   NodeMirrorStateStore,
@@ -28,6 +39,23 @@ export interface MirrorCredentials {
 export interface StoredMirrorProfile {
   profile: MirrorProfile;
   credentials: MirrorCredentials;
+}
+
+export interface AuthorityPromotionReceipt {
+  version: 1;
+  collection_id: string;
+  authority_epoch: number;
+  promoted_at: string;
+}
+
+export interface AuthorityPromotionCheckpoint {
+  version: 1;
+  transfer_id: string;
+  collection_id: string;
+  manifest_digest: string;
+  authority_epoch: number;
+  expires_at: string;
+  original_configuration: string;
 }
 
 interface LegacyMirrorConfiguration {
@@ -145,6 +173,150 @@ export async function mirrorProfileDirectory(
   return mirrorDeviceDirectory(root, stateRoot);
 }
 
+export async function setHostedCollectionIdentity(
+  root: string,
+  collectionId: string
+): Promise<string> {
+  const configurationPath = join(await realpath(root), "mdbase.yaml");
+  const metadata = await lstat(configurationPath);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new SyncError(
+      "unsafe_collection_configuration",
+      "mdbase.yaml must be an ordinary file inside the promoted collection."
+    );
+  }
+  const source = await readFile(configurationPath, "utf8");
+  const document = parseDocument(source);
+  if (document.errors.length || !isMap(document.contents)) {
+    throw new SyncError(
+      "invalid_collection_configuration",
+      "mdbase.yaml must contain a valid YAML mapping."
+    );
+  }
+  const extension = document.get("x-mdbase-connect", true);
+  if (extension !== undefined && !isMap(extension)) {
+    throw new SyncError(
+      "invalid_collection_configuration",
+      "x-mdbase-connect must be a YAML mapping."
+    );
+  }
+  if (extension === undefined) {
+    document.set("x-mdbase-connect", document.createNode({}));
+  }
+  const connect = document.get("x-mdbase-connect", true);
+  if (!isMap(connect)) {
+    throw new SyncError(
+      "invalid_collection_configuration",
+      "x-mdbase-connect must be a YAML mapping."
+    );
+  }
+  const existing = connect.get("collection_id");
+  if (existing !== undefined && existing !== collectionId) {
+    throw new SyncError(
+      "collection_identity_conflict",
+      "This folder already has a different mdbase connect collection identity."
+    );
+  }
+  connect.set("collection_id", collectionId);
+  await atomicWrite(configurationPath, document.toString(), metadata.mode & 0o777);
+  return source;
+}
+
+export async function readCollectionConfiguration(root: string): Promise<string> {
+  const configurationPath = join(await realpath(root), "mdbase.yaml");
+  const metadata = await lstat(configurationPath);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new SyncError(
+      "unsafe_collection_configuration",
+      "mdbase.yaml must be an ordinary file inside the promoted collection."
+    );
+  }
+  return readFile(configurationPath, "utf8");
+}
+
+export async function restoreCollectionConfiguration(
+  root: string,
+  source: string
+): Promise<void> {
+  const configurationPath = join(await realpath(root), "mdbase.yaml");
+  const metadata = await stat(configurationPath);
+  await atomicWrite(configurationPath, source, metadata.mode & 0o777);
+}
+
+export async function retireMirrorAfterPromotion(
+  root: string,
+  receipt: Omit<AuthorityPromotionReceipt, "version" | "promoted_at">,
+  stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
+): Promise<void> {
+  const directory = await mirrorDeviceDirectory(root, stateRoot);
+  await atomicWrite(
+    join(directory, "authority.json"),
+    `${JSON.stringify({
+      version: 1,
+      ...receipt,
+      promoted_at: new Date().toISOString()
+    } satisfies AuthorityPromotionReceipt, null, 2)}\n`
+  );
+  for (const name of [
+    "credentials.json",
+    "profile.json",
+    "mirror-state.json",
+    "authority-promotion.json"
+  ]) {
+    await unlinkOptional(join(directory, name));
+  }
+}
+
+export async function loadAuthorityPromotionCheckpoint(
+  root: string,
+  stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
+): Promise<AuthorityPromotionCheckpoint | null> {
+  const directory = await mirrorDeviceDirectory(root, stateRoot);
+  const checkpoint = await readJson<AuthorityPromotionCheckpoint>(
+    join(directory, "authority-promotion.json")
+  );
+  if (checkpoint === null) return null;
+  if (
+    checkpoint.version !== 1
+    || typeof checkpoint.transfer_id !== "string"
+    || typeof checkpoint.collection_id !== "string"
+    || typeof checkpoint.manifest_digest !== "string"
+    || !/^[a-f0-9]{64}$/.test(checkpoint.manifest_digest)
+    || !Number.isSafeInteger(checkpoint.authority_epoch)
+    || checkpoint.authority_epoch < 2
+    || typeof checkpoint.expires_at !== "string"
+    || !Number.isFinite(new Date(checkpoint.expires_at).getTime())
+    || typeof checkpoint.original_configuration !== "string"
+  ) {
+    throw new SyncError(
+      "invalid_authority_promotion_checkpoint",
+      "The saved authority promotion is invalid."
+    );
+  }
+  return checkpoint;
+}
+
+export async function saveAuthorityPromotionCheckpoint(
+  root: string,
+  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">,
+  stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
+): Promise<void> {
+  const directory = await mirrorDeviceDirectory(root, stateRoot);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await atomicWrite(
+    join(directory, "authority-promotion.json"),
+    `${JSON.stringify({ version: 1, ...checkpoint } satisfies AuthorityPromotionCheckpoint, null, 2)}\n`
+  );
+}
+
+export async function clearAuthorityPromotionCheckpoint(
+  root: string,
+  stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
+): Promise<void> {
+  const directory = await mirrorDeviceDirectory(root, stateRoot);
+  await unlinkOptional(join(directory, "authority-promotion.json"));
+}
+
 async function legacyMetadataDirectory(root: string): Promise<string | null> {
   const canonicalRoot = await realpath(root);
   const metadataPath = join(canonicalRoot, ".mdbase");
@@ -200,8 +372,16 @@ async function readOptional(path: string): Promise<string | null> {
   }
 }
 
-async function atomicWrite(path: string, value: string): Promise<void> {
+async function unlinkOptional(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function atomicWrite(path: string, value: string, mode = 0o600): Promise<void> {
   const temporary = `${path}.${randomUUID()}.tmp`;
-  await writeFile(temporary, value, { mode: 0o600 });
+  await writeFile(temporary, value, { mode });
   await rename(temporary, path);
 }

--- a/packages/sync/src/node.test.ts
+++ b/packages/sync/src/node.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MemoryHostedAuthority } from "./index.js";
 import {
+  authorityManifestDigest,
   DirectoryMirror,
   MemoryMirrorStateStore,
   MirrorDivergenceError,
@@ -197,6 +198,89 @@ describe("receive-only Markdown mirror", () => {
 });
 
 describe("writable Markdown mirror", () => {
+  it("builds a stable content-only authority manifest", async () => {
+    expect(authorityManifestDigest([
+      {
+        kind: "resource",
+        path: "mdbase.yaml",
+        document_hash: "ff".repeat(32)
+      },
+      {
+        kind: "record",
+        path: "tasks/a.md",
+        document_hash: "00".repeat(32)
+      }
+    ])).toBe("c3a6c98f15ed143bf4b9642e32c9f4c775ca8ad4978a42a4dbd69f79f6fc5e0f");
+
+    const hosted = new MemoryHostedAuthority({
+      resources: {
+        revision: "resources:1",
+        spec_version: "0.3.0",
+        types: [],
+        contracts: [],
+        documents: [{
+          path: "mdbase.yaml",
+          kind: "configuration",
+          revision: "config:1",
+          document: "spec_version: 0.3.0\n"
+        }]
+      }
+    });
+    const replicaId = hosted.registerReplica({ name: "Promotion candidate", mode: "read_write" });
+    await hosted.transport(replicaId).mutate({
+      mutation_id: crypto.randomUUID(),
+      replica_id: replicaId,
+      scope_epoch: 1,
+      operation: "create",
+      record_id: crypto.randomUUID(),
+      input: { path: "note.md", frontmatter: { title: "Local" }, types: [] },
+      created_at: new Date().toISOString()
+    });
+    const fileSystem = new MemoryMirrorFileSystem();
+    const mirror = new WritableDirectoryMirror(
+      "/virtual",
+      replicaId,
+      hosted.transport(replicaId),
+      { stateStore: new MemoryMirrorStateStore(), fileSystem }
+    );
+    await mirror.sync();
+
+    const first = await mirror.authorityPromotionManifest();
+    const second = await mirror.authorityPromotionManifest();
+    expect(first).toEqual(second);
+    expect(first.cursor).toBe(1);
+    expect(first.digest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("refuses promotion when the mirror is read-only or has unmanaged Markdown", async () => {
+    const hosted = new MemoryHostedAuthority();
+    const readOnlyId = hosted.registerReplica({ name: "Read only", mode: "read_only" });
+    const readOnly = new DirectoryMirror(
+      "/virtual",
+      readOnlyId,
+      hosted.transport(readOnlyId),
+      { stateStore: new MemoryMirrorStateStore(), fileSystem: new MemoryMirrorFileSystem() }
+    );
+    await readOnly.sync();
+    await expect(readOnly.authorityPromotionManifest()).rejects.toMatchObject({
+      code: "promotion_requires_writable_mirror"
+    });
+
+    const writableId = hosted.registerReplica({ name: "Writable", mode: "read_write" });
+    const fileSystem = new MemoryMirrorFileSystem();
+    const writable = new WritableDirectoryMirror(
+      "/virtual",
+      writableId,
+      hosted.transport(writableId),
+      { stateStore: new MemoryMirrorStateStore(), fileSystem }
+    );
+    await writable.sync();
+    fileSystem.files.set("unmanaged.md", "---\ntitle: Unmanaged\n---\n");
+    await expect(writable.authorityPromotionManifest()).rejects.toMatchObject({
+      code: "promotion_unmanaged_files"
+    });
+  });
+
   it("imports existing local Markdown during initialization", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-sync-writable-"));
     try {

--- a/packages/sync/src/node.ts
+++ b/packages/sync/src/node.ts
@@ -82,6 +82,11 @@ export interface MirrorInitializationPreview {
   collisions: string[];
 }
 
+export interface AuthorityPromotionManifest {
+  cursor: number;
+  digest: string;
+}
+
 export class MemoryMirrorStateStore implements MirrorStateStore {
   private state: MirrorState | null = null;
 
@@ -353,6 +358,62 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     };
   }
 
+  /**
+   * Prove that this directory is an exact, complete copy of its last applied
+   * authority cursor. The digest contains no paths or record content.
+   */
+  async authorityPromotionManifest(): Promise<AuthorityPromotionManifest> {
+    if (this.mode !== "read_write") {
+      throw new SyncError(
+        "promotion_requires_writable_mirror",
+        "Only a two-way full collection mirror can become the local source of truth."
+      );
+    }
+    const state = await this.readState();
+    if (!state) {
+      throw new SyncError(
+        "promotion_not_initialized",
+        "Synchronize this folder before moving the source of truth."
+      );
+    }
+    if ((state.pending?.length ?? 0) > 0 || Object.keys(state.conflicts ?? {}).length > 0) {
+      throw new SyncError(
+        "promotion_not_converged",
+        "Upload or resolve every local change before moving the source of truth."
+      );
+    }
+    await this.assertUndiverged(state);
+    const resourcePaths = new Set(Object.keys(state.resources ?? {}));
+    const managedPaths = new Set(Object.values(state.records).map((entry) => entry.path));
+    const unmanaged = (await this.fileSystem.listMarkdown(resourcePaths))
+      .filter((path) => !managedPaths.has(path));
+    if (unmanaged.length > 0) {
+      throw new SyncError(
+        "promotion_unmanaged_files",
+        `Synchronize unmanaged Markdown before promotion: ${unmanaged.join(", ")}.`
+      );
+    }
+    return {
+      cursor: state.cursor,
+      digest: authorityManifestDigest([
+        ...Object.entries(state.resources ?? {}).map(([path, entry]) => ({
+          kind: "resource" as const,
+          path,
+          document_hash: entry.hash
+        })),
+        ...Object.values(state.records).map((entry) => ({
+          kind: "record" as const,
+          path: entry.path,
+          // Hosted mdbase may normalize equivalent Markdown when it executes a
+          // mutation. The provider-issued revision is the shared content
+          // identity; assertUndiverged above separately proves the local bytes
+          // still match the exact document materialized for that revision.
+          document_hash: entry.revision
+        }))
+      ])
+    };
+  }
+
   async previewInitialization(): Promise<MirrorInitializationPreview> {
     if (await this.readState()) {
       return {
@@ -367,7 +428,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     const resources = session.resources.documents ?? [];
     const remoteDocuments = new Map<string, string>([
       ...resources.map((resource) => [resource.path, resource.document] as const),
-      ...records.map((record) => [record.path, markdown(record)] as const)
+      ...records.map((record) => [record.path, recordMarkdownDocument(record)] as const)
     ]);
     let downloadDocuments = 0;
     let unchangedDocuments = 0;
@@ -467,7 +528,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
       const managed = prior?.records[record.record_id];
       if (
         local !== null
-        && local !== markdown(record)
+        && local !== recordMarkdownDocument(record)
         && (!managed || managed.path !== record.path || digest(local) !== managed.hash)
       ) {
         collisions.push(record.path);
@@ -499,7 +560,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     managedState: MirrorState | undefined = state,
     acceptedHash?: string | null
   ): Promise<void> {
-    const document = markdown(record);
+    const document = recordMarkdownDocument(record);
     const existing = await this.fileSystem.read(record.path);
     const prior = managedState?.records[record.record_id];
     if (existing !== null && existing !== document) {
@@ -620,7 +681,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
         state.records[recordId] = {
           path: current.path,
           revision: current.revision,
-          hash: digest(markdown(current)),
+          hash: digest(recordMarkdownDocument(current)),
           record: current
         };
       } else {
@@ -714,7 +775,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
       }, localHash);
       return queued;
     }
-    if (localDocument !== markdown(current)) {
+    if (localDocument !== recordMarkdownDocument(current)) {
       queue({
         operation: "update",
         record_id: recordId,
@@ -1012,7 +1073,7 @@ export class WritableMirrorRejectedError extends SyncError {
   }
 }
 
-function markdown(record: SyncRecord): string {
+export function recordMarkdownDocument(record: SyncRecord): string {
   const yaml = stringify(record.frontmatter, { lineWidth: 0 }).trimEnd();
   const body = record.body ? `\n${record.body.replace(/^\n/, "")}` : "";
   return `---\n${yaml}\n---\n${body}`;
@@ -1060,4 +1121,23 @@ async function atomicWrite(path: string, value: string): Promise<void> {
 
 function digest(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+export function authorityManifestDigest(entries: Array<{
+  kind: "record" | "resource";
+  path: string;
+  document_hash: string;
+}>): string {
+  const manifest = createHash("sha256").update("mdbase-authority-manifest-v1\n");
+  for (const entry of [...entries].sort((left, right) =>
+    left.kind.localeCompare(right.kind) || left.path.localeCompare(right.path)
+  )) {
+    manifest.update(entry.kind);
+    manifest.update("\0");
+    manifest.update(entry.path);
+    manifest.update("\0");
+    manifest.update(entry.document_hash);
+    manifest.update("\n");
+  }
+  return manifest.digest("hex");
 }

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -22,6 +22,9 @@ const mirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-mirror-"));
 const writableMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-writable-mirror-"));
 const importMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-import-mirror-"));
 const browserMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-browser-mirror-"));
+const authorityMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-authority-mirror-"));
+const promotionMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-promotion-mirror-"));
+const promotionToolRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-promotion-tool-"));
 const mirrorStateRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-mirror-state-"));
 process.env.MDBASE_CONNECT_MIRROR_STATE_DIR = mirrorStateRoot;
 const children = new Set();
@@ -33,7 +36,11 @@ let notificationCallbackServer;
 
 const { HttpSyncTransport, MemoryReplicaStore, OfflineReplica, SyncError } =
   await import("../packages/sync/dist/index.js");
-const { DirectoryMirror, MirrorDivergenceError } = await import("../packages/sync/dist/node.js");
+const {
+  DirectoryMirror,
+  MirrorDivergenceError,
+  WritableDirectoryMirror
+} = await import("../packages/sync/dist/node.js");
 const { mirrorProfileDirectory } = await import("../packages/sync/dist/device.js");
 const { resolveTasknotesSyncContract, TasknotesOfflineCollection } =
   await import("../packages/tasknotes/dist/index.js");
@@ -513,6 +520,15 @@ try {
 
   phase("exercising hosted lifecycle and writable enrollment in a real browser");
   await portalLifecycleE2E(controlUrl, browserMirrorRoot);
+
+  phase("moving hosted authority through the CLI and browser confirmation flow");
+  await authorityPromotionCliE2E(
+    controlUrl,
+    cookie,
+    controlDatabase,
+    promotionMirrorRoot,
+    promotionToolRoot
+  );
 
   phase("creating the first compatible hosted collection inside browser authorization");
   const emptyLogin = await rawRequest(controlUrl, "/v1/dev/session", {
@@ -1112,6 +1128,204 @@ schema:
   );
   await writeFile(join(writableMirrorRoot, "_types", "task.md"), resourceDocument);
 
+  phase("fencing, proving, completing, and cancelling authority transfers");
+  const authorityCollectionId = crypto.randomUUID();
+  const authorityReplicaId = crypto.randomUUID();
+  const authorityToken = `authority-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+  await internalRequest(provider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: {
+      collection_id: authorityCollectionId,
+      template: "mdbase",
+      display_name: "Authority transfer probe"
+    }
+  });
+  await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${authorityCollectionId}/replicas`,
+    {
+      method: "POST",
+      body: {
+        replica_id: authorityReplicaId,
+        name: "Promotion mirror",
+        purpose: "mirror",
+        mode: "read_write",
+        allowed_types: [],
+        token: authorityToken
+      }
+    }
+  );
+  const authorityTransport = new HttpSyncTransport(
+    provider.url,
+    authorityCollectionId,
+    authorityToken
+  );
+  const authorityCreate = await authorityTransport.mutate({
+    mutation_id: crypto.randomUUID(),
+    replica_id: authorityReplicaId,
+    scope_epoch: 1,
+    operation: "create",
+    record_id: crypto.randomUUID(),
+    input: {
+      path: "notes/authority.md",
+      frontmatter: { title: "Authority" },
+      body: "Durable Markdown.\n",
+      types: []
+    },
+    created_at: new Date().toISOString()
+  });
+  assert.equal(authorityCreate.status, "applied");
+  const authorityMirror = new WritableDirectoryMirror(
+    authorityMirrorRoot,
+    authorityReplicaId,
+    authorityTransport
+  );
+  await authorityMirror.sync();
+  assert.equal(
+    await postgresQuery(
+      `SELECT acknowledged_sequence
+       FROM hosted_provider_replicas WHERE id = '${authorityReplicaId}'`
+    ),
+    "1"
+  );
+  const transferId = crypto.randomUUID();
+  const preparedTransfer = await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${authorityCollectionId}/authority-transfers`,
+    {
+      method: "POST",
+      body: {
+        transfer_id: transferId,
+        replica_id: authorityReplicaId,
+        ttl_seconds: 600
+      }
+    }
+  );
+  assert.equal(preparedTransfer.state, "prepared");
+  assert.equal(preparedTransfer.final_head, 1);
+  assert.equal(preparedTransfer.authority_epoch, 2);
+  assert.match(preparedTransfer.manifest_digest, /^[a-f0-9]{64}$/);
+  const fencedMutation = await rawRequest(
+    provider.url,
+    syncPath(authorityCollectionId, "mutations"),
+    {
+      method: "POST",
+      token: authorityToken,
+      body: {
+        mutation_id: crypto.randomUUID(),
+        replica_id: authorityReplicaId,
+        scope_epoch: 1,
+        operation: "create",
+        record_id: crypto.randomUUID(),
+        input: {
+          path: "notes/fenced.md",
+          frontmatter: { title: "Fenced" },
+          body: "",
+          types: []
+        },
+        created_at: new Date().toISOString()
+      }
+    }
+  );
+  assert.equal(fencedMutation.status, 404);
+  assert.equal(fencedMutation.body.error.code, "hosted_collection_not_found");
+  await authorityMirror.sync();
+  const authorityProof = await authorityMirror.authorityPromotionManifest();
+  assert.equal(authorityProof.cursor, preparedTransfer.final_head);
+  assert.equal(authorityProof.digest, preparedTransfer.manifest_digest);
+  const mismatchedProof = await rawRequest(
+    provider.url,
+    `/internal/v1/authority-transfers/${transferId}`,
+    {
+      method: "POST",
+      token: internalToken,
+      body: { manifest_digest: "0".repeat(64) }
+    }
+  );
+  assert.equal(mismatchedProof.status, 409);
+  assert.equal(mismatchedProof.body.error.code, "authority_manifest_mismatch");
+  const completedTransfer = await internalRequest(
+    provider.url,
+    `/internal/v1/authority-transfers/${transferId}`,
+    {
+      method: "POST",
+      body: { manifest_digest: authorityProof.digest }
+    }
+  );
+  assert.equal(completedTransfer.state, "completed");
+  assert.equal(
+    (await internalRequest(
+      provider.url,
+      `/internal/v1/authority-transfers/${transferId}`,
+      {
+        method: "POST",
+        body: { manifest_digest: authorityProof.digest }
+      }
+    )).state,
+    "completed"
+  );
+  await expectSyncError(() => authorityTransport.openSession(), "invalid_replica_token");
+  assert.equal(
+    await postgresQuery(
+      `SELECT state || ':' || authority_epoch
+       FROM hosted_provider_collections WHERE id = '${authorityCollectionId}'`
+    ),
+    "transferred:2"
+  );
+
+  const cancelledCollectionId = crypto.randomUUID();
+  const cancelledReplicaId = crypto.randomUUID();
+  const cancelledToken = `authority-cancel-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+  await internalRequest(provider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: {
+      collection_id: cancelledCollectionId,
+      template: "mdbase",
+      display_name: "Cancelled authority probe"
+    }
+  });
+  await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${cancelledCollectionId}/replicas`,
+    {
+      method: "POST",
+      body: {
+        replica_id: cancelledReplicaId,
+        name: "Cancelled promotion mirror",
+        mode: "read_write",
+        allowed_types: [],
+        token: cancelledToken
+      }
+    }
+  );
+  const cancelledTransferId = crypto.randomUUID();
+  await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${cancelledCollectionId}/authority-transfers`,
+    {
+      method: "POST",
+      body: {
+        transfer_id: cancelledTransferId,
+        replica_id: cancelledReplicaId,
+        ttl_seconds: 600
+      }
+    }
+  );
+  const cancelledTransfer = await internalRequest(
+    provider.url,
+    `/internal/v1/authority-transfers/${cancelledTransferId}`,
+    { method: "DELETE" }
+  );
+  assert.equal(cancelledTransfer.state, "aborted");
+  assert.equal(
+    (await new HttpSyncTransport(
+      provider.url,
+      cancelledCollectionId,
+      cancelledToken
+    ).openSession()).head,
+    0
+  );
+
   phase("forcing pagination and validating a restart against durable state");
   const bulkCount = Number(process.env.MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT ?? 205);
   assert.ok(Number.isInteger(bulkCount) && bulkCount >= 205 && bulkCount <= 20_000);
@@ -1361,6 +1575,9 @@ schema:
   await rm(writableMirrorRoot, { recursive: true, force: true });
   await rm(importMirrorRoot, { recursive: true, force: true });
   await rm(browserMirrorRoot, { recursive: true, force: true });
+  await rm(authorityMirrorRoot, { recursive: true, force: true });
+  await rm(promotionMirrorRoot, { recursive: true, force: true });
+  await rm(promotionToolRoot, { recursive: true, force: true });
   await rm(mirrorStateRoot, { recursive: true, force: true });
 }
 
@@ -1470,6 +1687,221 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
   }
 }
 
+async function authorityPromotionCliE2E(
+  controlUrl,
+  cookie,
+  database,
+  mirrorDirectory,
+  toolDirectory
+) {
+  const hosted = await controlRequest(controlUrl, "/v1/hosted/collections", cookie, {
+    method: "POST",
+    body: { display_name: "Promotion E2E collection", template: "mdbase" }
+  });
+  const collectionId = hosted.collection.id;
+  const mirrorCli = join(repoRoot, "packages", "sync", "dist", "cli.js");
+  const connectProcess = spawn(process.execPath, [
+    mirrorCli,
+    "connect",
+    mirrorDirectory,
+    "--server", controlUrl,
+    "--collection", collectionId,
+    "--name", "Promotion computer",
+    "--no-open"
+  ], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let connectOutput = "";
+  let connectError = "";
+  connectProcess.stdout.on("data", (chunk) => { connectOutput += chunk; });
+  connectProcess.stderr.on("data", (chunk) => { connectError += chunk; });
+  const mirrorVerificationUri = await waitForOutput(
+    () => connectOutput.match(/https?:\/\/[^\s]+\/mirror\/[0-9a-f-]+/)?.[0],
+    "Promotion mirror did not print its approval URL"
+  );
+  const pairingId = new URL(mirrorVerificationUri).pathname.split("/").at(-1);
+  await controlRequest(
+    controlUrl,
+    `/v1/mirror-pairing-requests/${pairingId}/approve`,
+    cookie,
+    { method: "POST", body: { collection_id: collectionId } }
+  );
+  const connectExit = connectProcess.exitCode
+    ?? await new Promise((resolveExit) => connectProcess.once("exit", resolveExit));
+  assert.equal(connectExit, 0, `Promotion mirror connect failed:\n${connectError}\n${connectOutput}`);
+
+  const connector = await controlRequest(controlUrl, "/v1/connectors", cookie, {
+    method: "POST",
+    body: { name: "Promotion computer" }
+  });
+  const fakeConnectCli = join(toolDirectory, "mdbase-connect-e2e.mjs");
+  await writeFile(fakeConnectCli, `#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+const args = process.argv.slice(2);
+const collection = args.indexOf("collection");
+const action = args[collection + 1];
+let id = args[collection + 2] ?? "";
+if (action === "add") {
+  const source = await readFile(id + "/mdbase.yaml", "utf8");
+  id = source.match(/collection_id:\\s*["']?([0-9a-f-]{36})/i)?.[1] ?? "";
+  if (process.env.MDBASE_PROMOTION_PUBLISH !== "0") {
+    const response = await fetch(process.env.MDBASE_PROMOTION_CONTROL_URL + "/v1/connectors/sync", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer " + process.env.MDBASE_PROMOTION_CONNECTOR_TOKEN,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        collections: [{
+          id,
+          display_name: "Promotion E2E collection",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      })
+    });
+    if (!response.ok) {
+      process.stderr.write(await response.text());
+      process.exit(1);
+    }
+  }
+}
+process.stdout.write(JSON.stringify({
+  id: crypto.randomUUID(),
+  protocol_version: 1,
+  ok: true,
+  result: action === "add" ? { id } : { valid: true }
+}) + "\\n");
+`, { mode: 0o700 });
+
+  const promotion = spawn(process.execPath, [
+    mirrorCli,
+    "promote",
+    mirrorDirectory,
+    "--no-open",
+    "--connect-cli", fakeConnectCli
+  ], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      MDBASE_PROMOTION_CONTROL_URL: controlUrl,
+      MDBASE_PROMOTION_CONNECTOR_TOKEN: connector.token,
+      MDBASE_PROMOTION_PUBLISH: "0"
+    },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let promotionOutput = "";
+  let promotionError = "";
+  promotion.stdout.on("data", (chunk) => { promotionOutput += chunk; });
+  promotion.stderr.on("data", (chunk) => { promotionError += chunk; });
+  const transferUri = await waitForOutput(
+    () => promotionOutput.match(/https?:\/\/[^\s]+\/transfer\/[0-9a-f-]+/)?.[0],
+    "Promotion CLI did not print an authority confirmation URL"
+  );
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const separator = cookie.indexOf("=");
+    const context = await browser.newContext();
+    await context.addCookies([{
+      name: cookie.slice(0, separator),
+      value: cookie.slice(separator + 1),
+      url: controlUrl
+    }]);
+    const page = await context.newPage();
+    await page.goto(transferUri);
+    await expect(page.getByRole("heading", {
+      name: "Make Promotion computer authoritative?"
+    })).toBeVisible();
+    await expect(page.getByText(
+      "Existing access is revoked. Connect applications again to use the local collection."
+    )).toBeVisible();
+    await page.getByRole("button", { name: "Move authority" }).click();
+    await waitForOutput(
+      () => promotionOutput.includes("Local collection registered.") || undefined,
+      "Promotion CLI did not materialize the local collection"
+    );
+    promotion.kill("SIGTERM");
+    await new Promise((resolveExit) => promotion.once("exit", resolveExit));
+
+    const resumedPromotion = spawn(process.execPath, [
+      mirrorCli,
+      "promote",
+      mirrorDirectory,
+      "--no-open",
+      "--connect-cli", fakeConnectCli
+    ], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        MDBASE_PROMOTION_CONTROL_URL: controlUrl,
+        MDBASE_PROMOTION_CONNECTOR_TOKEN: connector.token,
+        MDBASE_PROMOTION_PUBLISH: "1"
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let resumedOutput = "";
+    let resumedError = "";
+    resumedPromotion.stdout.on("data", (chunk) => { resumedOutput += chunk; });
+    resumedPromotion.stderr.on("data", (chunk) => { resumedError += chunk; });
+    const promotionExit = resumedPromotion.exitCode
+      ?? await new Promise((resolveExit) => resumedPromotion.once("exit", resolveExit));
+    assert.equal(
+      promotionExit,
+      0,
+      `Promotion CLI resume failed:\n${resumedError}\n${resumedOutput}`
+    );
+    assert.match(resumedOutput, /Resuming the materialized authority handoff/);
+    assert.match(resumedOutput, /Authority moved/);
+    await expect(page.getByRole("heading", {
+      name: "Promotion E2E collection now lives on your computer."
+    })).toBeVisible();
+  } finally {
+    if (promotion.exitCode === null && promotion.signalCode === null) promotion.kill("SIGTERM");
+    await browser.close();
+  }
+
+  assert.match(
+    await readFile(join(mirrorDirectory, "mdbase.yaml"), "utf8"),
+    new RegExp(`collection_id: ${collectionId}`)
+  );
+  const profileDirectory = await mirrorProfileDirectory(mirrorDirectory);
+  await assert.rejects(
+    () => readFile(join(profileDirectory, "credentials.json"), "utf8"),
+    { code: "ENOENT" }
+  );
+  const authorityReceipt = JSON.parse(
+    await readFile(join(profileDirectory, "authority.json"), "utf8")
+  );
+  assert.equal(authorityReceipt.collection_id, collectionId);
+  assert.equal(authorityReceipt.authority_epoch, 2);
+  const state = await database.query(
+    `SELECT hosted.authority_state AS hosted_state,
+            local.authority_state AS local_state,
+            local.enabled, local.authority_epoch
+     FROM hosted_collections hosted
+     JOIN collections local ON local.id = hosted.transferred_collection_id
+     WHERE hosted.id = $1`,
+    [collectionId]
+  );
+  assert.deepEqual(
+    {
+      hosted_state: state.rows[0].hosted_state,
+      local_state: state.rows[0].local_state,
+      enabled: state.rows[0].enabled,
+      authority_epoch: Number(state.rows[0].authority_epoch)
+    },
+    {
+      hosted_state: "transferred",
+      local_state: "active",
+      enabled: true,
+      authority_epoch: 2
+    }
+  );
+}
+
 async function authorizeHostedApplication(authorizationUrl, cookie, collectionId, callbackOrigin) {
   const browser = await chromium.launch({ headless: true });
   try {
@@ -1486,7 +1918,7 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     await expect(page.getByRole("heading", { name: "Hosted SDK E2E" })).toBeVisible();
     await expect(page.getByText("Hosted SDK E2E is asking to use one collection. Choose where it can work and review what it can do.")).toBeVisible();
     const collection = page.getByLabel("Collection and location");
-    await expect(collection.locator("option")).toHaveCount(2);
+    await expect(collection.locator(`option[value="${collectionId}"]`)).toHaveCount(1);
     await collection.selectOption(collectionId);
     await expect(collection.locator("option:checked")).toHaveText("Hosted writing · Hosted by mdbase");
     await page.getByRole("button", { name: "Allow Hosted SDK E2E" }).click();

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -162,6 +162,35 @@ interface ConnectorIdentity {
   user_id: string;
 }
 
+interface AuthorityTransferRow {
+  id: string;
+  user_id: string;
+  hosted_collection_id: string;
+  pairing_id: string;
+  replica_id: string;
+  local_collection_id: string | null;
+  state: "requested" | "approved" | "prepared" | "completed" | "cancelled" | "expired";
+  final_head: string | number | null;
+  next_authority_epoch: string | number | null;
+  manifest_digest: string | null;
+  expires_at: string | Date;
+}
+
+interface AuthorityTransferDetails extends AuthorityTransferRow {
+  collection_name?: string;
+  mirror_name?: string;
+}
+
+interface AuthorityPairing {
+  pairing_id: string;
+  user_id: string;
+  collection_id: string;
+  replica_id: string;
+  mode: "read_only" | "read_write";
+  allowed_types: string[];
+  authority_state: "active" | "transferring" | "transferred";
+}
+
 export async function buildApp(options: BuildOptions) {
   const app = Fastify({
     logger: process.env.NODE_ENV !== "test",
@@ -235,7 +264,11 @@ export async function buildApp(options: BuildOptions) {
   app.addHook("onRequest", async (request, reply) => {
     if (
       !options.hostedCollections
-      && (request.url.startsWith("/v1/hosted/") || request.url.startsWith("/v1/mirror-pairing-requests"))
+      && (
+        request.url.startsWith("/v1/hosted/")
+        || request.url.startsWith("/v1/mirror-pairing-requests")
+        || request.url.startsWith("/v1/authority-transfers")
+      )
     ) {
       return reply.code(404).send(apiError("not_found", "Not found."));
     }
@@ -672,7 +705,7 @@ export async function buildApp(options: BuildOptions) {
     }
     const collections = await options.db.query<{ id: string; display_name: string }>(
       `SELECT id, display_name FROM hosted_collections
-       WHERE user_id = $1 ORDER BY display_name`,
+       WHERE user_id = $1 AND authority_state = 'active' ORDER BY display_name`,
       [user.id]
     );
     const { user_id: _userId, ...publicPairing } = pending;
@@ -695,7 +728,7 @@ export async function buildApp(options: BuildOptions) {
          AND expires_at > now()
          AND EXISTS (
            SELECT 1 FROM hosted_collections
-           WHERE id = $3 AND user_id = $2
+           WHERE id = $3 AND user_id = $2 AND authority_state = 'active'
          )
        RETURNING id, mirror_name, mode`,
       [pairingId, user.id, input.collection_id]
@@ -896,6 +929,447 @@ export async function buildApp(options: BuildOptions) {
     );
   });
 
+  app.post("/v1/mirror-pairing-requests/:pairingId/authority-transfers", async (request, reply) => {
+    const { pairingId } = z.object({ pairingId: z.uuid() }).parse(request.params);
+    z.object({}).strict().parse(request.body ?? {});
+    await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+    const secret = bearerToken(request);
+    if (!secret) {
+      return reply.code(401).send(apiError(
+        "invalid_mirror_pairing",
+        "Mirror refresh credential required."
+      ));
+    }
+    const pairing = await authorityPairing(options.db, pairingId, secret);
+    if (!pairing) {
+      return reply.code(404).send(apiError(
+        "mirror_pairing_not_found",
+        "This device can no longer move collection authority."
+      ));
+    }
+    if (pairing.mode !== "read_write" || pairing.allowed_types.length > 0) {
+      return reply.code(409).send(apiError(
+        "promotion_mirror_ineligible",
+        "Authority can move only to an active, two-way, full collection mirror."
+      ));
+    }
+    const existing = await options.db.query<AuthorityTransferRow>(
+      `SELECT id, user_id, hosted_collection_id, pairing_id, replica_id, local_collection_id,
+              state, final_head, next_authority_epoch, manifest_digest, expires_at
+       FROM authority_transfers
+       WHERE pairing_id = $1 AND state IN ('requested', 'approved', 'prepared')
+       ORDER BY created_at DESC LIMIT 1`,
+      [pairingId]
+    );
+    if (existing.rows[0]) {
+      return reply.code(200).send(authorityTransferResponse(existing.rows[0], publicUrl));
+    }
+    if (pairing.authority_state !== "active") {
+      return reply.code(409).send(apiError(
+        "authority_transfer_unavailable",
+        "This hosted collection is not available for authority transfer."
+      ));
+    }
+    const transferId = randomUUID();
+    const transfer = await options.db.query<AuthorityTransferRow>(
+      `INSERT INTO authority_transfers
+         (id, user_id, hosted_collection_id, pairing_id, replica_id, expires_at)
+       VALUES ($1, $2, $3, $4, $5, now() + interval '30 minutes')
+       RETURNING id, user_id, hosted_collection_id, pairing_id, replica_id,
+                 local_collection_id, state, final_head, next_authority_epoch,
+                 manifest_digest, expires_at`,
+      [transferId, pairing.user_id, pairing.collection_id, pairingId, pairing.replica_id]
+    );
+    await audit(options.db, pairing.user_id, "authority_transfer.requested", transferId, {
+      collection_id: pairing.collection_id,
+      replica_id: pairing.replica_id
+    });
+    return reply.code(201).send(authorityTransferResponse(transfer.rows[0], publicUrl));
+  });
+
+  app.get("/v1/authority-transfers/:transferId", async (request, reply) => {
+    const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
+    if (!user) return;
+    const { transferId } = z.object({ transferId: z.uuid() }).parse(request.params);
+    await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+    const transfer = await options.db.query<AuthorityTransferDetails>(
+      `SELECT transfer.id, transfer.user_id, transfer.hosted_collection_id,
+              transfer.pairing_id, transfer.replica_id, transfer.local_collection_id,
+              transfer.state, transfer.final_head, transfer.next_authority_epoch,
+              transfer.manifest_digest, transfer.expires_at,
+              hosted.display_name AS collection_name,
+              replica.name AS mirror_name
+       FROM authority_transfers transfer
+       JOIN hosted_collections hosted ON hosted.id = transfer.hosted_collection_id
+       JOIN hosted_replicas replica ON replica.id = transfer.replica_id
+       WHERE transfer.id = $1 AND transfer.user_id = $2`,
+      [transferId, user.id]
+    );
+    if (!transfer.rows[0]) {
+      return reply.code(404).send(apiError(
+        "authority_transfer_not_found",
+        "Authority transfer was not found."
+      ));
+    }
+    return { transfer: authorityTransferView(transfer.rows[0], publicUrl) };
+  });
+
+  app.post("/v1/authority-transfers/:transferId/approve", async (request, reply) => {
+    const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
+    if (!user) return;
+    const { transferId } = z.object({ transferId: z.uuid() }).parse(request.params);
+    z.object({}).strict().parse(request.body ?? {});
+    await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+    const approved = await options.db.query<AuthorityTransferRow>(
+      `UPDATE authority_transfers
+       SET state = 'approved', approved_at = now()
+       WHERE id = $1 AND user_id = $2 AND state = 'requested' AND expires_at > now()
+       RETURNING id, user_id, hosted_collection_id, pairing_id, replica_id,
+                 local_collection_id, state, final_head, next_authority_epoch,
+                 manifest_digest, expires_at`,
+      [transferId, user.id]
+    );
+    if (!approved.rows[0]) {
+      const existing = await options.db.query<AuthorityTransferRow>(
+        `SELECT id, user_id, hosted_collection_id, pairing_id, replica_id,
+                local_collection_id, state, final_head, next_authority_epoch,
+                manifest_digest, expires_at
+         FROM authority_transfers WHERE id = $1 AND user_id = $2`,
+        [transferId, user.id]
+      );
+      if (existing.rows[0]?.state === "approved" || existing.rows[0]?.state === "prepared") {
+        return { transfer: authorityTransferView(existing.rows[0], publicUrl) };
+      }
+      return reply.code(409).send(apiError(
+        "authority_transfer_inactive",
+        "Authority transfer expired or is no longer awaiting approval."
+      ));
+    }
+    await audit(options.db, user.id, "authority_transfer.approved", transferId, {
+      collection_id: approved.rows[0].hosted_collection_id
+    });
+    return { transfer: authorityTransferView(approved.rows[0], publicUrl) };
+  });
+
+  app.post("/v1/authority-transfers/:transferId/prepare", async (request, reply) => {
+    const { transferId } = z.object({ transferId: z.uuid() }).parse(request.params);
+    z.object({}).strict().parse(request.body ?? {});
+    await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+    const transfer = await mirrorAuthorityTransfer(
+      options.db,
+      transferId,
+      bearerToken(request)
+    );
+    if (!transfer) {
+      return reply.code(404).send(apiError(
+        "authority_transfer_not_found",
+        "Authority transfer was not found for this mirror."
+      ));
+    }
+    const connection = await options.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const locked = await connection.query<AuthorityTransferRow>(
+        `SELECT id, user_id, hosted_collection_id, pairing_id, replica_id,
+                local_collection_id, state, final_head, next_authority_epoch,
+                manifest_digest, expires_at
+         FROM authority_transfers WHERE id = $1 FOR UPDATE`,
+        [transferId]
+      );
+      const current = locked.rows[0];
+      if (!current || current.pairing_id !== transfer.pairing_id) {
+        await connection.query("ROLLBACK");
+        return reply.code(404).send(apiError(
+          "authority_transfer_not_found",
+          "Authority transfer was not found for this mirror."
+        ));
+      }
+      if (current.state === "requested") {
+        await connection.query("COMMIT");
+        return reply.code(202).send({ status: "pending" });
+      }
+      if (current.state === "prepared") {
+        await connection.query("COMMIT");
+        return { transfer: authorityTransferView(current, publicUrl) };
+      }
+      if (current.state !== "approved") {
+        await connection.query("ROLLBACK");
+        return reply.code(409).send(apiError(
+          "authority_transfer_inactive",
+          "Authority transfer is no longer active."
+        ));
+      }
+      const prepared = options.hostedProvider
+        ? await options.hostedProvider.prepareAuthorityTransfer(
+            current.hosted_collection_id,
+            { transferId, replicaId: current.replica_id, ttlSeconds: 900 }
+          )
+        : await hostedReference!.prepareAuthorityTransfer(
+            current.hosted_collection_id,
+            { transferId, replicaId: current.replica_id, ttlSeconds: 900 }
+          );
+      const saved = await connection.query<AuthorityTransferRow>(
+        `UPDATE authority_transfers
+         SET state = 'prepared', final_head = $2, next_authority_epoch = $3,
+             manifest_digest = $4, expires_at = $5, prepared_at = now()
+         WHERE id = $1 AND state = 'approved'
+         RETURNING id, user_id, hosted_collection_id, pairing_id, replica_id,
+                   local_collection_id, state, final_head, next_authority_epoch,
+                   manifest_digest, expires_at`,
+        [
+          transferId,
+          prepared.final_head,
+          prepared.authority_epoch,
+          prepared.manifest_digest,
+          prepared.expires_at
+        ]
+      );
+      await connection.query(
+        `UPDATE hosted_collections
+         SET authority_state = 'transferring'
+         WHERE id = $1 AND authority_state = 'active'`,
+        [current.hosted_collection_id]
+      );
+      await audit(connection, current.user_id, "authority_transfer.prepared", transferId, {
+        collection_id: current.hosted_collection_id,
+        final_head: prepared.final_head,
+        authority_epoch: prepared.authority_epoch
+      });
+      await connection.query("COMMIT");
+      return { transfer: authorityTransferView(saved.rows[0], publicUrl) };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  });
+
+  app.post("/v1/authority-transfers/:transferId/complete", async (request, reply) => {
+    const { transferId } = z.object({ transferId: z.uuid() }).parse(request.params);
+    const input = z.object({
+      manifest_digest: z.string().regex(/^[a-f0-9]{64}$/)
+    }).strict().parse(request.body);
+    const transfer = await mirrorAuthorityTransfer(
+      options.db,
+      transferId,
+      bearerToken(request)
+    );
+    if (!transfer) {
+      return reply.code(404).send(apiError(
+        "authority_transfer_not_found",
+        "Authority transfer was not found for this mirror."
+      ));
+    }
+    if (transfer.state === "completed" && transfer.local_collection_id) {
+      return {
+        status: "completed",
+        collection_id: transfer.hosted_collection_id,
+        local_collection_id: transfer.local_collection_id,
+        authority_epoch: Number(transfer.next_authority_epoch)
+      };
+    }
+    if (transfer.state !== "prepared") {
+      return reply.code(409).send(apiError(
+        "authority_transfer_inactive",
+        "Authority transfer is not prepared."
+      ));
+    }
+    const candidates = await options.db.query<{ id: string; connector_id: string }>(
+      `SELECT collection.id, collection.connector_id
+       FROM collections collection
+       JOIN connectors connector ON connector.id = collection.connector_id
+       WHERE connector.user_id = $1
+         AND collection.local_id = $2
+         AND collection.authority_state = 'candidate'
+       ORDER BY collection.last_seen_at DESC`,
+      [transfer.user_id, transfer.hosted_collection_id]
+    );
+    if (candidates.rows.length === 0) {
+      return reply.code(202).send({
+        status: "waiting_for_connector",
+        message: "The local connector has not registered the promoted collection yet."
+      });
+    }
+    if (candidates.rows.length > 1) {
+      return reply.code(409).send(apiError(
+        "authority_target_ambiguous",
+        "More than one computer registered this promoted collection."
+      ));
+    }
+    const candidate = candidates.rows[0];
+    const completed = options.hostedProvider
+      ? await options.hostedProvider.completeAuthorityTransfer(transferId, input.manifest_digest)
+      : await hostedReference!.completeAuthorityTransfer(transferId, input.manifest_digest);
+    const connection = await options.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const locked = await connection.query<AuthorityTransferRow>(
+        `SELECT id, user_id, hosted_collection_id, pairing_id, replica_id,
+                local_collection_id, state, final_head, next_authority_epoch,
+                manifest_digest, expires_at
+         FROM authority_transfers WHERE id = $1 FOR UPDATE`,
+        [transferId]
+      );
+      if (locked.rows[0]?.state === "completed" && locked.rows[0].local_collection_id) {
+        await connection.query("COMMIT");
+        return {
+          status: "completed",
+          collection_id: transfer.hosted_collection_id,
+          local_collection_id: locked.rows[0].local_collection_id,
+          authority_epoch: Number(locked.rows[0].next_authority_epoch)
+        };
+      }
+      await connection.query(
+        `UPDATE collections
+         SET authority_state = 'active', authority_epoch = $2, enabled = true,
+             last_seen_at = now()
+         WHERE id = $1 AND authority_state = 'candidate'`,
+        [candidate.id, completed.authority_epoch]
+      );
+      await connection.query(
+        `UPDATE hosted_collections
+         SET authority_state = 'transferred', authority_epoch = $2,
+             transferred_collection_id = $3
+         WHERE id = $1`,
+        [transfer.hosted_collection_id, completed.authority_epoch, candidate.id]
+      );
+      const grants = await connection.query<{ id: string }>(
+        "SELECT id FROM grants WHERE hosted_collection_id = $1",
+        [transfer.hosted_collection_id]
+      );
+      const grantIds = grants.rows.map(({ id }) => id);
+      await connection.query(
+        `UPDATE access_tokens SET revoked_at = COALESCE(revoked_at, now())
+         WHERE grant_id IN (
+           SELECT id FROM grants WHERE hosted_collection_id = $1
+         )`,
+        [transfer.hosted_collection_id]
+      );
+      await connection.query(
+        `UPDATE refresh_tokens SET revoked_at = COALESCE(revoked_at, now())
+         WHERE grant_id IN (
+           SELECT id FROM grants WHERE hosted_collection_id = $1
+         )`,
+        [transfer.hosted_collection_id]
+      );
+      await connection.query(
+        `UPDATE grants SET revoked_at = COALESCE(revoked_at, now())
+         WHERE hosted_collection_id = $1`,
+        [transfer.hosted_collection_id]
+      );
+      await connection.query(
+        `UPDATE hosted_replicas
+         SET revoked_at = COALESCE(revoked_at, now()), token_hash = NULL
+         WHERE collection_id = $1`,
+        [transfer.hosted_collection_id]
+      );
+      await connection.query(
+        `UPDATE authority_transfers
+         SET state = 'completed', local_collection_id = $2,
+             next_authority_epoch = $3, completed_at = now()
+         WHERE id = $1`,
+        [transferId, candidate.id, completed.authority_epoch]
+      );
+      await audit(connection, transfer.user_id, "authority_transfer.completed", transferId, {
+        collection_id: transfer.hosted_collection_id,
+        local_collection_id: candidate.id,
+        connector_id: candidate.connector_id,
+        authority_epoch: completed.authority_epoch,
+        revoked_grants: grantIds.length
+      });
+      await connection.query("COMMIT");
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+    await relay.pushPolicy(candidate.connector_id);
+    return {
+      status: "completed",
+      collection_id: transfer.hosted_collection_id,
+      local_collection_id: candidate.id,
+      authority_epoch: completed.authority_epoch
+    };
+  });
+
+  app.delete("/v1/authority-transfers/:transferId", async (request, reply) => {
+    const { transferId } = z.object({ transferId: z.uuid() }).parse(request.params);
+    const user = await authenticatedUser(request, options.db, options.tailscaleAuth);
+    const transfer = user
+      ? (await options.db.query<AuthorityTransferRow>(
+          `SELECT id, user_id, hosted_collection_id, pairing_id, replica_id,
+                  local_collection_id, state, final_head, next_authority_epoch,
+                  manifest_digest, expires_at
+           FROM authority_transfers WHERE id = $1 AND user_id = $2`,
+          [transferId, user.id]
+        )).rows[0]
+      : await mirrorAuthorityTransfer(options.db, transferId, bearerToken(request));
+    if (!transfer) {
+      return reply.code(404).send(apiError(
+        "authority_transfer_not_found",
+        "Authority transfer was not found."
+      ));
+    }
+    const connection = await options.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const locked = await connection.query<AuthorityTransferRow>(
+        `SELECT id, user_id, hosted_collection_id, pairing_id, replica_id,
+                local_collection_id, state, final_head, next_authority_epoch,
+                manifest_digest, expires_at
+         FROM authority_transfers WHERE id = $1 FOR UPDATE`,
+        [transferId]
+      );
+      const current = locked.rows[0];
+      if (!current || current.user_id !== transfer.user_id) {
+        await connection.query("ROLLBACK");
+        return reply.code(404).send(apiError(
+          "authority_transfer_not_found",
+          "Authority transfer was not found."
+        ));
+      }
+      if (current.state === "completed") {
+        await connection.query("ROLLBACK");
+        return reply.code(409).send(apiError(
+          "authority_transfer_completed",
+          "Completed authority transfer cannot be cancelled."
+        ));
+      }
+      if (current.state === "prepared") {
+        if (options.hostedProvider) await options.hostedProvider.abortAuthorityTransfer(transferId);
+        else await hostedReference!.abortAuthorityTransfer(transferId);
+      }
+      await connection.query(
+        `UPDATE authority_transfers
+         SET state = 'cancelled', cancelled_at = now()
+         WHERE id = $1 AND state <> 'completed'`,
+        [transferId]
+      );
+      await connection.query(
+        `UPDATE hosted_collections SET authority_state = 'active'
+         WHERE id = $1 AND authority_state = 'transferring'`,
+        [current.hosted_collection_id]
+      );
+      await retireAuthorityCandidates(
+        connection,
+        current.user_id,
+        current.hosted_collection_id
+      );
+      await audit(connection, current.user_id, "authority_transfer.cancelled", transferId, {
+        collection_id: current.hosted_collection_id
+      });
+      await connection.query("COMMIT");
+      return { ok: true };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  });
+
   app.post("/v1/dev/session", async (request, reply) => {
     if (!options.devAuth) return reply.code(404).send({ error: { code: "not_found", message: "Not found." } });
     const input = z.object({ email: z.email(), name: z.string().trim().min(1).max(100) }).parse(request.body);
@@ -927,6 +1401,9 @@ export async function buildApp(options: BuildOptions) {
   app.get("/v1/me", async (request, reply) => {
     const authenticated = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!authenticated) return;
+    if (options.hostedCollections) {
+      await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+    }
     const { authentication_provider: authenticationProvider, ...user } = authenticated;
     const connectors = await options.db.query(
       `SELECT c.id, c.name, c.last_seen_at, c.created_at
@@ -935,10 +1412,11 @@ export async function buildApp(options: BuildOptions) {
     );
     const collections = await options.db.query(
       `SELECT col.id, col.connector_id, col.local_id, col.display_name, col.spec_version, col.enabled,
-              col.contracts, col.last_seen_at,
+              col.authority_state, col.authority_epoch, col.contracts, col.last_seen_at,
               c.name AS connector_name
        FROM collections col JOIN connectors c ON c.id = col.connector_id
-       WHERE c.user_id = $1 ORDER BY col.display_name`,
+       WHERE c.user_id = $1 AND col.authority_state = 'active'
+       ORDER BY col.display_name`,
       [user.id]
     );
     const hostedCollections = options.hostedCollections
@@ -948,9 +1426,13 @@ export async function buildApp(options: BuildOptions) {
           template: string;
           contracts: CollectionContractDescriptor[];
           provider_url: string | null;
+          authority_state: "active" | "transferring" | "transferred";
+          authority_epoch: string | number;
+          transferred_collection_id: string | null;
           created_at: string;
         }>(
-          `SELECT id, display_name, template, provider_url, contracts, created_at
+          `SELECT id, display_name, template, provider_url, contracts, authority_state,
+                  authority_epoch, transferred_collection_id, created_at
            FROM hosted_collections WHERE user_id = $1 ORDER BY display_name`,
           [user.id]
         )
@@ -1027,6 +1509,7 @@ export async function buildApp(options: BuildOptions) {
         ...collection,
         provider_url: collection.provider_url ?? publicUrl,
         spec_version: "0.3.0",
+        authority_epoch: Number(collection.authority_epoch),
         contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template)),
         replicas: hostedReplicas.rows
           .filter((replica) => replica.collection_id === collection.id)
@@ -1120,27 +1603,74 @@ export async function buildApp(options: BuildOptions) {
     }
     const synchronized = [];
     for (const collection of input.collections) {
-      const row = await options.db.query<{ id: string; local_id: string }>(
-        `INSERT INTO collections (id, connector_id, local_id, display_name, spec_version, enabled, contracts)
-         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+      const existing = await options.db.query<{
+        id: string;
+        authority_state: "active" | "candidate" | "retired";
+        authority_epoch: string | number;
+      }>(
+        `SELECT id, authority_state, authority_epoch
+         FROM collections WHERE connector_id = $1 AND local_id = $2`,
+        [connector.id, collection.id]
+      );
+      const hosted = await options.db.query<{
+        authority_state: "active" | "transferring" | "transferred";
+        authority_epoch: string | number;
+        transferred_collection_id: string | null;
+      }>(
+        `SELECT authority_state, authority_epoch, transferred_collection_id
+         FROM hosted_collections WHERE id = $1 AND user_id = $2`,
+        [collection.id, connector.user_id]
+      );
+      const hostedCollection = hosted.rows[0];
+      const isActivatedTransfer = Boolean(
+        hostedCollection?.authority_state === "transferred"
+        && hostedCollection.transferred_collection_id
+        && hostedCollection.transferred_collection_id === existing.rows[0]?.id
+      );
+      const authorityState = hostedCollection
+        ? (isActivatedTransfer ? "active" : "candidate")
+        : (existing.rows[0]?.authority_state ?? "active");
+      const authorityEpoch = Number(
+        hostedCollection?.authority_epoch
+        ?? existing.rows[0]?.authority_epoch
+        ?? 1
+      );
+      const enabled = authorityState === "active" ? collection.enabled : false;
+      const row = await options.db.query<{
+        id: string;
+        local_id: string;
+        authority_state: "active" | "candidate" | "retired";
+        authority_epoch: string | number;
+      }>(
+        `INSERT INTO collections
+           (id, connector_id, local_id, display_name, spec_version, enabled,
+            authority_state, authority_epoch, contracts)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
          ON CONFLICT(connector_id, local_id) DO UPDATE SET
            display_name = excluded.display_name,
            spec_version = excluded.spec_version,
            enabled = excluded.enabled,
+           authority_state = excluded.authority_state,
+           authority_epoch = excluded.authority_epoch,
            contracts = excluded.contracts,
            last_seen_at = now()
-         RETURNING id, local_id`,
+         RETURNING id, local_id, authority_state, authority_epoch`,
         [
           randomUUID(),
           connector.id,
           collection.id,
           collection.display_name,
           collection.spec_version,
-          collection.enabled,
+          enabled,
+          authorityState,
+          authorityEpoch,
           JSON.stringify(collection.contracts)
         ]
       );
-      synchronized.push(row.rows[0]);
+      synchronized.push({
+        ...row.rows[0],
+        authority_epoch: Number(row.rows[0].authority_epoch)
+      });
     }
     await options.db.query("UPDATE connectors SET last_seen_at = now() WHERE id = $1", [connector.id]);
     return { collections: synchronized };
@@ -1441,7 +1971,7 @@ export async function buildApp(options: BuildOptions) {
       mode: z.enum(["read_only", "read_write"]),
       allowed_types: z.array(z.string().min(1).max(100)).max(100).default([])
     }).strict().parse(request.body);
-    if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
+    if (!await ownsActiveHostedCollection(options.db, user.id, collectionId)) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
     }
     const replicaId = randomUUID();
@@ -1914,7 +2444,9 @@ export async function buildApp(options: BuildOptions) {
       `SELECT col.id, col.display_name, col.spec_version, col.contracts,
               c.name AS connector_name
        FROM collections col JOIN connectors c ON c.id = col.connector_id
-       WHERE c.user_id = $1 AND col.enabled = true ORDER BY col.display_name`,
+       WHERE c.user_id = $1 AND col.enabled = true
+         AND col.authority_state = 'active'
+       ORDER BY col.display_name`,
       [user.id]
     );
     const hosted = options.hostedCollections
@@ -1926,7 +2458,7 @@ export async function buildApp(options: BuildOptions) {
           contracts: CollectionContractDescriptor[];
         }>(
           `SELECT id, display_name, template, contracts FROM hosted_collections
-           WHERE user_id = $1 ORDER BY display_name`,
+           WHERE user_id = $1 AND authority_state = 'active' ORDER BY display_name`,
           [user.id]
         )
       : { rows: [] };
@@ -1992,7 +2524,8 @@ export async function buildApp(options: BuildOptions) {
     const input = z.object({ collection_id: z.uuid(), operations: z.array(operationSchema).min(1) }).parse(request.body);
     const collection = await options.db.query<{ connector_id: string }>(
       `SELECT col.connector_id FROM collections col JOIN connectors c ON c.id = col.connector_id
-       WHERE col.id = $1 AND c.user_id = $2 AND col.enabled = true`,
+       WHERE col.id = $1 AND c.user_id = $2 AND col.enabled = true
+         AND col.authority_state = 'active'`,
       [input.collection_id, user.id]
     );
     let approved: boolean;
@@ -2007,7 +2540,8 @@ export async function buildApp(options: BuildOptions) {
       });
     } else {
       const hosted = await options.db.query<{ id: string; template: string; display_name: string; contracts: CollectionContractDescriptor[] }>(
-        "SELECT id, template, display_name, contracts FROM hosted_collections WHERE id = $1 AND user_id = $2",
+        `SELECT id, template, display_name, contracts FROM hosted_collections
+         WHERE id = $1 AND user_id = $2 AND authority_state = 'active'`,
         [input.collection_id, user.id]
       );
       if (!hosted.rows[0] || !options.hostedProvider) {
@@ -3558,6 +4092,168 @@ async function authenticatedUser(
   return tailscaleAuth ? tailscaleUser(request, db) : sessionUser(request, db);
 }
 
+async function authorityPairing(
+  db: DatabasePool,
+  pairingId: string,
+  secret: string | null
+): Promise<AuthorityPairing | null> {
+  if (!secret) return null;
+  const result = await db.query<AuthorityPairing & {
+    replica_collection_id: string;
+    consumed_at: string | null;
+    purpose: "mirror" | "application";
+    revoked_at: string | null;
+  }>(
+    `SELECT pairing.id AS pairing_id, pairing.user_id,
+            pairing.collection_id, pairing.replica_id, pairing.mode, pairing.consumed_at,
+            replica.allowed_types, replica.collection_id AS replica_collection_id,
+            replica.purpose, replica.revoked_at, hosted.authority_state
+     FROM mirror_pairing_requests pairing
+     JOIN hosted_replicas replica ON replica.id = pairing.replica_id
+     JOIN hosted_collections hosted ON hosted.id = pairing.collection_id
+     WHERE pairing.id = $1 AND pairing.secret_hash = $2`,
+    [pairingId, tokenHash(secret)]
+  );
+  const pairing = result.rows[0];
+  if (
+    !pairing
+    || !pairing.consumed_at
+    || pairing.purpose !== "mirror"
+    || pairing.revoked_at
+    || pairing.replica_collection_id !== pairing.collection_id
+  ) {
+    return null;
+  }
+  const {
+    replica_collection_id: _replicaCollectionId,
+    consumed_at: _consumedAt,
+    purpose: _purpose,
+    revoked_at: _revokedAt,
+    ...authenticated
+  } = pairing;
+  return authenticated;
+}
+
+async function mirrorAuthorityTransfer(
+  db: DatabasePool,
+  transferId: string,
+  secret: string | null
+): Promise<AuthorityTransferRow | null> {
+  if (!secret) return null;
+  const result = await db.query<AuthorityTransferRow>(
+    `SELECT transfer.id, transfer.user_id, transfer.hosted_collection_id,
+            transfer.pairing_id, transfer.replica_id, transfer.local_collection_id,
+            transfer.state, transfer.final_head, transfer.next_authority_epoch,
+            transfer.manifest_digest, transfer.expires_at
+     FROM authority_transfers transfer
+     JOIN mirror_pairing_requests pairing ON pairing.id = transfer.pairing_id
+     WHERE transfer.id = $1 AND pairing.secret_hash = $2`,
+    [transferId, tokenHash(secret)]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function recoverExpiredAuthorityTransfers(
+  db: DatabasePool,
+  hostedProvider?: HostedProviderClient,
+  hostedReference?: HostedAuthorityRegistry
+): Promise<void> {
+  const prepared = await db.query<{ id: string; hosted_collection_id: string; user_id: string }>(
+    `SELECT id, hosted_collection_id, user_id FROM authority_transfers
+     WHERE state = 'prepared' AND expires_at <= now()`
+  );
+  for (const transfer of prepared.rows) {
+    try {
+      if (hostedProvider) await hostedProvider.abortAuthorityTransfer(transfer.id);
+      else await hostedReference?.abortAuthorityTransfer(transfer.id);
+    } catch (error) {
+      if (
+        (
+          error instanceof HostedProviderResponseError
+          || error instanceof SyncError
+        )
+        && error.code === "authority_transfer_completed"
+      ) {
+        // The provider committed but the control-plane transaction did not.
+        // Keep the transfer resumable instead of incorrectly restoring epoch one.
+        continue;
+      }
+      throw error;
+    }
+    await db.query(
+      `UPDATE authority_transfers SET state = 'expired'
+       WHERE id = $1 AND state = 'prepared'`,
+      [transfer.id]
+    );
+    await db.query(
+      `UPDATE hosted_collections SET authority_state = 'active'
+       WHERE id = $1 AND authority_state = 'transferring'`,
+      [transfer.hosted_collection_id]
+    );
+    await retireAuthorityCandidates(
+      db,
+      transfer.user_id,
+      transfer.hosted_collection_id
+    );
+  }
+  await db.query(
+    `UPDATE authority_transfers SET state = 'expired'
+     WHERE state IN ('requested', 'approved') AND expires_at <= now()`
+  );
+}
+
+async function retireAuthorityCandidates(
+  db: DatabaseQueryable,
+  userId: string,
+  hostedCollectionId: string
+): Promise<void> {
+  await db.query(
+    `UPDATE collections
+     SET authority_state = 'retired', enabled = false
+     WHERE local_id = $1 AND authority_state = 'candidate'
+       AND connector_id IN (SELECT id FROM connectors WHERE user_id = $2)`,
+    [hostedCollectionId, userId]
+  );
+}
+
+function authorityTransferView(
+  transfer: AuthorityTransferDetails,
+  publicUrl: string
+): Record<string, unknown> {
+  return {
+    id: transfer.id,
+    collection_id: transfer.hosted_collection_id,
+    replica_id: transfer.replica_id,
+    state: transfer.state,
+    final_head: transfer.final_head === null ? null : Number(transfer.final_head),
+    authority_epoch: transfer.next_authority_epoch === null
+      ? null
+      : Number(transfer.next_authority_epoch),
+    manifest_digest: transfer.manifest_digest,
+    expires_at: new Date(transfer.expires_at).toISOString(),
+    verification_uri: `${publicUrl}/transfer/${transfer.id}`,
+    ...(transfer.local_collection_id
+      ? { local_collection_id: transfer.local_collection_id }
+      : {}),
+    ...(transfer.collection_name ? { collection_name: transfer.collection_name } : {}),
+    ...(transfer.mirror_name ? { mirror_name: transfer.mirror_name } : {})
+  };
+}
+
+function authorityTransferResponse(
+  transfer: AuthorityTransferRow,
+  publicUrl: string
+): Record<string, unknown> {
+  return {
+    transfer: authorityTransferView(transfer, publicUrl),
+    verification_uri: `${publicUrl}/transfer/${transfer.id}`,
+    expires_in: Math.max(
+      0,
+      Math.floor((new Date(transfer.expires_at).getTime() - Date.now()) / 1_000)
+    )
+  };
+}
+
 async function ownsHostedCollection(
   db: DatabasePool,
   userId: string,
@@ -3565,6 +4261,19 @@ async function ownsHostedCollection(
 ): Promise<boolean> {
   const result = await db.query(
     "SELECT id FROM hosted_collections WHERE id = $1 AND user_id = $2",
+    [collectionId, userId]
+  );
+  return Boolean(result.rows[0]);
+}
+
+async function ownsActiveHostedCollection(
+  db: DatabasePool,
+  userId: string,
+  collectionId: string
+): Promise<boolean> {
+  const result = await db.query(
+    `SELECT id FROM hosted_collections
+     WHERE id = $1 AND user_id = $2 AND authority_state = 'active'`,
     [collectionId, userId]
   );
   return Boolean(result.rows[0]);

--- a/services/server/src/authority-transfer.test.ts
+++ b/services/server/src/authority-transfer.test.ts
@@ -1,0 +1,425 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+import { tokenHash } from "./security.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("hosted-to-local authority transfer", () => {
+  it("fences hosted writes, activates one local candidate, and revokes hosted access", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedReferenceAuthority: true,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Owner", email: "owner@example.com" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const user = await db.query<{ id: string }>(
+      "SELECT id FROM users WHERE email = 'owner@example.com'"
+    );
+    const userId = user.rows[0].id;
+
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/hosted/collections",
+      headers: { cookie },
+      payload: { display_name: "Writing", template: "mdbase" }
+    });
+    const collectionId = created.json().collection.id as string;
+    const pairing = await app.inject({
+      method: "POST",
+      url: "/v1/mirror-pairing-requests",
+      payload: {
+        mirror_name: "Writing folder",
+        mode: "read_write",
+        collection_id: collectionId
+      }
+    });
+    const pairingId = pairing.json().pairing_id as string;
+    const refreshToken = pairing.json().pairing_secret as string;
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${pairingId}/approve`,
+      headers: { cookie },
+      payload: { collection_id: collectionId }
+    })).statusCode).toBe(200);
+    const exchanged = await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${pairingId}/exchange`,
+      headers: { authorization: `Bearer ${refreshToken}` }
+    });
+    const replicaId = exchanged.json().replica.id as string;
+    let replicaToken = exchanged.json().token as string;
+
+    const sessionOpened = await app.inject({
+      method: "POST",
+      url: `/v1/hosted/collections/${collectionId}/sync/sessions`,
+      headers: { authorization: `Bearer ${replicaToken}` }
+    });
+    expect(sessionOpened.statusCode).toBe(200);
+    const firstRecordId = randomUUID();
+    const firstMutation = await app.inject({
+      method: "POST",
+      url: `/v1/hosted/collections/${collectionId}/sync/mutations`,
+      headers: { authorization: `Bearer ${replicaToken}` },
+      payload: {
+        mutation_id: randomUUID(),
+        replica_id: replicaId,
+        scope_epoch: 1,
+        operation: "create",
+        record_id: firstRecordId,
+        input: {
+          path: "notes/one.md",
+          frontmatter: { title: "One" },
+          body: "Body",
+          types: []
+        },
+        created_at: new Date().toISOString()
+      }
+    });
+    expect(firstMutation.statusCode).toBe(200);
+    expect(firstMutation.json().status).toBe("applied");
+    const renewed = await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${pairingId}/renew`,
+      headers: { authorization: `Bearer ${refreshToken}` }
+    });
+    expect(renewed.statusCode, renewed.body).toBe(200);
+    replicaToken = renewed.json().token as string;
+
+    const applicationId = randomUUID();
+    const grantId = randomUUID();
+    await db.query(
+      `INSERT INTO applications
+         (id, canonical_identity, name, homepage, redirect_uris)
+       VALUES ($1, $2, 'Editor', 'https://editor.example', '[]'::jsonb)`,
+      [applicationId, `bundle:test:${applicationId}`]
+    );
+    await db.query(
+      `INSERT INTO grants
+         (id, user_id, application_id, hosted_collection_id, operations)
+       VALUES ($1, $2, $3, $4, '["read","update"]'::jsonb)`,
+      [grantId, userId, applicationId, collectionId]
+    );
+    await db.query(
+      `INSERT INTO access_tokens (id, token_hash, grant_id, expires_at)
+       VALUES ($1, $2, $3, now() + interval '1 hour')`,
+      [randomUUID(), `access-${grantId}`, grantId]
+    );
+    await db.query(
+      `INSERT INTO refresh_tokens (id, token_hash, grant_id, expires_at)
+       VALUES ($1, $2, $3, now() + interval '1 hour')`,
+      [randomUUID(), `refresh-${grantId}`, grantId]
+    );
+
+    const promotionMirror = await db.query(
+      `SELECT pairing.id, pairing.secret_hash, pairing.user_id, pairing.collection_id, pairing.replica_id,
+              pairing.consumed_at, replica.purpose, replica.mode, replica.allowed_types,
+              replica.revoked_at, hosted.authority_state,
+              replica.collection_id AS replica_collection_id
+       FROM mirror_pairing_requests pairing
+       JOIN hosted_replicas replica ON replica.id = pairing.replica_id
+       JOIN hosted_collections hosted ON hosted.id = pairing.collection_id
+       WHERE pairing.id = $1`,
+      [pairingId]
+    );
+    expect(promotionMirror.rows[0]).toMatchObject({
+      user_id: userId,
+      collection_id: collectionId,
+      replica_id: replicaId,
+      consumed_at: expect.anything(),
+      purpose: "mirror",
+      mode: "read_write",
+      allowed_types: [],
+      revoked_at: null,
+      authority_state: "active"
+    });
+    expect(promotionMirror.rows[0].replica_collection_id).toBe(collectionId);
+    expect(promotionMirror.rows[0].secret_hash).toBe(tokenHash(refreshToken));
+    const requested = await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${pairingId}/authority-transfers`,
+      headers: { authorization: `Bearer ${refreshToken}` },
+      payload: {}
+    });
+    expect(requested.statusCode, requested.body).toBe(201);
+    const transferId = requested.json().transfer.id as string;
+    const browserView = await app.inject({
+      method: "GET",
+      url: `/v1/authority-transfers/${transferId}`,
+      headers: { cookie }
+    });
+    expect(browserView.json().transfer).toMatchObject({
+      collection_name: "Writing",
+      mirror_name: "Writing folder",
+      state: "requested"
+    });
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/authority-transfers/${transferId}/approve`,
+      headers: { cookie },
+      payload: {}
+    })).statusCode).toBe(200);
+    const prepared = await app.inject({
+      method: "POST",
+      url: `/v1/authority-transfers/${transferId}/prepare`,
+      headers: { authorization: `Bearer ${refreshToken}` },
+      payload: {}
+    });
+    expect(prepared.statusCode).toBe(200);
+    expect(prepared.json().transfer).toMatchObject({
+      state: "prepared",
+      final_head: 1,
+      authority_epoch: 2
+    });
+    const manifestDigest = prepared.json().transfer.manifest_digest as string;
+    expect(manifestDigest).toMatch(/^[a-f0-9]{64}$/);
+
+    const fencedWrite = await app.inject({
+      method: "POST",
+      url: `/v1/hosted/collections/${collectionId}/sync/mutations`,
+      headers: { authorization: `Bearer ${replicaToken}` },
+      payload: {
+        mutation_id: randomUUID(),
+        replica_id: replicaId,
+        scope_epoch: 1,
+        operation: "create",
+        record_id: randomUUID(),
+        input: {
+          path: "notes/two.md",
+          frontmatter: { title: "Two" },
+          body: "",
+          types: []
+        },
+        created_at: new Date().toISOString()
+      }
+    });
+    expect(fencedWrite.statusCode).toBe(400);
+    expect(fencedWrite.json().error.code).toBe("authority_transfer_in_progress");
+    expect((await app.inject({
+      method: "GET",
+      url: `/v1/hosted/collections/${collectionId}/sync/changes?after=0&limit=50`,
+      headers: { authorization: `Bearer ${replicaToken}` }
+    })).statusCode).toBe(200);
+
+    const connector = await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Writing computer" }
+    });
+    const synchronized = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${connector.json().token}` },
+      payload: {
+        collections: [{
+          id: collectionId,
+          display_name: "Writing",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    });
+    expect(synchronized.json().collections[0]).toMatchObject({
+      authority_state: "candidate",
+      authority_epoch: 1
+    });
+
+    const completed = await app.inject({
+      method: "POST",
+      url: `/v1/authority-transfers/${transferId}/complete`,
+      headers: { authorization: `Bearer ${refreshToken}` },
+      payload: { manifest_digest: manifestDigest }
+    });
+    expect(completed.statusCode).toBe(200);
+    expect(completed.json()).toMatchObject({
+      status: "completed",
+      collection_id: collectionId,
+      authority_epoch: 2
+    });
+    const repeated = await app.inject({
+      method: "POST",
+      url: `/v1/authority-transfers/${transferId}/complete`,
+      headers: { authorization: `Bearer ${refreshToken}` },
+      payload: { manifest_digest: manifestDigest }
+    });
+    expect(repeated.statusCode).toBe(200);
+    expect(repeated.json()).toMatchObject({ status: "completed", authority_epoch: 2 });
+
+    const local = await db.query<{
+      authority_state: string;
+      authority_epoch: string | number;
+      enabled: boolean;
+    }>("SELECT authority_state, authority_epoch, enabled FROM collections WHERE local_id = $1", [
+      collectionId
+    ]);
+    expect(local.rows[0]).toMatchObject({ authority_state: "active", enabled: true });
+    expect(Number(local.rows[0].authority_epoch)).toBe(2);
+    const hosted = await db.query<{
+      authority_state: string;
+      authority_epoch: string | number;
+      transferred_collection_id: string;
+    }>(
+      `SELECT authority_state, authority_epoch, transferred_collection_id
+       FROM hosted_collections WHERE id = $1`,
+      [collectionId]
+    );
+    expect(hosted.rows[0].authority_state).toBe("transferred");
+    expect(Number(hosted.rows[0].authority_epoch)).toBe(2);
+    expect(hosted.rows[0].transferred_collection_id).toBe(completed.json().local_collection_id);
+    const revoked = await db.query<{
+      grant_revoked: string | null;
+      access_revoked: string | null;
+      refresh_revoked: string | null;
+    }>(
+      `SELECT g.revoked_at AS grant_revoked,
+              atok.revoked_at AS access_revoked,
+              rtok.revoked_at AS refresh_revoked
+       FROM grants g
+       JOIN access_tokens atok ON atok.grant_id = g.id
+       JOIN refresh_tokens rtok ON rtok.grant_id = g.id
+       WHERE g.id = $1`,
+      [grantId]
+    );
+    expect(revoked.rows[0].grant_revoked).not.toBeNull();
+    expect(revoked.rows[0].access_revoked).not.toBeNull();
+    expect(revoked.rows[0].refresh_revoked).not.toBeNull();
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/hosted/collections/${collectionId}/sync/sessions`,
+      headers: { authorization: `Bearer ${replicaToken}` }
+    })).statusCode).toBe(401);
+    expect((await app.inject({
+      method: "DELETE",
+      url: `/v1/hosted/collections/${collectionId}`,
+      headers: { cookie }
+    })).statusCode).toBe(200);
+    const afterArchiveDeletion = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${connector.json().token}` },
+      payload: {
+        collections: [{
+          id: collectionId,
+          display_name: "Writing",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    });
+    expect(afterArchiveDeletion.json().collections[0]).toMatchObject({
+      authority_state: "active",
+      authority_epoch: 2
+    });
+
+    const cancellable = await app.inject({
+      method: "POST",
+      url: "/v1/hosted/collections",
+      headers: { cookie },
+      payload: { display_name: "Keep hosted", template: "mdbase" }
+    });
+    const cancellableCollectionId = cancellable.json().collection.id as string;
+    const cancellablePairing = await app.inject({
+      method: "POST",
+      url: "/v1/mirror-pairing-requests",
+      payload: {
+        mirror_name: "Cancelled folder",
+        mode: "read_write",
+        collection_id: cancellableCollectionId
+      }
+    });
+    const cancellablePairingId = cancellablePairing.json().pairing_id as string;
+    const cancellableRefresh = cancellablePairing.json().pairing_secret as string;
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${cancellablePairingId}/approve`,
+      headers: { cookie },
+      payload: { collection_id: cancellableCollectionId }
+    })).statusCode).toBe(200);
+    const cancellableExchange = await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${cancellablePairingId}/exchange`,
+      headers: { authorization: `Bearer ${cancellableRefresh}` }
+    });
+    const cancellableReplicaToken = cancellableExchange.json().token as string;
+    const cancellableRequest = await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${cancellablePairingId}/authority-transfers`,
+      headers: { authorization: `Bearer ${cancellableRefresh}` },
+      payload: {}
+    });
+    const cancellableTransferId = cancellableRequest.json().transfer.id as string;
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/authority-transfers/${cancellableTransferId}/approve`,
+      headers: { cookie },
+      payload: {}
+    })).statusCode).toBe(200);
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/authority-transfers/${cancellableTransferId}/prepare`,
+      headers: { authorization: `Bearer ${cancellableRefresh}` },
+      payload: {}
+    })).statusCode).toBe(200);
+    expect((await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${connector.json().token}` },
+      payload: {
+        collections: [{
+          id: cancellableCollectionId,
+          display_name: "Keep hosted",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    })).json().collections[0].authority_state).toBe("candidate");
+    expect((await app.inject({
+      method: "DELETE",
+      url: `/v1/authority-transfers/${cancellableTransferId}`,
+      headers: { cookie }
+    })).statusCode).toBe(200);
+    const cancelledState = await db.query<{
+      hosted_state: string;
+      local_state: string;
+      enabled: boolean;
+    }>(
+      `SELECT hosted.authority_state AS hosted_state,
+              local.authority_state AS local_state, local.enabled
+       FROM hosted_collections hosted
+       JOIN collections local ON local.local_id = hosted.id
+       WHERE hosted.id = $1`,
+      [cancellableCollectionId]
+    );
+    expect(cancelledState.rows[0]).toMatchObject({
+      hosted_state: "active",
+      local_state: "retired",
+      enabled: false
+    });
+    expect((await app.inject({
+      method: "POST",
+      url: `/v1/hosted/collections/${cancellableCollectionId}/sync/sessions`,
+      headers: { authorization: `Bearer ${cancellableReplicaToken}` }
+    })).statusCode).toBe(200);
+  });
+});

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -91,6 +91,9 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       display_name text NOT NULL,
       spec_version text NOT NULL,
       enabled boolean NOT NULL DEFAULT true,
+      authority_state text NOT NULL DEFAULT 'active'
+        CHECK (authority_state IN ('active', 'candidate', 'retired')),
+      authority_epoch bigint NOT NULL DEFAULT 1,
       contracts jsonb NOT NULL DEFAULT '[]'::jsonb,
       last_seen_at timestamptz NOT NULL DEFAULT now(),
       UNIQUE(connector_id, local_id)
@@ -102,6 +105,10 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       template text NOT NULL,
       provider_url text,
       contracts jsonb NOT NULL DEFAULT '[]'::jsonb,
+      authority_state text NOT NULL DEFAULT 'active'
+        CHECK (authority_state IN ('active', 'transferring', 'transferred')),
+      authority_epoch bigint NOT NULL DEFAULT 1,
+      transferred_collection_id uuid REFERENCES collections(id) ON DELETE SET NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     );
     CREATE TABLE IF NOT EXISTS hosted_replicas (
@@ -185,6 +192,27 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       expires_at timestamptz NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     );
+    CREATE TABLE IF NOT EXISTS authority_transfers (
+      id uuid PRIMARY KEY,
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      hosted_collection_id uuid NOT NULL REFERENCES hosted_collections(id) ON DELETE CASCADE,
+      pairing_id uuid NOT NULL REFERENCES mirror_pairing_requests(id) ON DELETE CASCADE,
+      replica_id uuid NOT NULL REFERENCES hosted_replicas(id) ON DELETE CASCADE,
+      local_collection_id uuid REFERENCES collections(id) ON DELETE SET NULL,
+      state text NOT NULL DEFAULT 'requested'
+        CHECK (state IN ('requested', 'approved', 'prepared', 'completed', 'cancelled', 'expired')),
+      final_head bigint,
+      next_authority_epoch bigint,
+      manifest_digest text,
+      expires_at timestamptz NOT NULL,
+      approved_at timestamptz,
+      prepared_at timestamptz,
+      completed_at timestamptz,
+      cancelled_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE INDEX IF NOT EXISTS authority_transfers_collection_idx
+      ON authority_transfers(hosted_collection_id, state);
     CREATE TABLE IF NOT EXISTS authorization_codes (
       id uuid PRIMARY KEY,
       code_hash text NOT NULL UNIQUE,
@@ -308,6 +336,18 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   );
   await ensureColumn(
     db,
+    "collections",
+    "authority_state",
+    "ALTER TABLE collections ADD COLUMN authority_state text NOT NULL DEFAULT 'active'"
+  );
+  await ensureColumn(
+    db,
+    "collections",
+    "authority_epoch",
+    "ALTER TABLE collections ADD COLUMN authority_epoch bigint NOT NULL DEFAULT 1"
+  );
+  await ensureColumn(
+    db,
     "applications",
     "manifest_version",
     "ALTER TABLE applications ADD COLUMN manifest_version integer NOT NULL DEFAULT 1"
@@ -372,6 +412,24 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "hosted_collections",
     "contracts",
     "ALTER TABLE hosted_collections ADD COLUMN contracts jsonb NOT NULL DEFAULT '[]'::jsonb"
+  );
+  await ensureColumn(
+    db,
+    "hosted_collections",
+    "authority_state",
+    "ALTER TABLE hosted_collections ADD COLUMN authority_state text NOT NULL DEFAULT 'active'"
+  );
+  await ensureColumn(
+    db,
+    "hosted_collections",
+    "authority_epoch",
+    "ALTER TABLE hosted_collections ADD COLUMN authority_epoch bigint NOT NULL DEFAULT 1"
+  );
+  await ensureColumn(
+    db,
+    "hosted_collections",
+    "transferred_collection_id",
+    "ALTER TABLE hosted_collections ADD COLUMN transferred_collection_id uuid"
   );
   await ensureColumn(
     db,
@@ -474,6 +532,27 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "grants_collection_target_check",
     `ALTER TABLE grants ADD CONSTRAINT grants_collection_target_check
      CHECK ((collection_id IS NULL) <> (hosted_collection_id IS NULL))`
+  );
+  await ensureConstraint(
+    db,
+    "hosted_collections",
+    "hosted_collections_transferred_collection_id_fkey",
+    `ALTER TABLE hosted_collections ADD CONSTRAINT hosted_collections_transferred_collection_id_fkey
+     FOREIGN KEY (transferred_collection_id) REFERENCES collections(id) ON DELETE SET NULL`
+  );
+  await ensureConstraint(
+    db,
+    "collections",
+    "collections_authority_state_check",
+    `ALTER TABLE collections ADD CONSTRAINT collections_authority_state_check
+     CHECK (authority_state IN ('active', 'candidate', 'retired'))`
+  );
+  await ensureConstraint(
+    db,
+    "hosted_collections",
+    "hosted_collections_authority_state_check",
+    `ALTER TABLE hosted_collections ADD CONSTRAINT hosted_collections_authority_state_check
+     CHECK (authority_state IN ('active', 'transferring', 'transferred'))`
   );
 }
 

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -32,6 +32,17 @@ export interface HostedReplicaStatus {
   token_expires_at: string;
 }
 
+export interface HostedAuthorityTransfer {
+  id: string;
+  collection_id: string;
+  replica_id: string;
+  final_head: number;
+  authority_epoch: number;
+  manifest_digest: string;
+  state: "prepared" | "completed" | "aborted";
+  expires_at: string;
+}
+
 export class HostedProviderClient {
   readonly url: string;
   private readonly internalToken: string;
@@ -165,6 +176,39 @@ export class HostedProviderClient {
       `/internal/v1/collections/${encodeURIComponent(collectionId)}/compact`,
       { through }
     );
+  }
+
+  async prepareAuthorityTransfer(
+    collectionId: string,
+    input: { transferId: string; replicaId: string; ttlSeconds: number }
+  ): Promise<HostedAuthorityTransfer> {
+    return await this.request(
+      "POST",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/authority-transfers`,
+      {
+        transfer_id: input.transferId,
+        replica_id: input.replicaId,
+        ttl_seconds: input.ttlSeconds
+      }
+    ) as HostedAuthorityTransfer;
+  }
+
+  async completeAuthorityTransfer(
+    transferId: string,
+    manifestDigest: string
+  ): Promise<HostedAuthorityTransfer> {
+    return await this.request(
+      "POST",
+      `/internal/v1/authority-transfers/${encodeURIComponent(transferId)}`,
+      { manifest_digest: manifestDigest }
+    ) as HostedAuthorityTransfer;
+  }
+
+  async abortAuthorityTransfer(transferId: string): Promise<HostedAuthorityTransfer> {
+    return await this.request(
+      "DELETE",
+      `/internal/v1/authority-transfers/${encodeURIComponent(transferId)}`
+    ) as HostedAuthorityTransfer;
   }
 
   private async request(

--- a/services/server/src/hosted.ts
+++ b/services/server/src/hosted.ts
@@ -12,6 +12,10 @@ import {
   type SerializedHostedAuthority,
   type SyncTransport
 } from "@mdbase/connect-sync";
+import {
+  authorityManifestDigest
+} from "@mdbase/connect-sync/node";
+import { createHash } from "node:crypto";
 import type { DatabasePool } from "./db.js";
 
 interface CachedAuthority {
@@ -20,6 +24,17 @@ interface CachedAuthority {
 }
 
 export type HostedTemplate = "mdbase" | "tasknotes";
+
+export interface ReferenceAuthorityTransfer {
+  id: string;
+  collection_id: string;
+  replica_id: string;
+  final_head: number;
+  authority_epoch: number;
+  manifest_digest: string;
+  state: "prepared" | "completed" | "aborted";
+  expires_at: string;
+}
 
 /**
  * Transactional persistence boundary for the sync reference authority.
@@ -79,19 +94,168 @@ export class HostedAuthorityRegistry {
     await this.write(collectionId, (authority) => authority.compactThrough(sequence));
   }
 
+  async prepareAuthorityTransfer(
+    collectionId: string,
+    input: { transferId: string; replicaId: string; ttlSeconds: number }
+  ): Promise<ReferenceAuthorityTransfer> {
+    if (input.ttlSeconds < 60 || input.ttlSeconds > 3_600) {
+      throw new SyncError(
+        "invalid_authority_transfer_ttl",
+        "Authority transfer preparation must expire between one minute and one hour."
+      );
+    }
+    return this.read(collectionId, (authority) => {
+      const state = authority.serialize();
+      const replica = state.replicas.find(({ id }) => id === input.replicaId);
+      if (
+        !replica
+        || replica.revoked
+        || replica.mode !== "read_write"
+        || replica.allowedTypes.length > 0
+      ) {
+        throw new SyncError(
+          "promotion_mirror_ineligible",
+          "Authority can move only to an active, two-way, full collection mirror."
+        );
+      }
+      const digestValue = manifestDigest(state);
+      const expiresAt = new Date(Date.now() + input.ttlSeconds * 1_000).toISOString();
+      return {
+        id: input.transferId,
+        collection_id: collectionId,
+        replica_id: input.replicaId,
+        final_head: state.head,
+        authority_epoch: 2,
+        manifest_digest: digestValue,
+        state: "prepared" as const,
+        expires_at: expiresAt
+      };
+    });
+  }
+
+  async completeAuthorityTransfer(
+    transferId: string,
+    manifestDigestValue: string
+  ): Promise<ReferenceAuthorityTransfer> {
+    const transfer = await this.transfer(transferId);
+    if (transfer.state === "completed") return transfer;
+    if (transfer.state !== "prepared") {
+      throw new SyncError("authority_transfer_inactive", "Authority transfer is no longer active.");
+    }
+    if (transfer.expires_at <= new Date().toISOString()) {
+      throw new SyncError(
+        "authority_transfer_expired",
+        "Authority transfer expired and hosted writes were restored."
+      );
+    }
+    if (transfer.manifest_digest !== manifestDigestValue) {
+      throw new SyncError(
+        "authority_manifest_mismatch",
+        "The local folder does not exactly match the fenced hosted collection."
+      );
+    }
+    await this.write(transfer.collection_id, (authority) => {
+      for (const replica of authority.serialize().replicas) {
+        if (!replica.revoked) authority.revokeReplica(replica.id);
+      }
+    });
+    return { ...transfer, state: "completed" };
+  }
+
+  async abortAuthorityTransfer(transferId: string): Promise<ReferenceAuthorityTransfer> {
+    const transfer = await this.transfer(transferId);
+    if (transfer.state === "completed") {
+      throw new SyncError(
+        "authority_transfer_completed",
+        "Completed authority transfer cannot be cancelled."
+      );
+    }
+    return { ...transfer, state: "aborted" };
+  }
+
   async transport(collectionId: string, replicaId: string): Promise<SyncTransport> {
     return {
-      openSession: () => this.read(collectionId, (authority) => authority.transport(replicaId).openSession()),
-      snapshot: (snapshotId, page) => this.read(
-        collectionId,
-        (authority) => authority.transport(replicaId).snapshot(snapshotId, page)
-      ),
-      changes: (after, limit) => this.read(
-        collectionId,
-        (authority) => authority.transport(replicaId).changes(after, limit)
-      ),
-      mutate: (mutation) => this.write(collectionId, (authority) => authority.transport(replicaId).mutate(mutation))
+      openSession: async () => {
+        await this.assertTransferReadAllowed(collectionId, replicaId);
+        return this.read(collectionId, (authority) => authority.transport(replicaId).openSession());
+      },
+      snapshot: async (snapshotId, page) => {
+        await this.assertTransferReadAllowed(collectionId, replicaId);
+        return this.read(
+          collectionId,
+          (authority) => authority.transport(replicaId).snapshot(snapshotId, page)
+        );
+      },
+      changes: async (after, limit) => {
+        await this.assertTransferReadAllowed(collectionId, replicaId);
+        return this.read(
+          collectionId,
+          (authority) => authority.transport(replicaId).changes(after, limit)
+        );
+      },
+      mutate: async (mutation) => {
+        if (await this.activeTransfer(collectionId)) {
+          throw new SyncError(
+            "authority_transfer_in_progress",
+            "Hosted writes are fenced while authority moves to the local collection."
+          );
+        }
+        return this.write(
+          collectionId,
+          (authority) => authority.transport(replicaId).mutate(mutation)
+        );
+      }
     };
+  }
+
+  private async assertTransferReadAllowed(collectionId: string, replicaId: string): Promise<void> {
+    const transfer = await this.activeTransfer(collectionId);
+    if (transfer && transfer.replica_id !== replicaId) {
+      throw new SyncError(
+        "authority_transfer_in_progress",
+        "Only the promotion mirror can read while authority is moving."
+      );
+    }
+  }
+
+  private async activeTransfer(collectionId: string): Promise<ReferenceAuthorityTransfer | null> {
+    await this.db.query(
+      `UPDATE authority_transfers SET state = 'expired'
+       WHERE hosted_collection_id = $1 AND state = 'prepared' AND expires_at <= now()`,
+      [collectionId]
+    );
+    await this.db.query(
+      `UPDATE hosted_collections SET authority_state = 'active'
+       WHERE id = $1 AND authority_state = 'transferring'
+         AND NOT EXISTS (
+           SELECT 1 FROM authority_transfers
+           WHERE hosted_collection_id = $1 AND state = 'prepared' AND expires_at > now()
+         )`,
+      [collectionId]
+    );
+    const result = await this.db.query<ReferenceTransferRow>(
+      `SELECT id, hosted_collection_id, replica_id, final_head, next_authority_epoch,
+              manifest_digest, state, expires_at
+       FROM authority_transfers
+       WHERE hosted_collection_id = $1 AND state = 'prepared' AND expires_at > now()
+       ORDER BY created_at DESC LIMIT 1`,
+      [collectionId]
+    );
+    return result.rows[0] ? referenceTransfer(result.rows[0]) : null;
+  }
+
+  private async transfer(transferId: string): Promise<ReferenceAuthorityTransfer> {
+    const result = await this.db.query<ReferenceTransferRow>(
+      `SELECT id, hosted_collection_id, replica_id, final_head, next_authority_epoch,
+              manifest_digest, state, expires_at
+       FROM authority_transfers WHERE id = $1`,
+      [transferId]
+    );
+    const row = result.rows[0];
+    if (!row || row.final_head === null || row.next_authority_epoch === null || !row.manifest_digest) {
+      throw new SyncError("authority_transfer_not_found", "Authority transfer was not found.");
+    }
+    return referenceTransfer(row);
   }
 
   private read<Result>(
@@ -173,6 +337,50 @@ export class HostedAuthorityRegistry {
     this.cache.set(collectionId, cached);
     return cached;
   }
+}
+
+interface ReferenceTransferRow {
+  id: string;
+  hosted_collection_id: string;
+  replica_id: string;
+  final_head: string | number | null;
+  next_authority_epoch: string | number | null;
+  manifest_digest: string | null;
+  state: "prepared" | "completed" | "cancelled" | "expired";
+  expires_at: string | Date;
+}
+
+function referenceTransfer(row: ReferenceTransferRow): ReferenceAuthorityTransfer {
+  return {
+    id: row.id,
+    collection_id: row.hosted_collection_id,
+    replica_id: row.replica_id,
+    final_head: Number(row.final_head),
+    authority_epoch: Number(row.next_authority_epoch),
+    manifest_digest: row.manifest_digest ?? "",
+    state: row.state === "completed"
+      ? "completed"
+      : row.state === "prepared"
+        ? "prepared"
+        : "aborted",
+    expires_at: new Date(row.expires_at).toISOString()
+  };
+}
+
+function manifestDigest(state: SerializedHostedAuthority): string {
+  const digest = (document: string) => createHash("sha256").update(document).digest("hex");
+  return authorityManifestDigest([
+    ...(state.resources?.documents ?? []).map((resource) => ({
+      kind: "resource" as const,
+      path: resource.path,
+      document_hash: digest(resource.document)
+    })),
+    ...state.records.map((record) => ({
+      kind: "record" as const,
+      path: record.path,
+      document_hash: record.revision
+    }))
+  ]);
 }
 
 function authorityOptions(resources: SyncCollectionResources) {

--- a/services/server/vitest.config.ts
+++ b/services/server/vitest.config.ts
@@ -3,10 +3,20 @@ import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   resolve: {
-    alias: {
-      "@mdbase/connect-sync": fileURLToPath(new URL("../../packages/sync/src/index.ts", import.meta.url)),
-      "@mdbase/connect-webhooks": fileURLToPath(new URL("../../packages/webhooks/src/index.ts", import.meta.url))
-    }
+    alias: [
+      {
+        find: "@mdbase/connect-sync/node",
+        replacement: fileURLToPath(new URL("../../packages/sync/src/node.ts", import.meta.url))
+      },
+      {
+        find: /^@mdbase\/connect-sync$/,
+        replacement: fileURLToPath(new URL("../../packages/sync/src/index.ts", import.meta.url))
+      },
+      {
+        find: "@mdbase/connect-webhooks",
+        replacement: fileURLToPath(new URL("../../packages/webhooks/src/index.ts", import.meta.url))
+      }
+    ]
   },
   test: { include: ["src/**/*.test.ts"] }
 });


### PR DESCRIPTION
## Summary

- add mdbase-mirror promote with exact final sync proof, durable crash-resume checkpointing, and local-agent materialization
- add browser confirmation plus authority epochs, local candidates, hosted retirement, and grant/token/replica revocation
- add provider fencing, retry-safe completion, cancellation/expiry recovery, and cross-language manifest verification
- retain the hosted copy until explicit deletion and preserve the local epoch afterward

## Verification

- cargo fmt --all -- --check
- cargo test --workspace
- pnpm typecheck
- pnpm test
- pnpm e2e
- pnpm e2e:sync
- pnpm e2e:relay
- pnpm e2e:provider (PostgreSQL 18, Chromium, forced CLI interruption/resume, fencing, proof rejection, completion retry, cancellation recovery)