### PR TITLE
Harden large authority transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e:relay": "pnpm build && node scripts/relay-e2e.mjs",
     "e2e:sync": "pnpm build && node scripts/sync-e2e.mjs",
     "e2e:provider": "pnpm build && cargo build -p mdbase-connect-hosted-provider && node scripts/hosted-provider-e2e.mjs",
+    "e2e:authority:stress": "MDBASE_CONNECT_PROVIDER_E2E_PROMOTION_COUNT=2500 pnpm e2e:provider",
     "e2e:provider:stress": "MDBASE_CONNECT_PROVIDER_E2E_BULK_COUNT=10000 pnpm e2e:provider",
     "package:audit": "pnpm build && node scripts/package-audit.mjs",
     "package:consumer": "node scripts/pack-consumer-sdk.mjs",

--- a/packages/sync/src/cli.ts
+++ b/packages/sync/src/cli.ts
@@ -9,6 +9,7 @@ import { HttpSyncTransport } from "./index.js";
 import {
   DirectoryMirror,
   WritableDirectoryMirror,
+  type MirrorProgress,
   type MirrorStatus
 } from "./node.js";
 import {
@@ -184,9 +185,49 @@ function mirrorFor(root: string, configuration: StoredMirrorProfile) {
     configuration.profile.collection_id,
     configuration.credentials.access_token
   );
+  const options = { onProgress: mirrorProgressReporter() };
   return configuration.profile.mode === "read_write"
-    ? new WritableDirectoryMirror(root, configuration.profile.replica_id, transport)
-    : new DirectoryMirror(root, configuration.profile.replica_id, transport);
+    ? new WritableDirectoryMirror(root, configuration.profile.replica_id, transport, options)
+    : new DirectoryMirror(root, configuration.profile.replica_id, transport, options);
+}
+
+function mirrorProgressReporter(): (progress: MirrorProgress) => void {
+  let lastPhase: MirrorProgress["phase"] | null = null;
+  let lastTotal: number | null = null;
+  let lastCompleted = 0;
+  return (progress) => {
+    if (
+      progress.phase !== lastPhase
+      || progress.total !== lastTotal
+      || progress.completed < lastCompleted
+    ) {
+      lastPhase = progress.phase;
+      lastTotal = progress.total;
+      lastCompleted = 0;
+    }
+    const interval = progress.total === null
+      ? 200
+      : Math.max(1, Math.ceil(progress.total / 10));
+    const atUnfinishedKnownEnd = progress.total !== null
+      && progress.completed === progress.total
+      && !progress.done;
+    if (
+      atUnfinishedKnownEnd
+      || (
+        !progress.done
+        && progress.completed !== 1
+        && progress.completed - lastCompleted < interval
+      )
+    ) return;
+    const label = progress.phase === "uploading"
+      ? "Uploading local changes"
+      : "Applying synchronized documents";
+    const count = progress.total === null
+      ? `${progress.completed} applied`
+      : `${progress.completed}/${progress.total}`;
+    process.stdout.write(`${label}: ${count}${progress.done ? " complete" : ""}.\n`);
+    lastCompleted = progress.completed;
+  };
 }
 
 async function currentProfile(root: string): Promise<StoredMirrorProfile> {

--- a/packages/sync/src/node.test.ts
+++ b/packages/sync/src/node.test.ts
@@ -10,7 +10,8 @@ import {
   MirrorDivergenceError,
   WritableDirectoryMirror,
   type DirectoryMirrorOptions,
-  type MirrorFileSystem
+  type MirrorFileSystem,
+  type MirrorProgress
 } from "./node.js";
 
 function deviceState(): DirectoryMirrorOptions {
@@ -36,6 +37,15 @@ class MemoryMirrorFileSystem implements MirrorFileSystem {
     return [...this.files.keys()]
       .filter((path) => path.endsWith(".md") && !excluded.has(path))
       .sort();
+  }
+}
+
+class CountingMirrorStateStore extends MemoryMirrorStateStore {
+  writes = 0;
+
+  override async write(state: Parameters<MemoryMirrorStateStore["write"]>[0]): Promise<void> {
+    this.writes += 1;
+    await super.write(state);
   }
 }
 
@@ -211,6 +221,19 @@ describe("writable Markdown mirror", () => {
         document_hash: "00".repeat(32)
       }
     ])).toBe("c3a6c98f15ed143bf4b9642e32c9f4c775ca8ad4978a42a4dbd69f79f6fc5e0f");
+
+    expect(authorityManifestDigest([
+      {
+        kind: "record",
+        path: "zulu.md",
+        document_hash: "aa".repeat(32)
+      },
+      {
+        kind: "record",
+        path: "äther.md",
+        document_hash: "bb".repeat(32)
+      }
+    ])).toBe("5f1f72e19ba871d569231de5cd71a4e1703fbc28e39d9357081f1a870d1fc7a9");
 
     const hosted = new MemoryHostedAuthority({
       resources: {
@@ -631,6 +654,77 @@ describe("writable Markdown mirror", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("checkpoints large imports in bounded batches and safely replays an interrupted batch", async () => {
+    const hosted = new MemoryHostedAuthority();
+    const replicaId = hosted.registerReplica({
+      name: "Large writable mirror",
+      mode: "read_write"
+    });
+    const upstream = hosted.transport(replicaId);
+    const fileSystem = new MemoryMirrorFileSystem();
+    const stateStore = new CountingMirrorStateStore();
+    const progress: MirrorProgress[] = [];
+    let mutationCalls = 0;
+    let loseResponseAt = 95;
+    const unreliable = {
+      openSession: () => upstream.openSession(),
+      snapshot: (snapshotId: string, page?: string) => upstream.snapshot(snapshotId, page),
+      changes: (after: number, limit?: number) => upstream.changes(after, limit),
+      async mutate(mutation: Parameters<typeof upstream.mutate>[0]) {
+        const receipt = await upstream.mutate(mutation);
+        mutationCalls += 1;
+        if (mutationCalls === loseResponseAt) {
+          loseResponseAt = -1;
+          throw new Error("connection reset after a checkpointed server commit");
+        }
+        return receipt;
+      }
+    };
+    const mirror = new WritableDirectoryMirror(".", replicaId, unreliable, {
+      fileSystem,
+      stateStore,
+      onProgress: (event) => progress.push(event)
+    });
+    await mirror.sync();
+    for (let index = 0; index < 150; index += 1) {
+      fileSystem.files.set(
+        `bulk-${String(index).padStart(3, "0")}.md`,
+        `---\ntype: note\ntitle: Bulk ${index}\n---\nLocal body ${index}\n`
+      );
+    }
+
+    await expect(mirror.sync()).rejects.toThrow(
+      "connection reset after a checkpointed server commit"
+    );
+    await mirror.sync();
+
+    const session = await upstream.openSession();
+    const snapshot = await upstream.snapshot(session.snapshot_id);
+    expect(snapshot.records).toHaveLength(100);
+    const secondPage = await upstream.snapshot(session.snapshot_id, snapshot.next_page);
+    expect(secondPage.records).toHaveLength(50);
+    expect(await mirror.status()).toMatchObject({ state: "up_to_date", pending: 0 });
+    expect(stateStore.writes).toBeLessThan(15);
+    expect(progress).toContainEqual({
+      phase: "uploading",
+      completed: 94,
+      total: 150,
+      done: false
+    });
+    expect(progress).toContainEqual({
+      phase: "uploading",
+      completed: 86,
+      total: 86,
+      done: true
+    });
+    expect(progress).toContainEqual({
+      phase: "applying",
+      completed: 150,
+      total: null,
+      done: true
+    });
   });
 
   it("never treats schema resources as writable record changes", async () => {

--- a/packages/sync/src/node.ts
+++ b/packages/sync/src/node.ts
@@ -30,6 +30,8 @@ interface PendingMirrorMutation {
   local_hash: string | null;
 }
 
+const MIRROR_MUTATION_CHECKPOINT_SIZE = 64;
+
 export interface MirrorState {
   protocol_version: 1;
   replica_id: string;
@@ -51,6 +53,14 @@ export interface MirrorStateStore {
 export interface DirectoryMirrorOptions {
   stateStore?: MirrorStateStore;
   fileSystem?: MirrorFileSystem;
+  onProgress?: (progress: MirrorProgress) => void;
+}
+
+export interface MirrorProgress {
+  phase: "uploading" | "applying";
+  completed: number;
+  total: number | null;
+  done: boolean;
 }
 
 export interface MirrorFileSystem {
@@ -255,6 +265,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
   private readonly root: string;
   private readonly stateStore: MirrorStateStore;
   private readonly fileSystem: MirrorFileSystem;
+  private readonly onProgress?: (progress: MirrorProgress) => void;
 
   constructor(
     root: string,
@@ -266,6 +277,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     this.root = resolve(root);
     this.stateStore = options.stateStore ?? new NodeMirrorStateStore(this.root);
     this.fileSystem = options.fileSystem ?? new NodeMirrorFileSystem(this.root);
+    this.onProgress = options.onProgress;
   }
 
   async sync(): Promise<void> {
@@ -285,6 +297,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     } else {
       await this.assertUndiverged(state);
     }
+    let appliedDocuments = 0;
     while (true) {
       const page = await this.transport.changes(state.cursor, 200);
       if (page.scope_epoch !== state.scope_epoch || page.reset_required) {
@@ -300,12 +313,27 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
         } else {
           await this.remove(state, event.record_id, event.previous_path);
         }
+        appliedDocuments += 1;
+        this.reportProgress({
+          phase: "applying",
+          completed: appliedDocuments,
+          total: null,
+          done: false
+        });
       }
       state.cursor = page.cursor;
       await this.writeState(state);
       if (!page.has_more) {
         state.last_synced_at = new Date().toISOString();
         await this.writeState(state);
+        if (appliedDocuments > 0) {
+          this.reportProgress({
+            phase: "applying",
+            completed: appliedDocuments,
+            total: null,
+            done: true
+          });
+        }
         return;
       }
     }
@@ -462,10 +490,28 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
       conflicts: {}
     };
     await this.assertRebuildSafe(prior, session.resources.documents ?? [], records);
+    const documentCount = (session.resources.documents ?? []).length + records.length;
+    let appliedDocuments = 0;
     for (const resource of session.resources.documents ?? []) {
       await this.putResource(state, resource, prior);
+      appliedDocuments += 1;
+      this.reportProgress({
+        phase: "applying",
+        completed: appliedDocuments,
+        total: documentCount,
+        done: appliedDocuments === documentCount
+      });
     }
-    for (const record of records) await this.put(state, record, prior);
+    for (const record of records) {
+      await this.put(state, record, prior);
+      appliedDocuments += 1;
+      this.reportProgress({
+        phase: "applying",
+        completed: appliedDocuments,
+        total: documentCount,
+        done: appliedDocuments === documentCount
+      });
+    }
     if (prior) {
       for (const [recordId, entry] of Object.entries(prior.records)) {
         if (!state.records[recordId]) await this.remove(prior, recordId, entry.path);
@@ -554,7 +600,8 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     state: MirrorState,
     record: SyncRecord<Frontmatter>,
     managedState: MirrorState | undefined = state,
-    acceptedHash?: string | null
+    acceptedHash?: string | null,
+    preserveAcceptedDocument = false
   ): Promise<void> {
     const document = recordMarkdownDocument(record);
     const existing = await this.fileSystem.read(record.path);
@@ -571,11 +618,17 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     if (prior && prior.path !== record.path) {
       await this.remove(managedState!, record.record_id, prior.path);
     }
-    await this.fileSystem.write(record.path, document);
+    const acceptedLocalHash = preserveAcceptedDocument
+      && typeof acceptedHash === "string"
+      && existing !== null
+      && digest(existing) === acceptedHash
+      ? acceptedHash
+      : null;
+    if (acceptedLocalHash === null) await this.fileSystem.write(record.path, document);
     state.records[record.record_id] = {
       path: record.path,
       revision: record.revision,
-      hash: digest(document),
+      hash: acceptedLocalHash ?? digest(document),
       record
     };
   }
@@ -913,6 +966,11 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
   private async flushPending(state: MirrorState): Promise<void> {
     const pendingQueue = state.pending ??= [];
     let index = 0;
+    let mutationsSinceCheckpoint = 0;
+    const uploadTotal = pendingQueue.filter(
+      (pending) => !state.conflicts?.[pending.mutation.record_id]
+    ).length;
+    let uploaded = 0;
     while (index < pendingQueue.length) {
       const pending = pendingQueue[index]!;
       if (state.conflicts?.[pending.mutation.record_id]) {
@@ -928,13 +986,21 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
         );
       }
       const receipt = await this.transport.mutate(pending.mutation);
+      uploaded += 1;
+      this.reportProgress({
+        phase: "uploading",
+        completed: uploaded,
+        total: uploadTotal,
+        done: false
+      });
       if (receipt.status === "applied" || receipt.status === "previously_applied") {
         if (receipt.record) {
           await this.put(
             state,
             receipt.record,
             state,
-            pending.local_hash
+            pending.local_hash,
+            true
           );
         } else {
           delete state.records[pending.mutation.record_id];
@@ -951,13 +1017,30 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
           }
         }
         pendingQueue.splice(index, 1);
-        await this.writeState(state);
+        mutationsSinceCheckpoint += 1;
+        if (mutationsSinceCheckpoint >= MIRROR_MUTATION_CHECKPOINT_SIZE) {
+          await this.writeState(state);
+          mutationsSinceCheckpoint = 0;
+        }
         continue;
       }
       state.conflicts ??= {};
       state.conflicts[pending.mutation.record_id] = receipt;
-      await this.writeState(state);
+      mutationsSinceCheckpoint += 1;
+      if (mutationsSinceCheckpoint >= MIRROR_MUTATION_CHECKPOINT_SIZE) {
+        await this.writeState(state);
+        mutationsSinceCheckpoint = 0;
+      }
       index += 1;
+    }
+    if (mutationsSinceCheckpoint > 0) await this.writeState(state);
+    if (uploadTotal > 0) {
+      this.reportProgress({
+        phase: "uploading",
+        completed: uploaded,
+        total: uploadTotal,
+        done: true
+      });
     }
   }
 
@@ -1008,6 +1091,10 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
 
   private async writeState(state: MirrorState): Promise<void> {
     await this.stateStore.write(state);
+  }
+
+  private reportProgress(progress: MirrorProgress): void {
+    this.onProgress?.(progress);
   }
 
   private async assertUndiverged(state: MirrorState): Promise<void> {
@@ -1125,9 +1212,10 @@ export function authorityManifestDigest(entries: Array<{
   document_hash: string;
 }>): string {
   const manifest = createHash("sha256").update("mdbase-authority-manifest-v1\n");
-  for (const entry of [...entries].sort((left, right) =>
-    left.kind.localeCompare(right.kind) || left.path.localeCompare(right.path)
-  )) {
+  for (const entry of [...entries].sort((left, right) => {
+    if (left.kind !== right.kind) return left.kind < right.kind ? -1 : 1;
+    return Buffer.compare(Buffer.from(left.path, "utf8"), Buffer.from(right.path, "utf8"));
+  })) {
     manifest.update(entry.kind);
     manifest.update("\0");
     manifest.update(entry.path);

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1,9 +1,20 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdtemp, readFile, rename, rm, stat, symlink, unlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  symlink,
+  unlink,
+  writeFile
+} from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { chromium, expect } from "@playwright/test";
 
@@ -1743,6 +1754,22 @@ async function authorityPromotionCliE2E(
     ?? await new Promise((resolveExit) => connectProcess.once("exit", resolveExit));
   assert.equal(connectExit, 0, `Promotion mirror connect failed:\n${connectError}\n${connectOutput}`);
 
+  const promotionStressCount = Number(
+    process.env.MDBASE_CONNECT_PROVIDER_E2E_PROMOTION_COUNT ?? 0
+  );
+  assert.ok(
+    Number.isInteger(promotionStressCount)
+      && (promotionStressCount === 0 || promotionStressCount >= 205)
+      && promotionStressCount <= 20_000
+  );
+  const promotionStress = promotionStressCount > 0
+    ? await prepareAuthorityPromotionStressFixture(
+        mirrorCli,
+        mirrorDirectory,
+        promotionStressCount
+      )
+    : null;
+
   const connector = await controlRequest(controlUrl, "/v1/connectors", cookie, {
     method: "POST",
     body: { name: "Promotion computer" }
@@ -1888,6 +1915,21 @@ process.stdout.write(JSON.stringify({
   );
   assert.equal(authorityReceipt.collection_id, collectionId);
   assert.equal(authorityReceipt.authority_epoch, 2);
+  if (promotionStress) {
+    assert.equal(await countMarkdownFiles(mirrorDirectory), promotionStress.expectedCount);
+    assert.match(
+      await readFile(join(mirrorDirectory, promotionStress.updatedPath), "utf8"),
+      /Updated during authority stress wave/
+    );
+    await assert.rejects(
+      () => readFile(join(mirrorDirectory, promotionStress.deletedPath), "utf8"),
+      { code: "ENOENT" }
+    );
+    assert.match(
+      await readFile(join(mirrorDirectory, promotionStress.addedPath), "utf8"),
+      /Added during authority stress wave/
+    );
+  }
   const state = await database.query(
     `SELECT hosted.authority_state AS hosted_state,
             local.authority_state AS local_state,
@@ -1911,6 +1953,181 @@ process.stdout.write(JSON.stringify({
       authority_epoch: 2
     }
   );
+}
+
+async function prepareAuthorityPromotionStressFixture(
+  mirrorCli,
+  mirrorDirectory,
+  recordCount
+) {
+  phase(`preparing ${recordCount} complex documents for authority promotion`);
+  const started = performance.now();
+  const paths = Array.from(
+    { length: recordCount },
+    (_, index) => authorityStressPath(index)
+  );
+  await writeFilesInBatches(paths, 64, async (path, index) => {
+    const absolutePath = join(mirrorDirectory, path);
+    await mkdir(dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, authorityStressDocument(index));
+  });
+  await syncPromotionMirror(mirrorCli, mirrorDirectory);
+
+  const updateIndexes = paths
+    .map((_, index) => index)
+    .filter((index) => index >= 4 && index % 47 === 0);
+  await writeFilesInBatches(updateIndexes, 64, async (index) => {
+    const absolutePath = join(mirrorDirectory, paths[index]);
+    const document = await readFile(absolutePath, "utf8");
+    await writeFile(
+      absolutePath,
+      `${document}\nUpdated during authority stress wave ${index}.\n`
+    );
+  });
+  await syncPromotionMirror(mirrorCli, mirrorDirectory);
+
+  const renameIndexes = paths
+    .map((_, index) => index)
+    .filter((index) => index >= 4 && index % 83 === 0);
+  for (const index of renameIndexes) {
+    const nextPath = paths[index].replace(/\.md$/, "-renamed.md");
+    await rename(join(mirrorDirectory, paths[index]), join(mirrorDirectory, nextPath));
+    paths[index] = nextPath;
+  }
+  await syncPromotionMirror(mirrorCli, mirrorDirectory);
+
+  const deleteIndexes = paths
+    .map((_, index) => index)
+    .filter((index) => index >= 4 && index % 101 === 0);
+  const deletedPath = paths[deleteIndexes[0]];
+  for (const index of deleteIndexes) {
+    await unlink(join(mirrorDirectory, paths[index]));
+  }
+  await syncPromotionMirror(mirrorCli, mirrorDirectory);
+
+  const addedCount = Math.min(25, Math.max(1, Math.ceil(recordCount / 200)));
+  const addedPaths = Array.from(
+    { length: addedCount },
+    (_, index) => `stress/late-arrivals/added-${String(index).padStart(3, "0")}.md`
+  );
+  await writeFilesInBatches(addedPaths, 64, async (path, index) => {
+    const absolutePath = join(mirrorDirectory, path);
+    await mkdir(dirname(absolutePath), { recursive: true });
+    await writeFile(
+      absolutePath,
+      `${authorityStressDocument(recordCount + index)}\nAdded during authority stress wave.\n`
+    );
+  });
+  await syncPromotionMirror(mirrorCli, mirrorDirectory);
+
+  const expectedCount = recordCount - deleteIndexes.length + addedCount;
+  assert.equal(await countMarkdownFiles(mirrorDirectory), expectedCount);
+  phase(
+    `authority promotion stress fixture converged at ${expectedCount} documents `
+      + `in ${Math.round(performance.now() - started)}ms`
+  );
+  return {
+    addedPath: addedPaths[0],
+    deletedPath,
+    expectedCount,
+    updatedPath: paths[updateIndexes[0]]
+  };
+}
+
+function authorityStressPath(index) {
+  const sentinels = [
+    "stress/ordering/zulu.md",
+    "stress/ordering/äther.md",
+    "stress/ordering/東京.md",
+    "stress/ordering/🧪-experiment.md"
+  ];
+  if (index < sentinels.length) return sentinels[index];
+  return [
+    "stress",
+    "deep",
+    `group-${String(index % 32).padStart(2, "0")}`,
+    `chapter-${String(Math.floor(index / 256)).padStart(2, "0")}`,
+    `record-${String(index).padStart(5, "0")}.md`
+  ].join("/");
+}
+
+function authorityStressDocument(index) {
+  const title = `Complex record ${index} — ${index % 2 === 0 ? "東京" : "naïve 🧪"}`;
+  return `---
+title: ${JSON.stringify(title)}
+category: research
+sequence: ${index}
+active: ${index % 7 !== 0}
+tags:
+  - authority-stress
+  - cohort-${index % 13}
+metadata:
+  owner:
+    name: ${JSON.stringify(`Researcher ${index % 17}`)}
+    locale: ${JSON.stringify(index % 2 === 0 ? "ja-JP" : "fr-FR")}
+  metrics:
+    confidence: ${((index % 100) / 100).toFixed(2)}
+    samples: [${index}, ${index + 1}, ${index + 2}]
+  reviewers:
+    - name: Reviewer A
+      approved: ${index % 3 === 0}
+    - name: Reviewer B
+      approved: ${index % 5 === 0}
+related:
+  - "[[stress/ordering/zulu]]"
+  - "[[stress/ordering/äther]]"
+---
+# ${title}
+
+This is a nested, Unicode-rich authority transfer fixture.
+
+| measure | value |
+| --- | ---: |
+| index | ${index} |
+| square | ${index * index} |
+
+\`\`\`json
+{"index":${index},"flags":[true,false,null],"label":${JSON.stringify(title)}}
+\`\`\`
+`;
+}
+
+async function syncPromotionMirror(mirrorCli, mirrorDirectory) {
+  await execute(process.execPath, [mirrorCli, "sync", mirrorDirectory]);
+  const status = JSON.parse(
+    (await execute(process.execPath, [
+      mirrorCli,
+      "status",
+      mirrorDirectory,
+      "--json"
+    ])).stdout
+  );
+  assert.equal(status.state, "up_to_date");
+  assert.equal(status.pending, 0);
+  assert.deepEqual(status.conflicts, []);
+}
+
+async function writeFilesInBatches(values, batchSize, action) {
+  for (let start = 0; start < values.length; start += batchSize) {
+    await Promise.all(
+      values
+        .slice(start, start + batchSize)
+        .map((value, offset) => action(value, start + offset))
+    );
+  }
+}
+
+async function countMarkdownFiles(root) {
+  let count = 0;
+  const visit = async (directory) => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile() && entry.name.endsWith(".md")) count += 1;
+    }
+  };
+  await visit(root);
+  return count;
 }
 
 async function authorizeHostedApplication(authorizationUrl, cookie, collectionId, callbackOrigin) {


### PR DESCRIPTION
## What changed

- make authority manifest ordering match the provider bytewise UTF-8 ordering, including Unicode paths
- checkpoint large writable uploads in bounded batches while preserving idempotent crash recovery
- expose bounded sync progress and print concise CLI checkpoints during long uploads and materialization
- add an opt-in 2,500-document PostgreSQL/browser authority-transfer stress target with nested metadata, Unicode paths, and update, rename, delete, and add waves

## Why

Large mirror imports rewrote the full durable mirror-state JSON after every mutation, making the flow unnecessarily slow. JavaScript locale ordering could also disagree with the Rust provider for Unicode paths, causing valid promotion manifests to fail. Long CLI syncs provided little indication that work was continuing.

## Validation

- pnpm test
- pnpm typecheck
- cargo test --workspace
- pnpm e2e
- pnpm e2e:sync
- pnpm e2e:relay
- pnpm e2e:authority:stress (2,500 initial complex documents; 2,489 after mutation waves; browser-confirmed handoff; 110.7s fixture convergence)