### PR TITLE
Enable hosted collections for portable apps

### DIFF
--- a/apps/portal/src/compatibility.ts
+++ b/apps/portal/src/compatibility.ts
@@ -17,14 +17,6 @@ export function collectionCompatibility(
   request: Pick<PendingAuthorization, "distribution" | "requirements" | "provisions" | "requested_operations">,
   collection: AvailableCollection
 ): CollectionCompatibility {
-  if (request.distribution === "portable" && collection.kind !== "local") {
-    return {
-      compatible: false,
-      code: "collection_kind",
-      label: "Computer-owned collection required",
-      detail: "Downloaded applications currently connect only through your local mdbase connector."
-    };
-  }
   if (request.requirements.collection_kind === "hosted" && collection.kind !== "hosted") {
     return {
       compatible: false,

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -1225,7 +1225,7 @@ function ApprovalForm({
           <p className="eyebrow">Downloaded file, unverified origin</p>
           <strong>Only continue if you intentionally opened this HTML file.</strong>
         </div>
-        {request.user_code && <p>Confirm that it shows <code>{request.user_code}</code>. The code binds this approval to the file’s temporary encryption key.</p>}
+        {request.user_code && <p>Confirm that it shows <code>{request.user_code}</code>. The code binds this approval to the file’s one-time device request.</p>}
         <p>{request.project_url
           ? `${host(request.project_url)} is a developer-supplied project link, not proof that the downloaded file came from that site.`
           : "A downloaded file has no website origin that mdbase can verify."}</p>
@@ -1250,16 +1250,13 @@ function ApprovalForm({
             <ul>{unavailable.map(({ collection, compatibility }) => <li key={collection.id}><span>{collection.display_name}</span><small>{compatibility.compatible ? "" : compatibility.detail}</small></li>)}</ul>
           </details>}
           {compatible.length === 0 && <div className="authorization-empty-collection">
-            <p className="field-note">{request.distribution === "portable"
-              ? "No compatible computer-owned collection is currently available through mdbase connect."
-              : "No compatible collection is ready."}</p>
-            {request.distribution !== "portable" &&
+            <p className="field-note">No compatible collection is ready.</p>
             <button
               className="button secondary"
               type="button"
               disabled={submitting !== null}
               onClick={() => void createCloudCollection()}
-            >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>}
+            >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>
           </div>}
           {setup.length > 0 && <p className="field-note">Setup needed: allowing access will add {provisionNames(setup)} to this hosted collection.</p>}
         </div>
@@ -1280,7 +1277,7 @@ function ApprovalForm({
       {error && <div className="message error compact">{error}</div>}
       <footer className="approval-footer">
         <p>{selected
-          ? `${request.application_name} will use ${selected.display_name} through ${selected.connector_name}. ${request.distribution === "portable" ? "The local connector checks every encrypted operation." : "Access lasts until you revoke it."}`
+          ? `${request.application_name} will use ${selected.display_name} through ${selected.connector_name}. Every operation is checked against this grant, and access lasts until you revoke it.`
           : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
         <div className="approval-actions">
           <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -3774,24 +3774,26 @@ fn validate_replica_capability(input: &RegisterReplica) -> ApiResult<()> {
                 &input.allowed_operations,
             )?;
             if let Some(origin) = input.allowed_origin.as_deref() {
-                let url = url::Url::parse(origin).map_err(|_| {
-                    ApiError::bad_request(
-                        "invalid_application_origin",
-                        "Application origin must be an absolute HTTP(S) origin.",
-                    )
-                })?;
-                if !matches!(url.scheme(), "http" | "https")
-                    || !url.username().is_empty()
-                    || url.password().is_some()
-                    || url.path() != "/"
-                    || url.query().is_some()
-                    || url.fragment().is_some()
-                    || url.origin().ascii_serialization() != origin
-                {
-                    return Err(ApiError::bad_request(
-                        "invalid_application_origin",
-                        "Application origin must be a canonical HTTP(S) origin.",
-                    ));
+                if origin != "null" {
+                    let url = url::Url::parse(origin).map_err(|_| {
+                        ApiError::bad_request(
+                            "invalid_application_origin",
+                            "Application origin must be `null` or an absolute HTTP(S) origin.",
+                        )
+                    })?;
+                    if !matches!(url.scheme(), "http" | "https")
+                        || !url.username().is_empty()
+                        || url.password().is_some()
+                        || url.path() != "/"
+                        || url.query().is_some()
+                        || url.fragment().is_some()
+                        || url.origin().ascii_serialization() != origin
+                    {
+                        return Err(ApiError::bad_request(
+                            "invalid_application_origin",
+                            "Application origin must be `null` or a canonical HTTP(S) origin.",
+                        ));
+                    }
                 }
             }
         }
@@ -4154,6 +4156,31 @@ mod tests {
             token_ttl_seconds: Some(3600),
         };
         validate_replica_capability(&capability).unwrap();
+        let mut portable_capability = capability.clone();
+        portable_capability.allowed_origin = Some("null".to_string());
+        validate_replica_capability(&portable_capability).unwrap();
+        let portable_replica = Replica {
+            id: portable_capability.replica_id,
+            purpose: portable_capability.purpose,
+            mode: portable_capability.mode,
+            allowed_types: portable_capability.allowed_types,
+            full_collection: portable_capability.full_collection,
+            allowed_operations: portable_capability.allowed_operations,
+            allowed_origin: portable_capability.allowed_origin,
+            grant_id: portable_capability.grant_id,
+            scope_epoch: 1,
+        };
+        authorize_application_operation(&portable_replica, "query", Some("null")).unwrap();
+        assert_eq!(
+            authorize_application_operation(
+                &portable_replica,
+                "query",
+                Some("https://tasks.example")
+            )
+            .unwrap_err()
+            .code,
+            "origin_denied"
+        );
         let mut missing_grant = capability.clone();
         missing_grant.grant_id = None;
         assert_eq!(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,9 +198,11 @@ Downloaded HTML applications use the v1 portable distribution profile described
 in [portable-apps.md](portable-apps.md). They make no web-origin claim and use a
 single-use OAuth device code plus PKCE and the existing per-grant P-256 key.
 Their browser origin is the exact opaque value `null`, tokens and non-extractable
-keys are memory-only by default, and the local connector still requires a
-matching encrypted grant for every operation. Portable grants are currently
-limited to local-authority collections.
+keys are memory-only by default. A local connector requires a matching
+encrypted grant for every operation. A hosted provider instead receives a
+short-lived capability bound to the exact grant, collection, operation set,
+record scope, expiry, and opaque `null` origin. The SDK exposes the same
+connection API for both routes.
 Collections that do not provide the required contracts are excluded from the
 decision. Local pause and revocation take effect at the connector even when
 cloud policy is stale.

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -20,7 +20,8 @@ Application capabilities also authorize the scoped replication stream used by
 offline caches. Session and snapshot reads require record-read access, change
 pages require change access, and each queued mutation requires its corresponding
 create, update, rename, or delete permission. Browser requests are checked
-against the exact origin stored on that application capability. Mirror
+against the exact origin stored on that application capability, including the
+opaque `null` origin used by downloaded portable applications. Mirror
 credentials have no browser origin and are rejected when presented by browser
 JavaScript.
 

--- a/docs/portable-apps.md
+++ b/docs/portable-apps.md
@@ -29,43 +29,57 @@ Connect identifies the exact normalized declaration by its SHA-256 digest.
 Changing any declared field creates a different application identity and
 requires approval again.
 
-Portable applications currently authorize computer-owned collections only.
-Hosted provider capabilities remain unavailable until they can be
-sender-constrained to the portable installation key.
+Portable applications can authorize either computer-owned or hosted
+collections through the same `MdbaseConnection` API. Add
+`"collection_kind": "hosted"` to `requirements` when the application
+specifically needs a durable cloud collection; omit it to let the user choose
+any compatible local or hosted collection.
 
 ## Authorization
 
 The SDK uses OAuth device authorization with PKCE:
 
-1. The file registers its inline manifest and generates a P-256 relay key.
+1. The file registers its inline manifest and generates an ephemeral P-256 key
+   so a local collection remains available as a choice.
 2. Connect returns a random, short-lived device code and an eight-character
    user code.
 3. The SDK opens Connect's approval page in a popup and also returns the code
    through `onDeviceCode`.
 4. The signed-in user confirms the same code, reviews the unverified downloaded
-   file warning, selects a local collection, and narrows the operations.
-5. The SDK polls at the server-provided interval. A successful token response
-   must contain the same application public key, encrypted relay protocol 1,
-   and the opaque application origin `null`.
+   file warning, selects a compatible local or hosted collection, and narrows
+   the operations.
+5. The SDK polls at the server-provided interval. Every successful response is
+   bound to the opaque application origin `null`. A local grant must also
+   contain the same application public key and encrypted relay protocol 1; a
+   hosted grant instead contains a scoped provider capability.
 
 Device codes expire after ten minutes, are stored only as hashes by the control
 plane, are rate limited, and can be consumed once. Polling faster than the
 returned interval receives `slow_down`. PKCE prevents a copied device code from
 being exchanged by another installation.
 
-The local connector remains the final authorization boundary. It accepts the
-opaque `Origin: null` only when an active local grant has that exact origin and
-encrypted relay binding. Every operation must then authenticate the grant,
-application, connector, collection, key ID, epoch, counter, request ID, and
-ciphertext. CORS permission alone is never an operation capability.
+For a local collection, the connector remains the final authorization boundary.
+It accepts the opaque `Origin: null` only when an active local grant has that
+exact origin and encrypted relay binding. Every operation must authenticate the
+grant, application, connector, collection, key ID, epoch, counter, request ID,
+and ciphertext.
+
+For a hosted collection, the SDK sends operations directly to the hosted data
+provider. Its short-lived bearer capability is limited to one replica,
+collection, grant, operation set, record scope, expiry, and the exact
+`Origin: null` value. The provider checks those fields for each request.
+Refreshing rotates both the Connect credential and provider capability. CORS
+permission alone is never an operation capability.
 
 ## Storage and `file://`
 
 All local files have an opaque browser origin serialized as `null`. A portable
 SDK instance therefore uses process-memory token storage and a non-extractable
-process-memory private key by default. Another downloaded file cannot inherit
-those values through `localStorage` or IndexedDB. Reloading or reopening the
-file requires authorization again.
+process-memory private key by default. The key is discarded after a hosted
+collection is selected because hosted requests do not use the encrypted local
+relay. Another downloaded file cannot inherit the credentials through
+`localStorage` or IndexedDB. Reloading or reopening the file requires
+authorization again.
 
 An embedding shell may inject custom `storage` and `keyStore` adapters. That is
 an explicit trust decision by the application. `connect.environment()` reports
@@ -127,6 +141,11 @@ or omit SRI in a downloaded application.
   };
 </script>
 ```
+
+The application code does not choose a transport. The returned connection uses
+the local connector, relay, or hosted provider as required; `describe`,
+`query`, `create`, and the other collection methods remain the same. The
+read-only `connection.route` property can be used for diagnostics.
 
 Authorization must start from a user gesture so browsers permit the approval
 popup. If a caller supplies `openVerification`, it is responsible for showing

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -520,6 +520,84 @@ describe("provider-neutral collection client", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
+  it("accepts a scoped hosted capability from the same portable device flow", async () => {
+    vi.useFakeTimers();
+    const keyStore = new MemoryGrantKeyStore();
+    const deleteKey = vi.spyOn(keyStore, "delete");
+    const opened = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request) => {
+      const url = String(request);
+      if (url.endsWith("/v1/apps/register")) {
+        return jsonResponse({
+          application: {
+            id: "00000000-0000-0000-0000-000000000001",
+            name: "Portable hosted notes",
+            distribution: "portable"
+          }
+        });
+      }
+      if (url.endsWith("/oauth/device_authorization")) {
+        return jsonResponse({
+          device_code: "hosted-device-secret",
+          user_code: "HOST-CODE",
+          verification_uri: "https://connect.example/device",
+          verification_uri_complete: "https://connect.example/device?user_code=HOST-CODE",
+          expires_in: 600,
+          interval: 1
+        });
+      }
+      if (url.endsWith("/oauth/token")) {
+        return jsonResponse({
+          access_token: "mdb_portable_hosted",
+          refresh_token: "ref_portable_hosted",
+          token_type: "Bearer",
+          expires_in: 900,
+          refresh_expires_in: 86_400,
+          collection_id: TEST_COLLECTION_ID,
+          collection_name: "Portable hosted notes",
+          operations: ["describe", "query"],
+          scope: { contracts: [], access: "full_collection" },
+          grant_id: "00000000-0000-0000-0000-000000000003",
+          application_origin: "null",
+          encryption: null,
+          hosted: {
+            provider_url: "https://provider.example",
+            replica_id: "00000000-0000-0000-0000-000000000005",
+            access_token: "hsa_portable_hosted"
+          }
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const connect = new MdbaseConnect({
+      serverUrl: "https://connect.example",
+      manifest: {
+        ...portableManifest(),
+        requirements: {
+          contracts: [],
+          access: "full_collection",
+          collection_kind: "hosted"
+        }
+      },
+      keyStore
+    });
+
+    const authorization = connect.authorize({
+      operations: ["describe", "query"],
+      openVerification: opened
+    });
+    await vi.waitFor(() => expect(opened).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const result = await authorization;
+    expect(result.connection).toMatchObject({
+      collectionId: TEST_COLLECTION_ID,
+      route: "hosted"
+    });
+    expect(deleteKey).toHaveBeenCalledOnce();
+    expect(connect.connections()).toHaveLength(1);
+  });
+
   it("returns the verification details when a portable approval popup is blocked", async () => {
     const keyStore = new MemoryGrantKeyStore();
     vi.spyOn(globalThis, "fetch")

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1371,20 +1371,35 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
             tokenResponse.status
           );
         }
-        if (
-          tokenBody.hosted
-          || !tokenBody.encryption
-          || tokenBody.encryption.protocol_version !== ENCRYPTED_RELAY_PROTOCOL_VERSION
-          || tokenBody.encryption.suite !== RELAY_ENCRYPTION_SUITE
-          || tokenBody.encryption.application_public_key !== grantKey.publicKey
-          || tokenBody.application_origin !== "null"
-        ) {
+        const hosted = validHostedTokenResponse(tokenBody.hosted);
+        const localEncryption = tokenBody.encryption
+          && tokenBody.encryption.protocol_version === ENCRYPTED_RELAY_PROTOCOL_VERSION
+          && tokenBody.encryption.suite === RELAY_ENCRYPTION_SUITE
+          && tokenBody.encryption.application_public_key === grantKey.publicKey;
+        if (tokenBody.application_origin !== "null") {
           throw new MdbaseConnectError(
-            "encryption_required",
-            "Authorization did not establish the expected key-bound portable grant."
+            "invalid_token_response",
+            "Authorization did not bind the portable grant to its opaque application origin."
           );
         }
-        const token = this.storeTokenResponse(tokenBody, application.id, keyHandle);
+        if (tokenBody.hosted && (!hosted || tokenBody.encryption != null)) {
+          throw new MdbaseConnectError(
+            "invalid_token_response",
+            "Authorization returned an invalid hosted capability for the portable grant."
+          );
+        }
+        if (!tokenBody.hosted && !localEncryption) {
+          throw new MdbaseConnectError(
+            "encryption_required",
+            "Authorization did not establish the expected key-bound local portable grant."
+          );
+        }
+        if (hosted) await this.keyStore.delete(keyHandle);
+        const token = this.storeTokenResponse(
+          tokenBody,
+          application.id,
+          hosted ? undefined : keyHandle
+        );
         if (options.collectionId && options.collectionId !== token.collectionId) {
           this.removeToken(token.collectionId, token.keyHandle);
           throw new MdbaseConnectError(
@@ -3125,6 +3140,33 @@ function apiError(body: any, fallbackCode: string, fallbackMessage: string, stat
 
 function oauthErrorCode(body: any): string | undefined {
   return typeof body?.error === "string" ? body.error : undefined;
+}
+
+function validHostedTokenResponse(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const hosted = value as {
+    provider_url?: unknown;
+    replica_id?: unknown;
+    access_token?: unknown;
+  };
+  if (
+    typeof hosted.provider_url !== "string"
+    || typeof hosted.replica_id !== "string"
+    || hosted.replica_id.length === 0
+    || typeof hosted.access_token !== "string"
+    || hosted.access_token.length === 0
+  ) return false;
+  try {
+    const provider = new URL(hosted.provider_url);
+    return ["http:", "https:"].includes(provider.protocol)
+      && !provider.username
+      && !provider.password
+      && provider.pathname === "/"
+      && !provider.search
+      && !provider.hash;
+  } catch {
+    return false;
+  }
 }
 
 function parseDeviceAuthorization(body: any): MdbaseDeviceAuthorization {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -37,6 +37,7 @@ const authorityMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-author
 const promotionMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-promotion-mirror-"));
 const promotionToolRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-promotion-tool-"));
 const mirrorStateRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-mirror-state-"));
+const portableRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-portable-"));
 process.env.MDBASE_CONNECT_MIRROR_STATE_DIR = mirrorStateRoot;
 const children = new Set();
 let postgresStarted = false;
@@ -836,6 +837,10 @@ schema:
     { method: "POST", token: appToken, headers: { origin: manifest.origin }, body: {} }
   );
   assert.equal(revokedApp.status, 401);
+
+  phase("authorizing a real file URL directly against the hosted data plane");
+  await portableHostedFileE2E(controlUrl, cookie, genericCollectionId, portableRoot);
+
   assert.equal(
     (
       await rawRequest(provider.url, syncPath(genericCollectionId, "sessions"), {
@@ -1601,10 +1606,149 @@ schema:
   await rm(promotionMirrorRoot, { recursive: true, force: true });
   await rm(promotionToolRoot, { recursive: true, force: true });
   await rm(mirrorStateRoot, { recursive: true, force: true });
+  await rm(portableRoot, { recursive: true, force: true });
 }
 
 function phase(message) {
   process.stdout.write(`[provider-e2e] ${message}\n`);
+}
+
+async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory) {
+  const bundle = (await readFile(
+    join(repoRoot, "packages", "client", "dist", "browser", "mdbase-connect.min.js"),
+    "utf8"
+  )).replaceAll("</script", "<\\/script");
+  const file = join(directory, "portable-hosted.html");
+  await writeFile(file, `<!doctype html>
+<meta charset="utf-8">
+<title>Portable hosted mdbase E2E</title>
+<button id="connect">Connect</button>
+<output id="code"></output>
+<script>${bundle}</script>
+<script>
+  const manager = new MdbaseConnect.MdbaseConnect({
+    serverUrl: ${JSON.stringify(controlUrl)},
+    manifest: {
+      manifest_version: 1,
+      distribution: "portable",
+      id: "dev.mdbase.portable-hosted-e2e",
+      name: "Portable Hosted E2E",
+      project_url: "https://apps.example/portable-hosted-e2e",
+      requirements: {
+        access: "full_collection",
+        contracts: [],
+        collection_kind: "hosted"
+      }
+    }
+  });
+  globalThis.portableHarness = {
+    environment: manager.environment(),
+    initialConnections: manager.connections().length
+  };
+  document.querySelector("#connect").onclick = () => {
+    manager.authorize({
+      operations: ["describe", "query", "create"],
+      openVerification() {},
+      onDeviceCode(authorization) {
+        globalThis.portableHarness.authorization = authorization;
+        document.querySelector("#code").textContent = authorization.userCode;
+      }
+    }).then(async ({ connection }) => {
+      const created = await connection.create({
+        path: "portable-hosted-e2e.md",
+        frontmatter: { title: "Created from a downloaded file" },
+        body: "Direct to the hosted provider."
+      });
+      const description = await connection.describe();
+      const records = await connection.query({
+        where: 'file.path == "portable-hosted-e2e.md"'
+      });
+      globalThis.portableHarness.result = {
+        route: connection.route,
+        collectionId: connection.collectionId,
+        displayName: description.display_name,
+        created: created.valid,
+        records: records.result.results.length,
+        connections: manager.connections().length
+      };
+    }).catch((error) => {
+      globalThis.portableHarness.error = {
+        code: error && error.code,
+        message: error && error.message
+      };
+    });
+  };
+</script>`);
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(new URL(`file://${file}`).href);
+    const environment = await page.evaluate(() => globalThis.portableHarness);
+    assert.equal(environment.environment.applicationOrigin, "null");
+    assert.equal(environment.environment.credentialStorage, "memory");
+    assert.equal(environment.initialConnections, 0);
+    await page.click("#connect");
+    await page.waitForFunction(() => Boolean(globalThis.portableHarness.authorization));
+    const authorization = await page.evaluate(
+      () => globalThis.portableHarness.authorization
+    );
+    const claimed = await controlRequest(
+      controlUrl,
+      "/v1/device-authorization-requests/lookup",
+      cookie,
+      {
+        method: "POST",
+        body: { user_code: authorization.userCode }
+      }
+    );
+    const pending = await controlRequest(
+      controlUrl,
+      `/v1/authorization-requests/${claimed.request_id}`,
+      cookie
+    );
+    assert.ok(pending.collections.length > 0);
+    assert.ok(pending.collections.every((collection) => collection.kind === "hosted"));
+    assert.ok(pending.collections.some((collection) => collection.id === collectionId));
+    await controlRequest(
+      controlUrl,
+      `/v1/authorization-requests/${claimed.request_id}/approve`,
+      cookie,
+      {
+        method: "POST",
+        body: {
+          collection_id: collectionId,
+          operations: ["describe", "query", "create"]
+        }
+      }
+    );
+    await page.waitForFunction(
+      () => Boolean(globalThis.portableHarness.result || globalThis.portableHarness.error),
+      undefined,
+      { timeout: 20_000 }
+    );
+    const result = await page.evaluate(() => globalThis.portableHarness);
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.result, {
+      route: "hosted",
+      collectionId,
+      displayName: "Hosted writing",
+      created: true,
+      records: 1,
+      connections: 1
+    });
+
+    const independentPage = await context.newPage();
+    await independentPage.goto(new URL(`file://${file}`).href);
+    const independent = await independentPage.evaluate(() => globalThis.portableHarness);
+    assert.equal(independent.initialConnections, 0);
+    assert.equal(independent.environment.credentialStorage, "memory");
+    await independentPage.close();
+    await context.close();
+  } finally {
+    await browser.close();
+  }
 }
 
 async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -937,6 +937,185 @@ describe("mdbase connect server", () => {
     })).json()).toMatchObject({ error: "expired_token" });
   });
 
+  it("authorizes a portable v1 application directly against a hosted collection", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const hostedProvider = {
+      url: "https://sync.example",
+      ready: vi.fn(),
+      createCollection: vi.fn(),
+      renameCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      provisionTypes: vi.fn(),
+      registerReplica: vi.fn(),
+      updateApplicationReplica: vi.fn(),
+      revokeReplica: vi.fn(),
+      upsertNotificationGrant: vi.fn(),
+      revokeNotificationGrant: vi.fn(),
+      rotateReplicaToken: vi.fn(),
+      compactThrough: vi.fn()
+    } as unknown as HostedProviderClient;
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedProvider,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Portable cloud owner", email: "portable-cloud@example.com" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/hosted/collections",
+      headers: { cookie },
+      payload: { display_name: "Portable cloud notes", template: "mdbase" }
+    });
+    expect(created.statusCode).toBe(201);
+    const collectionId = created.json().collection.id as string;
+    const manifest: MdbaseAppManifest = {
+      manifest_version: 1,
+      distribution: "portable",
+      id: "dev.mdbase.portable-cloud-notes",
+      name: "Portable cloud notes",
+      project_url: "https://apps.example/portable-cloud-notes",
+      requirements: {
+        contracts: [],
+        access: "full_collection",
+        collection_kind: "hosted"
+      }
+    };
+    const registration = await app.inject({
+      method: "POST",
+      url: "/v1/apps/register",
+      payload: { manifest }
+    });
+    expect(registration.statusCode, JSON.stringify(registration.json())).toBe(200);
+    const applicationId = registration.json().application.id as string;
+    const applicationKey = createECDH("prime256v1");
+    applicationKey.generateKeys();
+    const verifier = "portable-hosted-verifier-that-is-long-enough-0001";
+    const device = await app.inject({
+      method: "POST",
+      url: "/oauth/device_authorization",
+      headers: {
+        origin: "null",
+        "content-type": "application/x-www-form-urlencoded"
+      },
+      payload: new URLSearchParams({
+        client_id: applicationId,
+        operations: "describe,query,create,update",
+        collection_hint: collectionId,
+        code_challenge: pkceChallenge(verifier),
+        code_challenge_method: "S256",
+        relay_protocol: "1",
+        application_public_key: applicationKey
+          .getPublicKey(undefined, "uncompressed")
+          .toString("base64url")
+      }).toString()
+    });
+    expect(device.statusCode, JSON.stringify(device.json())).toBe(200);
+    const lookup = await app.inject({
+      method: "POST",
+      url: "/v1/device-authorization-requests/lookup",
+      headers: { cookie },
+      payload: { user_code: device.json().user_code }
+    });
+    expect(lookup.statusCode).toBe(200);
+    const requestId = lookup.json().request_id as string;
+    const pending = await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${requestId}`,
+      headers: { cookie }
+    });
+    expect(pending.json().collections).toEqual([
+      expect.objectContaining({ id: collectionId, kind: "hosted" })
+    ]);
+
+    const approved = await app.inject({
+      method: "POST",
+      url: `/v1/authorization-requests/${requestId}/approve`,
+      headers: { cookie },
+      payload: {
+        collection_id: collectionId,
+        operations: ["describe", "query", "create", "update"]
+      }
+    });
+    expect(approved.statusCode, JSON.stringify(approved.json())).toBe(200);
+    expect(hostedProvider.registerReplica).toHaveBeenCalledWith(
+      collectionId,
+      expect.objectContaining({
+        purpose: "application",
+        fullCollection: true,
+        allowedOperations: ["describe", "query", "create", "update"],
+        allowedOrigin: "null"
+      })
+    );
+    const token = await pollDeviceToken(app, {
+      applicationId,
+      deviceCode: device.json().device_code,
+      verifier
+    });
+    expect(token.statusCode, JSON.stringify(token.json())).toBe(200);
+    expect(token.json()).toMatchObject({
+      collection_id: collectionId,
+      application_origin: "null",
+      operations: ["describe", "query", "create", "update"],
+      encryption: null,
+      hosted: {
+        provider_url: "https://sync.example"
+      }
+    });
+    expect(token.json().hosted.replica_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+    expect(token.json().hosted.access_token).toMatch(/^hsa_/);
+    expect(hostedProvider.rotateReplicaToken).toHaveBeenCalledWith(
+      token.json().hosted.replica_id,
+      token.json().hosted.access_token,
+      3_600
+    );
+
+    const refreshed = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      payload: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: token.json().refresh_token,
+        client_id: applicationId
+      }).toString(),
+      headers: {
+        origin: "null",
+        "content-type": "application/x-www-form-urlencoded"
+      }
+    });
+    expect(refreshed.statusCode, JSON.stringify(refreshed.json())).toBe(200);
+    expect(refreshed.json()).toMatchObject({
+      collection_id: collectionId,
+      application_origin: "null",
+      encryption: null,
+      hosted: {
+        provider_url: "https://sync.example",
+        replica_id: token.json().hosted.replica_id
+      }
+    });
+    expect(refreshed.json().hosted.access_token).not.toBe(token.json().hosted.access_token);
+    const grant = await db.query<{ application_origin: string; encryption: unknown }>(
+      "SELECT application_origin, encryption FROM grants WHERE id = $1",
+      [token.json().grant_id]
+    );
+    expect(grant.rows[0]).toEqual({
+      application_origin: "null",
+      encryption: null
+    });
+  });
+
   it("provisions and reconciles contract-free hosted application access as unrestricted", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -2643,11 +2643,9 @@ export async function buildApp(options: BuildOptions) {
     ];
     return {
       authorization: authorization.rows[0],
-      collections: authorization.rows[0].distribution === "portable"
-        ? availableCollections.filter((collection) => collection.kind === "local")
-        : requiresHostedCollection(authorization.rows[0].requirements)
-          ? availableCollections.filter((collection) => collection.kind === "hosted")
-          : availableCollections
+      collections: requiresHostedCollection(authorization.rows[0].requirements)
+        ? availableCollections.filter((collection) => collection.kind === "hosted")
+        : availableCollections
     };
   });
 
@@ -3892,11 +3890,15 @@ async function approveHostedAuthorization(
       requirements: ApplicationRequirements;
       provisions: ApplicationProvisions;
       notifications: ApplicationNotifications;
+      relay_protocol: number | null;
+      application_public_key: string | null;
+      flow: "authorization_code" | "device_code";
     }>(
       `SELECT ar.application_id, a.name AS application_name,
               a.distribution, a.homepage AS application_homepage,
               ar.redirect_uri, ar.requested_operations,
-              a.requirements, a.provisions, a.notifications
+              a.requirements, a.provisions, a.notifications,
+              ar.relay_protocol, ar.application_public_key, ar.flow
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
@@ -3909,9 +3911,21 @@ async function approveHostedAuthorization(
       await connection.query("ROLLBACK");
       return false;
     }
-    if (pending.distribution === "portable") {
+    if (
+      pending.distribution === "portable"
+      && (
+        pending.flow !== "device_code"
+        || pending.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
+        || !pending.application_public_key
+      )
+    ) {
       throw new RequestValidationError(
-        "Downloaded applications can currently authorize local collections only."
+        "Downloaded applications require a key-bound device authorization request."
+      );
+    }
+    if (pending.flow === "device_code" && pending.distribution !== "portable") {
+      throw new RequestValidationError(
+        "Device authorization is reserved for downloaded applications."
       );
     }
     if (input.operations.some((operation) => !pending.requested_operations.includes(operation))) {
@@ -3952,14 +3966,17 @@ async function approveHostedAuthorization(
     await provider.renameCollection(input.collectionId, input.displayName);
     const operations = [...new Set(input.operations)];
     const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type", "create_view_source", "update_view_source", "delete_view_source", "put_timer", "cancel_timer", "reconcile_timers"].includes(operation));
-    const applicationUrl = new URL(pending.redirect_uri!);
-    const allowedOrigin = ["http:", "https:"].includes(applicationUrl.protocol)
-      ? applicationUrl.origin
-      : undefined;
-    const applicationOrigin = applicationOriginForRedirect(
-      pending.redirect_uri!,
-      pending.application_homepage
-    );
+    const applicationOrigin = pending.flow === "device_code"
+      ? "null"
+      : applicationOriginForRedirect(
+          pending.redirect_uri!,
+          pending.application_homepage
+        );
+    const allowedOrigin = pending.flow === "device_code"
+      ? "null"
+      : ["http:", "https:"].includes(new URL(pending.redirect_uri!).protocol)
+        ? new URL(pending.redirect_uri!).origin
+        : undefined;
     const grantId = randomUUID();
     notificationGrantId = grantId;
     replicaId = randomUUID();

--- a/services/server/src/manifest.test.ts
+++ b/services/server/src/manifest.test.ts
@@ -57,7 +57,7 @@ describe("portable application manifests", () => {
     expect(registered.manifest).not.toHaveProperty("redirect_uris");
   });
 
-  it("rejects web identity fields, cross-origin icons, and hosted-only portable access", () => {
+  it("rejects web identity fields and cross-origin icons", () => {
     const base = {
       manifest_version: 1,
       distribution: "portable",
@@ -75,12 +75,12 @@ describe("portable application manifests", () => {
       project_url: "https://workouts.example/source",
       icon: "https://tracking.example/icon.svg"
     })).toThrow("Portable application icons must use the project URL origin.");
-    expect(() => registerApplicationManifest({
+    expect(registerApplicationManifest({
       ...base,
       requirements: {
         contracts: [],
         collection_kind: "hosted"
       }
-    })).toThrow("Portable applications cannot request hosted-only collection access.");
+    }).manifest.requirements.collection_kind).toBe("hosted");
   });
 });

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -179,11 +179,6 @@ function validateManifestIdentity(
   allowInsecure: boolean
 ): void {
   if (manifest.distribution === "portable") {
-    if (manifest.requirements.collection_kind === "hosted") {
-      throw new ApplicationManifestError(
-        "Portable applications cannot request hosted-only collection access."
-      );
-    }
     if (manifest.project_url) {
       const project = new URL(manifest.project_url);
       if (project.protocol !== "https:") {


### PR DESCRIPTION
## Summary
- allow v1 portable manifests to select or require hosted collections
- issue exact-`Origin: null`, scoped hosted provider capabilities through the existing device flow
- keep the SDK route-neutral and memory-only for `file://`, discarding the unused relay key after hosted approval
- update approval UX, architecture/security docs, and real-browser coverage

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm package:audit`
- `pnpm e2e`
- `pnpm e2e:provider` (PostgreSQL-backed, including real Chromium `file://` hosted create/query and second-file isolation)
- `node scripts/relay-e2e.mjs`
- `node scripts/sync-e2e.mjs`
- `mdbase validate .` in `.ops`