### PR TITLE
Require live connectors for local collection authorization

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -179,6 +179,24 @@ function registerIpc(): void {
     if (typeof path !== "string" || path.length === 0) throw new Error("Choose a folder.");
     return requestReadyAgent("collections.add-copy", { path });
   });
+  ipcMain.handle("connect:collections:make-independent", async (event, collectionId: unknown) => {
+    trustedIpc(event);
+    if (typeof collectionId !== "string") throw new Error("Invalid collection ID.");
+    return requestReadyAgent(
+      "collections.make-independent",
+      { collection_id: collectionId },
+      10_000
+    );
+  });
+  ipcMain.handle("connect:collections:take-authority", async (event, collectionId: unknown) => {
+    trustedIpc(event);
+    if (typeof collectionId !== "string") throw new Error("Invalid collection ID.");
+    return requestReadyAgent(
+      "collections.take-authority",
+      { collection_id: collectionId },
+      15_000
+    );
+  });
   ipcMain.handle("connect:collections:choose-create", async (event) => {
     trustedIpc(event);
     return chooseFolder();

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -6,6 +6,10 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
   addCollection: () => ipcRenderer.invoke("connect:collections:add"),
   addCopiedCollection: (path: string) =>
     ipcRenderer.invoke("connect:collections:add-copy", path),
+  makeCollectionIndependent: (collectionId: string) =>
+    ipcRenderer.invoke("connect:collections:make-independent", collectionId),
+  takeCollectionAuthority: (collectionId: string) =>
+    ipcRenderer.invoke("connect:collections:take-authority", collectionId),
   chooseCreateFolder: () => ipcRenderer.invoke("connect:collections:choose-create"),
   createCollection: (input: { path: string; name: string }) =>
     ipcRenderer.invoke("connect:collections:create", input),

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -118,6 +118,13 @@ interface AccessSnapshot {
   account?: ConnectorAccount;
   grants: GrantSummary[];
   pending_authorizations: PendingAuthorization[];
+  authority_conflicts: AuthorityConflict[];
+}
+
+interface AuthorityConflict {
+  collection_id: string;
+  display_name: string;
+  active_connector_name: string;
 }
 
 interface ActivityEntry {
@@ -142,6 +149,8 @@ interface Window {
       | null
     >;
     addCopiedCollection(path: string): Promise<CollectionSummary>;
+    makeCollectionIndependent(collectionId: string): Promise<CollectionSummary>;
+    takeCollectionAuthority(collectionId: string): Promise<{ ok: true }>;
     chooseCreateFolder(): Promise<string | null>;
     createCollection(input: { path: string; name: string }): Promise<CollectionSummary>;
     updateCollectionMetadata(input: { collectionId: string; name: string; description?: string }): Promise<CollectionSummary>;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -57,7 +57,7 @@ function App() {
   const [collections, setCollections] = useState<CollectionSummary[]>([]);
   const [startup, setStartup] = useState<StartupSetting>({ enabled: false, available: false });
   const [cloud, setCloud] = useState<CloudSetting | null>(null);
-  const [access, setAccess] = useState<AccessSnapshot>({ configured: false, online: false, grants: [], pending_authorizations: [] });
+  const [access, setAccess] = useState<AccessSnapshot>({ configured: false, online: false, grants: [], pending_authorizations: [], authority_conflicts: [] });
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -202,6 +202,7 @@ function App() {
         ) : route === "collections" ? (
           <Collections
             collections={collections}
+            authorityConflicts={access.authority_conflicts}
             busy={busy}
             copiedCollectionPath={copiedCollectionPath}
             onAdd={() => void addExisting()}
@@ -309,8 +310,9 @@ function OverviewRow({ label, value, detail, action, onClick }: { label: string;
   return <div className="overview-row"><span>{label}</span><div><strong>{value}</strong><small>{detail}</small></div><button className="quiet-action" onClick={onClick}>{action}</button></div>;
 }
 
-function Collections({ collections, busy, copiedCollectionPath, onAdd, onCancelCopy, onCreate, onRegisterCopy, onAct, onNotice }: {
+function Collections({ collections, authorityConflicts, busy, copiedCollectionPath, onAdd, onCancelCopy, onCreate, onRegisterCopy, onAct, onNotice }: {
   collections: CollectionSummary[];
+  authorityConflicts: AuthorityConflict[];
   busy: boolean;
   copiedCollectionPath: string | null;
   onAdd(): void;
@@ -341,6 +343,27 @@ function Collections({ collections, busy, copiedCollectionPath, onAdd, onCancelC
           </div>
         </section>
       )}
+      {authorityConflicts.map((conflict) => (
+        <section className="copy-registration" aria-labelledby={`authority-${conflict.collection_id}`} key={conflict.collection_id}>
+          <div>
+            <p className="eyebrow">Collection identity conflict</p>
+            <h2 id={`authority-${conflict.collection_id}`}>{conflict.display_name} is already active elsewhere.</h2>
+            <p>This folder has the same embedded collection ID as the copy on {conflict.active_connector_name}. Choose which identity this folder should keep.</p>
+            <small>Moving authority revokes the old computer’s application grants. Making this folder independent writes a new ID to only this folder’s <code>mdbase.yaml</code>.</small>
+          </div>
+          <div className="copy-registration-actions">
+            <button className="button secondary" disabled={busy} onClick={() => void onAct(async () => {
+              const independent = await window.mdbaseConnect.makeCollectionIndependent(conflict.collection_id);
+              onNotice(`${independent.display_name} now has an independent collection identity.`);
+            })}>Make independent</button>
+            <button className="button primary" disabled={busy} onClick={() => void onAct(async () => {
+              if (!window.confirm(`Move ${conflict.display_name} authority from ${conflict.active_connector_name} to this computer? Existing application access through the old computer will be revoked.`)) return;
+              await window.mdbaseConnect.takeCollectionAuthority(conflict.collection_id);
+              onNotice(`${conflict.display_name} now uses this computer as its authority.`);
+            })}>Use this computer</button>
+          </div>
+        </section>
+      ))}
       {collections.length === 0 ? (
         <Empty title="No collections registered" text="Add a folder with an existing mdbase.yaml, or create a new collection." action="Create the first collection" onAction={onCreate} />
       ) : (

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -48,6 +48,7 @@ export interface DashboardData {
     collection_name: string;
     collection_kind: "local" | "hosted";
     application_id: string;
+    application_family_id?: string;
     application_name: string;
     distribution: "web" | "portable";
     homepage: string;
@@ -118,15 +119,24 @@ export interface PendingAuthorization {
   requirements: ApplicationRequirements;
   provisions: ApplicationProvisions;
   notifications: ApplicationNotifications;
+  available_collections?: AvailableCollection[];
+  unavailable_connectors?: UnavailableConnector[];
 }
 
 export interface AvailableCollection {
   id: string;
+  offer_id?: string;
   kind?: "local" | "hosted";
   connector_name: string;
   display_name: string;
   spec_version: string;
   contracts: ContractRequirement[];
+}
+
+export interface UnavailableConnector {
+  connector_id: string;
+  connector_name: string;
+  reason: "offline" | "paused";
 }
 
 export interface ContractRequirement {

--- a/apps/portal/src/compatibility.ts
+++ b/apps/portal/src/compatibility.ts
@@ -35,9 +35,9 @@ export function collectionCompatibility(
   }
   const unavailable = request.requirements.contracts.filter((requirement) =>
     !hasContract(collection.contracts, requirement)
-    && !(collection.kind === "hosted" && request.provisions.types.some((provision) =>
+    && !request.provisions.types.some((provision) =>
       provision.provides.some((provided) => sameContract(provided, requirement))
-    ))
+    )
   );
   if (unavailable.length > 0) {
     return {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -27,7 +27,8 @@ import {
   type DashboardData,
   type HostedCollection,
   type PendingAuthorization,
-  type TypeProvision
+  type TypeProvision,
+  type UnavailableConnector
 } from "./api";
 import { collectionCompatibility } from "./compatibility";
 import "./styles.css";
@@ -309,8 +310,7 @@ function Dashboard() {
                 <ApprovalForm
                   request={request}
                   collections={[
-                    ...data.collections.filter((collection) => collection.enabled)
-                      .map((collection) => ({ ...collection, kind: "local" as const })),
+                    ...(request.available_collections ?? []),
                     ...data.hosted_collections
                       .filter((collection) => collection.authority_state === "active")
                       .map((collection) => ({
@@ -319,6 +319,7 @@ function Dashboard() {
                       connector_name: "Hosted by mdbase"
                     }))
                   ]}
+                  unavailableConnectors={request.unavailable_connectors}
                   onDecision={refresh}
                   onCollectionCreated={() => void refresh()}
                 />
@@ -349,7 +350,9 @@ function Dashboard() {
           {data.connectors.length === 0 ? <Empty title="No computers connected" text="Open mdbase connect on a computer and choose Connect this computer." /> : (
             <div className="computer-list">{data.connectors.map((connector) => {
               const collections = data.collections.filter((collection) => collection.connector_id === connector.id);
-              return <ComputerRow key={connector.id} connector={connector} collectionCount={collections.length} availableCount={collections.filter((collection) => collection.enabled).length} onChanged={refresh} onError={setError} />;
+              const online = connector.last_seen_at !== null
+                && Date.now() - new Date(connector.last_seen_at).getTime() < 45_000;
+              return <ComputerRow key={connector.id} connector={connector} collectionCount={collections.length} availableCount={online ? collections.filter((collection) => collection.enabled).length : 0} onChanged={refresh} onError={setError} />;
             })}</div>
           )}
         </section>
@@ -1035,6 +1038,7 @@ function Authorization({ requestId }: { requestId: string }) {
   const [request, setRequest] = useState<{
     authorization: PendingAuthorization;
     collections: AvailableCollection[];
+    unavailable_connectors: UnavailableConnector[];
   } | null>(null);
   const [status, setStatus] = useState<"pending" | "approved" | "denied">("pending");
   const [error, setError] = useState("");
@@ -1042,12 +1046,33 @@ function Authorization({ requestId }: { requestId: string }) {
   useSystemTheme();
 
   useEffect(() => {
-    api<{ authorization: PendingAuthorization; collections: AvailableCollection[] }>(`/v1/authorization-requests/${requestId}`)
-      .then(setRequest)
-      .catch((reason) => {
-        if (reason instanceof ApiError && reason.status === 401) location.href = `/login?return_to=${encodeURIComponent(location.href)}`;
-        else setError(message(reason));
-      });
+    let active = true;
+    async function refreshCollections() {
+      try {
+        const next = await api<{
+          authorization: PendingAuthorization;
+          collections: AvailableCollection[];
+          unavailable_connectors: UnavailableConnector[];
+        }>(`/v1/authorization-requests/${requestId}`);
+        if (active) {
+          setRequest(next);
+          setError("");
+        }
+      } catch (reason) {
+        if (!active) return;
+        if (reason instanceof ApiError && reason.status === 401) {
+          location.href = `/login?return_to=${encodeURIComponent(location.href)}`;
+        } else if (!(reason instanceof ApiError && reason.status === 404)) {
+          setError(message(reason));
+        }
+      }
+    }
+    void refreshCollections();
+    const timer = window.setInterval(() => void refreshCollections(), 10_000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
   }, [requestId]);
 
   useEffect(() => {
@@ -1085,6 +1110,7 @@ function Authorization({ requestId }: { requestId: string }) {
           <ApprovalForm
             request={authorization}
             collections={request.collections}
+            unavailableConnectors={request.unavailable_connectors}
             onDecision={(decision) => setStatus(decision)}
             onCollectionCreated={(collection) => setRequest((current) => current ? {
               ...current,
@@ -1123,11 +1149,13 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
 function ApprovalForm({
   request,
   collections,
+  unavailableConnectors = [],
   onDecision,
   onCollectionCreated
 }: {
   request: PendingAuthorization;
   collections: AvailableCollection[];
+  unavailableConnectors?: UnavailableConnector[];
   onDecision(decision: "approved" | "denied"): void | Promise<void>;
   onCollectionCreated(collection: AvailableCollection): void;
 }) {
@@ -1180,7 +1208,11 @@ function ApprovalForm({
       await api(`/v1/authorization-requests/${request.id}/${decision === "approved" ? "approve" : "deny"}`, {
         method: "POST",
         ...(decision === "approved" ? {
-          body: JSON.stringify({ collection_id: collectionId, operations: [...operations] })
+          body: JSON.stringify({
+            collection_id: collectionId,
+            ...(selected?.offer_id ? { offer_id: selected.offer_id } : {}),
+            operations: [...operations]
+          })
         } : {})
       });
       await onDecision(decision);
@@ -1249,6 +1281,11 @@ function ApprovalForm({
               : `${unavailable.length} ${unavailable.length === 1 ? "collection is" : "collections are"} unavailable`}</summary>
             <ul>{unavailable.map(({ collection, compatibility }) => <li key={collection.id}><span>{collection.display_name}</span><small>{compatibility.compatible ? "" : compatibility.detail}</small></li>)}</ul>
           </details>}
+          {unavailableConnectors.length > 0 && <div className="field-note" role="status">
+            {unavailableConnectors.map((connector) => connector.reason === "paused"
+              ? `${connector.connector_name} has remote access paused.`
+              : `${connector.connector_name} is offline.`).join(" ")} Those local collections cannot be selected until their computer is available.
+          </div>}
           {compatible.length === 0 && <div className="authorization-empty-collection">
             <p className="field-note">No compatible collection is ready.</p>
             <button
@@ -1258,7 +1295,7 @@ function ApprovalForm({
               onClick={() => void createCloudCollection()}
             >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>
           </div>}
-          {setup.length > 0 && <p className="field-note">Setup needed: allowing access will add {provisionNames(setup)} to this hosted collection.</p>}
+          {setup.length > 0 && <p className="field-note">Setup needed: allowing access will add {provisionNames(setup)} to this collection through its live authority.</p>}
         </div>
       </section>
       <section className="approval-section">

--- a/crates/connect-agent/src/cloud.rs
+++ b/crates/connect-agent/src/cloud.rs
@@ -1,7 +1,7 @@
 use mdbase_connect_core::ConnectError;
 use mdbase_connect_protocol::{
     AccessSnapshot, ApplicationSummary, AuthorizationApproveParams, AuthorizationIdParams,
-    CollectionSummary, ComputerNameParams, GrantCreateParams, GrantIdParams, GrantUpdateParams,
+    ComputerNameParams, GrantCreateParams, GrantIdParams, GrantUpdateParams,
 };
 use reqwest::{Client, Method, Response};
 use serde::de::DeserializeOwned;
@@ -40,6 +40,18 @@ impl CloudControlClient {
         .await
     }
 
+    pub async fn take_collection_authority(
+        &self,
+        collection_id: uuid::Uuid,
+    ) -> Result<Value, ConnectError> {
+        self.json(
+            Method::POST,
+            &format!("/v1/connectors/authority-conflicts/{collection_id}/move"),
+            None,
+        )
+        .await
+    }
+
     pub async fn application(
         &self,
         application_id: uuid::Uuid,
@@ -52,28 +64,6 @@ impl CloudControlClient {
             )
             .await?;
         serde_json::from_value(value["application"].clone()).map_err(ConnectError::from)
-    }
-
-    pub async fn sync_collection(
-        &self,
-        collection: &CollectionSummary,
-    ) -> Result<(), ConnectError> {
-        let _: Value = self
-            .json(
-                Method::POST,
-                "/v1/connectors/sync",
-                Some(serde_json::json!({
-                    "collections": [{
-                        "id": collection.id,
-                        "display_name": collection.display_name,
-                        "spec_version": collection.spec_version,
-                        "enabled": collection.enabled,
-                        "contracts": collection.contracts,
-                    }]
-                })),
-            )
-            .await?;
-        Ok(())
     }
 
     pub async fn create_grant(

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -115,8 +115,10 @@ async fn sync_collections(
     state: &AgentState,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let collections = state.collections()?;
+    let inventory_revision = state.next_inventory_revision()?;
     let payload = serde_json::json!({
         "relay_public_key": state.relay_public_key(),
+        "inventory_revision": inventory_revision,
         "collections": collections.into_iter().map(|collection| serde_json::json!({
             "id": collection.id,
             "display_name": collection.display_name,

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -8,8 +8,10 @@ use mdbase_connect_protocol::crypto::{
     parse_counter, validate_envelope, RelayBinding, RelayDirection, RelayIdentity, RelayMetadata,
 };
 use mdbase_connect_protocol::{
-    AgentConnectionState, AgentStatus, ControlCommand, ControlError, ControlRequest,
-    ControlResponse, RelayMessage, CONTROL_PROTOCOL_VERSION, ENCRYPTED_RELAY_PROTOCOL_VERSION,
+    AgentConnectionState, AgentStatus, ApplicationAccess, ApplicationRequirements,
+    AuthorizationCollectionOffer, ContractRequirement, ControlCommand, ControlError,
+    ControlRequest, ControlResponse, GrantScope, RelayMessage, CONTROL_PROTOCOL_VERSION,
+    ENCRYPTED_RELAY_PROTOCOL_VERSION,
 };
 use std::io;
 use std::sync::Arc;
@@ -103,6 +105,10 @@ impl AgentState {
         &self,
     ) -> Result<Vec<mdbase_connect_protocol::CollectionSummary>, ConnectError> {
         self.registry.list()
+    }
+
+    pub fn next_inventory_revision(&self) -> Result<u64, ConnectError> {
+        self.registry.next_inventory_revision()
     }
 
     pub fn origin_allowed(&self, origin: &str) -> bool {
@@ -208,6 +214,110 @@ impl AgentState {
                     tracing::debug!(grants = grants.len(), "relay policy snapshot applied");
                 }
                 None
+            }
+            RelayMessage::AuthorizationOfferRequest {
+                request_id,
+                authorization_id: _,
+                ..
+            } => {
+                let paused = self.registry.paused().unwrap_or(true);
+                let collections = if paused {
+                    Vec::new()
+                } else {
+                    self.registry
+                        .list()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|collection| collection.enabled)
+                        .filter_map(|collection| {
+                            let description = self.registry.describe(collection.id).ok()?;
+                            Some(AuthorizationCollectionOffer {
+                                collection_id: collection.id,
+                                display_name: description.display_name,
+                                spec_version: description.spec_version,
+                                contracts: contract_requirements(&description.contracts),
+                            })
+                        })
+                        .collect()
+                };
+                Some(RelayMessage::AuthorizationOfferResponse {
+                    protocol_version: CONTROL_PROTOCOL_VERSION,
+                    request_id,
+                    paused,
+                    collections,
+                })
+            }
+            RelayMessage::AuthorizationActivationRequest {
+                request_id,
+                collection_id,
+                requirements,
+                provisions,
+                grant,
+                ..
+            } => {
+                let result = (|| {
+                    if self.registry.paused()? {
+                        return Err(ConnectError::AccessDenied(
+                            "Remote access is paused on this computer.".to_string(),
+                        ));
+                    }
+                    if grant.collection_id != collection_id {
+                        return Err(ConnectError::AccessDenied(
+                            "The proposed grant names a different collection.".to_string(),
+                        ));
+                    }
+                    if !scope_matches_requirements(&grant.scope, &requirements) {
+                        return Err(ConnectError::AccessDenied(
+                            "The proposed grant scope does not match the application request."
+                                .to_string(),
+                        ));
+                    }
+                    let registered = self.registry.get(collection_id)?;
+                    if !registered.enabled {
+                        return Err(ConnectError::AccessDenied(
+                            "This collection is disabled on its computer.".to_string(),
+                        ));
+                    }
+                    let before = self.registry.describe(collection_id)?;
+                    if let Some(operation) = grant
+                        .operations
+                        .iter()
+                        .find(|operation| !before.operations.contains(operation))
+                    {
+                        return Err(ConnectError::AccessDenied(format!(
+                            "{} does not support the requested {operation} operation.",
+                            before.display_name
+                        )));
+                    }
+                    let contracts = self.registry.provision_types(
+                        collection_id,
+                        &requirements,
+                        &provisions.types,
+                    )?;
+                    self.watcher.rescan(collection_id);
+                    self.registry.upsert_grant(&grant)?;
+                    Ok(contracts)
+                })();
+                Some(match result {
+                    Ok(contracts) => RelayMessage::AuthorizationActivationResponse {
+                        protocol_version: CONTROL_PROTOCOL_VERSION,
+                        request_id,
+                        ok: true,
+                        contracts,
+                        error: None,
+                    },
+                    Err(error) => RelayMessage::AuthorizationActivationResponse {
+                        protocol_version: CONTROL_PROTOCOL_VERSION,
+                        request_id,
+                        ok: false,
+                        contracts: Vec::new(),
+                        error: Some(ControlError {
+                            code: error.code().to_string(),
+                            message: error.to_string(),
+                            details: None,
+                        }),
+                    },
+                })
             }
             RelayMessage::OperationRequest {
                 request_id,
@@ -339,6 +449,8 @@ impl AgentState {
                 Some(self.handle_encrypted_operation(envelope))
             }
             RelayMessage::OperationResponse { .. }
+            | RelayMessage::AuthorizationOfferResponse { .. }
+            | RelayMessage::AuthorizationActivationResponse { .. }
             | RelayMessage::EncryptedOperationResponse { .. }
             | RelayMessage::EncryptedOperationRejected { .. } => None,
         }
@@ -549,6 +661,17 @@ impl AgentState {
                 }
                 result.and_then(|value| serde_json::to_value(value).map_err(ConnectError::from))
             }
+            ControlCommand::CollectionMakeIndependent(params) => {
+                let result = self.registry.make_independent(params.collection_id);
+                if result.is_ok() {
+                    self.refresh_watchers();
+                }
+                result.and_then(|value| serde_json::to_value(value).map_err(ConnectError::from))
+            }
+            ControlCommand::CollectionTakeAuthority(params) => match self.cloud() {
+                Ok(cloud) => cloud.take_collection_authority(params.collection_id).await,
+                Err(error) => Err(error),
+            },
             ControlCommand::CollectionCreate(params) => {
                 let result = self.registry.create(params.path, params.name.as_deref());
                 if result.is_ok() {
@@ -666,7 +789,6 @@ impl AgentState {
         }
         let contracts = self
             .ensure_application_types(
-                cloud,
                 params.collection_id,
                 &pending.requirements,
                 &pending.provisions,
@@ -683,7 +805,6 @@ impl AgentState {
         let application = cloud.application(params.application_id).await?;
         let contracts = self
             .ensure_application_types(
-                cloud,
                 params.collection_id,
                 &application.requirements,
                 &application.provisions,
@@ -694,7 +815,6 @@ impl AgentState {
 
     async fn ensure_application_types(
         &self,
-        cloud: &CloudControlClient,
         collection_id: uuid::Uuid,
         requirements: &mdbase_connect_protocol::ApplicationRequirements,
         provisions: &mdbase_connect_protocol::ApplicationProvisions,
@@ -711,7 +831,6 @@ impl AgentState {
         self.watcher.rescan(collection_id);
         let mut collection = self.registry.get(collection_id)?;
         collection.contracts = contracts;
-        cloud.sync_collection(&collection).await?;
         Ok(collection.contracts)
     }
 
@@ -723,6 +842,7 @@ impl AgentState {
                 account: None,
                 grants: self.registry.list_grants()?,
                 pending_authorizations: Vec::new(),
+                authority_conflicts: Vec::new(),
             })
             .map_err(ConnectError::from);
         };
@@ -739,6 +859,7 @@ impl AgentState {
                     account: None,
                     grants: self.registry.list_grants()?,
                     pending_authorizations: Vec::new(),
+                    authority_conflicts: Vec::new(),
                 }
             }
         };
@@ -799,6 +920,48 @@ impl AgentState {
         }
         serde_json::to_value(snapshot).map_err(ConnectError::from)
     }
+}
+
+fn contract_requirements(
+    contracts: &[mdbase_connect_protocol::CollectionContractDescriptor],
+) -> Vec<ContractRequirement> {
+    let mut contracts = contracts
+        .iter()
+        .map(|contract| ContractRequirement {
+            id: contract.id.clone(),
+            version: contract.version,
+        })
+        .collect::<Vec<_>>();
+    contracts.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+    contracts.dedup();
+    contracts
+}
+
+fn scope_matches_requirements(scope: &GrantScope, requirements: &ApplicationRequirements) -> bool {
+    let expected_access = requirements.access.unwrap_or(ApplicationAccess::Contract);
+    let mut actual_contracts = scope.contracts.clone();
+    let mut expected_contracts = if expected_access == ApplicationAccess::FullCollection {
+        Vec::new()
+    } else {
+        requirements.contracts.clone()
+    };
+    actual_contracts.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+    expected_contracts.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+    actual_contracts.dedup();
+    expected_contracts.dedup();
+    scope.access == expected_access && actual_contracts == expected_contracts
 }
 
 fn requirements_can_be_provisioned(
@@ -940,7 +1103,8 @@ mod tests {
     use mdbase_connect_core::CollectionRegistry;
     use mdbase_connect_protocol::crypto::{RelayDirection, RelayMetadata};
     use mdbase_connect_protocol::{
-        GrantEncryption, GrantPolicy, GrantScope, RELAY_ENCRYPTION_SUITE,
+        ApplicationAccess, ApplicationProvisions, ApplicationRequirements, GrantEncryption,
+        GrantPolicy, GrantScope, RELAY_ENCRYPTION_SUITE,
     };
     use std::fs;
     use tokio::net::UnixStream;
@@ -983,6 +1147,84 @@ mod tests {
 
         server.abort();
         let _ = server.await;
+        fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[test]
+    fn live_authorization_is_acknowledged_only_after_the_grant_is_stored() {
+        let test_root = std::env::temp_dir().join(format!(
+            "mdbase-connect-authorization-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let registry = CollectionRegistry::open(test_root.join("state")).unwrap();
+        let collection = registry
+            .create(test_root.join("collection"), Some("Live notes"))
+            .unwrap();
+        let watcher = CollectionWatchService::start(registry.clone());
+        let state = AgentState::new(registry.clone(), watcher, None);
+        let authorization_id = Uuid::new_v4();
+        let offer_request_id = Uuid::new_v4();
+        let offer = state
+            .handle_relay_message(RelayMessage::AuthorizationOfferRequest {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: offer_request_id,
+                authorization_id,
+            })
+            .unwrap();
+        let RelayMessage::AuthorizationOfferResponse {
+            request_id,
+            paused,
+            collections,
+            ..
+        } = offer
+        else {
+            panic!("expected authorization offer")
+        };
+        assert_eq!(request_id, offer_request_id);
+        assert!(!paused);
+        assert_eq!(collections.len(), 1);
+        assert_eq!(collections[0].collection_id, collection.id);
+
+        let grant = GrantPolicy {
+            id: Uuid::new_v4(),
+            application_id: Uuid::new_v4(),
+            collection_id: collection.id,
+            operations: vec!["describe".to_string()],
+            scope: GrantScope::full_collection(),
+            application_name: "Live application".to_string(),
+            application_distribution: "web".to_string(),
+            application_homepage: "https://example.test".to_string(),
+            application_project_url: None,
+            application_origin: "https://example.test".to_string(),
+            application_icon: None,
+            collection_name: collection.display_name,
+            notification_criteria: Vec::new(),
+            created_at: "2026-07-26T00:00:00Z".to_string(),
+            encryption: None,
+        };
+        let activation = state
+            .handle_relay_message(RelayMessage::AuthorizationActivationRequest {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: Uuid::new_v4(),
+                authorization_id,
+                collection_id: collection.id,
+                requirements: ApplicationRequirements {
+                    contracts: Vec::new(),
+                    access: Some(ApplicationAccess::FullCollection),
+                },
+                provisions: ApplicationProvisions::default(),
+                grant: grant.clone(),
+            })
+            .unwrap();
+        assert!(matches!(
+            activation,
+            RelayMessage::AuthorizationActivationResponse {
+                ok: true,
+                error: None,
+                ..
+            }
+        ));
+        assert_eq!(registry.list_grants().unwrap()[0].id, grant.id);
         fs::remove_dir_all(test_root).unwrap();
     }
 

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -481,6 +481,55 @@ impl CollectionRegistry {
         self.add(path)
     }
 
+    pub fn make_independent(&self, id: Uuid) -> Result<CollectionSummary, ConnectError> {
+        let collection = self.get(id)?;
+        let path = PathBuf::from(&collection.path);
+        let new_id = Uuid::new_v4();
+        write_collection_id(&path, new_id)?;
+        let result = (|| {
+            let mut connection = self.connection()?;
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute(
+                "DELETE FROM grant_crypto_state
+                 WHERE grant_id IN (SELECT id FROM grants WHERE collection_id = ?1)",
+                [id.to_string()],
+            )?;
+            transaction.execute(
+                "DELETE FROM grant_crypto_requests
+                 WHERE grant_id IN (SELECT id FROM grants WHERE collection_id = ?1)",
+                [id.to_string()],
+            )?;
+            transaction.execute(
+                "DELETE FROM grants WHERE collection_id = ?1",
+                [id.to_string()],
+            )?;
+            transaction.execute(
+                "DELETE FROM collection_changes WHERE collection_id = ?1",
+                [id.to_string()],
+            )?;
+            transaction.execute(
+                "UPDATE collections SET id = ?1, updated_at = CURRENT_TIMESTAMP WHERE id = ?2",
+                params![new_id.to_string(), id.to_string()],
+            )?;
+            transaction.commit()?;
+            Ok::<(), ConnectError>(())
+        })();
+        if let Err(error) = result {
+            let _ = write_collection_id(&path, id);
+            return Err(error);
+        }
+        let mut providers = self
+            .providers
+            .lock()
+            .map_err(|_| ConnectError::CollectionOpen("provider registry lock poisoned".into()))?;
+        if let Some(provider) = providers.remove(&id) {
+            providers.insert(new_id, provider);
+        }
+        drop(providers);
+        self.get(new_id)
+    }
+
     pub fn create(
         &self,
         path: impl AsRef<Path>,
@@ -1330,6 +1379,77 @@ impl CollectionRegistry {
         Ok(())
     }
 
+    pub fn upsert_grant(&self, grant: &GrantPolicy) -> Result<(), ConnectError> {
+        let connection = self.connection()?;
+        connection.execute(
+            "INSERT INTO grants
+               (id, application_id, collection_id, operations, scope, application_name,
+                application_distribution, application_homepage, application_project_url,
+                application_origin, application_icon, collection_name, created_at, encryption,
+                notification_criteria)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+             ON CONFLICT(id) DO UPDATE SET
+               application_id = excluded.application_id,
+               collection_id = excluded.collection_id,
+               operations = excluded.operations,
+               scope = excluded.scope,
+               application_name = excluded.application_name,
+               application_distribution = excluded.application_distribution,
+               application_homepage = excluded.application_homepage,
+               application_project_url = excluded.application_project_url,
+               application_origin = excluded.application_origin,
+               application_icon = excluded.application_icon,
+               collection_name = excluded.collection_name,
+               created_at = excluded.created_at,
+               encryption = excluded.encryption,
+               notification_criteria = excluded.notification_criteria,
+               updated_at = CURRENT_TIMESTAMP",
+            params![
+                grant.id.to_string(),
+                grant.application_id.to_string(),
+                grant.collection_id.to_string(),
+                serde_json::to_string(&grant.operations)?,
+                serde_json::to_string(&grant.scope)?,
+                grant.application_name,
+                grant.application_distribution,
+                grant.application_homepage,
+                grant.application_project_url,
+                grant.application_origin,
+                grant.application_icon,
+                grant.collection_name,
+                grant.created_at,
+                grant
+                    .encryption
+                    .as_ref()
+                    .map(serde_json::to_string)
+                    .transpose()?,
+                serde_json::to_string(&grant.notification_criteria)?,
+            ],
+        )?;
+        if let Some(encryption) = &grant.encryption {
+            connection.execute(
+                "DELETE FROM grant_crypto_state
+                 WHERE grant_id = ?1 AND key_id <> ?2",
+                params![grant.id.to_string(), encryption.key_id],
+            )?;
+            connection.execute(
+                "DELETE FROM grant_crypto_requests
+                 WHERE grant_id = ?1 AND key_id <> ?2",
+                params![grant.id.to_string(), encryption.key_id],
+            )?;
+        } else {
+            connection.execute(
+                "DELETE FROM grant_crypto_state WHERE grant_id = ?1",
+                [grant.id.to_string()],
+            )?;
+            connection.execute(
+                "DELETE FROM grant_crypto_requests WHERE grant_id = ?1",
+                [grant.id.to_string()],
+            )?;
+        }
+        Ok(())
+    }
+
     pub fn replace_grant_summaries(&self, grants: &[GrantSummary]) -> Result<(), ConnectError> {
         self.replace_grants(
             &grants
@@ -1444,6 +1564,28 @@ impl CollectionRegistry {
             )
             .optional()?;
         Ok(value.as_deref() == Some("true"))
+    }
+
+    pub fn next_inventory_revision(&self) -> Result<u64, ConnectError> {
+        let mut connection = self.connection()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let current = transaction
+            .query_row(
+                "SELECT value FROM settings WHERE key = 'inventory_revision'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        let next = current.saturating_add(1);
+        transaction.execute(
+            "INSERT INTO settings (key, value) VALUES ('inventory_revision', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP",
+            [next.to_string()],
+        )?;
+        transaction.commit()?;
+        Ok(next)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2380,6 +2522,38 @@ mod tests {
                 if message.contains("registered original")
         ));
         assert_eq!(read_collection_id(&original).unwrap(), Some(created.id));
+    }
+
+    #[test]
+    fn registered_conflict_can_become_independent_without_moving_files() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("notes");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let created = registry.create(&root, Some("Notes")).unwrap();
+
+        let independent = registry.make_independent(created.id).unwrap();
+
+        assert_ne!(independent.id, created.id);
+        assert_eq!(independent.path, created.path);
+        assert_eq!(read_collection_id(&root).unwrap(), Some(independent.id));
+        assert!(matches!(
+            registry.get(created.id),
+            Err(ConnectError::CollectionNotFound(id)) if id == created.id
+        ));
+        assert_eq!(registry.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn inventory_revisions_are_monotonic_across_registry_restarts() {
+        let state = tempdir().unwrap();
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        assert_eq!(registry.next_inventory_revision().unwrap(), 1);
+        assert_eq!(registry.next_inventory_revision().unwrap(), 2);
+        drop(registry);
+
+        let reopened = CollectionRegistry::open(state.path()).unwrap();
+        assert_eq!(reopened.next_inventory_revision().unwrap(), 3);
     }
 
     #[test]

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -40,6 +40,10 @@ pub enum ControlCommand {
     CollectionAdd(CollectionPathParams),
     #[serde(rename = "collections.add-copy")]
     CollectionAddCopy(CollectionPathParams),
+    #[serde(rename = "collections.make-independent")]
+    CollectionMakeIndependent(CollectionIdParams),
+    #[serde(rename = "collections.take-authority")]
+    CollectionTakeAuthority(CollectionIdParams),
     #[serde(rename = "collections.create")]
     CollectionCreate(CollectionCreateParams),
     #[serde(rename = "collections.update-metadata")]
@@ -622,6 +626,13 @@ pub struct ConnectorAccount {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorityConflict {
+    pub collection_id: Uuid,
+    pub display_name: String,
+    pub active_connector_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccessSnapshot {
     pub configured: bool,
     pub online: bool,
@@ -629,6 +640,8 @@ pub struct AccessSnapshot {
     pub account: Option<ConnectorAccount>,
     pub grants: Vec<GrantSummary>,
     pub pending_authorizations: Vec<PendingAuthorization>,
+    #[serde(default)]
+    pub authority_conflicts: Vec<AuthorityConflict>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -673,6 +686,15 @@ pub struct GrantPolicy {
     pub created_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encryption: Option<GrantEncryption>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorizationCollectionOffer {
+    pub collection_id: Uuid,
+    pub display_name: String,
+    pub spec_version: String,
+    #[serde(default)]
+    pub contracts: Vec<ContractRequirement>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -725,6 +747,35 @@ pub enum RelayMessage {
     PolicySnapshot {
         protocol_version: u32,
         grants: Vec<GrantPolicy>,
+    },
+    AuthorizationOfferRequest {
+        protocol_version: u32,
+        request_id: Uuid,
+        authorization_id: Uuid,
+    },
+    AuthorizationOfferResponse {
+        protocol_version: u32,
+        request_id: Uuid,
+        paused: bool,
+        collections: Vec<AuthorizationCollectionOffer>,
+    },
+    AuthorizationActivationRequest {
+        protocol_version: u32,
+        request_id: Uuid,
+        authorization_id: Uuid,
+        collection_id: Uuid,
+        requirements: ApplicationRequirements,
+        provisions: ApplicationProvisions,
+        grant: GrantPolicy,
+    },
+    AuthorizationActivationResponse {
+        protocol_version: u32,
+        request_id: Uuid,
+        ok: bool,
+        #[serde(default)]
+        contracts: Vec<ContractRequirement>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<ControlError>,
     },
     OperationRequest {
         protocol_version: u32,
@@ -879,6 +930,29 @@ mod tests {
             Uuid::parse_str("01944444-4444-7444-8444-444444444444").unwrap(),
         ];
         for message in [
+            RelayMessage::AuthorizationOfferRequest {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: ids[0],
+                authorization_id: ids[1],
+            },
+            RelayMessage::AuthorizationOfferResponse {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: ids[0],
+                paused: false,
+                collections: vec![AuthorizationCollectionOffer {
+                    collection_id: ids[2],
+                    display_name: "My tasks".to_string(),
+                    spec_version: "0.3.0".to_string(),
+                    contracts: Vec::new(),
+                }],
+            },
+            RelayMessage::AuthorizationActivationResponse {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: ids[0],
+                ok: true,
+                contracts: Vec::new(),
+                error: None,
+            },
             RelayMessage::OperationRequest {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
                 request_id: ids[0],

--- a/packages/protocol/schemas/connect-protocol.v1.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v1.schema.json
@@ -6,7 +6,11 @@
   "oneOf": [
     { "$ref": "#/$defs/relayOperationRequest" },
     { "$ref": "#/$defs/relayOperationResponse" },
-    { "$ref": "#/$defs/relayPolicySnapshot" }
+    { "$ref": "#/$defs/relayPolicySnapshot" },
+    { "$ref": "#/$defs/authorizationOfferRequest" },
+    { "$ref": "#/$defs/authorizationOfferResponse" },
+    { "$ref": "#/$defs/authorizationActivationRequest" },
+    { "$ref": "#/$defs/authorizationActivationResponse" }
   ],
   "$defs": {
     "uuid": {
@@ -144,6 +148,140 @@
         "created_at": { "type": "string", "format": "date-time" },
         "encryption": { "$ref": "#/$defs/grantEncryption" }
       }
+    },
+    "authorizationCollectionOffer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collection_id", "display_name", "spec_version", "contracts"],
+      "properties": {
+        "collection_id": { "$ref": "#/$defs/uuid" },
+        "display_name": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "spec_version": { "type": "string", "minLength": 1, "maxLength": 30 },
+        "contracts": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/contractRequirement" }
+        }
+      }
+    },
+    "applicationRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contracts"],
+      "properties": {
+        "contracts": {
+          "type": "array",
+          "maxItems": 20,
+          "items": { "$ref": "#/$defs/contractRequirement" }
+        },
+        "access": { "enum": ["contract", "full_collection"] }
+      }
+    },
+    "typeProvision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "document", "provides"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "path": { "type": "string", "minLength": 1, "maxLength": 500 },
+        "document": { "type": "string", "minLength": 1, "maxLength": 262144 },
+        "provides": {
+          "type": "array",
+          "maxItems": 20,
+          "items": { "$ref": "#/$defs/contractRequirement" }
+        }
+      }
+    },
+    "applicationProvisions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["types"],
+      "properties": {
+        "types": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/typeProvision" }
+        }
+      }
+    },
+    "authorizationOfferRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "request_id", "authorization_id"],
+      "properties": {
+        "type": { "const": "authorization_offer_request" },
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "authorization_id": { "$ref": "#/$defs/uuid" }
+      }
+    },
+    "authorizationOfferResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "request_id", "paused", "collections"],
+      "properties": {
+        "type": { "const": "authorization_offer_response" },
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "paused": { "type": "boolean" },
+        "collections": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": { "$ref": "#/$defs/authorizationCollectionOffer" }
+        }
+      }
+    },
+    "authorizationActivationRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "request_id", "authorization_id", "collection_id", "requirements", "provisions", "grant"],
+      "properties": {
+        "type": { "const": "authorization_activation_request" },
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "authorization_id": { "$ref": "#/$defs/uuid" },
+        "collection_id": { "$ref": "#/$defs/uuid" },
+        "requirements": { "$ref": "#/$defs/applicationRequirements" },
+        "provisions": { "$ref": "#/$defs/applicationProvisions" },
+        "grant": { "$ref": "#/$defs/grantPolicy" }
+      }
+    },
+    "authorizationActivationResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "request_id", "ok", "contracts"],
+      "properties": {
+        "type": { "const": "authorization_activation_response" },
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "ok": { "type": "boolean" },
+        "contracts": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/contractRequirement" }
+        },
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message"],
+          "properties": {
+            "code": { "type": "string", "minLength": 1 },
+            "message": { "type": "string", "minLength": 1 },
+            "details": true
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "ok": { "const": true } }, "required": ["ok"] },
+          "then": {
+            "not": { "properties": { "error": true }, "required": ["error"] }
+          },
+          "else": {
+            "required": ["error"]
+          }
+        }
+      ]
     },
     "notificationCriterion": {
       "type": "object",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -380,6 +380,34 @@ export interface RelayPolicySnapshot {
   grants: GrantPolicy[];
 }
 
+export interface AuthorizationCollectionOffer {
+  collection_id: string;
+  display_name: string;
+  spec_version: string;
+  contracts: ContractRequirement[];
+}
+
+export interface AuthorizationOfferResponse {
+  type: "authorization_offer_response";
+  protocol_version: 1;
+  request_id: string;
+  paused: boolean;
+  collections: AuthorizationCollectionOffer[];
+}
+
+export interface AuthorizationActivationResponse {
+  type: "authorization_activation_response";
+  protocol_version: 1;
+  request_id: string;
+  ok: boolean;
+  contracts: ContractRequirement[];
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
 export interface ConnectorCollection {
   id: string;
   display_name: string;

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -332,6 +332,37 @@ test("relay request and response discriminators reject malformed wire messages",
   };
   assert.equal(validate(response), true, JSON.stringify(validate.errors));
   assert.equal(validate({ ...response, result: {} }), false);
+
+  const offer = {
+    type: "authorization_offer_response",
+    protocol_version: 1,
+    request_id: request.request_id,
+    paused: false,
+    collections: [{
+      collection_id: request.collection_id,
+      display_name: "Tasks",
+      spec_version: "0.3.0",
+      contracts: []
+    }]
+  };
+  assert.equal(validate(offer), true, JSON.stringify(validate.errors));
+  assert.equal(validate({
+    ...offer,
+    collections: [{ ...offer.collections[0], path: "/private/vault" }]
+  }), false);
+
+  const activation = {
+    type: "authorization_activation_response",
+    protocol_version: 1,
+    request_id: request.request_id,
+    ok: true,
+    contracts: []
+  };
+  assert.equal(validate(activation), true, JSON.stringify(validate.errors));
+  assert.equal(validate({
+    ...activation,
+    ok: false
+  }), false);
 });
 
 test("collection descriptions and operation envelopes have addressable schemas", () => {

--- a/packages/ui/access.test.ts
+++ b/packages/ui/access.test.ts
@@ -30,6 +30,26 @@ test("does not mutate the incoming grant order", () => {
   assert.deepEqual(grants.map((item) => item.id), ["newest", "oldest"]);
 });
 
+test("groups manifest revisions by application family without changing grant identity", () => {
+  const groups = groupApplicationAccess([
+    {
+      ...grant("old", "revision-a", "Notes", "collection-a", "2026-07-22T01:00:00Z"),
+      application_family_id: "bundle:dev.mdbase.notes"
+    },
+    {
+      ...grant("new", "revision-b", "Archive", "collection-b", "2026-07-22T02:00:00Z"),
+      application_family_id: "bundle:dev.mdbase.notes"
+    }
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].applicationId, "bundle:dev.mdbase.notes");
+  assert.deepEqual(new Set(groups[0].grants.map((item) => item.application_id)), new Set([
+    "revision-a",
+    "revision-b"
+  ]));
+});
+
 test("groups requested operations into plain-language permission categories", () => {
   assert.deepEqual(
     groupAuthorizationOperations(["read", "query", "create", "delete", "create_view_source"]),

--- a/packages/ui/access.ts
+++ b/packages/ui/access.ts
@@ -1,5 +1,6 @@
 export interface ApplicationAccessGrant {
   application_id: string;
+  application_family_id?: string;
   application_name: string;
   collection_id: string;
   collection_name: string;
@@ -102,13 +103,14 @@ export function groupApplicationAccess<Grant extends ApplicationAccessGrant>(
   const groups = new Map<string, ApplicationAccessGroup<Grant>>();
 
   for (const grant of grants) {
-    const current = groups.get(grant.application_id);
+    const groupId = grant.application_family_id || grant.application_id;
+    const current = groups.get(groupId);
     if (current) {
       current.grants.push(grant);
       continue;
     }
-    groups.set(grant.application_id, {
-      applicationId: grant.application_id,
+    groups.set(groupId, {
+      applicationId: groupId,
       applicationName: grant.application_name,
       collectionCount: 0,
       grants: [grant]

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -215,6 +215,77 @@ secret: connector scope test
       || !token.body.grant_id) {
     throw new Error(`Authorization did not establish encrypted relay protocol 1: ${JSON.stringify(token.body)}`);
   }
+
+  const portalVerifier = "portal-live-offer-pkce-verifier-with-forty-three-characters";
+  const portalChallenge = createHash("sha256").update(portalVerifier).digest("base64url");
+  const portalAuthorize = await fetch(
+    `${serverUrl}/oauth/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(manifest.redirectUri)}&code_challenge=${portalChallenge}&code_challenge_method=S256&state=portal-e2e&operations=describe`,
+    { headers: { cookie }, redirect: "manual" }
+  );
+  if (portalAuthorize.status !== 302) {
+    throw new Error(`Portal authorization start returned HTTP ${portalAuthorize.status}`);
+  }
+  const portalAuthorizationId = portalAuthorize.headers.get("location")?.split("/").at(-1);
+  if (!portalAuthorizationId) throw new Error("Portal authorization request ID missing");
+  const portalRequest = await request(
+    `/v1/authorization-requests/${portalAuthorizationId}`,
+    { cookie }
+  );
+  const portalOffer = portalRequest.body.collections?.find(
+    (candidate) => candidate.id === collection.id
+  );
+  if (!portalOffer?.offer_id || portalOffer.connector_name !== "MVP computer") {
+    throw new Error(
+      `The live connector did not offer its local collection to the portal: ${JSON.stringify(portalRequest.body)}`
+    );
+  }
+  await request(`/v1/authorization-requests/${portalAuthorizationId}/approve`, {
+    method: "POST",
+    cookie,
+    body: {
+      collection_id: portalOffer.id,
+      offer_id: portalOffer.offer_id,
+      operations: ["describe"]
+    }
+  });
+  const portalCompleted = await poll(async () => {
+    const current = await request(
+      `/v1/authorization-requests/${portalAuthorizationId}/status`,
+      { cookie }
+    );
+    return current.body.redirect_uri ? current : null;
+  }, "portal-approved local authorization did not complete");
+  const portalCallback = new URL(portalCompleted.body.redirect_uri);
+  const portalToken = await request("/oauth/token", {
+    method: "POST",
+    form: {
+      grant_type: "authorization_code",
+      code: portalCallback.searchParams.get("code"),
+      client_id: appId,
+      redirect_uri: manifest.redirectUri,
+      code_verifier: portalVerifier
+    }
+  });
+  const portalDescription = await fetch(
+    `${serverUrl}/v1/collections/${collection.id}/operations/describe`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${portalToken.body.access_token}`,
+        "content-type": "application/json"
+      },
+      body: "{}"
+    }
+  );
+  const portalDescriptionBody = await portalDescription.json();
+  if (portalDescription.status !== 200
+      || portalDescriptionBody.result?.display_name !== "Workouts") {
+    throw new Error(
+      `Portal-activated local grant could not describe its collection: ${JSON.stringify(portalDescriptionBody)}`
+    );
+  }
+  await cliJson(["access", "revoke", portalToken.body.grant_id]);
+
   relayContext = {
     store: applicationKeyStore,
     handle: "e2e-grant",

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1936,6 +1936,7 @@ if (action === "add") {
         "content-type": "application/json"
       },
       body: JSON.stringify({
+        inventory_revision: 1,
         collections: [{
           id,
           display_name: "Promotion E2E collection",

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -50,7 +50,7 @@ try {
     } catch {
       return null;
     }
-  }, "PostgreSQL did not become ready", 200, 100);
+  }, "PostgreSQL did not become ready", 600, 100);
   // The image briefly starts a bootstrap server before restarting PostgreSQL
   // as PID 1. Do not mistake that initialization window for final readiness.
   await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_000));
@@ -360,9 +360,10 @@ async function seed(db, hash) {
     [connectorId, userId, "Relay E2E connector", hash(connectorToken)]
   );
   await db.query(
-    `INSERT INTO collections (id, connector_id, local_id, display_name, spec_version, contracts)
-     VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
-    [collectionId, connectorId, localCollectionId, "Relay E2E collection", "0.3.0", "[]"]
+    `INSERT INTO collections
+       (id, user_id, connector_id, local_id, display_name, spec_version, contracts)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+    [collectionId, userId, connectorId, localCollectionId, "Relay E2E collection", "0.3.0", "[]"]
   );
   await db.query(
     `INSERT INTO applications

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -193,6 +193,7 @@ describe("mdbase connect server", () => {
       headers: { authorization: `Bearer ${connector.token}` },
       payload: {
         relay_public_key: connectorKey.getPublicKey(undefined, "uncompressed").toString("base64url"),
+        inventory_revision: 1,
         collections: [{
           id: localCollectionId,
           display_name: "Workouts",
@@ -327,10 +328,13 @@ describe("mdbase connect server", () => {
     expect(pending.statusCode).toBe(200);
     expect(pending.json().authorization.application_name).toBe("Workout Tracker");
     expect(pending.json().authorization.collection_hint).toBe(collectionId);
-    expect(pending.json().collections).toContainEqual(expect.objectContaining({
-      display_name: "Legacy workouts",
-      spec_version: "0.2.0"
-    }));
+    expect(pending.json().collections).toEqual([]);
+    expect(pending.json().unavailable_connectors).toContainEqual(
+      expect.objectContaining({
+        connector_name: "Home computer",
+        reason: "offline"
+      })
+    );
 
     const portalLegacyApproval = await app.inject({
       method: "POST",
@@ -341,8 +345,7 @@ describe("mdbase connect server", () => {
         operations: ["read", "query"]
       }
     });
-    expect(portalLegacyApproval.statusCode).toBe(400);
-    expect(portalLegacyApproval.json().error.message).toContain("does not support the query operation");
+    expect(portalLegacyApproval.statusCode).toBe(404);
 
     const localControl = await app.inject({
       method: "GET",
@@ -511,7 +514,11 @@ describe("mdbase connect server", () => {
     const portalRequestId = portalAuthorization.headers.location!.split("/").at(-1)!;
     const waitingDashboard = await app.inject({ method: "GET", url: "/v1/me", headers: { cookie } });
     expect(waitingDashboard.json().pending_authorizations).toEqual([
-      expect.objectContaining({ id: portalRequestId, application_name: "Workout Tracker" })
+      expect.objectContaining({
+        id: portalRequestId,
+        application_name: "Workout Tracker",
+        available_collections: []
+      })
     ]);
     const portalApproved = await app.inject({
       method: "POST",
@@ -519,8 +526,15 @@ describe("mdbase connect server", () => {
       headers: { cookie },
       payload: { collection_id: collectionId, operations: ["read"] }
     });
-    expect(portalApproved.statusCode).toBe(200);
-    expect(portalApproved.json()).toEqual({ ok: true });
+    expect(portalApproved.statusCode).toBe(404);
+    const locallyApproved = await app.inject({
+      method: "POST",
+      url: `/v1/connectors/authorization-requests/${portalRequestId}/approve`,
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: { collection_id: localCollectionId, operations: ["read"] }
+    });
+    expect(locallyApproved.statusCode).toBe(200);
+    expect(locallyApproved.json()).toEqual({ ok: true });
     const policyAfterPortalApproval = await app.inject({
       method: "GET",
       url: "/v1/connectors/control",
@@ -639,6 +653,7 @@ describe("mdbase connect server", () => {
       headers: { authorization: `Bearer ${connector.token}` },
       payload: {
         relay_public_key: connectorKey.getPublicKey(undefined, "uncompressed").toString("base64url"),
+        inventory_revision: 1,
         collections: [{
           id: localCollectionId,
           display_name: "Portable notes",
@@ -787,8 +802,12 @@ describe("mdbase connect server", () => {
       user_code: device.json().user_code,
       requested_operations: ["describe", "query"]
     });
-    expect(pending.json().collections).toEqual([
-      expect.objectContaining({ id: collectionId, kind: "local" })
+    expect(pending.json().collections).toEqual([]);
+    expect(pending.json().unavailable_connectors).toEqual([
+      expect.objectContaining({
+        connector_name: "Portable computer",
+        reason: "offline"
+      })
     ]);
 
     const control = await app.inject({
@@ -1163,6 +1182,7 @@ describe("mdbase connect server", () => {
       url: "/v1/connectors/sync",
       headers: { authorization: `Bearer ${connector.token}` },
       payload: {
+        inventory_revision: 1,
         collections: [{
           id: localCollectionId,
           display_name: "Local writing",
@@ -1227,10 +1247,7 @@ describe("mdbase connect server", () => {
         operations: ["describe", "query", "create", "update"]
       }
     });
-    expect(localApproval.statusCode).toBe(400);
-    expect(localApproval.json().error.message).toBe(
-      "This application requires an mdbase cloud collection."
-    );
+    expect(localApproval.statusCode).toBe(404);
     const approved = await app.inject({
       method: "POST",
       url: `/v1/authorization-requests/${requestId}/approve`,

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -315,6 +315,12 @@ export async function buildApp(options: BuildOptions) {
     if (error instanceof RequestValidationError) {
       return reply.code(400).send(apiError("invalid_request", error.message));
     }
+    if (error instanceof RelayUnavailableError) {
+      return reply.code(409).send(apiError("connector_offline", error.message));
+    }
+    if (error instanceof ConnectorOperationError) {
+      return reply.code(409).send(apiError(error.code, error.message));
+    }
     if (error instanceof SyncError) {
       const denied = error.code === "replica_revoked" || error.code === "scope_denied" || error.code === "read_only_replica";
       return reply.code(denied ? 403 : 400).send(apiError(error.code, error.message));
@@ -1426,6 +1432,7 @@ export async function buildApp(options: BuildOptions) {
               c.name AS connector_name
        FROM collections col JOIN connectors c ON c.id = col.connector_id
        WHERE c.user_id = $1 AND col.authority_state = 'active'
+         AND col.present = true
        ORDER BY col.display_name`,
       [user.id]
     );
@@ -1486,7 +1493,9 @@ export async function buildApp(options: BuildOptions) {
               CASE WHEN g.application_origin = '' THEN a.homepage
                    ELSE g.application_origin END AS application_origin,
               COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
-              a.id AS application_id, a.distribution, a.name AS application_name,
+              a.id AS application_id,
+              a.family_identity AS application_family_id,
+              a.distribution, a.name AS application_name,
               a.homepage, a.project_url, a.icon,
               COALESCE(col.display_name, hosted.display_name) AS collection_name,
               CASE WHEN g.hosted_collection_id IS NULL THEN 'local' ELSE 'hosted' END AS collection_kind
@@ -1494,7 +1503,9 @@ export async function buildApp(options: BuildOptions) {
        JOIN applications a ON a.id = g.application_id
        LEFT JOIN collections col ON col.id = g.collection_id
        LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
-       WHERE g.user_id = $1 ORDER BY g.created_at DESC`,
+       WHERE g.user_id = $1
+         AND (g.activated_at IS NOT NULL OR g.revoked_at IS NOT NULL)
+       ORDER BY g.created_at DESC`,
       [user.id]
     );
     const pendingAuthorizations = await options.db.query(
@@ -1535,7 +1546,21 @@ export async function buildApp(options: BuildOptions) {
         ...grant,
         application_origin: normalizedApplicationOrigin(grant.application_origin)
       })),
-      pending_authorizations: pendingAuthorizations.rows
+      pending_authorizations: await Promise.all(pendingAuthorizations.rows.map(async (authorization) => {
+        const live = requiresHostedCollection(authorization.requirements)
+          ? { collections: [], unavailable_connectors: [] }
+          : await liveAuthorizationCollections(
+              options.db,
+              relay,
+              user.id,
+              authorization.id
+            );
+        return {
+          ...authorization,
+          available_collections: live.collections,
+          unavailable_connectors: live.unavailable_connectors
+        };
+      }))
     };
   });
 
@@ -1600,6 +1625,7 @@ export async function buildApp(options: BuildOptions) {
     if (!connector) return;
     const input = z.object({
       relay_public_key: z.string().min(80).max(200).refine(isP256PublicKey).optional(),
+      inventory_revision: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
       collections: z.array(z.object({
         id: z.uuid(),
         display_name: z.string().min(1).max(200),
@@ -1608,85 +1634,279 @@ export async function buildApp(options: BuildOptions) {
         contracts: z.array(contractRequirementSchema).max(100).default([])
       })).max(1_000)
     }).parse(request.body);
-    if (input.relay_public_key) {
-      await options.db.query(
-        "UPDATE connectors SET relay_public_key = $2 WHERE id = $1",
-        [connector.id, input.relay_public_key]
-      );
+    if (new Set(input.collections.map((collection) => collection.id)).size !== input.collections.length) {
+      throw new RequestValidationError("A collection may appear only once in an inventory.");
     }
-    const synchronized = [];
-    for (const collection of input.collections) {
-      const existing = await options.db.query<{
-        id: string;
-        authority_state: "active" | "candidate" | "retired";
-        authority_epoch: string | number;
-      }>(
-        `SELECT id, authority_state, authority_epoch
-         FROM collections WHERE connector_id = $1 AND local_id = $2`,
-        [connector.id, collection.id]
-      );
-      const hosted = await options.db.query<{
-        authority_state: "active" | "transferring" | "transferred";
-        authority_epoch: string | number;
-        transferred_collection_id: string | null;
-      }>(
-        `SELECT authority_state, authority_epoch, transferred_collection_id
-         FROM hosted_collections WHERE id = $1 AND user_id = $2`,
-        [collection.id, connector.user_id]
-      );
-      const hostedCollection = hosted.rows[0];
-      const isActivatedTransfer = Boolean(
-        hostedCollection?.authority_state === "transferred"
-        && hostedCollection.transferred_collection_id
-        && hostedCollection.transferred_collection_id === existing.rows[0]?.id
-      );
-      const authorityState = hostedCollection
-        ? (isActivatedTransfer ? "active" : "candidate")
-        : (existing.rows[0]?.authority_state ?? "active");
-      const authorityEpoch = Number(
-        hostedCollection?.authority_epoch
-        ?? existing.rows[0]?.authority_epoch
-        ?? 1
-      );
-      const enabled = authorityState === "active" ? collection.enabled : false;
-      const row = await options.db.query<{
-        id: string;
-        local_id: string;
-        authority_state: "active" | "candidate" | "retired";
-        authority_epoch: string | number;
-      }>(
-        `INSERT INTO collections
-           (id, connector_id, local_id, display_name, spec_version, enabled,
-            authority_state, authority_epoch, contracts)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
-         ON CONFLICT(connector_id, local_id) DO UPDATE SET
-           display_name = excluded.display_name,
-           spec_version = excluded.spec_version,
-           enabled = excluded.enabled,
-           authority_state = excluded.authority_state,
-           authority_epoch = excluded.authority_epoch,
-           contracts = excluded.contracts,
+    const connection = await options.db.connect();
+    try {
+      await connection.query("BEGIN");
+      await connection.query("SELECT id FROM users WHERE id = $1 FOR UPDATE", [
+        connector.user_id
+      ]);
+      const accepted = await connection.query(
+        `UPDATE connectors SET
+           inventory_revision = $2,
+           relay_public_key = COALESCE($3, relay_public_key),
            last_seen_at = now()
-         RETURNING id, local_id, authority_state, authority_epoch`,
-        [
-          randomUUID(),
-          connector.id,
-          collection.id,
-          collection.display_name,
-          collection.spec_version,
-          enabled,
-          authorityState,
-          authorityEpoch,
-          JSON.stringify(collection.contracts)
-        ]
+         WHERE id = $1 AND inventory_revision < $2
+         RETURNING id`,
+        [connector.id, input.inventory_revision, input.relay_public_key ?? null]
       );
-      synchronized.push({
-        ...row.rows[0],
-        authority_epoch: Number(row.rows[0].authority_epoch)
-      });
+      if (!accepted.rows[0]) {
+        const current = await connection.query<{ inventory_revision: string | number }>(
+          "SELECT inventory_revision FROM connectors WHERE id = $1",
+          [connector.id]
+        );
+        await connection.query("COMMIT");
+        return {
+          accepted: false,
+          inventory_revision: Number(current.rows[0]?.inventory_revision ?? 0),
+          collections: []
+        };
+      }
+
+      const synchronized = [];
+      for (const collection of input.collections) {
+        const existing = await connection.query<{
+          id: string;
+          authority_state: "active" | "candidate" | "retired";
+          authority_epoch: string | number;
+        }>(
+          `SELECT id, authority_state, authority_epoch
+           FROM collections WHERE connector_id = $1 AND local_id = $2`,
+          [connector.id, collection.id]
+        );
+        const activeAuthority = await connection.query<{
+          id: string;
+          authority_epoch: string | number;
+        }>(
+          `SELECT id, authority_epoch FROM collections
+           WHERE user_id = $1 AND local_id = $2 AND authority_state = 'active'`,
+          [connector.user_id, collection.id]
+        );
+        const hosted = await connection.query<{
+          authority_state: "active" | "transferring" | "transferred";
+          authority_epoch: string | number;
+          transferred_collection_id: string | null;
+        }>(
+          `SELECT authority_state, authority_epoch, transferred_collection_id
+           FROM hosted_collections WHERE id = $1 AND user_id = $2`,
+          [collection.id, connector.user_id]
+        );
+        const existingCollection = existing.rows[0];
+        const currentAuthority = activeAuthority.rows[0];
+        const hostedCollection = hosted.rows[0];
+        const isActivatedTransfer = Boolean(
+          hostedCollection?.authority_state === "transferred"
+          && hostedCollection.transferred_collection_id
+          && hostedCollection.transferred_collection_id === existingCollection?.id
+        );
+        const authorityState: "active" | "candidate" = hostedCollection
+          ? (isActivatedTransfer ? "active" : "candidate")
+          : (currentAuthority && currentAuthority.id !== existingCollection?.id
+            ? "candidate"
+            : "active");
+        const authorityEpoch = Number(
+          hostedCollection?.authority_epoch
+          ?? currentAuthority?.authority_epoch
+          ?? existingCollection?.authority_epoch
+          ?? 1
+        );
+        const enabled = authorityState === "active" && collection.enabled;
+        const row = await connection.query<{
+          id: string;
+          local_id: string;
+          authority_state: "active" | "candidate" | "retired";
+          authority_epoch: string | number;
+        }>(
+          `INSERT INTO collections
+             (id, user_id, connector_id, local_id, display_name, spec_version, enabled,
+              reported_enabled, present, authority_state, authority_epoch, contracts,
+              last_inventory_revision)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, true, $9, $10, $11::jsonb, $12)
+           ON CONFLICT(connector_id, local_id) DO UPDATE SET
+             user_id = excluded.user_id,
+             display_name = excluded.display_name,
+             spec_version = excluded.spec_version,
+             enabled = excluded.enabled,
+             reported_enabled = excluded.reported_enabled,
+             present = true,
+             authority_state = excluded.authority_state,
+             authority_epoch = excluded.authority_epoch,
+             contracts = excluded.contracts,
+             last_inventory_revision = excluded.last_inventory_revision,
+             last_seen_at = now(),
+             removed_at = NULL
+           RETURNING id, local_id, authority_state, authority_epoch`,
+          [
+            randomUUID(),
+            connector.user_id,
+            connector.id,
+            collection.id,
+            collection.display_name,
+            collection.spec_version,
+            enabled,
+            collection.enabled,
+            authorityState,
+            authorityEpoch,
+            JSON.stringify(collection.contracts),
+            input.inventory_revision
+          ]
+        );
+        synchronized.push({
+          ...row.rows[0],
+          authority_epoch: Number(row.rows[0].authority_epoch)
+        });
+      }
+
+      const removed = await connection.query<{ id: string }>(
+        `UPDATE collections SET
+           present = false,
+           enabled = false,
+           authority_state = 'retired',
+           removed_at = now()
+         WHERE connector_id = $1 AND present = true
+           AND last_inventory_revision < $2
+         RETURNING id`,
+        [connector.id, input.inventory_revision]
+      );
+      for (const collection of removed.rows) {
+        const revoked = await connection.query<{ id: string }>(
+          `UPDATE grants SET revoked_at = COALESCE(revoked_at, now())
+           WHERE collection_id = $1 AND revoked_at IS NULL
+           RETURNING id`,
+          [collection.id]
+        );
+        for (const grant of revoked.rows) {
+          await connection.query(
+            "UPDATE access_tokens SET revoked_at = COALESCE(revoked_at, now()) WHERE grant_id = $1",
+            [grant.id]
+          );
+          await connection.query(
+            "UPDATE refresh_tokens SET revoked_at = COALESCE(revoked_at, now()) WHERE grant_id = $1",
+            [grant.id]
+          );
+        }
+      }
+      await connection.query("COMMIT");
+      return {
+        accepted: true,
+        inventory_revision: input.inventory_revision,
+        collections: synchronized
+      };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
     }
-    await options.db.query("UPDATE connectors SET last_seen_at = now() WHERE id = $1", [connector.id]);
-    return { collections: synchronized };
+  });
+
+  app.post("/v1/connectors/authority-conflicts/:collectionId/move", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
+    const connection = await options.db.connect();
+    const affectedConnectors = new Set<string>([connector.id]);
+    try {
+      await connection.query("BEGIN");
+      await connection.query("SELECT id FROM users WHERE id = $1 FOR UPDATE", [
+        connector.user_id
+      ]);
+      const candidate = await connection.query<{
+        id: string;
+        reported_enabled: boolean;
+        authority_epoch: string | number;
+      }>(
+        `SELECT id, reported_enabled, authority_epoch FROM collections
+         WHERE connector_id = $1 AND user_id = $2 AND local_id = $3
+           AND present = true AND authority_state = 'candidate'
+         FOR UPDATE`,
+        [connector.id, connector.user_id, collectionId]
+      );
+      if (!candidate.rows[0]) {
+        await connection.query("ROLLBACK");
+        return reply.code(404).send(apiError(
+          "authority_conflict_not_found",
+          "This folder no longer has an authority conflict."
+        ));
+      }
+      const hosted = await connection.query<{ authority_state: string }>(
+        `SELECT authority_state FROM hosted_collections
+         WHERE id = $1 AND user_id = $2 AND authority_state <> 'transferred'`,
+        [collectionId, connector.user_id]
+      );
+      if (hosted.rows[0]) {
+        throw new RequestValidationError(
+          "Use the hosted collection transfer flow before moving this authority."
+        );
+      }
+      const current = await connection.query<{
+        id: string;
+        connector_id: string;
+        authority_epoch: string | number;
+      }>(
+        `SELECT id, connector_id, authority_epoch FROM collections
+         WHERE user_id = $1 AND local_id = $2 AND authority_state = 'active'
+         FOR UPDATE`,
+        [connector.user_id, collectionId]
+      );
+      const nextEpoch = Math.max(
+        Number(candidate.rows[0].authority_epoch),
+        ...current.rows.map((authority) => Number(authority.authority_epoch))
+      ) + 1;
+      for (const authority of current.rows) {
+        affectedConnectors.add(authority.connector_id);
+        await connection.query(
+          `UPDATE collections SET authority_state = 'retired', enabled = false,
+                                  authority_epoch = $2
+           WHERE id = $1`,
+          [authority.id, nextEpoch]
+        );
+        const revoked = await connection.query<{ id: string }>(
+          `UPDATE grants SET revoked_at = COALESCE(revoked_at, now())
+           WHERE collection_id = $1 AND revoked_at IS NULL RETURNING id`,
+          [authority.id]
+        );
+        for (const grant of revoked.rows) {
+          await connection.query(
+            "UPDATE access_tokens SET revoked_at = COALESCE(revoked_at, now()) WHERE grant_id = $1",
+            [grant.id]
+          );
+          await connection.query(
+            "UPDATE refresh_tokens SET revoked_at = COALESCE(revoked_at, now()) WHERE grant_id = $1",
+            [grant.id]
+          );
+        }
+      }
+      await connection.query(
+        `UPDATE collections SET authority_state = 'active',
+                                authority_epoch = $2,
+                                enabled = reported_enabled
+         WHERE id = $1`,
+        [candidate.rows[0].id, nextEpoch]
+      );
+      await connection.query(
+        `DELETE FROM authorization_collection_offers
+         WHERE collection_id = $1 OR collection_id IN (
+           SELECT id FROM collections
+           WHERE user_id = $2 AND local_id = $3
+         )`,
+        [candidate.rows[0].id, connector.user_id, collectionId]
+      );
+      await audit(connection, connector.user_id, "collection.authority_moved", collectionId, {
+        connector_id: connector.id,
+        authority_epoch: nextEpoch
+      });
+      await connection.query("COMMIT");
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+    for (const connectorId of affectedConnectors) await relay.pushPolicy(connectorId);
+    return { ok: true };
   });
 
   app.get("/v1/connectors/control", async (request, reply) => {
@@ -1721,6 +1941,7 @@ export async function buildApp(options: BuildOptions) {
        JOIN applications a ON a.id = g.application_id
        JOIN collections col ON col.id = g.collection_id
        WHERE col.connector_id = $1 AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL
        ORDER BY a.name, col.display_name`,
       [connector.id]
     );
@@ -1741,6 +1962,22 @@ export async function buildApp(options: BuildOptions) {
        ORDER BY ar.expires_at`,
       [connector.user_id, connector.id]
     );
+    const authorityConflicts = await options.db.query(
+      `SELECT candidate.local_id AS collection_id,
+              candidate.display_name,
+              COALESCE(active_connector.name, 'mdbase cloud') AS active_connector_name
+       FROM collections candidate
+       LEFT JOIN collections active
+         ON active.user_id = candidate.user_id
+        AND active.local_id = candidate.local_id
+        AND active.authority_state = 'active'
+       LEFT JOIN connectors active_connector ON active_connector.id = active.connector_id
+       WHERE candidate.connector_id = $1
+         AND candidate.present = true
+         AND candidate.authority_state = 'candidate'
+       ORDER BY candidate.display_name`,
+      [connector.id]
+    );
     return {
       configured: true,
       online: true,
@@ -1750,7 +1987,8 @@ export async function buildApp(options: BuildOptions) {
         application_origin: normalizedApplicationOrigin(grant.application_origin)
       })),
       pending_authorizations: pendingAuthorizations.rows
-        .filter((authorization) => !requiresHostedCollection(authorization.requirements))
+        .filter((authorization) => !requiresHostedCollection(authorization.requirements)),
+      authority_conflicts: authorityConflicts.rows
     };
   });
 
@@ -1782,12 +2020,15 @@ export async function buildApp(options: BuildOptions) {
     if (input.contracts) {
       await options.db.query(
         `UPDATE collections SET contracts = $3::jsonb, last_seen_at = now()
-         WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
+         WHERE connector_id = $1 AND local_id = $2 AND enabled = true
+           AND present = true AND authority_state = 'active'`,
         [connector.id, input.collection_id, JSON.stringify(input.contracts)]
       );
     }
     const collection = await options.db.query<{ id: string; contracts: ContractRequirement[]; spec_version: string }>(
-      `SELECT id, contracts, spec_version FROM collections WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
+      `SELECT id, contracts, spec_version FROM collections
+       WHERE connector_id = $1 AND local_id = $2 AND enabled = true
+         AND present = true AND authority_state = 'active'`,
       [connector.id, input.collection_id]
     );
     if (!collection.rows[0]) return reply.code(404).send(apiError("collection_not_found", "Collection is not synchronized yet."));
@@ -1852,7 +2093,8 @@ export async function buildApp(options: BuildOptions) {
       `SELECT a.requirements, col.spec_version FROM grants g
        JOIN applications a ON a.id = g.application_id
        JOIN collections col ON col.id = g.collection_id
-       WHERE g.id = $1 AND g.revoked_at IS NULL AND g.collection_id IN
+       WHERE g.id = $1 AND g.revoked_at IS NULL AND g.activated_at IS NOT NULL
+         AND g.collection_id IN
          (SELECT id FROM collections WHERE connector_id = $2)`,
       [grantId, connector.id]
     );
@@ -1861,7 +2103,8 @@ export async function buildApp(options: BuildOptions) {
     assertCollectionSupportsOperations(current.rows[0].spec_version, input.operations);
     const grant = await options.db.query(
       `UPDATE grants SET operations = $3::jsonb
-       WHERE id = $1 AND revoked_at IS NULL AND collection_id IN
+       WHERE id = $1 AND revoked_at IS NULL AND activated_at IS NOT NULL
+         AND collection_id IN
          (SELECT id FROM collections WHERE connector_id = $2)
        RETURNING id, operations`,
       [grantId, connector.id, JSON.stringify([...new Set(input.operations)])]
@@ -1879,7 +2122,8 @@ export async function buildApp(options: BuildOptions) {
     const { grantId } = z.object({ grantId: z.uuid() }).parse(request.params);
     const active = await options.db.query(
       `UPDATE grants SET revoked_at = now()
-       WHERE id = $1 AND revoked_at IS NULL AND collection_id IN
+       WHERE id = $1 AND revoked_at IS NULL AND activated_at IS NOT NULL
+         AND collection_id IN
          (SELECT id FROM collections WHERE connector_id = $2)
        RETURNING id`,
       [grantId, connector.id]
@@ -1904,13 +2148,15 @@ export async function buildApp(options: BuildOptions) {
     if (input.contracts) {
       await options.db.query(
         `UPDATE collections SET contracts = $3::jsonb, last_seen_at = now()
-         WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
+         WHERE connector_id = $1 AND local_id = $2 AND enabled = true
+           AND present = true AND authority_state = 'active'`,
         [connector.id, input.collection_id, JSON.stringify(input.contracts)]
       );
     }
     const collection = await options.db.query<{ id: string }>(
       `SELECT id FROM collections
-       WHERE connector_id = $1 AND local_id = $2 AND enabled = true`,
+       WHERE connector_id = $1 AND local_id = $2 AND enabled = true
+         AND present = true AND authority_state = 'active'`,
       [connector.id, input.collection_id]
     );
     if (!collection.rows[0]) return reply.code(404).send(apiError("collection_not_found", "Collection is not available on this computer."));
@@ -2399,7 +2645,8 @@ export async function buildApp(options: BuildOptions) {
        JOIN applications a ON a.id = g.application_id
        LEFT JOIN collections col ON col.id = g.collection_id
        LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
-       WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL`,
+       WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL`,
       [grantId, user.id]
     );
     const current = active.rows[0];
@@ -2453,7 +2700,8 @@ export async function buildApp(options: BuildOptions) {
     }>(
       `SELECT g.id, col.connector_id, g.hosted_collection_id, g.hosted_replica_id FROM grants g
        LEFT JOIN collections col ON col.id = g.collection_id
-       WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL`,
+       WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL`,
       [grantId, user.id]
     );
     if (!active.rows[0]) return reply.code(404).send(apiError("grant_not_found", "Active grant not found."));
@@ -2605,19 +2853,14 @@ export async function buildApp(options: BuildOptions) {
               a.homepage, a.project_url, a.icon,
               a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar JOIN applications a ON a.id = ar.application_id
-       WHERE ar.id = $1 AND ar.user_id = $2 AND ar.expires_at > now()`,
+       WHERE ar.id = $1 AND ar.user_id = $2 AND ar.expires_at > now()
+         AND ar.completed_at IS NULL AND ar.denied_at IS NULL`,
       [requestId, user.id]
     );
     if (!authorization.rows[0]) return reply.code(404).send(apiError("authorization_not_found", "Authorization request expired or was not found."));
-    const collections = await options.db.query(
-      `SELECT col.id, col.display_name, col.spec_version, col.contracts,
-              c.name AS connector_name
-       FROM collections col JOIN connectors c ON c.id = col.connector_id
-       WHERE c.user_id = $1 AND col.enabled = true
-         AND col.authority_state = 'active'
-       ORDER BY col.display_name`,
-      [user.id]
-    );
+    const local = requiresHostedCollection(authorization.rows[0].requirements)
+      ? { collections: [], unavailable_connectors: [] }
+      : await liveAuthorizationCollections(options.db, relay, user.id, requestId);
     const hosted = options.hostedCollections
       ? await options.db.query<{
           id: string;
@@ -2632,7 +2875,7 @@ export async function buildApp(options: BuildOptions) {
         )
       : { rows: [] };
     const availableCollections = [
-      ...collections.rows.map((collection) => ({ ...collection, kind: "local" as const })),
+      ...local.collections,
       ...hosted.rows.map((collection) => ({
         ...collection,
         kind: "hosted" as const,
@@ -2643,6 +2886,7 @@ export async function buildApp(options: BuildOptions) {
     ];
     return {
       authorization: authorization.rows[0],
+      unavailable_connectors: local.unavailable_connectors,
       collections: requiresHostedCollection(authorization.rows[0].requirements)
         ? availableCollections.filter((collection) => collection.kind === "hosted")
         : availableCollections
@@ -2700,22 +2944,19 @@ export async function buildApp(options: BuildOptions) {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
     const { requestId } = z.object({ requestId: z.uuid() }).parse(request.params);
-    const input = z.object({ collection_id: z.uuid(), operations: z.array(operationSchema).min(1) }).parse(request.body);
-    const collection = await options.db.query<{ connector_id: string }>(
-      `SELECT col.connector_id FROM collections col JOIN connectors c ON c.id = col.connector_id
-       WHERE col.id = $1 AND c.user_id = $2 AND col.enabled = true
-         AND col.authority_state = 'active'`,
-      [input.collection_id, user.id]
-    );
+    const input = z.object({
+      collection_id: z.uuid(),
+      offer_id: z.uuid().optional(),
+      operations: z.array(operationSchema).min(1)
+    }).parse(request.body);
     let approved: boolean;
-    if (collection.rows[0]) {
-      approved = await approveAuthorization(options.db, relay, {
+    if (input.offer_id) {
+      approved = await approvePortalAuthorization(options.db, relay, {
         requestId,
         userId: user.id,
-        connectorId: collection.rows[0].connector_id,
+        offerId: input.offer_id,
         collectionId: input.collection_id,
-        operations: input.operations,
-        source: "portal"
+        operations: input.operations
       });
     } else {
       const hosted = await options.db.query<{ id: string; template: string; display_name: string; contracts: CollectionContractDescriptor[] }>(
@@ -2904,7 +3145,8 @@ export async function buildApp(options: BuildOptions) {
        FROM refresh_tokens rt
        JOIN grants g ON g.id = rt.grant_id
        WHERE rt.token_hash = $1 AND rt.used_at IS NULL AND rt.revoked_at IS NULL
-         AND rt.expires_at > now() AND g.revoked_at IS NULL AND g.application_id = $2`,
+         AND rt.expires_at > now() AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL AND g.application_id = $2`,
       [tokenHash(input.refresh_token), input.client_id]
     );
     const current = refresh.rows[0];
@@ -2986,7 +3228,8 @@ export async function buildApp(options: BuildOptions) {
         `SELECT a.notifications, g.notification_criteria
          FROM grants g
          JOIN applications a ON a.id = g.application_id
-         WHERE g.id = $1 AND g.revoked_at IS NULL`,
+         WHERE g.id = $1 AND g.revoked_at IS NULL
+           AND g.activated_at IS NOT NULL`,
         [grant.grant_id]
       );
       const declared = new Set(
@@ -3126,7 +3369,8 @@ export async function buildApp(options: BuildOptions) {
        FROM grants g
        LEFT JOIN push_channels pc
          ON pc.grant_id = g.id AND pc.id = $2 AND pc.disabled_at IS NULL
-       WHERE g.id = $1 AND g.revoked_at IS NULL`,
+       WHERE g.id = $1 AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL`,
       [grant.grant_id, input.channel_id]
     );
     const row = application.rows[0];
@@ -3187,7 +3431,7 @@ export async function buildApp(options: BuildOptions) {
       `SELECT g.notification_criteria
        FROM grants g
        WHERE g.id = $1 AND g.hosted_collection_id IS NOT NULL
-         AND g.revoked_at IS NULL`,
+         AND g.revoked_at IS NULL AND g.activated_at IS NOT NULL`,
       [input.grant_id]
     );
     const authorized = authorization.rows[0]?.notification_criteria.some(
@@ -3231,7 +3475,9 @@ export async function buildApp(options: BuildOptions) {
        FROM grants g
        JOIN collections c ON c.id = g.collection_id
        WHERE g.id = $1 AND c.connector_id = $2
-         AND g.revoked_at IS NULL AND c.enabled = true`,
+         AND g.revoked_at IS NULL AND g.activated_at IS NOT NULL
+         AND c.enabled = true AND c.present = true
+         AND c.authority_state = 'active'`,
       [input.grant_id, connector.id]
     );
     const authorized = authorization.rows[0]?.notification_criteria.some(
@@ -3274,7 +3520,9 @@ export async function buildApp(options: BuildOptions) {
        JOIN grants g ON g.id = tok.grant_id
        JOIN collections col ON col.id = g.collection_id
        WHERE tok.token_hash = $1 AND tok.expires_at > now() AND tok.revoked_at IS NULL
-         AND g.revoked_at IS NULL AND col.id = $2 AND col.enabled = true`,
+         AND g.revoked_at IS NULL AND g.activated_at IS NOT NULL
+         AND col.id = $2 AND col.enabled = true AND col.present = true
+         AND col.authority_state = 'active'`,
       [tokenHash(bearer), params.collectionId]
     );
     const grant = authorized.rows[0];
@@ -3366,6 +3614,7 @@ async function upsertApplication(
   icon: string | null;
   redirect_uris: string[];
   canonical_identity: string;
+  family_identity: string;
   requirements: ApplicationRequirements;
   provisions: ApplicationProvisions;
   notifications: ApplicationNotifications;
@@ -3379,16 +3628,18 @@ async function upsertApplication(
     icon: string | null;
     redirect_uris: string[];
     canonical_identity: string;
+    family_identity: string;
     requirements: ApplicationRequirements;
     provisions: ApplicationProvisions;
     notifications: ApplicationNotifications;
   }>(
     `INSERT INTO applications
-       (id, canonical_identity, manifest_version, distribution, name, homepage,
+       (id, canonical_identity, family_identity, manifest_version, distribution, name, homepage,
         project_url, icon, redirect_uris, requirements, provisions, notifications)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb,
-             $11::jsonb, $12::jsonb)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb,
+             $12::jsonb, $13::jsonb)
      ON CONFLICT(canonical_identity) DO UPDATE SET
+       family_identity = excluded.family_identity,
        manifest_version = excluded.manifest_version,
        distribution = excluded.distribution,
        name = excluded.name,
@@ -3401,10 +3652,11 @@ async function upsertApplication(
        notifications = excluded.notifications,
        updated_at = now()
      RETURNING id, distribution, name, homepage, project_url, icon, redirect_uris,
-               canonical_identity, requirements, provisions, notifications`,
+               canonical_identity, family_identity, requirements, provisions, notifications`,
     [
       randomUUID(),
       discovered.canonicalIdentity,
+      discovered.familyIdentity,
       discovered.manifest.manifest_version,
       discovered.manifest.distribution === "portable" ? "portable" : "web",
       discovered.manifest.name,
@@ -3443,7 +3695,8 @@ async function createOrUpdateGrant(
   const operations = [...new Set(input.operations)];
   const existing = await db.query<{ id: string; encryption: GrantEncryption | null }>(
     `SELECT id, encryption FROM grants WHERE user_id = $1 AND application_id = $2
-     AND collection_id = $3 AND revoked_at IS NULL ORDER BY created_at DESC LIMIT 1`,
+     AND collection_id = $3 AND revoked_at IS NULL AND activated_at IS NOT NULL
+     ORDER BY created_at DESC LIMIT 1`,
     [input.userId, input.applicationId, input.collectionId]
   );
   const grant = existing.rows[0]
@@ -3511,7 +3764,8 @@ async function syncHostedNotificationGrant(
      FROM grants g
      JOIN applications a ON a.id = g.application_id
      JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
-     WHERE g.id = $1 AND g.revoked_at IS NULL`,
+     WHERE g.id = $1 AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL`,
     [grantId]
   );
   const row = result.rows[0];
@@ -3572,7 +3826,8 @@ async function reconcileApplicationGrants(
      LEFT JOIN collections col ON col.id = g.collection_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
      LEFT JOIN hosted_replicas replica ON replica.id = g.hosted_replica_id
-     WHERE g.application_id = $1 AND g.revoked_at IS NULL`,
+     WHERE g.application_id = $1 AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL`,
     [application.id]
   );
   const changedConnectors = new Set<string>();
@@ -3709,6 +3964,441 @@ function sameStrings(left: string[], right: string[]): boolean {
     && [...leftValues].every((value) => rightValues.has(value));
 }
 
+interface LiveAuthorizationCollection {
+  id: string;
+  offer_id: string;
+  kind: "local";
+  connector_name: string;
+  display_name: string;
+  spec_version: string;
+  contracts: ContractRequirement[];
+}
+
+async function liveAuthorizationCollections(
+  db: DatabasePool,
+  relay: RelayHub,
+  userId: string,
+  authorizationId: string
+): Promise<{
+  collections: LiveAuthorizationCollection[];
+  unavailable_connectors: Array<{
+    connector_id: string;
+    connector_name: string;
+    reason: "offline" | "paused";
+  }>;
+}> {
+  await db.query(
+    `DELETE FROM authorization_collection_offers
+     WHERE authorization_id = $1 AND expires_at <= now()`,
+    [authorizationId]
+  );
+  const connectors = await db.query<{
+    id: string;
+    name: string;
+    inventory_revision: string | number;
+  }>(
+    `SELECT id, name, inventory_revision FROM connectors
+     WHERE user_id = $1 ORDER BY created_at`,
+    [userId]
+  );
+  const settled = await Promise.allSettled(connectors.rows.map(async (connector) => ({
+    connector,
+    response: await relay.authorizationOffers(connector.id, authorizationId)
+  })));
+  const collections: LiveAuthorizationCollection[] = [];
+  const unavailableConnectors: Array<{
+    connector_id: string;
+    connector_name: string;
+    reason: "offline" | "paused";
+  }> = [];
+
+  for (const [index, result] of settled.entries()) {
+    const connector = connectors.rows[index];
+    if (result.status === "rejected") {
+      unavailableConnectors.push({
+        connector_id: connector.id,
+        connector_name: connector.name,
+        reason: "offline"
+      });
+      continue;
+    }
+    if (result.value.response.paused) {
+      unavailableConnectors.push({
+        connector_id: connector.id,
+        connector_name: connector.name,
+        reason: "paused"
+      });
+      continue;
+    }
+    const authoritative = await db.query<{
+      id: string;
+      local_id: string;
+      authority_epoch: string | number;
+    }>(
+      `SELECT id, local_id, authority_epoch FROM collections
+       WHERE user_id = $1 AND connector_id = $2
+         AND present = true AND enabled = true AND authority_state = 'active'`,
+      [userId, connector.id]
+    );
+    const byLocalId = new Map(authoritative.rows.map((collection) => [
+      collection.local_id,
+      collection
+    ]));
+    for (const offered of result.value.response.collections) {
+      const collection = byLocalId.get(offered.collection_id);
+      if (!collection) continue;
+      const offer = await db.query<{ id: string }>(
+        `INSERT INTO authorization_collection_offers
+           (id, authorization_id, user_id, connector_id, collection_id, local_id,
+            authority_epoch, inventory_revision, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now() + interval '45 seconds')
+         ON CONFLICT(authorization_id, connector_id, collection_id) DO UPDATE SET
+           local_id = excluded.local_id,
+           authority_epoch = excluded.authority_epoch,
+           inventory_revision = excluded.inventory_revision,
+           expires_at = excluded.expires_at
+         WHERE authorization_collection_offers.consumed_at IS NULL
+         RETURNING id`,
+        [
+          randomUUID(),
+          authorizationId,
+          userId,
+          connector.id,
+          collection.id,
+          offered.collection_id,
+          Number(collection.authority_epoch),
+          Number(connector.inventory_revision)
+        ]
+      );
+      if (!offer.rows[0]) continue;
+      collections.push({
+        id: collection.id,
+        offer_id: offer.rows[0].id,
+        kind: "local",
+        connector_name: connector.name,
+        display_name: offered.display_name,
+        spec_version: offered.spec_version,
+        contracts: offered.contracts
+      });
+    }
+  }
+
+  collections.sort((left, right) =>
+    left.display_name.localeCompare(right.display_name, undefined, { sensitivity: "base" })
+    || left.connector_name.localeCompare(right.connector_name, undefined, { sensitivity: "base" })
+  );
+  return {
+    collections,
+    unavailable_connectors: unavailableConnectors
+  };
+}
+
+async function approvePortalAuthorization(
+  db: DatabasePool,
+  relay: RelayHub,
+  input: {
+    requestId: string;
+    userId: string;
+    offerId: string;
+    collectionId: string;
+    operations: string[];
+  }
+): Promise<boolean> {
+  const connection = await db.connect();
+  const grantId = randomUUID();
+  let connectorId = "";
+  let localCollectionId = "";
+  let requirements: ApplicationRequirements;
+  let provisions: ApplicationProvisions;
+  let grant: GrantPolicy;
+  try {
+    await connection.query("BEGIN");
+    const authorization = await connection.query<{
+      application_id: string;
+      application_name: string;
+      distribution: "web" | "portable";
+      application_homepage: string;
+      application_project_url: string | null;
+      application_icon: string | null;
+      requested_operations: string[];
+      requirements: ApplicationRequirements;
+      provisions: ApplicationProvisions;
+      notifications: ApplicationNotifications;
+      relay_protocol: number | null;
+      application_public_key: string | null;
+      flow: "authorization_code" | "device_code";
+      redirect_uri: string | null;
+      grant_id: string | null;
+      activation_started_at: string | Date | null;
+    }>(
+      `SELECT ar.application_id, a.name AS application_name,
+              a.distribution, a.homepage AS application_homepage,
+              a.project_url AS application_project_url, a.icon AS application_icon,
+              ar.requested_operations, a.requirements, a.provisions, a.notifications,
+              ar.relay_protocol, ar.application_public_key, ar.flow, ar.redirect_uri,
+              ar.grant_id, ar.activation_started_at
+       FROM authorization_requests ar
+       JOIN applications a ON a.id = ar.application_id
+       WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
+         AND ar.denied_at IS NULL AND ar.expires_at > now()
+       FOR UPDATE`,
+      [input.requestId, input.userId]
+    );
+    const pending = authorization.rows[0];
+    if (!pending) {
+      await connection.query("ROLLBACK");
+      return false;
+    }
+    if (pending.grant_id) {
+      const started = pending.activation_started_at
+        ? new Date(pending.activation_started_at).getTime()
+        : Date.now();
+      if (Date.now() - started < 60_000) {
+        throw new RequestValidationError(
+          "This authorization is already being activated. Wait a moment and try again."
+        );
+      }
+      await connection.query(
+        `UPDATE authorization_requests
+         SET grant_id = NULL, activation_started_at = NULL
+         WHERE id = $1`,
+        [input.requestId]
+      );
+      await connection.query(
+        "DELETE FROM grants WHERE id = $1 AND activated_at IS NULL",
+        [pending.grant_id]
+      );
+    }
+    if (
+      pending.distribution === "portable"
+      && (
+        pending.flow !== "device_code"
+        || pending.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
+        || !pending.application_public_key
+      )
+    ) {
+      throw new RequestValidationError(
+        "Downloaded applications require a key-bound device authorization request."
+      );
+    }
+    if (pending.flow === "device_code" && pending.distribution !== "portable") {
+      throw new RequestValidationError(
+        "Device authorization is reserved for downloaded applications."
+      );
+    }
+    if (requiresHostedCollection(pending.requirements)) {
+      throw new RequestValidationError("This application requires an mdbase cloud collection.");
+    }
+    const operations = [...new Set(input.operations)];
+    if (operations.some((operation) => !pending.requested_operations.includes(operation))) {
+      throw new RequestValidationError(
+        "Approved operations must be requested by the application."
+      );
+    }
+    assertOperationsAllowedByRequirements(operations, pending.requirements);
+    const offer = await connection.query<{
+      connector_id: string;
+      local_id: string;
+      display_name: string;
+      spec_version: string;
+      relay_public_key: string | null;
+      authority_epoch: string | number;
+    }>(
+      `SELECT offer.connector_id, offer.local_id, col.display_name, col.spec_version,
+              con.relay_public_key, col.authority_epoch
+       FROM authorization_collection_offers offer
+       JOIN collections col ON col.id = offer.collection_id
+       JOIN connectors con ON con.id = offer.connector_id
+       WHERE offer.id = $1 AND offer.authorization_id = $2
+         AND offer.user_id = $3 AND offer.collection_id = $4
+         AND offer.consumed_at IS NULL AND offer.expires_at > now()
+         AND col.user_id = $3 AND col.present = true AND col.enabled = true
+         AND col.authority_state = 'active'
+         AND col.authority_epoch = offer.authority_epoch
+         AND con.inventory_revision >= offer.inventory_revision
+       FOR UPDATE`,
+      [input.offerId, input.requestId, input.userId, input.collectionId]
+    );
+    const selected = offer.rows[0];
+    if (!selected) {
+      throw new RequestValidationError(
+        "That collection is no longer being offered by a live connector. Refresh and choose again."
+      );
+    }
+    assertCollectionSupportsOperations(selected.spec_version, operations);
+    const scope = scopeForRequirements(pending.requirements);
+    let encryption: GrantEncryption | undefined;
+    if (pending.relay_protocol === ENCRYPTED_RELAY_PROTOCOL_VERSION) {
+      if (!pending.application_public_key || !selected.relay_public_key) {
+        throw new RequestValidationError(
+          "Encrypted relay protocol 1 requires an up-to-date connector."
+        );
+      }
+      encryption = {
+        protocol_version: ENCRYPTED_RELAY_PROTOCOL_VERSION,
+        suite: RELAY_ENCRYPTION_SUITE,
+        key_id: `enc_${randomUUID()}`,
+        scope_epoch: 1,
+        connector_id: selected.connector_id,
+        collection_id: selected.local_id,
+        application_public_key: pending.application_public_key,
+        connector_public_key: selected.relay_public_key
+      };
+    }
+    const applicationOrigin = pending.flow === "device_code"
+      ? "null"
+      : applicationOriginForRedirect(
+          pending.redirect_uri!,
+          pending.application_homepage
+        );
+    const inserted = await connection.query<{ created_at: string | Date }>(
+      `INSERT INTO grants
+         (id, user_id, application_id, collection_id, operations, scope, encryption,
+          application_origin, notification_criteria, activated_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, $9::jsonb, NULL)
+       RETURNING created_at`,
+      [
+        grantId,
+        input.userId,
+        pending.application_id,
+        input.collectionId,
+        JSON.stringify(operations),
+        JSON.stringify(scope),
+        encryption ? JSON.stringify(encryption) : null,
+        applicationOrigin,
+        JSON.stringify(pending.notifications.criteria)
+      ]
+    );
+    await connection.query(
+      `UPDATE authorization_requests
+       SET grant_id = $2, activation_started_at = now()
+       WHERE id = $1`,
+      [input.requestId, grantId]
+    );
+    connectorId = selected.connector_id;
+    localCollectionId = selected.local_id;
+    requirements = pending.requirements;
+    provisions = pending.provisions;
+    grant = {
+      id: grantId,
+      application_id: pending.application_id,
+      collection_id: selected.local_id,
+      operations: operations as GrantPolicy["operations"],
+      scope,
+      application_name: pending.application_name,
+      application_distribution: pending.distribution,
+      application_homepage: pending.application_homepage,
+      ...(pending.application_project_url
+        ? { application_project_url: pending.application_project_url }
+        : {}),
+      application_origin: normalizedApplicationOrigin(applicationOrigin),
+      ...(pending.application_icon ? { application_icon: pending.application_icon } : {}),
+      collection_name: selected.display_name,
+      notification_criteria: pending.notifications.criteria,
+      created_at: new Date(inserted.rows[0].created_at).toISOString(),
+      ...(encryption ? { encryption } : {})
+    };
+    await connection.query("COMMIT");
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+
+  let activation: Awaited<ReturnType<RelayHub["activateAuthorization"]>>;
+  try {
+    activation = await relay.activateAuthorization(connectorId, {
+      authorizationId: input.requestId,
+      collectionId: localCollectionId,
+      requirements: requirements!,
+      provisions: provisions!,
+      grant: grant!
+    });
+  } catch (error) {
+    await abandonPendingAuthorizationGrant(db, input.requestId, grantId);
+    await relay.pushPolicy(connectorId);
+    throw error;
+  }
+
+  const finalize = await db.connect();
+  try {
+    await finalize.query("BEGIN");
+    const completed = await finalize.query(
+      `UPDATE authorization_requests SET
+         completed_at = now(),
+         activation_started_at = NULL
+       WHERE id = $1 AND user_id = $2 AND grant_id = $3
+         AND completed_at IS NULL AND denied_at IS NULL
+       RETURNING id`,
+      [input.requestId, input.userId, grantId]
+    );
+    if (!completed.rows[0]) {
+      throw new RequestValidationError(
+        "The authorization request changed before activation completed."
+      );
+    }
+    await finalize.query(
+      "UPDATE grants SET activated_at = now() WHERE id = $1 AND activated_at IS NULL",
+      [grantId]
+    );
+    await finalize.query(
+      `UPDATE authorization_collection_offers SET consumed_at = now()
+       WHERE id = $1 AND authorization_id = $2`,
+      [input.offerId, input.requestId]
+    );
+    await finalize.query(
+      `UPDATE collections SET contracts = $2::jsonb, last_seen_at = now()
+       WHERE id = $1`,
+      [input.collectionId, JSON.stringify(activation.contracts)]
+    );
+    await finalize.query("COMMIT");
+  } catch (error) {
+    await finalize.query("ROLLBACK");
+    await abandonPendingAuthorizationGrant(db, input.requestId, grantId);
+    await relay.pushPolicy(connectorId);
+    throw error;
+  } finally {
+    finalize.release();
+  }
+  await relay.pushPolicy(connectorId);
+  await audit(db, input.userId, "authorization.approved", input.requestId, {
+    connector_id: connectorId,
+    collection_id: input.collectionId,
+    operations: input.operations,
+    scope: grant!.scope,
+    source: "portal_live_offer"
+  });
+  return true;
+}
+
+async function abandonPendingAuthorizationGrant(
+  db: DatabasePool,
+  authorizationId: string,
+  grantId: string
+): Promise<void> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    await connection.query(
+      `UPDATE authorization_requests
+       SET grant_id = NULL, activation_started_at = NULL
+       WHERE id = $1 AND grant_id = $2`,
+      [authorizationId, grantId]
+    );
+    await connection.query(
+      "DELETE FROM grants WHERE id = $1 AND activated_at IS NULL",
+      [grantId]
+    );
+    await connection.query("COMMIT");
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
 async function approveAuthorization(
   db: DatabasePool,
   relay: RelayHub,
@@ -3744,7 +4434,7 @@ async function approveAuthorization(
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id
      WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
-       AND ar.denied_at IS NULL AND ar.expires_at > now()
+       AND ar.grant_id IS NULL AND ar.denied_at IS NULL AND ar.expires_at > now()
      FOR UPDATE`,
     [input.requestId, input.userId]
     );
@@ -3785,7 +4475,8 @@ async function approveAuthorization(
     }>(
     `SELECT col.contracts, col.local_id, col.spec_version, con.relay_public_key
      FROM collections col JOIN connectors con ON con.id = col.connector_id
-     WHERE col.id = $1 AND col.connector_id = $2 AND col.enabled = true`,
+     WHERE col.id = $1 AND col.connector_id = $2 AND col.enabled = true
+       AND col.present = true AND col.authority_state = 'active'`,
     [input.collectionId, input.connectorId]
     );
     scope = scopeForRequirements(pending.requirements);
@@ -3902,7 +4593,7 @@ async function approveHostedAuthorization(
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
-         AND ar.expires_at > now()
+         AND ar.grant_id IS NULL AND ar.denied_at IS NULL AND ar.expires_at > now()
        FOR UPDATE`,
       [input.requestId, input.userId]
     );
@@ -4063,7 +4754,8 @@ async function denyAuthorization(
 ): Promise<boolean> {
   const pending = await db.query<{ id: string }>(
     `UPDATE authorization_requests SET completed_at = now(), denied_at = now()
-     WHERE id = $1 AND user_id = $2 AND completed_at IS NULL AND expires_at > now()
+     WHERE id = $1 AND user_id = $2 AND completed_at IS NULL
+       AND grant_id IS NULL AND expires_at > now()
      RETURNING id`,
     [input.requestId, input.userId]
   );
@@ -4162,7 +4854,8 @@ async function issueApplicationTokens(
      JOIN applications app ON app.id = g.application_id
      LEFT JOIN collections col ON col.id = g.collection_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
-     WHERE g.id = $1 AND g.revoked_at IS NULL`,
+     WHERE g.id = $1 AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL`,
     [grantId]
   );
   if (!grant.rows[0]) throw new RequestValidationError("The application grant is no longer active.");
@@ -4352,7 +5045,8 @@ function matchesGrantIdentity(
 
 async function rotateGrantEncryption(db: DatabasePool, grantId: string): Promise<void> {
   const grant = await db.query<{ encryption: GrantEncryption | null }>(
-    "SELECT encryption FROM grants WHERE id = $1 AND revoked_at IS NULL",
+    `SELECT encryption FROM grants
+     WHERE id = $1 AND revoked_at IS NULL AND activated_at IS NOT NULL`,
     [grantId]
   );
   const encryption = grant.rows[0]?.encryption;

--- a/services/server/src/authority-transfer.test.ts
+++ b/services/server/src/authority-transfer.test.ts
@@ -229,6 +229,7 @@ describe("hosted-to-local authority transfer", () => {
       url: "/v1/connectors/sync",
       headers: { authorization: `Bearer ${connector.json().token}` },
       payload: {
+        inventory_revision: 1,
         collections: [{
           id: collectionId,
           display_name: "Writing",
@@ -317,6 +318,7 @@ describe("hosted-to-local authority transfer", () => {
       url: "/v1/connectors/sync",
       headers: { authorization: `Bearer ${connector.json().token}` },
       payload: {
+        inventory_revision: 2,
         collections: [{
           id: collectionId,
           display_name: "Writing",
@@ -385,6 +387,7 @@ describe("hosted-to-local authority transfer", () => {
       url: "/v1/connectors/sync",
       headers: { authorization: `Bearer ${connector.json().token}` },
       payload: {
+        inventory_revision: 3,
         collections: [{
           id: cancellableCollectionId,
           display_name: "Keep hosted",

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -81,21 +81,27 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       name text NOT NULL,
       token_hash text NOT NULL UNIQUE,
       relay_generation bigint NOT NULL DEFAULT 0,
+      inventory_revision bigint NOT NULL DEFAULT 0,
       last_seen_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now()
     );
     CREATE TABLE IF NOT EXISTS collections (
       id uuid PRIMARY KEY,
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       connector_id uuid NOT NULL REFERENCES connectors(id) ON DELETE CASCADE,
       local_id uuid NOT NULL,
       display_name text NOT NULL,
       spec_version text NOT NULL,
       enabled boolean NOT NULL DEFAULT true,
+      reported_enabled boolean NOT NULL DEFAULT true,
+      present boolean NOT NULL DEFAULT true,
       authority_state text NOT NULL DEFAULT 'active'
         CHECK (authority_state IN ('active', 'candidate', 'retired')),
       authority_epoch bigint NOT NULL DEFAULT 1,
       contracts jsonb NOT NULL DEFAULT '[]'::jsonb,
+      last_inventory_revision bigint NOT NULL DEFAULT 0,
       last_seen_at timestamptz NOT NULL DEFAULT now(),
+      removed_at timestamptz,
       UNIQUE(connector_id, local_id)
     );
     CREATE TABLE IF NOT EXISTS hosted_collections (
@@ -125,6 +131,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     CREATE TABLE IF NOT EXISTS applications (
       id uuid PRIMARY KEY,
       canonical_identity text NOT NULL UNIQUE,
+      family_identity text NOT NULL DEFAULT '',
       manifest_version integer NOT NULL DEFAULT 1,
       distribution text NOT NULL DEFAULT 'web'
         CHECK (distribution IN ('web', 'portable')),
@@ -152,6 +159,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       encryption jsonb,
       application_origin text NOT NULL DEFAULT '',
       created_at timestamptz NOT NULL DEFAULT now(),
+      activated_at timestamptz DEFAULT now(),
       revoked_at timestamptz,
       CHECK ((collection_id IS NULL) <> (hosted_collection_id IS NULL))
     );
@@ -176,8 +184,23 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       last_polled_at timestamptz,
       device_consumed_at timestamptz,
       expires_at timestamptz NOT NULL,
+      activation_started_at timestamptz,
       completed_at timestamptz,
       denied_at timestamptz
+    );
+    CREATE TABLE IF NOT EXISTS authorization_collection_offers (
+      id uuid PRIMARY KEY,
+      authorization_id uuid NOT NULL REFERENCES authorization_requests(id) ON DELETE CASCADE,
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      connector_id uuid NOT NULL REFERENCES connectors(id) ON DELETE CASCADE,
+      collection_id uuid NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+      local_id uuid NOT NULL,
+      authority_epoch bigint NOT NULL,
+      inventory_revision bigint NOT NULL,
+      expires_at timestamptz NOT NULL,
+      consumed_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE(authorization_id, connector_id, collection_id)
     );
     CREATE TABLE IF NOT EXISTS pairing_requests (
       id uuid PRIMARY KEY,
@@ -359,10 +382,75 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   );
   await ensureColumn(
     db,
+    "connectors",
+    "inventory_revision",
+    "ALTER TABLE connectors ADD COLUMN inventory_revision bigint NOT NULL DEFAULT 0"
+  );
+  await ensureColumn(
+    db,
+    "collections",
+    "user_id",
+    "ALTER TABLE collections ADD COLUMN user_id uuid REFERENCES users(id) ON DELETE CASCADE"
+  );
+  await db.query(
+    `UPDATE collections SET user_id = connectors.user_id
+     FROM connectors WHERE collections.connector_id = connectors.id
+       AND collections.user_id IS NULL`
+  );
+  await ensureNotNullable(db, "collections", "user_id");
+  await ensureColumn(
+    db,
+    "collections",
+    "present",
+    "ALTER TABLE collections ADD COLUMN present boolean NOT NULL DEFAULT true"
+  );
+  await ensureColumn(
+    db,
+    "collections",
+    "reported_enabled",
+    "ALTER TABLE collections ADD COLUMN reported_enabled boolean NOT NULL DEFAULT true"
+  );
+  await ensureColumn(
+    db,
+    "collections",
+    "last_inventory_revision",
+    "ALTER TABLE collections ADD COLUMN last_inventory_revision bigint NOT NULL DEFAULT 0"
+  );
+  await ensureColumn(
+    db,
+    "collections",
+    "removed_at",
+    "ALTER TABLE collections ADD COLUMN removed_at timestamptz"
+  );
+  await ensureColumn(
+    db,
     "applications",
     "manifest_version",
     "ALTER TABLE applications ADD COLUMN manifest_version integer NOT NULL DEFAULT 1"
   );
+  await ensureColumn(
+    db,
+    "applications",
+    "family_identity",
+    "ALTER TABLE applications ADD COLUMN family_identity text DEFAULT ''"
+  );
+  const applicationsWithoutFamily = await db.query<{
+    id: string;
+    canonical_identity: string;
+  }>(
+    `SELECT id, canonical_identity FROM applications
+     WHERE family_identity IS NULL OR family_identity = ''`
+  );
+  for (const application of applicationsWithoutFamily.rows) {
+    await db.query(
+      "UPDATE applications SET family_identity = $2 WHERE id = $1",
+      [
+        application.id,
+        application.canonical_identity.replace(/:sha256:[a-f0-9]+$/i, "")
+      ]
+    );
+  }
+  await ensureNotNullable(db, "applications", "family_identity");
   await ensureColumn(
     db,
     "applications",
@@ -411,6 +499,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "grants",
     "notification_criteria",
     "ALTER TABLE grants ADD COLUMN notification_criteria jsonb NOT NULL DEFAULT '[]'::jsonb"
+  );
+  await ensureColumn(
+    db,
+    "grants",
+    "activated_at",
+    "ALTER TABLE grants ADD COLUMN activated_at timestamptz DEFAULT now()"
   );
   await db.query(
     `UPDATE grants
@@ -469,6 +563,12 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "authorization_requests",
     "last_polled_at",
     "ALTER TABLE authorization_requests ADD COLUMN last_polled_at timestamptz"
+  );
+  await ensureColumn(
+    db,
+    "authorization_requests",
+    "activation_started_at",
+    "ALTER TABLE authorization_requests ADD COLUMN activation_started_at timestamptz"
   );
   await ensureColumn(
     db,
@@ -633,6 +733,36 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     `ALTER TABLE hosted_collections ADD CONSTRAINT hosted_collections_authority_state_check
      CHECK (authority_state IN ('active', 'transferring', 'transferred'))`
   );
+  const activeAuthorities = await db.query<{
+    id: string;
+    user_id: string;
+    local_id: string;
+  }>(
+    `SELECT id, user_id, local_id FROM collections
+     WHERE authority_state = 'active'
+     ORDER BY last_seen_at DESC, id`
+  );
+  const retainedAuthorities = new Set<string>();
+  for (const authority of activeAuthorities.rows) {
+    const identity = `${authority.user_id}:${authority.local_id}`;
+    if (retainedAuthorities.has(identity)) {
+      await db.query(
+        `UPDATE collections SET authority_state = 'candidate', enabled = false
+         WHERE id = $1`,
+        [authority.id]
+      );
+    } else {
+      retainedAuthorities.add(identity);
+    }
+  }
+  await db.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS collections_active_authority_idx
+     ON collections(user_id, local_id) WHERE authority_state = 'active'`
+  );
+  await db.query(
+    `CREATE INDEX IF NOT EXISTS authorization_collection_offers_lookup_idx
+     ON authorization_collection_offers(authorization_id, expires_at)`
+  );
 }
 
 export async function backfillSessionProviders(db: DatabaseQueryable): Promise<void> {
@@ -653,6 +783,21 @@ async function ensureNullable(db: DatabaseQueryable, table: string, column: stri
   );
   if (result.rows[0]?.is_nullable === "NO") {
     await db.query(`ALTER TABLE ${table} ALTER COLUMN ${column} DROP NOT NULL`);
+  }
+}
+
+async function ensureNotNullable(
+  db: DatabaseQueryable,
+  table: string,
+  column: string
+): Promise<void> {
+  const result = await db.query<{ is_nullable: string }>(
+    `SELECT is_nullable FROM information_schema.columns
+     WHERE table_name = $1 AND column_name = $2`,
+    [table, column]
+  );
+  if (result.rows[0]?.is_nullable === "YES") {
+    await db.query(`ALTER TABLE ${table} ALTER COLUMN ${column} SET NOT NULL`);
   }
 }
 

--- a/services/server/src/inventory-authority.test.ts
+++ b/services/server/src/inventory-authority.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("authoritative connector inventory", () => {
+  it("retires omitted collections, ignores stale snapshots, and resolves duplicate authorities explicitly", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Owner", email: "inventory@example.test" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const first = (await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "First computer" }
+    })).json();
+    const second = (await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Second computer" }
+    })).json();
+    const sharedId = "125cc8cf-dad5-4fc9-b0bc-a1c92e99f3ed";
+    const omittedId = "225cc8cf-dad5-4fc9-b0bc-a1c92e99f3ed";
+
+    const firstSnapshot = await sync(app, first.token, 1, [
+      collection(sharedId, "Shared"),
+      collection(omittedId, "Temporary")
+    ]);
+    expect(firstSnapshot.statusCode).toBe(200);
+    expect(firstSnapshot.json().accepted).toBe(true);
+    const omittedServerId = firstSnapshot.json().collections[1].id as string;
+
+    const secondSnapshot = await sync(app, second.token, 1, [
+      collection(sharedId, "Shared copy")
+    ]);
+    expect(secondSnapshot.json().collections[0]).toMatchObject({
+      authority_state: "candidate",
+      authority_epoch: 1
+    });
+    const secondControl = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/control",
+      headers: { authorization: `Bearer ${second.token}` }
+    });
+    expect(secondControl.json().authority_conflicts).toEqual([
+      {
+        collection_id: sharedId,
+        display_name: "Shared copy",
+        active_connector_name: "First computer"
+      }
+    ]);
+
+    const reduced = await sync(app, first.token, 2, [
+      collection(sharedId, "Shared")
+    ]);
+    expect(reduced.json().accepted).toBe(true);
+    const retired = await db.query<{
+      present: boolean;
+      enabled: boolean;
+      authority_state: string;
+    }>(
+      "SELECT present, enabled, authority_state FROM collections WHERE id = $1",
+      [omittedServerId]
+    );
+    expect(retired.rows[0]).toEqual({
+      present: false,
+      enabled: false,
+      authority_state: "retired"
+    });
+
+    const stale = await sync(app, first.token, 1, [
+      collection(sharedId, "Stale"),
+      collection(omittedId, "Must not return")
+    ]);
+    expect(stale.json()).toMatchObject({
+      accepted: false,
+      inventory_revision: 2,
+      collections: []
+    });
+    expect(Number((await db.query<{ count: string | number }>(
+      `SELECT COUNT(*) AS count FROM collections
+       WHERE connector_id = $1 AND local_id = $2 AND present = true`,
+      [first.connector.id, omittedId]
+    )).rows[0].count)).toBe(0);
+
+    const moved = await app.inject({
+      method: "POST",
+      url: `/v1/connectors/authority-conflicts/${sharedId}/move`,
+      headers: { authorization: `Bearer ${second.token}` }
+    });
+    expect(moved.statusCode).toBe(200);
+    const authorities = await db.query<{
+      connector_id: string;
+      authority_state: string;
+      authority_epoch: string | number;
+      enabled: boolean;
+    }>(
+      `SELECT connector_id, authority_state, authority_epoch, enabled
+       FROM collections WHERE local_id = $1 ORDER BY connector_id`,
+      [sharedId]
+    );
+    expect(authorities.rows).toContainEqual(expect.objectContaining({
+      connector_id: second.connector.id,
+      authority_state: "active",
+      authority_epoch: 2,
+      enabled: true
+    }));
+    expect(authorities.rows).toContainEqual(expect.objectContaining({
+      connector_id: first.connector.id,
+      authority_state: "retired",
+      authority_epoch: 2,
+      enabled: false
+    }));
+    expect(authorities.rows.filter((row) => row.authority_state === "active")).toHaveLength(1);
+  });
+});
+
+function collection(id: string, displayName: string) {
+  return {
+    id,
+    display_name: displayName,
+    spec_version: "0.3.0",
+    enabled: true,
+    contracts: []
+  };
+}
+
+function sync(
+  app: Awaited<ReturnType<typeof buildApp>>["app"],
+  token: string,
+  inventoryRevision: number,
+  collections: ReturnType<typeof collection>[]
+) {
+  return app.inject({
+    method: "POST",
+    url: "/v1/connectors/sync",
+    headers: { authorization: `Bearer ${token}` },
+    payload: {
+      inventory_revision: inventoryRevision,
+      collections
+    }
+  });
+}

--- a/services/server/src/live-authorization.test.ts
+++ b/services/server/src/live-authorization.test.ts
@@ -1,0 +1,270 @@
+import { once } from "node:events";
+import WebSocket from "ws";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+import { pkceChallenge } from "./security.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("live connector-mediated authorization", () => {
+  it("offers only live local collections and activates a grant after connector acknowledgement", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test",
+      allowInsecureManifests: true
+    });
+    resources.push(() => app.close());
+
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Owner", email: "owner@example.test" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const registered = await app.inject({
+      method: "POST",
+      url: "/v1/apps/register",
+      payload: {
+        manifest: {
+          manifest_version: 1,
+          id: "dev.mdbase.live-test",
+          name: "Live test",
+          homepage: "http://localhost:4180",
+          redirect_uris: ["http://localhost:4180/callback"],
+          requirements: { contracts: [], access: "full_collection" }
+        }
+      }
+    });
+    expect(registered.statusCode).toBe(200);
+    const applicationId = registered.json().application.id as string;
+    const connector = (await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Live computer" }
+    })).json();
+    const offlineConnector = (await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Offline computer" }
+    })).json();
+    const localCollectionId = "225cc8cf-dad5-4fc9-b0bc-a1c92e99f3ed";
+    const offlineCollectionId = "325cc8cf-dad5-4fc9-b0bc-a1c92e99f3ed";
+    const synchronized = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: {
+        inventory_revision: 1,
+        collections: [{
+          id: localCollectionId,
+          display_name: "Current notes",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    });
+    const serverCollectionId = synchronized.json().collections[0].id as string;
+    const offlineSynchronized = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/sync",
+      headers: { authorization: `Bearer ${offlineConnector.token}` },
+      payload: {
+        inventory_revision: 1,
+        collections: [{
+          id: offlineCollectionId,
+          display_name: "Offline notes",
+          spec_version: "0.3.0",
+          enabled: true,
+          contracts: []
+        }]
+      }
+    });
+    const offlineServerCollectionId =
+      offlineSynchronized.json().collections[0].id as string;
+
+    const address = await app.listen({ host: "127.0.0.1", port: 0 });
+    const socket = new WebSocket(
+      `${address.replace(/^http/, "ws")}/v1/relay`,
+      { headers: { authorization: `Bearer ${connector.token}` } }
+    );
+    resources.push(async () => {
+      if (socket.readyState === WebSocket.OPEN) socket.close();
+    });
+    const relayMessages: Array<Record<string, unknown>> = [];
+    let rejectActivation = false;
+    socket.on("message", (raw) => {
+      const message = JSON.parse(raw.toString()) as Record<string, unknown>;
+      relayMessages.push(message);
+      if (message.type === "authorization_offer_request") {
+        socket.send(JSON.stringify({
+          type: "authorization_offer_response",
+          protocol_version: 1,
+          request_id: message.request_id,
+          paused: false,
+          collections: [{
+            collection_id: localCollectionId,
+            display_name: "Current notes",
+            spec_version: "0.3.0",
+            contracts: []
+          }]
+        }));
+      }
+      if (message.type === "authorization_activation_request") {
+        socket.send(JSON.stringify(rejectActivation
+          ? {
+              type: "authorization_activation_response",
+              protocol_version: 1,
+              request_id: message.request_id,
+              ok: false,
+              contracts: [],
+              error: {
+                code: "access_paused",
+                message: "Remote access was paused before activation."
+              }
+            }
+          : {
+              type: "authorization_activation_response",
+              protocol_version: 1,
+              request_id: message.request_id,
+              ok: true,
+              contracts: []
+            }));
+      }
+    });
+    await once(socket, "open");
+
+    const firstRequestId = await createAuthorizationRequest(app, applicationId, cookie, "one");
+    const offered = await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${firstRequestId}`,
+      headers: { cookie }
+    });
+    expect(offered.statusCode).toBe(200);
+    expect(offered.json().collections).toEqual([
+      expect.objectContaining({
+        id: serverCollectionId,
+        kind: "local",
+        connector_name: "Live computer",
+        display_name: "Current notes",
+        offer_id: expect.any(String)
+      })
+    ]);
+    expect(offered.json().collections).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: offlineServerCollectionId })
+    ]));
+    expect(offered.json().unavailable_connectors).toEqual([
+      {
+        connector_id: offlineConnector.connector.id,
+        connector_name: "Offline computer",
+        reason: "offline"
+      }
+    ]);
+    const offer = offered.json().collections[0];
+    const approved = await app.inject({
+      method: "POST",
+      url: `/v1/authorization-requests/${firstRequestId}/approve`,
+      headers: { cookie },
+      payload: {
+        collection_id: serverCollectionId,
+        offer_id: offer.offer_id,
+        operations: ["describe"]
+      }
+    });
+    expect(approved.statusCode).toBe(200);
+    const activation = relayMessages.find((message) =>
+      message.type === "authorization_activation_request"
+    );
+    expect(activation).toMatchObject({
+      authorization_id: firstRequestId,
+      collection_id: localCollectionId,
+      grant: expect.objectContaining({
+        application_id: applicationId,
+        collection_id: localCollectionId,
+        operations: ["describe"]
+      })
+    });
+    const active = await db.query<{
+      activated_at: string | null;
+      completed_at: string | null;
+    }>(
+      `SELECT g.activated_at, ar.completed_at
+       FROM authorization_requests ar JOIN grants g ON g.id = ar.grant_id
+       WHERE ar.id = $1`,
+      [firstRequestId]
+    );
+    expect(active.rows[0].activated_at).not.toBeNull();
+    expect(active.rows[0].completed_at).not.toBeNull();
+
+    rejectActivation = true;
+    const rejectedRequestId = await createAuthorizationRequest(
+      app,
+      applicationId,
+      cookie,
+      "two"
+    );
+    const secondOffer = (await app.inject({
+      method: "GET",
+      url: `/v1/authorization-requests/${rejectedRequestId}`,
+      headers: { cookie }
+    })).json().collections[0];
+    const rejected = await app.inject({
+      method: "POST",
+      url: `/v1/authorization-requests/${rejectedRequestId}/approve`,
+      headers: { cookie },
+      payload: {
+        collection_id: serverCollectionId,
+        offer_id: secondOffer.offer_id,
+        operations: ["describe"]
+      }
+    });
+    expect(rejected.statusCode).toBe(409);
+    expect(rejected.json().error).toMatchObject({
+      code: "access_paused",
+      message: "Remote access was paused before activation."
+    });
+    const abandoned = await db.query<{
+      grant_id: string | null;
+      completed_at: string | null;
+    }>(
+      `SELECT ar.grant_id, ar.completed_at
+       FROM authorization_requests ar WHERE ar.id = $1`,
+      [rejectedRequestId]
+    );
+    expect(abandoned.rows[0]).toMatchObject({
+      grant_id: null,
+      completed_at: null
+    });
+    const pendingGrants = await db.query<{ count: string | number }>(
+      "SELECT COUNT(*) AS count FROM grants WHERE activated_at IS NULL"
+    );
+    expect(Number(pendingGrants.rows[0].count)).toBe(0);
+  });
+});
+
+async function createAuthorizationRequest(
+  app: Awaited<ReturnType<typeof buildApp>>["app"],
+  applicationId: string,
+  cookie: string,
+  suffix: string
+): Promise<string> {
+  const verifier = `live-connector-verifier-${suffix}-that-is-long-enough-000001`;
+  const authorization = await app.inject({
+    method: "GET",
+    url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent("http://localhost:4180/callback")}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&operations=describe`,
+    headers: { cookie }
+  });
+  expect(authorization.statusCode).toBe(302);
+  return authorization.headers.location!.split("/").at(-1)!;
+}

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -120,6 +120,7 @@ export type AppManifest = WebAppManifest | PortableAppManifest;
 export interface RegisteredApplicationManifest {
   manifest: AppManifest;
   canonicalIdentity: string;
+  familyIdentity: string;
 }
 
 export class ApplicationManifestError extends Error {
@@ -146,7 +147,8 @@ export function registerApplicationManifest(
       .digest("hex");
     return {
       manifest,
-      canonicalIdentity: `bundle:${parsed.id}:sha256:${digest}`
+      canonicalIdentity: `bundle:${parsed.id}:sha256:${digest}`,
+      familyIdentity: `bundle:${parsed.id}`
     };
   } catch (error) {
     throw asManifestError(error);

--- a/services/server/src/notifications.test.ts
+++ b/services/server/src/notifications.test.ts
@@ -400,9 +400,9 @@ async function notificationFixture(
   );
   await db.query(
     `INSERT INTO collections
-       (id, connector_id, local_id, display_name, spec_version, enabled)
-     VALUES ($1, $2, $3, $4, $5, true)`,
-    [collectionId, connectorId, localCollectionId, "Tasks", "0.3.0"]
+       (id, user_id, connector_id, local_id, display_name, spec_version, enabled)
+     VALUES ($1, $2, $3, $4, $5, $6, true)`,
+    [collectionId, userId, connectorId, localCollectionId, "Tasks", "0.3.0"]
   );
   if (hosted) {
     await db.query(

--- a/services/server/src/notifications.ts
+++ b/services/server/src/notifications.ts
@@ -167,7 +167,8 @@ export class NotificationService {
          JOIN push_channels pc ON pc.id = ns.channel_id
          JOIN grants g ON g.id = ns.grant_id
          WHERE ns.grant_id = $1 AND ns.criterion_id = $2
-           AND pc.disabled_at IS NULL AND g.revoked_at IS NULL`,
+           AND pc.disabled_at IS NULL AND g.revoked_at IS NULL
+           AND g.activated_at IS NOT NULL`,
         [input.grantId, input.criterionId]
       );
       let deliveries = 0;
@@ -187,7 +188,8 @@ export class NotificationService {
         `SELECT a.notifications
          FROM grants g
          JOIN applications a ON a.id = g.application_id
-         WHERE g.id = $1 AND g.revoked_at IS NULL`,
+         WHERE g.id = $1 AND g.revoked_at IS NULL
+           AND g.activated_at IS NOT NULL`,
         [input.grantId]
       );
       const nativeDelivery = route.rows[0]?.notifications.native_delivery;
@@ -244,6 +246,7 @@ export class NotificationService {
          OR (nd.status = 'sending' AND nd.leased_until < now())
        )
          AND pc.disabled_at IS NULL AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL
        ORDER BY nd.created_at, nd.id
        LIMIT $1`,
       [limit]
@@ -286,7 +289,7 @@ export class NotificationService {
          (nwd.status IN ('pending', 'retry') AND nwd.available_at <= now())
          OR (nwd.status = 'sending' AND nwd.leased_until < now())
        )
-         AND g.revoked_at IS NULL
+         AND g.revoked_at IS NULL AND g.activated_at IS NOT NULL
        ORDER BY nwd.created_at, nwd.id
        LIMIT $1`,
       [limit]
@@ -526,7 +529,8 @@ export async function activeGrantForToken(
      FROM access_tokens tok
      JOIN grants g ON g.id = tok.grant_id
      WHERE tok.token_hash = $1 AND tok.expires_at > now()
-       AND tok.revoked_at IS NULL AND g.revoked_at IS NULL`,
+       AND tok.revoked_at IS NULL AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL`,
     [tokenHash]
   );
   return result.rows[0] ?? null;

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
 import type {
+  ApplicationProvisions,
+  ApplicationRequirements,
+  AuthorizationActivationResponse,
+  AuthorizationOfferResponse,
   EncryptedRelayEnvelope,
   EncryptedRelayOperationRequest,
-  EncryptedRelayOperationResponse
+  EncryptedRelayOperationResponse,
+  GrantPolicy
 } from "@mdbase/connect-protocol";
 import type { DatabasePool } from "./db.js";
 import {
@@ -17,6 +22,8 @@ import type { WebSocket } from "ws";
 
 const OPERATION_TIMEOUT_MS = 30_000;
 const BROKER_OPERATION_TIMEOUT_MS = OPERATION_TIMEOUT_MS + 1_000;
+const OFFER_TIMEOUT_MS = 3_000;
+const BROKER_OFFER_TIMEOUT_MS = OFFER_TIMEOUT_MS + 1_000;
 const POLICY_TIMEOUT_MS = 5_000;
 
 interface PendingRequest {
@@ -25,6 +32,7 @@ interface PendingRequest {
   timer: NodeJS.Timeout;
   socket: WebSocket;
   expectedEncrypted?: EncryptedRelayEnvelope;
+  expectedType?: "operation_response" | "authorization_offer_response" | "authorization_activation_response";
 }
 
 interface ConnectorSession {
@@ -101,6 +109,9 @@ export class RelayHub {
           key_id?: string;
           counter?: string;
           ciphertext?: string;
+          paused?: boolean;
+          collections?: unknown[];
+          contracts?: unknown[];
         };
         if (!message.request_id) return;
         const pending = this.pending.get(message.request_id);
@@ -133,7 +144,54 @@ export class RelayHub {
           this.resolvePending(message.request_id, message);
           return;
         }
+        if (message.type === "authorization_offer_response") {
+          if (pending.expectedType !== "authorization_offer_response") {
+            this.rejectPending(
+              message.request_id,
+              new ConnectorOperationError(
+                "invalid_relay_response",
+                "The connector returned the wrong relay response type."
+              )
+            );
+            return;
+          }
+          this.resolvePending(message.request_id, message);
+          return;
+        }
+        if (message.type === "authorization_activation_response") {
+          if (pending.expectedType !== "authorization_activation_response") {
+            this.rejectPending(
+              message.request_id,
+              new ConnectorOperationError(
+                "invalid_relay_response",
+                "The connector returned the wrong relay response type."
+              )
+            );
+            return;
+          }
+          if (message.ok) this.resolvePending(message.request_id, message);
+          else {
+            this.rejectPending(
+              message.request_id,
+              new ConnectorOperationError(
+                message.error?.code ?? "authorization_activation_failed",
+                message.error?.message ?? "The connector could not activate this authorization."
+              )
+            );
+          }
+          return;
+        }
         if (message.type !== "operation_response") return;
+        if (pending.expectedType !== "operation_response") {
+          this.rejectPending(
+            message.request_id,
+            new ConnectorOperationError(
+              "invalid_relay_response",
+              "The connector returned the wrong relay response type."
+            )
+          );
+          return;
+        }
         if (message.ok) this.resolvePending(message.request_id, message.result);
         else {
           this.rejectPending(
@@ -204,7 +262,8 @@ export class RelayHub {
        FROM grants g
        JOIN collections c ON c.id = g.collection_id
        JOIN applications a ON a.id = g.application_id
-       WHERE c.connector_id = $1 AND g.revoked_at IS NULL`,
+       WHERE c.connector_id = $1 AND g.revoked_at IS NULL
+         AND g.activated_at IS NOT NULL`,
       [connectorId]
     );
     const generation = await this.currentGeneration(connectorId);
@@ -288,6 +347,46 @@ export class RelayHub {
     return response as EncryptedRelayOperationResponse;
   }
 
+  async authorizationOffers(
+    connectorId: string,
+    authorizationId: string
+  ): Promise<AuthorizationOfferResponse> {
+    const generation = await this.requireCurrentGeneration(connectorId);
+    const requestId = randomUUID();
+    const response = await this.deliver(connectorId, generation, {
+      type: "authorization_offer_request",
+      protocol_version: 1,
+      request_id: requestId,
+      authorization_id: authorizationId
+    }, BROKER_OFFER_TIMEOUT_MS);
+    return response as AuthorizationOfferResponse;
+  }
+
+  async activateAuthorization(
+    connectorId: string,
+    input: {
+      authorizationId: string;
+      collectionId: string;
+      requirements: ApplicationRequirements;
+      provisions: ApplicationProvisions;
+      grant: GrantPolicy;
+    }
+  ): Promise<AuthorizationActivationResponse> {
+    const generation = await this.requireCurrentGeneration(connectorId);
+    const requestId = randomUUID();
+    const response = await this.deliver(connectorId, generation, {
+      type: "authorization_activation_request",
+      protocol_version: 1,
+      request_id: requestId,
+      authorization_id: input.authorizationId,
+      collection_id: input.collectionId,
+      requirements: input.requirements,
+      provisions: input.provisions,
+      grant: input.grant
+    });
+    return response as AuthorizationActivationResponse;
+  }
+
   async ready(): Promise<void> {
     await this.broker.ready();
   }
@@ -307,7 +406,8 @@ export class RelayHub {
   private async deliver(
     connectorId: string,
     generation: string,
-    message: unknown
+    message: unknown,
+    timeoutMs = BROKER_OPERATION_TIMEOUT_MS
   ): Promise<unknown> {
     let reply: RelayBrokerReply;
     try {
@@ -315,7 +415,7 @@ export class RelayHub {
         connectorId,
         generation,
         { version: 1, kind: "deliver", message },
-        BROKER_OPERATION_TIMEOUT_MS
+        timeoutMs
       );
     } catch (error) {
       if (error instanceof RelayBrokerUnavailableError) throw new RelayUnavailableError();
@@ -351,12 +451,16 @@ export class RelayHub {
       return brokerError("internal", "invalid_relay_request", "The relay request did not contain a request ID.");
     }
     const expectedEncrypted = encryptedRequestFromMessage(command.message);
+    const expectedType = expectedEncrypted
+      ? undefined
+      : expectedResponseType(command.message);
     try {
       const value = await this.sendToConnector(
         session.socket,
         requestId,
         command.message,
-        expectedEncrypted
+        expectedEncrypted,
+        expectedType
       );
       return { version: 1, ok: true, value };
     } catch (error) {
@@ -374,7 +478,8 @@ export class RelayHub {
     socket: WebSocket,
     requestId: string,
     message: unknown,
-    expectedEncrypted?: EncryptedRelayEnvelope
+    expectedEncrypted?: EncryptedRelayEnvelope,
+    expectedType?: PendingRequest["expectedType"]
   ): Promise<unknown> {
     if (this.pending.has(requestId)) {
       return Promise.reject(new ConnectorOperationError(
@@ -389,8 +494,17 @@ export class RelayHub {
           "connector_timeout",
           "The connector operation timed out."
         ));
-      }, OPERATION_TIMEOUT_MS);
-      this.pending.set(requestId, { resolve, reject, timer, socket, expectedEncrypted });
+      }, expectedType === "authorization_offer_response"
+        ? OFFER_TIMEOUT_MS
+        : OPERATION_TIMEOUT_MS);
+      this.pending.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        socket,
+        expectedEncrypted,
+        expectedType
+      });
       try {
         socket.send(JSON.stringify(message), (error) => {
           if (error) this.rejectPending(requestId, new RelayUnavailableError());
@@ -449,6 +563,20 @@ function encryptedRequestFromMessage(message: unknown): EncryptedRelayEnvelope |
   return (message as { type?: unknown }).type === "encrypted_operation_request"
     ? message as EncryptedRelayEnvelope
     : undefined;
+}
+
+function expectedResponseType(message: unknown): PendingRequest["expectedType"] {
+  if (typeof message !== "object" || message === null || Array.isArray(message)) return undefined;
+  switch ((message as { type?: unknown }).type) {
+    case "operation_request":
+      return "operation_response";
+    case "authorization_offer_request":
+      return "authorization_offer_response";
+    case "authorization_activation_request":
+      return "authorization_activation_response";
+    default:
+      return undefined;
+  }
 }
 
 function brokerError(


### PR DESCRIPTION
## Summary

- replace cached local collection selection with short-lived offers from currently connected authorities
- make connector inventory complete, monotonic, and authoritative, retiring omitted collections and preventing duplicate active authorities
- activate portal grants in two phases, completing only after the connector validates, provisions, and persists the exact policy
- expose explicit authority conflict actions and group immutable manifest revisions under a stable application family in the portal

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (all 72 server tests and all workspace suites)
- `pnpm package:audit`
- `cargo test --workspace` against the production-pinned mdbase-rs revision
- `pnpm e2e` including real-agent portal live-offer activation
- `pnpm e2e:relay`
- `pnpm e2e:sync`
- `pnpm e2e:provider`
- production Docker builds for server, hosted provider, and NATS