### PR TITLE
Bind portable hosted capabilities to grant keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "mdbase-connect-protocol",
  "mdbase-connect-runtime",
  "mdbase-runtime",
+ "p256",
  "rand_core 0.6.4",
  "reqwest",
  "serde",

--- a/crates/connect-hosted-provider/Cargo.toml
+++ b/crates/connect-hosted-provider/Cargo.toml
@@ -17,6 +17,7 @@ mdbase.workspace = true
 mdbase-connect-protocol = { path = "../connect-protocol" }
 mdbase-connect-runtime = { path = "../connect-runtime" }
 mdbase-runtime = { workspace = true, features = ["postgres"] }
+p256.workspace = true
 rand_core.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/connect-hosted-provider/migrations/0009_application_request_proofs.sql
+++ b/crates/connect-hosted-provider/migrations/0009_application_request_proofs.sql
@@ -1,0 +1,18 @@
+ALTER TABLE hosted_provider_replicas
+  ADD COLUMN IF NOT EXISTS proof_public_key text;
+
+UPDATE hosted_provider_replicas
+SET revoked_at = COALESCE(revoked_at, now())
+WHERE purpose = 'application'
+  AND allowed_origin = 'null'
+  AND proof_public_key IS NULL;
+
+CREATE TABLE IF NOT EXISTS hosted_provider_request_proofs (
+  replica_id uuid NOT NULL REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
+  nonce uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (replica_id, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_request_proofs_created_idx
+  ON hosted_provider_request_proofs(created_at);

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -1,8 +1,9 @@
 use axum::{
-    extract::{DefaultBodyLimit, Path, Query, Request, State},
+    body::Bytes,
+    extract::{DefaultBodyLimit, OriginalUri, Path, Query, Request, State},
     http::{
         header::{AUTHORIZATION, CONTENT_TYPE, ORIGIN},
-        HeaderMap, HeaderName, Method, StatusCode,
+        HeaderMap, HeaderName, Method, StatusCode, Uri,
     },
     middleware::{self, Next},
     response::Response,
@@ -11,7 +12,8 @@ use axum::{
 };
 use mdbase_connect_protocol::{
     GrantSummary, SyncChangesPage, SyncMutation, SyncMutationReceipt, SyncSession,
-    SyncSnapshotPage, TypeProvision,
+    SyncSnapshotPage, TypeProvision, HOSTED_PROOF_NONCE_HEADER, HOSTED_PROOF_SIGNATURE_HEADER,
+    HOSTED_PROOF_TIMESTAMP_HEADER, HOSTED_PROOF_VERSION_HEADER,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -29,15 +31,14 @@ use uuid::Uuid;
 use crate::{
     error::{ApiError, ApiResult},
     provider::{
-        validate_limit, HostedProvider, PrepareAuthorityTransfer, RegisterReplica,
-        UpdateApplicationReplica,
+        validate_limit, HostedProvider, HostedRequestProof, PrepareAuthorityTransfer,
+        RegisterReplica, UpdateApplicationReplica,
     },
 };
 
 // Leave room for the mutation envelope, frontmatter, and JSON escaping around
 // the default 2 MiB canonical-document quota.
 const MAX_BODY_BYTES: usize = 3 * 1024 * 1024;
-
 #[derive(Clone)]
 pub struct AppState {
     provider: HostedProvider,
@@ -125,7 +126,14 @@ pub fn app(state: AppState) -> Router {
     // requests are bound to the origin stored with that provider capability.
     let cors = CorsLayer::new()
         .allow_origin(Any)
-        .allow_headers([AUTHORIZATION, CONTENT_TYPE])
+        .allow_headers([
+            AUTHORIZATION,
+            CONTENT_TYPE,
+            HeaderName::from_static(HOSTED_PROOF_VERSION_HEADER),
+            HeaderName::from_static(HOSTED_PROOF_TIMESTAMP_HEADER),
+            HeaderName::from_static(HOSTED_PROOF_NONCE_HEADER),
+            HeaderName::from_static(HOSTED_PROOF_SIGNATURE_HEADER),
+        ])
         .allow_methods([Method::GET, Method::POST])
         .max_age(std::time::Duration::from_secs(600));
     let internal = Router::new()
@@ -444,10 +452,16 @@ async fn abort_authority_transfer(
 async fn open_session(
     State(state): State<AppState>,
     headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     Path(collection_id): Path<Uuid>,
 ) -> ApiResult<Json<SyncSession>> {
     let token = bearer(&headers)?;
     let origin = request_origin(&headers);
+    let proof = request_proof(&headers, Method::POST, &uri, &[])?;
+    state
+        .provider
+        .authorize_request(collection_id, token, origin, proof.as_ref())
+        .await?;
     Ok(Json(
         state
             .provider
@@ -459,11 +473,17 @@ async fn open_session(
 async fn snapshot(
     State(state): State<AppState>,
     headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     Path(collection_id): Path<Uuid>,
     Query(query): Query<SnapshotQuery>,
 ) -> ApiResult<Json<SyncSnapshotPage>> {
     let token = bearer(&headers)?;
     let origin = request_origin(&headers);
+    let proof = request_proof(&headers, Method::GET, &uri, &[])?;
+    state
+        .provider
+        .authorize_request(collection_id, token, origin, proof.as_ref())
+        .await?;
     Ok(Json(
         state
             .provider
@@ -481,12 +501,18 @@ async fn snapshot(
 async fn changes(
     State(state): State<AppState>,
     headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     Path(collection_id): Path<Uuid>,
     Query(query): Query<ChangesQuery>,
 ) -> ApiResult<Json<SyncChangesPage>> {
     let token = bearer(&headers)?;
     let origin = request_origin(&headers);
     let limit = validate_limit(query.limit)?;
+    let proof = request_proof(&headers, Method::GET, &uri, &[])?;
+    state
+        .provider
+        .authorize_request(collection_id, token, origin, proof.as_ref())
+        .await?;
     Ok(Json(
         state
             .provider
@@ -498,11 +524,20 @@ async fn changes(
 async fn mutate(
     State(state): State<AppState>,
     headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     Path(collection_id): Path<Uuid>,
-    Json(mutation): Json<SyncMutation>,
+    body: Bytes,
 ) -> ApiResult<Json<SyncMutationReceipt>> {
     let token = bearer(&headers)?;
     let origin = request_origin(&headers);
+    let proof = request_proof(&headers, Method::POST, &uri, &body)?;
+    state
+        .provider
+        .authorize_request(collection_id, token, origin, proof.as_ref())
+        .await?;
+    let mutation = serde_json::from_slice::<SyncMutation>(&body).map_err(|_| {
+        ApiError::bad_request("invalid_json", "The hosted mutation body is invalid.")
+    })?;
     Ok(Json(
         state
             .provider
@@ -532,11 +567,20 @@ async fn provision_types(
 async fn operation(
     State(state): State<AppState>,
     headers: HeaderMap,
+    OriginalUri(uri): OriginalUri,
     Path((collection_id, operation)): Path<(Uuid, String)>,
-    Json(input): Json<Value>,
+    body: Bytes,
 ) -> ApiResult<Json<Value>> {
     let token = bearer(&headers)?;
     let origin = request_origin(&headers);
+    let proof = request_proof(&headers, Method::POST, &uri, &body)?;
+    state
+        .provider
+        .authorize_request(collection_id, token, origin, proof.as_ref())
+        .await?;
+    let input = serde_json::from_slice::<Value>(&body).map_err(|_| {
+        ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
+    })?;
     let result = state
         .provider
         .operation(collection_id, token, &operation, input, origin)
@@ -546,6 +590,70 @@ async fn operation(
 
 fn request_origin(headers: &HeaderMap) -> Option<&str> {
     headers.get(ORIGIN).and_then(|value| value.to_str().ok())
+}
+
+fn request_proof(
+    headers: &HeaderMap,
+    method: Method,
+    uri: &Uri,
+    body: &[u8],
+) -> ApiResult<Option<HostedRequestProof>> {
+    let values = [
+        header_text(headers, HOSTED_PROOF_VERSION_HEADER),
+        header_text(headers, HOSTED_PROOF_TIMESTAMP_HEADER),
+        header_text(headers, HOSTED_PROOF_NONCE_HEADER),
+        header_text(headers, HOSTED_PROOF_SIGNATURE_HEADER),
+    ];
+    if values.iter().all(Option::is_none) {
+        return Ok(None);
+    }
+    let [Some(version), Some(timestamp), Some(nonce), Some(signature)] = values else {
+        return Err(ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof is incomplete.",
+        ));
+    };
+    let version = version.parse::<u32>().map_err(|_| {
+        ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof version is invalid.",
+        )
+    })?;
+    let timestamp = timestamp.parse::<i64>().map_err(|_| {
+        ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof timestamp is invalid.",
+        )
+    })?;
+    let nonce = Uuid::parse_str(nonce).map_err(|_| {
+        ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof nonce is invalid.",
+        )
+    })?;
+    if signature.is_empty() {
+        return Err(ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof signature is invalid.",
+        ));
+    }
+    Ok(Some(HostedRequestProof {
+        version,
+        timestamp,
+        nonce,
+        signature: signature.to_string(),
+        method: method.to_string(),
+        target: uri
+            .path_and_query()
+            .map(|value| value.as_str())
+            .unwrap_or_else(|| uri.path())
+            .to_string(),
+        body: body.to_vec(),
+    }))
+}
+
+fn header_text<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|value| value.to_str().ok())
 }
 
 fn bearer(headers: &HeaderMap) -> ApiResult<&str> {

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::http::StatusCode;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use mdbase::v03::{Diagnostic, OperationResult};
@@ -11,8 +12,9 @@ use mdbase_connect_protocol::{
     GrantSummary, SyncChange, SyncChangesPage, SyncCollectionResources, SyncConflict, SyncMutation,
     SyncMutationError, SyncMutationOperation, SyncMutationReceipt, SyncRecord, SyncReplicaMode,
     SyncResourceDocument, SyncSession, SyncSnapshotPage, TypeProvision, CONTROL_PROTOCOL_VERSION,
-    SYNC_PROTOCOL_VERSION,
+    HOSTED_PROOF_DOMAIN, HOSTED_PROOF_VERSION, SYNC_PROTOCOL_VERSION,
 };
+use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
@@ -80,6 +82,8 @@ pub struct RegisterReplica {
     pub allowed_operations: Vec<String>,
     #[serde(default)]
     pub allowed_origin: Option<String>,
+    #[serde(default)]
+    pub proof_public_key: Option<String>,
     #[serde(default)]
     pub grant_id: Option<Uuid>,
     pub token: String,
@@ -152,8 +156,20 @@ struct Replica {
     full_collection: bool,
     allowed_operations: Vec<String>,
     allowed_origin: Option<String>,
+    proof_public_key: Option<String>,
     grant_id: Option<Uuid>,
     scope_epoch: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct HostedRequestProof {
+    pub version: u32,
+    pub timestamp: i64,
+    pub nonce: Uuid,
+    pub signature: String,
+    pub method: String,
+    pub target: String,
+    pub body: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -469,7 +485,8 @@ impl HostedProvider {
         let max_replicas = number(collection.get::<i64, _>("max_replicas"), "replica quota")?;
         if let Some(existing) = sqlx::query(
             r#"SELECT collection_id, name, purpose, mode, allowed_types, full_collection,
-                      allowed_operations, allowed_origin, grant_id, token_hash, revoked_at
+                      allowed_operations, allowed_origin, proof_public_key, grant_id,
+                      token_hash, revoked_at
                FROM hosted_provider_replicas WHERE id = $1 FOR UPDATE"#,
         )
         .bind(input.replica_id)
@@ -488,6 +505,10 @@ impl HostedProvider {
                     .get::<Option<String>, _>("allowed_origin")
                     .as_deref()
                     == input.allowed_origin.as_deref()
+                && existing
+                    .get::<Option<String>, _>("proof_public_key")
+                    .as_deref()
+                    == input.proof_public_key.as_deref()
                 && existing.get::<Option<Uuid>, _>("grant_id") == input.grant_id
                 && existing
                     .get::<Option<chrono::DateTime<Utc>>, _>("revoked_at")
@@ -518,9 +539,10 @@ impl HostedProvider {
         let result = sqlx::query(
             r#"INSERT INTO hosted_provider_replicas
                  (id, collection_id, name, purpose, mode, allowed_types, full_collection,
-                  allowed_operations, allowed_origin, grant_id, token_hash, token_expires_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
-                       now() + ($12 * interval '1 second'))"#,
+                  allowed_operations, allowed_origin, proof_public_key, grant_id, token_hash,
+                  token_expires_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                       now() + ($13 * interval '1 second'))"#,
         )
         .bind(input.replica_id)
         .bind(collection_id)
@@ -531,6 +553,7 @@ impl HostedProvider {
         .bind(input.full_collection)
         .bind(input.allowed_operations)
         .bind(input.allowed_origin)
+        .bind(input.proof_public_key)
         .bind(input.grant_id)
         .bind(requested_token_hash)
         .bind(to_i64(token_ttl_seconds, "replica credential lifetime")?)
@@ -939,6 +962,81 @@ impl HostedProvider {
                 "Active replica not found.",
             ));
         }
+        Ok(())
+    }
+
+    pub async fn authorize_request(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        request_origin: Option<&str>,
+        proof: Option<&HostedRequestProof>,
+    ) -> ApiResult<()> {
+        // Originless mirror traffic is authenticated again inside the requested
+        // operation. Avoid a duplicate database round trip for that hot path.
+        // Application capabilities with an allowed origin still fail closed in
+        // the operation-level origin check when the header is omitted.
+        if request_origin.is_none() && proof.is_none() {
+            return Ok(());
+        }
+        let mut transaction = self.pool.begin().await?;
+        let row = sqlx::query(
+            r#"SELECT id, purpose, mode, allowed_types, full_collection, allowed_operations,
+                      allowed_origin, proof_public_key, grant_id, scope_epoch
+               FROM hosted_provider_replicas
+               WHERE collection_id = $1 AND token_hash = $2
+                 AND revoked_at IS NULL AND token_expires_at > now()
+               FOR SHARE"#,
+        )
+        .bind(collection_id)
+        .bind(token_hash(token))
+        .fetch_optional(&mut *transaction)
+        .await?;
+        let replica = replica_from_row(row)?;
+        match replica.purpose {
+            ReplicaPurpose::Mirror => {
+                if request_origin.is_some() || proof.is_some() {
+                    return Err(ApiError::forbidden(
+                        "origin_denied",
+                        "Mirror credentials cannot be used by browser applications.",
+                    ));
+                }
+            }
+            ReplicaPurpose::Application => {
+                authorize_application_origin(&replica, request_origin)?;
+                if let Some(public_key) = replica.proof_public_key.as_deref() {
+                    let proof = proof.ok_or_else(|| {
+                        ApiError::unauthorized(
+                            "hosted_proof_required",
+                            "The hosted capability requires proof from its approved application key.",
+                        )
+                    })?;
+                    verify_hosted_request_proof(public_key, token, proof)?;
+                    let inserted = sqlx::query(
+                        r#"INSERT INTO hosted_provider_request_proofs (replica_id, nonce)
+                           VALUES ($1, $2)
+                           ON CONFLICT (replica_id, nonce) DO NOTHING
+                           RETURNING nonce"#,
+                    )
+                    .bind(replica.id)
+                    .bind(proof.nonce)
+                    .fetch_optional(&mut *transaction)
+                    .await?;
+                    if inserted.is_none() {
+                        return Err(ApiError::unauthorized(
+                            "hosted_proof_replayed",
+                            "The hosted request proof has already been used.",
+                        ));
+                    }
+                    sqlx::query(
+                        "DELETE FROM hosted_provider_request_proofs WHERE created_at < now() - interval '10 minutes'",
+                    )
+                    .execute(&mut *transaction)
+                    .await?;
+                }
+            }
+        }
+        transaction.commit().await?;
         Ok(())
     }
 
@@ -3033,7 +3131,7 @@ impl HostedProvider {
     ) -> ApiResult<Replica> {
         let row = sqlx::query(
             r#"SELECT id, purpose, mode, allowed_types, full_collection, allowed_operations,
-                      allowed_origin, grant_id, scope_epoch
+                      allowed_origin, proof_public_key, grant_id, scope_epoch
                FROM hosted_provider_replicas
                WHERE collection_id = $1 AND token_hash = $2 AND purpose = $3
                  AND revoked_at IS NULL AND token_expires_at > now()"#,
@@ -3055,7 +3153,7 @@ impl HostedProvider {
     ) -> ApiResult<Replica> {
         let row = sqlx::query(
             r#"SELECT id, purpose, mode, allowed_types, full_collection, allowed_operations,
-                      allowed_origin, grant_id, scope_epoch
+                      allowed_origin, proof_public_key, grant_id, scope_epoch
                FROM hosted_provider_replicas
                WHERE collection_id = $1 AND token_hash = $2
                  AND revoked_at IS NULL AND token_expires_at > now()"#,
@@ -3121,7 +3219,7 @@ async fn authenticate_in(
 ) -> ApiResult<Replica> {
     let row = sqlx::query(
         r#"SELECT id, purpose, mode, allowed_types, full_collection, allowed_operations,
-                  allowed_origin, grant_id, scope_epoch
+                  allowed_origin, proof_public_key, grant_id, scope_epoch
            FROM hosted_provider_replicas
            WHERE collection_id = $1 AND token_hash = $2 AND purpose = $3
              AND revoked_at IS NULL AND token_expires_at > now()
@@ -3144,7 +3242,7 @@ async fn authenticate_in_for_sync(
 ) -> ApiResult<Replica> {
     let row = sqlx::query(
         r#"SELECT id, purpose, mode, allowed_types, full_collection, allowed_operations,
-                  allowed_origin, grant_id, scope_epoch
+                  allowed_origin, proof_public_key, grant_id, scope_epoch
            FROM hosted_provider_replicas
            WHERE collection_id = $1 AND token_hash = $2
              AND revoked_at IS NULL AND token_expires_at > now()
@@ -3187,6 +3285,7 @@ fn replica_from_row(row: Option<sqlx::postgres::PgRow>) -> ApiResult<Replica> {
         full_collection: row.get("full_collection"),
         allowed_operations: row.get("allowed_operations"),
         allowed_origin: row.get("allowed_origin"),
+        proof_public_key: row.get("proof_public_key"),
         grant_id: row.get("grant_id"),
         scope_epoch: number(row.get::<i64, _>("scope_epoch"), "scope epoch")?,
     })
@@ -3446,13 +3545,15 @@ fn authorize_application_operation(
             "The application is not allowed to perform this operation.",
         ));
     }
-    if let Some(origin) = request_origin {
-        if replica.allowed_origin.as_deref() != Some(origin) {
-            return Err(ApiError::forbidden(
-                "origin_denied",
-                "The application origin does not match this capability.",
-            ));
-        }
+    authorize_application_origin(replica, request_origin)
+}
+
+fn authorize_application_origin(replica: &Replica, request_origin: Option<&str>) -> ApiResult<()> {
+    if replica.allowed_origin.as_deref() != request_origin {
+        return Err(ApiError::forbidden(
+            "origin_denied",
+            "The application origin does not match this capability.",
+        ));
     }
     Ok(())
 }
@@ -3740,12 +3841,115 @@ fn replica_purpose(purpose: ReplicaPurpose) -> &'static str {
     }
 }
 
+fn verify_hosted_request_proof(
+    public_key: &str,
+    credential: &str,
+    proof: &HostedRequestProof,
+) -> ApiResult<()> {
+    if proof.version != HOSTED_PROOF_VERSION {
+        return Err(ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof version is unsupported.",
+        ));
+    }
+    if Utc::now().timestamp().abs_diff(proof.timestamp) > 5 * 60 {
+        return Err(ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof timestamp is invalid or expired.",
+        ));
+    }
+    if proof.method.is_empty()
+        || proof.target.is_empty()
+        || [proof.method.as_str(), proof.target.as_str()]
+            .iter()
+            .any(|value| value.contains('\n') || value.contains('\r'))
+    {
+        return Err(ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof metadata is invalid.",
+        ));
+    }
+    let verifying_key = proof_verifying_key(public_key).map_err(|_| {
+        ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof key is invalid.",
+        )
+    })?;
+    let signature_bytes = decode_base64url(&proof.signature).map_err(|_| {
+        ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof signature is invalid.",
+        )
+    })?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|_| {
+        ApiError::unauthorized(
+            "invalid_hosted_proof",
+            "The hosted request proof signature is invalid.",
+        )
+    })?;
+    verifying_key
+        .verify(
+            hosted_proof_message(credential, proof).as_bytes(),
+            &signature,
+        )
+        .map_err(|_| {
+            ApiError::unauthorized(
+                "invalid_hosted_proof",
+                "The hosted request proof signature is invalid.",
+            )
+        })
+}
+
+fn hosted_proof_message(credential: &str, proof: &HostedRequestProof) -> String {
+    [
+        HOSTED_PROOF_DOMAIN.to_string(),
+        HOSTED_PROOF_VERSION.to_string(),
+        proof.method.to_uppercase(),
+        proof.target.clone(),
+        digest_base64url(&proof.body),
+        digest_base64url(credential.as_bytes()),
+        proof.timestamp.to_string(),
+        proof.nonce.to_string(),
+    ]
+    .join("\n")
+}
+
+fn digest_base64url(value: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(value))
+}
+
+fn decode_base64url(value: &str) -> Result<Vec<u8>, ()> {
+    let decoded = URL_SAFE_NO_PAD.decode(value).map_err(|_| ())?;
+    if URL_SAFE_NO_PAD.encode(&decoded) != value {
+        return Err(());
+    }
+    Ok(decoded)
+}
+
+fn proof_verifying_key(value: &str) -> Result<VerifyingKey, ()> {
+    let bytes = decode_base64url(value)?;
+    if bytes.len() != 65 || bytes[0] != 4 {
+        return Err(());
+    }
+    VerifyingKey::from_sec1_bytes(&bytes).map_err(|_| ())
+}
+
+fn validate_proof_public_key(value: &str) -> ApiResult<()> {
+    proof_verifying_key(value).map(|_| ()).map_err(|_| {
+        ApiError::bad_request(
+            "invalid_hosted_proof_key",
+            "Hosted proof keys must be uncompressed P-256 public keys.",
+        )
+    })
+}
+
 fn validate_replica_capability(input: &RegisterReplica) -> ApiResult<()> {
     validate_operations(&input.allowed_operations, input.mode)?;
     match input.purpose {
         ReplicaPurpose::Mirror => {
             if !input.allowed_operations.is_empty()
                 || input.allowed_origin.is_some()
+                || input.proof_public_key.is_some()
                 || input.grant_id.is_some()
                 || input.full_collection
             {
@@ -3773,7 +3977,19 @@ fn validate_replica_capability(input: &RegisterReplica) -> ApiResult<()> {
                 &input.allowed_types,
                 &input.allowed_operations,
             )?;
+            if input.proof_public_key.is_some() && input.allowed_origin.is_none() {
+                return Err(ApiError::bad_request(
+                    "invalid_hosted_proof_key",
+                    "Hosted proof keys require an exact application origin.",
+                ));
+            }
             if let Some(origin) = input.allowed_origin.as_deref() {
+                if origin == "null" && input.proof_public_key.is_none() {
+                    return Err(ApiError::bad_request(
+                        "hosted_proof_required",
+                        "Opaque-origin application capabilities require a proof-of-possession key.",
+                    ));
+                }
                 if origin != "null" {
                     let url = url::Url::parse(origin).map_err(|_| {
                         ApiError::bad_request(
@@ -3795,6 +4011,9 @@ fn validate_replica_capability(input: &RegisterReplica) -> ApiResult<()> {
                         ));
                     }
                 }
+            }
+            if let Some(public_key) = input.proof_public_key.as_deref() {
+                validate_proof_public_key(public_key)?;
             }
         }
     }
@@ -4151,6 +4370,7 @@ mod tests {
                 "execute_view".to_string(),
             ],
             allowed_origin: Some("https://tasks.example".to_string()),
+            proof_public_key: None,
             grant_id: Some(Uuid::new_v4()),
             token: "x".repeat(40),
             token_ttl_seconds: Some(3600),
@@ -4158,7 +4378,24 @@ mod tests {
         validate_replica_capability(&capability).unwrap();
         let mut portable_capability = capability.clone();
         portable_capability.allowed_origin = Some("null".to_string());
+        let signing_key = p256::ecdsa::SigningKey::random(&mut rand_core::OsRng);
+        portable_capability.proof_public_key = Some(
+            URL_SAFE_NO_PAD.encode(
+                signing_key
+                    .verifying_key()
+                    .to_encoded_point(false)
+                    .as_bytes(),
+            ),
+        );
         validate_replica_capability(&portable_capability).unwrap();
+        let mut proof_without_origin = portable_capability.clone();
+        proof_without_origin.allowed_origin = None;
+        assert_eq!(
+            validate_replica_capability(&proof_without_origin)
+                .unwrap_err()
+                .code,
+            "invalid_hosted_proof_key"
+        );
         let portable_replica = Replica {
             id: portable_capability.replica_id,
             purpose: portable_capability.purpose,
@@ -4167,10 +4404,17 @@ mod tests {
             full_collection: portable_capability.full_collection,
             allowed_operations: portable_capability.allowed_operations,
             allowed_origin: portable_capability.allowed_origin,
+            proof_public_key: portable_capability.proof_public_key,
             grant_id: portable_capability.grant_id,
             scope_epoch: 1,
         };
         authorize_application_operation(&portable_replica, "query", Some("null")).unwrap();
+        assert_eq!(
+            authorize_application_operation(&portable_replica, "query", None)
+                .unwrap_err()
+                .code,
+            "origin_denied"
+        );
         assert_eq!(
             authorize_application_operation(
                 &portable_replica,
@@ -4205,6 +4449,7 @@ mod tests {
             full_collection: capability.full_collection,
             allowed_operations: capability.allowed_operations,
             allowed_origin: capability.allowed_origin,
+            proof_public_key: capability.proof_public_key,
             grant_id: capability.grant_id,
             scope_epoch: 1,
         };
@@ -4241,6 +4486,54 @@ mod tests {
     }
 
     #[test]
+    fn hosted_request_proofs_bind_the_body_credential_and_timestamp() {
+        use p256::ecdsa::{signature::Signer, SigningKey};
+
+        let signing_key = SigningKey::random(&mut rand_core::OsRng);
+        let public_key = URL_SAFE_NO_PAD.encode(
+            signing_key
+                .verifying_key()
+                .to_encoded_point(false)
+                .as_bytes(),
+        );
+        let mut proof = HostedRequestProof {
+            version: HOSTED_PROOF_VERSION,
+            timestamp: Utc::now().timestamp(),
+            nonce: Uuid::new_v4(),
+            signature: String::new(),
+            method: "POST".to_string(),
+            target: "/v1/hosted/collections/example/operations/create".to_string(),
+            body: br#"{"title":"proof"}"#.to_vec(),
+        };
+        let signature: Signature =
+            signing_key.sign(hosted_proof_message("hsa_secret", &proof).as_bytes());
+        proof.signature = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+        verify_hosted_request_proof(&public_key, "hsa_secret", &proof).unwrap();
+
+        proof.body = br#"{"title":"tampered"}"#.to_vec();
+        assert_eq!(
+            verify_hosted_request_proof(&public_key, "hsa_secret", &proof)
+                .unwrap_err()
+                .code,
+            "invalid_hosted_proof"
+        );
+        proof.body = br#"{"title":"proof"}"#.to_vec();
+        assert_eq!(
+            verify_hosted_request_proof(&public_key, "hsa_other", &proof)
+                .unwrap_err()
+                .code,
+            "invalid_hosted_proof"
+        );
+        proof.timestamp -= 301;
+        assert_eq!(
+            verify_hosted_request_proof(&public_key, "hsa_secret", &proof)
+                .unwrap_err()
+                .code,
+            "invalid_hosted_proof"
+        );
+    }
+
+    #[test]
     fn mirror_sync_credentials_are_not_browser_capabilities() {
         let replica = Replica {
             id: Uuid::new_v4(),
@@ -4250,6 +4543,7 @@ mod tests {
             full_collection: false,
             allowed_operations: Vec::new(),
             allowed_origin: None,
+            proof_public_key: None,
             grant_id: None,
             scope_epoch: 1,
         };
@@ -4293,6 +4587,7 @@ mod tests {
             full_collection: false,
             allowed_operations: vec!["create".to_string()],
             allowed_origin: Some("https://tasks.example".to_string()),
+            proof_public_key: None,
             grant_id: Some(Uuid::new_v4()),
             token: "x".repeat(40),
             token_ttl_seconds: Some(3600),

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -10,6 +10,13 @@ pub const LOOPBACK_PROTOCOL_VERSION: u32 = 1;
 pub const DEFAULT_LOOPBACK_PORT: u16 = 28_485;
 pub const SYNC_PROTOCOL_VERSION: u32 = 1;
 pub const RELAY_ENCRYPTION_SUITE: &str = "P256-HKDF-SHA256-AES256GCM";
+pub const HOSTED_PROOF_VERSION: u32 = 1;
+pub const HOSTED_PROOF_ALGORITHM: &str = "P256-SHA256";
+pub const HOSTED_PROOF_DOMAIN: &str = "mdbase-hosted-request-proof-v1";
+pub const HOSTED_PROOF_VERSION_HEADER: &str = "x-mdbase-proof-version";
+pub const HOSTED_PROOF_TIMESTAMP_HEADER: &str = "x-mdbase-proof-timestamp";
+pub const HOSTED_PROOF_NONCE_HEADER: &str = "x-mdbase-proof-nonce";
+pub const HOSTED_PROOF_SIGNATURE_HEADER: &str = "x-mdbase-proof-signature";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ControlRequest {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1654,6 +1654,7 @@ dependencies = [
  "mdbase-connect-protocol",
  "mdbase-connect-runtime",
  "mdbase-runtime",
+ "p256",
  "rand_core 0.6.4",
  "reqwest",
  "serde",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,7 +201,9 @@ Their browser origin is the exact opaque value `null`, tokens and non-extractabl
 keys are memory-only by default. A local connector requires a matching
 encrypted grant for every operation. A hosted provider instead receives a
 short-lived capability bound to the exact grant, collection, operation set,
-record scope, expiry, and opaque `null` origin. The SDK exposes the same
+record scope, expiry, opaque `null` origin, and application public key. Every
+hosted request and refresh carries a replay-protected ECDSA proof over its
+method, target, body, credential, timestamp, and nonce. The SDK exposes the same
 connection API for both routes.
 Collections that do not provide the required contracts are excluded from the
 decision. Local pause and revocation take effect at the connector even when

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -20,8 +20,10 @@ Application capabilities also authorize the scoped replication stream used by
 offline caches. Session and snapshot reads require record-read access, change
 pages require change access, and each queued mutation requires its corresponding
 create, update, rename, or delete permission. Browser requests are checked
-against the exact origin stored on that application capability, including the
-opaque `null` origin used by downloaded portable applications. Mirror
+against the exact origin stored on that application capability. Opaque `null`
+capabilities used by downloaded portable applications also require a P-256
+signature over the request and consume a one-use nonce. Missing origins, stale
+or replayed proofs, and body or credential substitutions are rejected. Mirror
 credentials have no browser origin and are rejected when presented by browser
 JavaScript.
 

--- a/docs/portable-apps.md
+++ b/docs/portable-apps.md
@@ -39,8 +39,8 @@ any compatible local or hosted collection.
 
 The SDK uses OAuth device authorization with PKCE:
 
-1. The file registers its inline manifest and generates an ephemeral P-256 key
-   so a local collection remains available as a choice.
+1. The file registers its inline manifest and generates a non-extractable P-256
+   grant key.
 2. Connect returns a random, short-lived device code and an eight-character
    user code.
 3. The SDK opens Connect's approval page in a popup and also returns the code
@@ -51,7 +51,8 @@ The SDK uses OAuth device authorization with PKCE:
 5. The SDK polls at the server-provided interval. Every successful response is
    bound to the opaque application origin `null`. A local grant must also
    contain the same application public key and encrypted relay protocol 1; a
-   hosted grant instead contains a scoped provider capability.
+   hosted grant instead contains a scoped provider capability bound to the same
+   public key.
 
 Device codes expire after ten minutes, are stored only as hashes by the control
 plane, are rate limited, and can be consumed once. Polling faster than the
@@ -65,25 +66,32 @@ grant, application, connector, collection, key ID, epoch, counter, request ID,
 and ciphertext.
 
 For a hosted collection, the SDK sends operations directly to the hosted data
-provider. Its short-lived bearer capability is limited to one replica,
-collection, grant, operation set, record scope, expiry, and the exact
-`Origin: null` value. The provider checks those fields for each request.
-Refreshing rotates both the Connect credential and provider capability. CORS
-permission alone is never an operation capability.
+provider. Its short-lived bearer capability selects one replica, collection,
+grant, operation set, record scope, and expiry. Every request additionally
+carries an ECDSA proof from the approved P-256 key over the method, target, body,
+credential, timestamp, and a one-use nonce. The provider requires the exact
+`Origin: null`, verifies the signature, and persists the nonce before serving
+the operation. Refreshing is signed by the same key and rotates both the Connect
+credential and provider capability. A copied bearer or refresh token is
+therefore insufficient, and CORS permission alone is never an operation
+capability.
 
 ## Storage and `file://`
 
 All local files have an opaque browser origin serialized as `null`. A portable
 SDK instance therefore uses process-memory token storage and a non-extractable
-process-memory private key by default. The key is discarded after a hosted
-collection is selected because hosted requests do not use the encrypted local
-relay. Another downloaded file cannot inherit the credentials through
+process-memory private key by default. Portable hosted capabilities keep that
+key for request and refresh signing. Another downloaded file cannot inherit the
+credentials through
 `localStorage` or IndexedDB. Reloading or reopening the file requires
 authorization again.
 
 An embedding shell may inject custom `storage` and `keyStore` adapters. That is
-an explicit trust decision by the application. `connect.environment()` reports
-whether the defaults are `memory`, `persistent`, or `custom`.
+an explicit trust decision by the application. A custom key store used with
+portable hosted collections must preserve and return the `signingKey` included
+in `GrantKeyRecord`; existing local-collection adapters remain compatible.
+`connect.environment()` reports whether the defaults are `memory`, `persistent`,
+or `custom`.
 
 Code running inside an already approved page has the page's authorized access,
 as it would for a website application. A portable app must therefore avoid

--- a/packages/client/src/crypto.test.ts
+++ b/packages/client/src/crypto.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import type { GrantEncryption } from "@mdbase/connect-protocol";
 import {
   encryptRelayRequest,
+  hostedProofMessage,
   MemoryGrantKeyStore,
-  RelayCryptoError
+  RelayCryptoError,
+  signHostedRequest
 } from "./crypto.js";
+import { HOSTED_PROOF_HEADERS } from "@mdbase/connect-protocol";
 
 const ids = {
   grant: "01911111-1111-7111-8111-111111111111",
@@ -103,4 +106,54 @@ describe("encrypted relay client", () => {
       {}
     )).rejects.toEqual(expect.objectContaining<Partial<RelayCryptoError>>({ code: "invalid_public_key" }));
   });
+
+  it("uses the same non-extractable P-256 key for hosted ECDSA proofs", async () => {
+    const store = new MemoryGrantKeyStore();
+    const record = await store.create("hosted");
+    expect(record.privateKey.algorithm.name).toBe("ECDH");
+    expect(record.signingKey?.algorithm.name).toBe("ECDSA");
+    expect(record.signingKey?.extractable).toBe(false);
+    const timestamp = 1_785_000_000;
+    const nonce = "01955555-5555-4555-8555-555555555555";
+    const headers = await signHostedRequest(store, "hosted", record.publicKey, {
+      method: "POST",
+      target: "/v1/hosted/collections/one/operations/create",
+      body: "{\"title\":\"proof\"}",
+      credential: "hsa_secret",
+      timestamp,
+      nonce
+    });
+    const publicKey = await crypto.subtle.importKey(
+      "raw",
+      base64UrlBytes(record.publicKey),
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["verify"]
+    );
+    const message = await hostedProofMessage({
+      method: "POST",
+      target: "/v1/hosted/collections/one/operations/create",
+      body: "{\"title\":\"proof\"}",
+      credential: "hsa_secret",
+      timestamp,
+      nonce
+    });
+    expect(await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      publicKey,
+      base64UrlBytes(headers[HOSTED_PROOF_HEADERS.signature]),
+      new TextEncoder().encode(message)
+    )).toBe(true);
+  });
 });
+
+function base64UrlBytes(value: string): Uint8Array<ArrayBuffer> {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/")
+    .padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/packages/client/src/crypto.ts
+++ b/packages/client/src/crypto.ts
@@ -1,5 +1,8 @@
 import {
   ENCRYPTED_RELAY_PROTOCOL_VERSION,
+  HOSTED_PROOF_DOMAIN,
+  HOSTED_PROOF_HEADERS,
+  HOSTED_PROOF_VERSION,
   RELAY_ENCRYPTION_SUITE,
   type CollectionOperation,
   type EncryptedRelayOperationRequest,
@@ -16,6 +19,7 @@ const RESPONSE_INFO = "mdbase-connect relay response key v1";
 export interface GrantKeyRecord {
   handle: string;
   privateKey: CryptoKey;
+  signingKey?: CryptoKey;
   publicKey: string;
 }
 
@@ -46,7 +50,12 @@ export class IndexedDbGrantKeyStore implements GrantKeyStore {
     const value = await idbRequest<PersistedGrantKey | undefined>(
       database.transaction(STORE_NAME).objectStore(STORE_NAME).get(handle)
     );
-    return value ? { handle: value.handle, privateKey: value.privateKey, publicKey: value.publicKey } : null;
+    return value ? {
+      handle: value.handle,
+      privateKey: value.privateKey,
+      signingKey: value.signingKey,
+      publicKey: value.publicKey
+    } : null;
   }
 
   async nextCounter(handle: string): Promise<string> {
@@ -123,7 +132,12 @@ export class MemoryGrantKeyStore implements GrantKeyStore {
 
   async get(handle: string): Promise<GrantKeyRecord | null> {
     const value = this.records.get(handle);
-    return value ? { handle: value.handle, privateKey: value.privateKey, publicKey: value.publicKey } : null;
+    return value ? {
+      handle: value.handle,
+      privateKey: value.privateKey,
+      signingKey: value.signingKey,
+      publicKey: value.publicKey
+    } : null;
   }
 
   nextCounter(handle: string): Promise<string> {
@@ -152,6 +166,69 @@ export interface RelayBinding {
   grantId: string;
   applicationId: string;
   encryption: GrantEncryption;
+}
+
+export interface HostedProofInput {
+  method: string;
+  target: string;
+  body?: string;
+  credential: string;
+  timestamp?: number;
+  nonce?: string;
+}
+
+/** Sign one hosted-provider or token-refresh request with the approved grant key. */
+export async function signHostedRequest(
+  store: GrantKeyStore,
+  handle: string,
+  expectedPublicKey: string,
+  input: HostedProofInput
+): Promise<Record<string, string>> {
+  const record = await requireKey(store, handle, expectedPublicKey);
+  if (!record.signingKey) {
+    throw new RelayCryptoError(
+      "missing_grant_key",
+      "The hosted grant signing key is unavailable. Reconnect this application."
+    );
+  }
+  const timestamp = input.timestamp ?? Math.floor(Date.now() / 1_000);
+  const nonce = input.nonce ?? crypto.randomUUID();
+  const message = await hostedProofMessage({ ...input, timestamp, nonce });
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    record.signingKey,
+    new TextEncoder().encode(message)
+  );
+  return {
+    [HOSTED_PROOF_HEADERS.version]: String(HOSTED_PROOF_VERSION),
+    [HOSTED_PROOF_HEADERS.timestamp]: String(timestamp),
+    [HOSTED_PROOF_HEADERS.nonce]: nonce,
+    [HOSTED_PROOF_HEADERS.signature]: bytesToBase64Url(new Uint8Array(signature))
+  };
+}
+
+export async function hostedProofMessage(
+  input: Required<Pick<HostedProofInput, "method" | "target" | "credential" | "timestamp" | "nonce">>
+    & Pick<HostedProofInput, "body">
+): Promise<string> {
+  const method = input.method.toUpperCase();
+  const bodyHash = await sha256Base64Url(input.body ?? "");
+  const credentialHash = await sha256Base64Url(input.credential);
+  for (const value of [method, input.target, String(input.timestamp), input.nonce]) {
+    if (!value || value.includes("\n") || value.includes("\r")) {
+      throw new RelayCryptoError("invalid_proof_input", "Hosted request proof metadata is invalid.");
+    }
+  }
+  return [
+    HOSTED_PROOF_DOMAIN,
+    HOSTED_PROOF_VERSION,
+    method,
+    input.target,
+    bodyHash,
+    credentialHash,
+    input.timestamp,
+    input.nonce
+  ].join("\n");
 }
 
 export async function encryptRelayRequest(
@@ -226,9 +303,9 @@ export class RelayCryptoError extends Error {
 
 async function generateGrantKey(handle: string): Promise<GrantKeyRecord> {
   const generated = await crypto.subtle.generateKey(
-    { name: "ECDH", namedCurve: "P-256" },
+    { name: "ECDSA", namedCurve: "P-256" },
     true,
-    ["deriveBits"]
+    ["sign", "verify"]
   ) as CryptoKeyPair;
   const publicKey = bytesToBase64Url(new Uint8Array(
     await crypto.subtle.exportKey("raw", generated.publicKey)
@@ -241,7 +318,14 @@ async function generateGrantKey(handle: string): Promise<GrantKeyRecord> {
     false,
     ["deriveBits"]
   );
-  return { handle, privateKey, publicKey };
+  const signingKey = await crypto.subtle.importKey(
+    "pkcs8",
+    privatePkcs8,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+  return { handle, privateKey, signingKey, publicKey };
 }
 
 async function requireKey(store: GrantKeyStore, handle: string, expectedPublicKey: string): Promise<GrantKeyRecord> {
@@ -373,6 +457,11 @@ function bytesToBase64Url(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+async function sha256Base64Url(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return bytesToBase64Url(new Uint8Array(digest));
 }
 
 function base64UrlToBytes(value: string): Uint8Array {

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -17,6 +17,7 @@ import type {
   GrantEncryption,
   MdbaseAppManifest
 } from "@mdbase/connect-protocol";
+import { HOSTED_PROOF_HEADERS } from "@mdbase/connect-protocol";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -525,7 +526,9 @@ describe("provider-neutral collection client", () => {
     const keyStore = new MemoryGrantKeyStore();
     const deleteKey = vi.spyOn(keyStore, "delete");
     const opened = vi.fn();
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (request) => {
+    let applicationPublicKey = "";
+    let providerHeaders: Record<string, string> | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
       const url = String(request);
       if (url.endsWith("/v1/apps/register")) {
         return jsonResponse({
@@ -537,6 +540,8 @@ describe("provider-neutral collection client", () => {
         });
       }
       if (url.endsWith("/oauth/device_authorization")) {
+        applicationPublicKey = new URLSearchParams(String(init?.body))
+          .get("application_public_key")!;
         return jsonResponse({
           device_code: "hosted-device-secret",
           user_code: "HOST-CODE",
@@ -563,8 +568,16 @@ describe("provider-neutral collection client", () => {
           hosted: {
             provider_url: "https://provider.example",
             replica_id: "00000000-0000-0000-0000-000000000005",
-            access_token: "hsa_portable_hosted"
+            access_token: "hsa_portable_hosted",
+            proof_public_key: applicationPublicKey
           }
+        });
+      }
+      if (url.includes("/operations/query")) {
+        providerHeaders = init?.headers as Record<string, string>;
+        return jsonResponse({
+          ok: true,
+          result: { valid: true, result: { results: [] }, diagnostics: [] }
         });
       }
       throw new Error(`Unexpected request: ${url}`);
@@ -594,8 +607,11 @@ describe("provider-neutral collection client", () => {
       collectionId: TEST_COLLECTION_ID,
       route: "hosted"
     });
-    expect(deleteKey).toHaveBeenCalledOnce();
+    expect(deleteKey).not.toHaveBeenCalled();
     expect(connect.connections()).toHaveLength(1);
+    expect((await result.connection.query()).valid).toBe(true);
+    expect(providerHeaders?.[HOSTED_PROOF_HEADERS.version]).toBe("1");
+    expect(providerHeaders?.[HOSTED_PROOF_HEADERS.signature]).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it("returns the verification details when a portable approval popup is blocked", async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -42,6 +42,7 @@ import {
   IndexedDbGrantKeyStore,
   MemoryGrantKeyStore,
   RelayCryptoError,
+  signHostedRequest,
   type GrantKeyStore
 } from "./crypto.js";
 
@@ -835,6 +836,7 @@ interface StoredToken {
     providerUrl: string;
     replicaId: string;
     accessToken: string;
+    proofPublicKey?: string;
   };
 }
 
@@ -1382,10 +1384,17 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
             "Authorization did not bind the portable grant to its opaque application origin."
           );
         }
-        if (tokenBody.hosted && (!hosted || tokenBody.encryption != null)) {
+        if (
+          tokenBody.hosted
+          && (
+            !hosted
+            || tokenBody.encryption != null
+            || tokenBody.hosted.proof_public_key !== grantKey.publicKey
+          )
+        ) {
           throw new MdbaseConnectError(
             "invalid_token_response",
-            "Authorization returned an invalid hosted capability for the portable grant."
+            "Authorization returned a hosted capability that is not bound to this portable grant key."
           );
         }
         if (!tokenBody.hosted && !localEncryption) {
@@ -1394,11 +1403,10 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
             "Authorization did not establish the expected key-bound local portable grant."
           );
         }
-        if (hosted) await this.keyStore.delete(keyHandle);
         const token = this.storeTokenResponse(
           tokenBody,
           application.id,
-          hosted ? undefined : keyHandle
+          keyHandle
         );
         if (options.collectionId && options.collectionId !== token.collectionId) {
           this.removeToken(token.collectionId, token.keyHandle);
@@ -1490,11 +1498,26 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
         "Authorization did not establish the required encrypted relay grant."
       );
     }
-    if (body.hosted && pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
+    if (body.hosted?.proof_public_key) {
+      if (
+        !pending.keyHandle
+        || !pending.applicationPublicKey
+        || body.hosted.proof_public_key !== pending.applicationPublicKey
+      ) {
+        if (pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
+        this.storage.removeItem(pendingKey);
+        throw new MdbaseConnectError(
+          "invalid_token_response",
+          "Authorization returned a hosted capability bound to another application key."
+        );
+      }
+    } else if (body.hosted && pending.keyHandle) {
+      await this.keyStore.delete(pending.keyHandle);
+    }
     const token = this.storeTokenResponse(
       body,
       pending.clientId,
-      body.hosted ? undefined : pending.keyHandle
+      body.hosted?.proof_public_key ? pending.keyHandle : body.hosted ? undefined : pending.keyHandle
     );
     if (pending.collectionId && pending.collectionId !== token.collectionId) {
       this.removeToken(token.collectionId, token.keyHandle);
@@ -1572,7 +1595,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
       hosted: body.hosted ? {
         providerUrl: body.hosted.provider_url,
         replicaId: body.hosted.replica_id,
-        accessToken: body.hosted.access_token
+        accessToken: body.hosted.access_token,
+        proofPublicKey: body.hosted.proof_public_key
       } : undefined
     };
     this.storage.setItem(this.tokenKey(collectionId), JSON.stringify(token));
@@ -2449,7 +2473,7 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     return body as Result;
   }
 
-  private sendHostedSyncRequest(
+  private async sendHostedSyncRequest(
     token: StoredToken,
     collectionId: string,
     method: "GET" | "POST",
@@ -2459,15 +2483,19 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     if (!token.hosted) {
       throw new MdbaseConnectError("not_hosted", "This authorization is not for a hosted collection.");
     }
+    const url = `${stripTrailingSlash(token.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(collectionId)}/sync/${path}`;
+    const body = input === undefined ? undefined : JSON.stringify(input);
+    const proof = await this.hostedProofHeaders(token, method, url, body, token.hosted.accessToken);
     return fetch(
-      `${stripTrailingSlash(token.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(collectionId)}/sync/${path}`,
+      url,
       {
         method,
         headers: {
           authorization: `Bearer ${token.hosted.accessToken}`,
-          ...(input === undefined ? {} : { "content-type": "application/json" })
+          ...(input === undefined ? {} : { "content-type": "application/json" }),
+          ...proof
         },
-        ...(input === undefined ? {} : { body: JSON.stringify(input) })
+        ...(body === undefined ? {} : { body })
       }
     );
   }
@@ -2595,13 +2623,24 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     const operationUrl = token.hosted
       ? `${stripTrailingSlash(token.hosted.providerUrl)}/v1/hosted/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`
       : `${this.serverUrl}/v1/collections/${encodeURIComponent(token.collectionId)}/operations/${operation}`;
+    const operationBody = JSON.stringify(body);
+    const proof = token.hosted
+      ? await this.hostedProofHeaders(
+          token,
+          "POST",
+          operationUrl,
+          operationBody,
+          token.hosted.accessToken
+        )
+      : {};
     const response = await fetch(operationUrl, {
         method: "POST",
         headers: {
           authorization: `Bearer ${token.hosted?.accessToken ?? token.accessToken}`,
-          "content-type": "application/json"
+          "content-type": "application/json",
+          ...proof
         },
-        body: JSON.stringify(body),
+        body: operationBody,
         signal: options.signal
       });
     if (response.ok) this.setRoute(token.hosted ? "hosted" : "relay");
@@ -2766,14 +2805,28 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
       );
     }
     const attemptedRefreshToken = current.refreshToken;
-    const response = await fetch(`${this.serverUrl}/oauth/token`, {
+    const refreshUrl = `${this.serverUrl}/oauth/token`;
+    const refreshBody = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: current.refreshToken,
+      client_id: current.clientId
+    }).toString();
+    const proof = current.hosted
+      ? await this.hostedProofHeaders(
+          current,
+          "POST",
+          refreshUrl,
+          refreshBody,
+          current.refreshToken
+        )
+      : {};
+    const response = await fetch(refreshUrl, {
       method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        grant_type: "refresh_token",
-        refresh_token: current.refreshToken,
-        client_id: current.clientId
-      })
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        ...proof
+      },
+      body: refreshBody
     });
     const body = await response.json();
     if (!response.ok) {
@@ -2787,6 +2840,41 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
       throw apiError(body, "authorization_expired", "Reconnect this application to continue.", response.status);
     }
     return this.storeTokenResponse(body, current.clientId, current.keyHandle);
+  }
+
+  private async hostedProofHeaders(
+    token: StoredToken,
+    method: string,
+    url: string,
+    body: string | undefined,
+    credential: string
+  ): Promise<Record<string, string>> {
+    if (!token.hosted?.proofPublicKey) return {};
+    if (!token.keyHandle) {
+      throw new MdbaseConnectError(
+        "missing_grant_key",
+        "Reconnect this application to restore hosted request signing."
+      );
+    }
+    try {
+      const target = new URL(url);
+      return await signHostedRequest(
+        this.keyStore,
+        token.keyHandle,
+        token.hosted.proofPublicKey,
+        {
+          method,
+          target: `${target.pathname}${target.search}`,
+          body,
+          credential
+        }
+      );
+    } catch (error) {
+      if (error instanceof RelayCryptoError) {
+        throw new MdbaseConnectError(error.code, error.message);
+      }
+      throw error;
+    }
   }
 
   private storeTokenResponse(body: any, clientId: string, keyHandle?: string): StoredToken {
@@ -3148,6 +3236,7 @@ function validHostedTokenResponse(value: unknown): boolean {
     provider_url?: unknown;
     replica_id?: unknown;
     access_token?: unknown;
+    proof_public_key?: unknown;
   };
   if (
     typeof hosted.provider_url !== "string"
@@ -3155,6 +3244,7 @@ function validHostedTokenResponse(value: unknown): boolean {
     || hosted.replica_id.length === 0
     || typeof hosted.access_token !== "string"
     || hosted.access_token.length === 0
+    || (hosted.proof_public_key !== undefined && typeof hosted.proof_public_key !== "string")
   ) return false;
   try {
     const provider = new URL(hosted.provider_url);

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -4,6 +4,15 @@ export const LOOPBACK_PROTOCOL_VERSION = 1 as const;
 export const DEFAULT_LOOPBACK_PORT = 28_485 as const;
 export const RELAY_ENCRYPTION_SUITE = "P256-HKDF-SHA256-AES256GCM" as const;
 export const SYNC_PROTOCOL_VERSION = 1 as const;
+export const HOSTED_PROOF_VERSION = 1 as const;
+export const HOSTED_PROOF_ALGORITHM = "P256-SHA256" as const;
+export const HOSTED_PROOF_DOMAIN = "mdbase-hosted-request-proof-v1" as const;
+export const HOSTED_PROOF_HEADERS = {
+  version: "x-mdbase-proof-version",
+  timestamp: "x-mdbase-proof-timestamp",
+  nonce: "x-mdbase-proof-nonce",
+  signature: "x-mdbase-proof-signature"
+} as const;
 
 /**
  * Validate a native OAuth callback against the publisher of its web manifest.

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -595,7 +595,19 @@ try {
     const { connection: inlineConnection } = await inlineSdk.completeAuthorization(inlineCallback);
     const inlineToken = inlineStorage.token();
     assert.equal(inlineToken.hosted.providerUrl, provider.url);
-    const inlineDescription = await inlineConnection.describe();
+    const inlineOriginalFetch = globalThis.fetch;
+    globalThis.fetch = (input, init = {}) => {
+      const url = String(input);
+      if (!url.startsWith(`${provider.url}/v1/hosted/`)) {
+        return inlineOriginalFetch(input, init);
+      }
+      const headers = new Headers(init.headers);
+      headers.set("origin", inlineManifest.origin);
+      return inlineOriginalFetch(input, { ...init, headers });
+    };
+    const inlineDescription = await inlineConnection.describe().finally(() => {
+      globalThis.fetch = inlineOriginalFetch;
+    });
     assert.equal(inlineDescription.contracts[0]?.id, "workout.record");
   } finally {
     await new Promise((resolveClose) => inlineManifest.server.close(resolveClose));
@@ -1358,8 +1370,9 @@ schema:
   assert.ok(Number.isInteger(bulkCount) && bulkCount >= 205 && bulkCount <= 20_000);
   const stressRun = bulkCount >= 10_000;
   let finalBulkRecordId;
+  const bulkStartSession = await writerTransport.openSession();
   const recordsBeforeBulk = (
-    await snapshotAll(writerTransport, await writerTransport.openSession())
+    await snapshotAll(writerTransport, bulkStartSession)
   ).length;
   const mutationLatencies = [];
   for (let index = 0; index < bulkCount; index += 1) {
@@ -1394,7 +1407,10 @@ schema:
 
   if (stressRun) {
     const changeLatencies = [];
-    let changeCursor = 0;
+    // Resource changes intentionally require a fresh snapshot. Start from the
+    // snapshot immediately before this record-only bulk phase so the benchmark
+    // measures its change pages instead of rediscovering that earlier reset.
+    let changeCursor = bulkStartSession.head;
     while (changeCursor < pagedSession.head) {
       const changesStarted = performance.now();
       const changes = await writerTransport.changes(changeCursor, 200);
@@ -1645,6 +1661,19 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
     environment: manager.environment(),
     initialConnections: manager.connections().length
   };
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = async (input, init = {}) => {
+    const url = String(input);
+    if (url.includes("/v1/hosted/collections/") && init.headers?.authorization) {
+      globalThis.portableHarness.capturedRequest = {
+        url,
+        method: init.method,
+        headers: { ...init.headers },
+        body: init.body
+      };
+    }
+    return nativeFetch(input, init);
+  };
   document.querySelector("#connect").onclick = () => {
     manager.authorize({
       operations: ["describe", "query", "create"],
@@ -1738,6 +1767,50 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
       records: 1,
       connections: 1
     });
+    const captured = result.capturedRequest;
+    assert.ok(captured.headers["x-mdbase-proof-signature"]);
+    const noProof = await fetch(captured.url, {
+      method: captured.method,
+      headers: {
+        authorization: captured.headers.authorization,
+        "content-type": captured.headers["content-type"],
+        origin: "null"
+      },
+      body: captured.body
+    });
+    assert.equal(noProof.status, 401);
+    assert.equal((await noProof.json()).error.code, "hosted_proof_required");
+    const noProofOrOrigin = await fetch(captured.url, {
+      method: captured.method,
+      headers: {
+        authorization: captured.headers.authorization,
+        "content-type": captured.headers["content-type"]
+      },
+      body: captured.body
+    });
+    assert.equal(noProofOrOrigin.status, 403);
+    assert.equal((await noProofOrOrigin.json()).error.code, "origin_denied");
+    const replay = await fetch(captured.url, {
+      method: captured.method,
+      headers: { ...captured.headers, origin: "null" },
+      body: captured.body
+    });
+    assert.equal(replay.status, 401);
+    assert.equal((await replay.json()).error.code, "hosted_proof_replayed");
+    const tampered = await fetch(captured.url, {
+      method: captured.method,
+      headers: { ...captured.headers, origin: "null" },
+      body: `${captured.body} `
+    });
+    assert.equal(tampered.status, 401);
+    assert.equal((await tampered.json()).error.code, "invalid_hosted_proof");
+    const missingOrigin = await fetch(captured.url, {
+      method: captured.method,
+      headers: captured.headers,
+      body: captured.body
+    });
+    assert.equal(missingOrigin.status, 403);
+    assert.equal((await missingOrigin.json()).error.code, "origin_denied");
 
     const independentPage = await context.newPage();
     await independentPage.goto(new URL(`file://${file}`).href);

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1,12 +1,22 @@
-import { createECDH } from "node:crypto";
+import {
+  createECDH,
+  generateKeyPairSync,
+  randomUUID,
+  sign
+} from "node:crypto";
 import type {
   ApplicationRequirements,
   MdbaseAppManifest
+} from "@mdbase/connect-protocol";
+import {
+  HOSTED_PROOF_HEADERS,
+  HOSTED_PROOF_VERSION
 } from "@mdbase/connect-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
 import type { HostedProviderClient } from "./hosted-provider.js";
+import { hostedProofMessage } from "./hosted-proof.js";
 import { pkceChallenge } from "./security.js";
 
 const resources: Array<() => Promise<void>> = [];
@@ -688,8 +698,13 @@ describe("mdbase connect server", () => {
     });
     const applicationId = registration.json().application.id as string;
 
-    const applicationKey = createECDH("prime256v1");
-    applicationKey.generateKeys();
+    const applicationKeys = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+    const applicationJwk = applicationKeys.publicKey.export({ format: "jwk" });
+    const applicationPublicKey = Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from(applicationJwk.x!, "base64url"),
+      Buffer.from(applicationJwk.y!, "base64url")
+    ]).toString("base64url");
     const verifier = "portable-verifier-that-is-long-enough-for-pkce-0001";
     const device = await app.inject({
       method: "POST",
@@ -705,9 +720,7 @@ describe("mdbase connect server", () => {
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
-        application_public_key: applicationKey
-          .getPublicKey(undefined, "uncompressed")
-          .toString("base64url")
+        application_public_key: applicationPublicKey
       }).toString()
     });
     expect(device.statusCode, JSON.stringify(device.json())).toBe(200);
@@ -862,9 +875,7 @@ describe("mdbase connect server", () => {
         protocol_version: 1,
         connector_id: connector.connector.id,
         collection_id: localCollectionId,
-        application_public_key: applicationKey
-          .getPublicKey(undefined, "uncompressed")
-          .toString("base64url")
+        application_public_key: applicationPublicKey
       }
     });
     const policy = await app.inject({
@@ -1017,8 +1028,13 @@ describe("mdbase connect server", () => {
     });
     expect(registration.statusCode, JSON.stringify(registration.json())).toBe(200);
     const applicationId = registration.json().application.id as string;
-    const applicationKey = createECDH("prime256v1");
-    applicationKey.generateKeys();
+    const applicationKeys = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+    const applicationJwk = applicationKeys.publicKey.export({ format: "jwk" });
+    const applicationPublicKey = Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from(applicationJwk.x!, "base64url"),
+      Buffer.from(applicationJwk.y!, "base64url")
+    ]).toString("base64url");
     const verifier = "portable-hosted-verifier-that-is-long-enough-0001";
     const device = await app.inject({
       method: "POST",
@@ -1034,9 +1050,7 @@ describe("mdbase connect server", () => {
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
-        application_public_key: applicationKey
-          .getPublicKey(undefined, "uncompressed")
-          .toString("base64url")
+        application_public_key: applicationPublicKey
       }).toString()
     });
     expect(device.statusCode, JSON.stringify(device.json())).toBe(200);
@@ -1073,7 +1087,8 @@ describe("mdbase connect server", () => {
         purpose: "application",
         fullCollection: true,
         allowedOperations: ["describe", "query", "create", "update"],
-        allowedOrigin: "null"
+        allowedOrigin: "null",
+        proofPublicKey: applicationPublicKey
       })
     );
     const token = await pollDeviceToken(app, {
@@ -1088,7 +1103,8 @@ describe("mdbase connect server", () => {
       operations: ["describe", "query", "create", "update"],
       encryption: null,
       hosted: {
-        provider_url: "https://sync.example"
+        provider_url: "https://sync.example",
+        proof_public_key: applicationPublicKey
       }
     });
     expect(token.json().hosted.replica_id).toMatch(
@@ -1101,17 +1117,47 @@ describe("mdbase connect server", () => {
       3_600
     );
 
-    const refreshed = await app.inject({
+    const refreshBody = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: token.json().refresh_token,
+      client_id: applicationId
+    }).toString();
+    const unsignedRefresh = await app.inject({
       method: "POST",
       url: "/oauth/token",
-      payload: new URLSearchParams({
-        grant_type: "refresh_token",
-        refresh_token: token.json().refresh_token,
-        client_id: applicationId
-      }).toString(),
+      payload: refreshBody,
       headers: {
         origin: "null",
         "content-type": "application/x-www-form-urlencoded"
+      }
+    });
+    expect(unsignedRefresh.statusCode).toBe(400);
+    expect(unsignedRefresh.json()).toMatchObject({ error: "invalid_grant" });
+    const proofTimestamp = Math.floor(Date.now() / 1_000);
+    const proofNonce = randomUUID();
+    const proofSignature = sign(
+      "sha256",
+      Buffer.from(hostedProofMessage({
+        method: "POST",
+        target: "/oauth/token",
+        body: refreshBody,
+        credential: token.json().refresh_token,
+        timestamp: proofTimestamp,
+        nonce: proofNonce
+      })),
+      { key: applicationKeys.privateKey, dsaEncoding: "ieee-p1363" }
+    ).toString("base64url");
+    const refreshed = await app.inject({
+      method: "POST",
+      url: "/oauth/token",
+      payload: refreshBody,
+      headers: {
+        origin: "null",
+        "content-type": "application/x-www-form-urlencoded",
+        [HOSTED_PROOF_HEADERS.version]: String(HOSTED_PROOF_VERSION),
+        [HOSTED_PROOF_HEADERS.timestamp]: String(proofTimestamp),
+        [HOSTED_PROOF_HEADERS.nonce]: proofNonce,
+        [HOSTED_PROOF_HEADERS.signature]: proofSignature
       }
     });
     expect(refreshed.statusCode, JSON.stringify(refreshed.json())).toBe(200);
@@ -1121,17 +1167,23 @@ describe("mdbase connect server", () => {
       encryption: null,
       hosted: {
         provider_url: "https://sync.example",
-        replica_id: token.json().hosted.replica_id
+        replica_id: token.json().hosted.replica_id,
+        proof_public_key: applicationPublicKey
       }
     });
     expect(refreshed.json().hosted.access_token).not.toBe(token.json().hosted.access_token);
-    const grant = await db.query<{ application_origin: string; encryption: unknown }>(
-      "SELECT application_origin, encryption FROM grants WHERE id = $1",
+    const grant = await db.query<{
+      application_origin: string;
+      encryption: unknown;
+      proof_public_key: string | null;
+    }>(
+      "SELECT application_origin, encryption, proof_public_key FROM grants WHERE id = $1",
       [token.json().grant_id]
     );
     expect(grant.rows[0]).toEqual({
       application_origin: "null",
-      encryption: null
+      encryption: null,
+      proof_public_key: applicationPublicKey
     });
   });
 

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -60,6 +60,10 @@ import {
   HostedProviderUnavailableError
 } from "./hosted-provider.js";
 import {
+  HostedProofError,
+  verifyHostedRequestProof
+} from "./hosted-proof.js";
+import {
   exchangeGitHubCode,
   GitHubIdentityError,
   type GitHubAuthConfig
@@ -3140,8 +3144,12 @@ export async function buildApp(options: BuildOptions) {
       return issueApplicationTokens(options.db, options.hostedProvider, authorizationCode.grant_id);
     }
 
-    const refresh = await options.db.query<{ id: string; grant_id: string }>(
-      `SELECT rt.id, rt.grant_id
+    const refresh = await options.db.query<{
+      id: string;
+      grant_id: string;
+      proof_public_key: string | null;
+    }>(
+      `SELECT rt.id, rt.grant_id, g.proof_public_key
        FROM refresh_tokens rt
        JOIN grants g ON g.id = rt.grant_id
        WHERE rt.token_hash = $1 AND rt.used_at IS NULL AND rt.revoked_at IS NULL
@@ -3152,6 +3160,31 @@ export async function buildApp(options: BuildOptions) {
     const current = refresh.rows[0];
     if (!current) {
       return reply.code(400).send(apiError("invalid_grant", "Refresh token is invalid or expired."));
+    }
+    if (current.proof_public_key) {
+      const refreshBody = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: input.refresh_token,
+        client_id: input.client_id
+      }).toString();
+      try {
+        verifyHostedRequestProof(
+          request.headers,
+          current.proof_public_key,
+          {
+            method: "POST",
+            target: "/oauth/token",
+            body: refreshBody,
+            credential: input.refresh_token
+          }
+        );
+      } catch (error) {
+        if (!(error instanceof HostedProofError)) throw error;
+        return reply.code(400).send(oauthError(
+          "invalid_grant",
+          "The refresh request is not signed by the approved application key."
+        ));
+      }
     }
     const rotated = await options.db.query(
       `UPDATE refresh_tokens SET used_at = now()
@@ -4681,6 +4714,9 @@ async function approveHostedAuthorization(
       fullCollection: pending.requirements.access === "full_collection",
       allowedOperations: operations,
       allowedOrigin,
+      proofPublicKey: pending.flow === "device_code"
+        ? pending.application_public_key!
+        : undefined,
       grantId,
       token: bootstrapToken,
       tokenTtlSeconds: 3_600
@@ -4700,9 +4736,9 @@ async function approveHostedAuthorization(
     await connection.query(
       `INSERT INTO grants
           (id, user_id, application_id, hosted_collection_id, hosted_replica_id,
-          operations, scope, encryption, application_origin,
+          operations, scope, encryption, proof_public_key, application_origin,
           notification_criteria)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL, $8, $9::jsonb)`,
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, NULL, $8, $9, $10::jsonb)`,
       [
         grantId,
         input.userId,
@@ -4711,6 +4747,7 @@ async function approveHostedAuthorization(
         replicaId,
         JSON.stringify(operations),
         JSON.stringify(scope),
+        pending.flow === "device_code" ? pending.application_public_key : null,
         applicationOrigin,
         JSON.stringify(pending.notifications.criteria)
       ]
@@ -4831,6 +4868,7 @@ async function issueApplicationTokens(
     provider_url: string;
     replica_id: string;
     access_token: string;
+    proof_public_key?: string;
   };
 }> {
   const grant = await db.query<{
@@ -4842,12 +4880,13 @@ async function issueApplicationTokens(
     operations: string[];
     scope: GrantScope;
     encryption: GrantEncryption | null;
+    proof_public_key: string | null;
     application_origin: string;
   }>(
     `SELECT COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
             COALESCE(col.display_name, hosted.display_name) AS collection_name,
             g.hosted_collection_id, g.hosted_replica_id, hosted.provider_url,
-            g.operations, g.scope, g.encryption,
+            g.operations, g.scope, g.encryption, g.proof_public_key,
             CASE WHEN g.application_origin = '' THEN app.homepage
                  ELSE g.application_origin END AS application_origin
      FROM grants g
@@ -4861,7 +4900,12 @@ async function issueApplicationTokens(
   if (!grant.rows[0]) throw new RequestValidationError("The application grant is no longer active.");
   const accessToken = randomToken("mdb");
   const refreshToken = randomToken("ref");
-  let hosted: { provider_url: string; replica_id: string; access_token: string } | undefined;
+  let hosted: {
+    provider_url: string;
+    replica_id: string;
+    access_token: string;
+    proof_public_key?: string;
+  } | undefined;
   if (grant.rows[0].hosted_collection_id) {
     if (!hostedProvider || !grant.rows[0].hosted_replica_id || !grant.rows[0].provider_url) {
       throw new RequestValidationError("The hosted application capability is unavailable.");
@@ -4871,7 +4915,10 @@ async function issueApplicationTokens(
     hosted = {
       provider_url: grant.rows[0].provider_url,
       replica_id: grant.rows[0].hosted_replica_id,
-      access_token: providerToken
+      access_token: providerToken,
+      ...(grant.rows[0].proof_public_key
+        ? { proof_public_key: grant.rows[0].proof_public_key }
+        : {})
     };
   }
   await db.query(

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
-import { backfillSessionProviders, createDatabase } from "./db.js";
+import {
+  backfillSessionProviders,
+  createDatabase,
+  revokeLegacyHostedBearerGrants
+} from "./db.js";
 
 const resources: Array<() => Promise<void>> = [];
 
@@ -37,5 +41,66 @@ describe("database migrations", () => {
       [userId]
     );
     expect(session.rows[0]?.provider).toBe("github");
+  });
+
+  it("revokes legacy opaque-origin hosted grants that have no proof key", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const userId = randomUUID();
+    const collectionId = randomUUID();
+    const applicationId = randomUUID();
+    const grantId = randomUUID();
+    await db.query("INSERT INTO users (id, email, name) VALUES ($1, $2, $3)", [
+      userId,
+      "portable@example.com",
+      "Portable User"
+    ]);
+    await db.query(
+      `INSERT INTO hosted_collections (id, user_id, display_name, template)
+       VALUES ($1, $2, 'Portable notes', 'mdbase')`,
+      [collectionId, userId]
+    );
+    await db.query(
+      `INSERT INTO applications
+         (id, canonical_identity, distribution, name, homepage, redirect_uris)
+       VALUES ($1, 'portable-legacy', 'portable', 'Portable', '', '[]'::jsonb)`,
+      [applicationId]
+    );
+    await db.query(
+      `INSERT INTO grants
+         (id, user_id, application_id, hosted_collection_id, operations, scope,
+          application_origin)
+       VALUES ($1, $2, $3, $4, '["query"]'::jsonb,
+               '{"contracts":[],"access":"full_collection"}'::jsonb, 'null')`,
+      [grantId, userId, applicationId, collectionId]
+    );
+    await db.query(
+      `INSERT INTO access_tokens (id, token_hash, grant_id, expires_at)
+       VALUES ($1, 'legacy-access', $2, now() + interval '1 hour')`,
+      [randomUUID(), grantId]
+    );
+    await db.query(
+      `INSERT INTO refresh_tokens (id, token_hash, grant_id, expires_at)
+       VALUES ($1, 'legacy-refresh', $2, now() + interval '30 days')`,
+      [randomUUID(), grantId]
+    );
+
+    await revokeLegacyHostedBearerGrants(db);
+
+    const grant = await db.query<{ revoked_at: Date | null }>(
+      "SELECT revoked_at FROM grants WHERE id = $1",
+      [grantId]
+    );
+    const access = await db.query<{ revoked_at: Date | null }>(
+      "SELECT revoked_at FROM access_tokens WHERE grant_id = $1",
+      [grantId]
+    );
+    const refresh = await db.query<{ revoked_at: Date | null }>(
+      "SELECT revoked_at FROM refresh_tokens WHERE grant_id = $1",
+      [grantId]
+    );
+    expect(grant.rows[0]?.revoked_at).not.toBeNull();
+    expect(access.rows[0]?.revoked_at).not.toBeNull();
+    expect(refresh.rows[0]?.revoked_at).not.toBeNull();
   });
 });

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -157,6 +157,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       scope jsonb NOT NULL DEFAULT '{"contracts":[],"access":"full_collection"}'::jsonb,
       notification_criteria jsonb NOT NULL DEFAULT '[]'::jsonb,
       encryption jsonb,
+      proof_public_key text,
       application_origin text NOT NULL DEFAULT '',
       created_at timestamptz NOT NULL DEFAULT now(),
       activated_at timestamptz DEFAULT now(),
@@ -525,6 +526,13 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "application_origin",
     "ALTER TABLE grants ADD COLUMN application_origin text NOT NULL DEFAULT ''"
   );
+  await ensureColumn(
+    db,
+    "grants",
+    "proof_public_key",
+    "ALTER TABLE grants ADD COLUMN proof_public_key text"
+  );
+  await revokeLegacyHostedBearerGrants(db);
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
   await ensureColumn(db, "authorization_requests", "collection_hint", "ALTER TABLE authorization_requests ADD COLUMN collection_hint uuid");
@@ -772,6 +780,36 @@ export async function backfillSessionProviders(db: DatabaseQueryable): Promise<v
      WHERE sessions.provider = 'session'
        AND external_identities.user_id = sessions.user_id
        AND external_identities.provider = 'github'`
+  );
+}
+
+export async function revokeLegacyHostedBearerGrants(db: DatabaseQueryable): Promise<void> {
+  await db.query(
+    `UPDATE grants
+     SET revoked_at = COALESCE(revoked_at, now())
+     WHERE hosted_collection_id IS NOT NULL
+       AND application_origin = 'null'
+       AND proof_public_key IS NULL`
+  );
+  await db.query(
+    `UPDATE access_tokens
+     SET revoked_at = COALESCE(revoked_at, now())
+     WHERE grant_id IN (
+       SELECT id FROM grants
+       WHERE hosted_collection_id IS NOT NULL
+         AND application_origin = 'null'
+         AND proof_public_key IS NULL
+     )`
+  );
+  await db.query(
+    `UPDATE refresh_tokens
+     SET revoked_at = COALESCE(revoked_at, now())
+     WHERE grant_id IN (
+       SELECT id FROM grants
+       WHERE hosted_collection_id IS NOT NULL
+         AND application_origin = 'null'
+         AND proof_public_key IS NULL
+     )`
   );
 }
 

--- a/services/server/src/hosted-proof.test.ts
+++ b/services/server/src/hosted-proof.test.ts
@@ -1,0 +1,63 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  HOSTED_PROOF_HEADERS,
+  HOSTED_PROOF_VERSION
+} from "@mdbase/connect-protocol";
+import {
+  hostedProofMessage,
+  HostedProofError,
+  verifyHostedRequestProof
+} from "./hosted-proof.js";
+
+const timestamp = 1_785_000_000;
+const nonce = "01955555-5555-4555-8555-555555555555";
+
+describe("hosted request proof verification", () => {
+  it("accepts an exact P-256 proof and rejects body, credential, and time changes", () => {
+    const keys = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+    const publicJwk = keys.publicKey.export({ format: "jwk" });
+    const publicKey = Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from(publicJwk.x!, "base64url"),
+      Buffer.from(publicJwk.y!, "base64url")
+    ]).toString("base64url");
+    const request = {
+      method: "POST",
+      target: "/v1/hosted/collections/one/operations/create",
+      body: "{\"title\":\"proof\"}",
+      credential: "hsa_secret"
+    };
+    const signature = sign(
+      "sha256",
+      Buffer.from(hostedProofMessage({ ...request, timestamp, nonce })),
+      { key: keys.privateKey, dsaEncoding: "ieee-p1363" }
+    ).toString("base64url");
+    const headers = {
+      [HOSTED_PROOF_HEADERS.version]: String(HOSTED_PROOF_VERSION),
+      [HOSTED_PROOF_HEADERS.timestamp]: String(timestamp),
+      [HOSTED_PROOF_HEADERS.nonce]: nonce,
+      [HOSTED_PROOF_HEADERS.signature]: signature
+    };
+    expect(() => verifyHostedRequestProof(headers, publicKey, request, timestamp))
+      .not.toThrow();
+    expect(() => verifyHostedRequestProof(
+      headers,
+      publicKey,
+      { ...request, body: "{\"title\":\"tampered\"}" },
+      timestamp
+    )).toThrow(HostedProofError);
+    expect(() => verifyHostedRequestProof(
+      headers,
+      publicKey,
+      { ...request, credential: "hsa_other" },
+      timestamp
+    )).toThrow(HostedProofError);
+    expect(() => verifyHostedRequestProof(
+      headers,
+      publicKey,
+      request,
+      timestamp + 301
+    )).toThrow("timestamp");
+  });
+});

--- a/services/server/src/hosted-proof.ts
+++ b/services/server/src/hosted-proof.ts
@@ -1,0 +1,121 @@
+import {
+  createHash,
+  createPublicKey,
+  verify
+} from "node:crypto";
+import {
+  HOSTED_PROOF_DOMAIN,
+  HOSTED_PROOF_HEADERS,
+  HOSTED_PROOF_VERSION
+} from "@mdbase/connect-protocol";
+
+const PROOF_WINDOW_SECONDS = 5 * 60;
+
+export interface HostedProofRequest {
+  method: string;
+  target: string;
+  body?: string;
+  credential: string;
+}
+
+export class HostedProofError extends Error {
+  readonly code = "invalid_hosted_proof";
+}
+
+export function verifyHostedRequestProof(
+  headers: Record<string, string | string[] | undefined>,
+  expectedPublicKey: string,
+  request: HostedProofRequest,
+  nowSeconds = Math.floor(Date.now() / 1_000)
+): void {
+  const version = header(headers, HOSTED_PROOF_HEADERS.version);
+  const timestampText = header(headers, HOSTED_PROOF_HEADERS.timestamp);
+  const nonce = header(headers, HOSTED_PROOF_HEADERS.nonce);
+  const signatureText = header(headers, HOSTED_PROOF_HEADERS.signature);
+  if (
+    version !== String(HOSTED_PROOF_VERSION)
+    || !timestampText
+    || !nonce
+    || !signatureText
+  ) {
+    throw new HostedProofError("The hosted request proof is missing or unsupported.");
+  }
+  const timestamp = Number(timestampText);
+  if (
+    !Number.isSafeInteger(timestamp)
+    || String(timestamp) !== timestampText
+    || Math.abs(nowSeconds - timestamp) > PROOF_WINDOW_SECONDS
+  ) {
+    throw new HostedProofError("The hosted request proof timestamp is invalid or expired.");
+  }
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(nonce)
+  ) {
+    throw new HostedProofError("The hosted request proof nonce is invalid.");
+  }
+  const publicBytes = base64Url(expectedPublicKey);
+  const signature = base64Url(signatureText);
+  if (publicBytes.length !== 65 || publicBytes[0] !== 4 || signature.length !== 64) {
+    throw new HostedProofError("The hosted request proof key or signature is invalid.");
+  }
+  const publicKey = createPublicKey({
+    key: {
+      kty: "EC",
+      crv: "P-256",
+      x: publicBytes.subarray(1, 33).toString("base64url"),
+      y: publicBytes.subarray(33).toString("base64url")
+    },
+    format: "jwk"
+  });
+  const valid = verify(
+    "sha256",
+    Buffer.from(hostedProofMessage({
+      ...request,
+      timestamp,
+      nonce
+    })),
+    { key: publicKey, dsaEncoding: "ieee-p1363" },
+    signature
+  );
+  if (!valid) {
+    throw new HostedProofError("The hosted request proof signature is invalid.");
+  }
+}
+
+export function hostedProofMessage(
+  request: HostedProofRequest & { timestamp: number; nonce: string }
+): string {
+  return [
+    HOSTED_PROOF_DOMAIN,
+    HOSTED_PROOF_VERSION,
+    request.method.toUpperCase(),
+    request.target,
+    digest(request.body ?? ""),
+    digest(request.credential),
+    request.timestamp,
+    request.nonce
+  ].join("\n");
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+function base64Url(value: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new HostedProofError("The hosted request proof encoding is invalid.");
+  }
+  const decoded = Buffer.from(value, "base64url");
+  if (decoded.toString("base64url") !== value) {
+    throw new HostedProofError("The hosted request proof encoding is not canonical.");
+  }
+  return decoded;
+}
+
+function header(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | undefined {
+  const value = headers[name];
+  return typeof value === "string" ? value : undefined;
+}

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -19,6 +19,7 @@ export interface HostedReplicaEnrollment {
   fullCollection?: boolean;
   allowedOperations?: string[];
   allowedOrigin?: string;
+  proofPublicKey?: string;
   grantId?: string;
   token: string;
   tokenTtlSeconds?: number;
@@ -105,6 +106,7 @@ export class HostedProviderClient {
         full_collection: replica.fullCollection ?? false,
         allowed_operations: replica.allowedOperations ?? [],
         ...(replica.allowedOrigin ? { allowed_origin: replica.allowedOrigin } : {}),
+        ...(replica.proofPublicKey ? { proof_public_key: replica.proofPublicKey } : {}),
         ...(replica.grantId ? { grant_id: replica.grantId } : {}),
         token: replica.token,
         ...(replica.tokenTtlSeconds ? { token_ttl_seconds: replica.tokenTtlSeconds } : {})


### PR DESCRIPTION
## Summary

- require exact Origin matching for hosted application capabilities, including rejecting a missing Origin
- bind portable hosted provider requests and OAuth refreshes to the approved P-256 grant key
- persist one-use request nonces to reject replay, and bind signatures to method, target, body, credential, and timestamp
- revoke legacy opaque-origin hosted grants and provider replicas that lack proof keys
- keep the public SDK workflow unchanged and document the custom key-store requirement
- correct the large-history stress fixture to begin change pagination after its resource-reset snapshot

## Why

Portable `file://` applications share the opaque `null` origin. A bearer capability by itself therefore did not prove which approved portable application was using it, and the provider's prior origin comparison did not reject requests that omitted the Origin header. Proof-of-possession makes copied bearer and refresh tokens insufficient while exact origin matching closes the omission bypass.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm package:audit`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- live PostgreSQL/provider/browser E2E, including unsigned, replayed, tampered, and missing-Origin requests
- 10,002-record live stress E2E: mutation p95 74.69 ms; snapshot 1.39 s; change-page p95 26.21 ms; warm read p95 12.67 ms; warm query p95 3.23 ms
