### PR TITLE
Forward MCP application origin

### DIFF
--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -202,6 +202,10 @@ describe("mdbase MCP gateway", () => {
     });
     expect(upstream.localInputs).toContainEqual({ types: ["note"], limit: 5 });
     expect(upstream.operationAuthorizations).toContain("Bearer upstream-access-one");
+    expect(upstream.operationOrigins).toEqual([
+      "https://mcp.example",
+      "https://mcp.example"
+    ]);
 
     await client.close();
     await app.close();
@@ -224,6 +228,7 @@ function testConfig(): McpRuntimeConfig {
 async function fakeUpstream(realFetch: typeof fetch) {
   const applicationPublicKeys: string[] = [];
   const operationAuthorizations: string[] = [];
+  const operationOrigins: string[] = [];
   const localInputs: unknown[] = [];
   const connectorKeys = await crypto.subtle.generateKey(
     { name: "ECDH", namedCurve: "P-256" },
@@ -270,7 +275,9 @@ async function fakeUpstream(realFetch: typeof fetch) {
       });
     }
     if (url.origin === "https://connect.example" && url.pathname.endsWith("/operations/query")) {
-      operationAuthorizations.push(new Headers(init?.headers).get("authorization")!);
+      const headers = new Headers(init?.headers);
+      operationAuthorizations.push(headers.get("authorization")!);
+      operationOrigins.push(headers.get("origin")!);
       const envelope = JSON.parse(String(init?.body));
       const input = await decryptConnectorRequest(connectorKeys.privateKey, applicationPublicKeys[0], envelope);
       localInputs.push(input);
@@ -282,7 +289,9 @@ async function fakeUpstream(realFetch: typeof fetch) {
       return Response.json({ envelope: responseEnvelope });
     }
     if (url.origin === "https://sync.example" && url.pathname.endsWith("/operations/query")) {
-      operationAuthorizations.push(new Headers(init?.headers).get("authorization")!);
+      const headers = new Headers(init?.headers);
+      operationAuthorizations.push(headers.get("authorization")!);
+      operationOrigins.push(headers.get("origin")!);
       return Response.json({
         result: {
           valid: true,
@@ -294,7 +303,7 @@ async function fakeUpstream(realFetch: typeof fetch) {
     if (url.hostname === "127.0.0.1") return realFetch(input, init);
     return Response.json({ error: { code: "unexpected_fetch", message: url.href } }, { status: 500 });
   });
-  return { fetch: fetchMock, applicationPublicKeys, operationAuthorizations, localInputs };
+  return { fetch: fetchMock, applicationPublicKeys, operationAuthorizations, operationOrigins, localInputs };
 }
 
 async function decryptConnectorRequest(privateKey: CryptoKey, applicationPublicKey: string, envelope: any): Promise<unknown> {

--- a/services/mcp/src/connect.ts
+++ b/services/mcp/src/connect.ts
@@ -86,6 +86,8 @@ interface ConnectionRow {
 }
 
 export class ConnectGateway {
+  private readonly applicationOrigin: string;
+
   constructor(
     private readonly db: DatabasePool,
     private readonly secrets: SecretBox,
@@ -93,7 +95,9 @@ export class ConnectGateway {
     readonly connectUrl: string,
     private readonly manifest: MdbaseAppManifest,
     readonly callbackUrl: string
-  ) {}
+  ) {
+    this.applicationOrigin = new URL(callbackUrl).origin;
+  }
 
   async registerApplication(): Promise<{ id: string }> {
     const response = await fetch(`${this.connectUrl}/v1/apps/register`, {
@@ -226,7 +230,8 @@ export class ConnectGateway {
       method: "POST",
       headers: {
         authorization: `Bearer ${bearer}`,
-        "content-type": "application/json"
+        "content-type": "application/json",
+        origin: this.applicationOrigin
       },
       body: JSON.stringify(body)
     });


### PR DESCRIPTION
## What changed

The MCP gateway now forwards its exact public application origin on collection
operation requests. The gateway integration test verifies that both
hosted-provider and local relay routes receive the approved origin.

## Why

Hosted application capabilities are bound to the exact origin approved during
Connect OAuth. The MCP gateway registered and received a correctly origin-bound
grant, but omitted the `Origin` header on subsequent server-to-server operation
requests. Staging therefore listed approved connections but rejected record
operations with `origin_denied`.

## Impact

OAuth-connected MCP hosts can use record tools against hosted and
local-authority collections while preserving exact-origin enforcement.

## Validation

- `pnpm --filter @mdbase/connect-mcp test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @mdbase/connect-server test`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm e2e`
