### PR TITLE
Prevent hosted mirror and relay overlap

### DIFF
--- a/crates/connect-agent/src/watcher.rs
+++ b/crates/connect-agent/src/watcher.rs
@@ -245,6 +245,24 @@ fn persist_event(
     event: &mdbase::watch::WatchEvent,
     runtime_events: Option<&tokio::sync::mpsc::UnboundedSender<CollectionRuntimeEvent>>,
 ) {
+    match registry.get(collection_id) {
+        Ok(collection) if collection.enabled => {}
+        Ok(_) => {
+            tracing::debug!(
+                collection_id = %collection_id,
+                "ignored a filesystem event for an unavailable collection"
+            );
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(
+                collection_id = %collection_id,
+                %error,
+                "ignored a filesystem event because collection authority could not be confirmed"
+            );
+            return;
+        }
+    }
     match registry.append_change(collection_id, event) {
         Err(error) => {
             tracing::warn!(collection_id = %collection_id, %error, "failed to persist collection change");

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -23,6 +23,8 @@ use uuid::Uuid;
 const ENCRYPTED_REPLAY_WINDOW: u64 = 1024;
 const CONNECT_EXTENSION: &str = "x-mdbase-connect";
 const CONNECT_COLLECTION_ID: &str = "collection_id";
+const HOSTED_MIRROR_MARKER_DIRECTORY: &str = ".mdbase";
+const HOSTED_MIRROR_MARKER_FILE: &str = "connect-role.json";
 
 #[derive(Debug, Error)]
 pub enum ConnectError {
@@ -43,6 +45,12 @@ pub enum ConnectError {
         collection_id: Uuid,
         existing_path: String,
     },
+    #[error(
+        "This folder is a mirror of hosted collection {collection_id}. A hosted mirror cannot also be registered as a local-authority collection."
+    )]
+    HostedMirrorCannotRegister { collection_id: Uuid },
+    #[error("Hosted mirror role marker is invalid: {0}")]
+    InvalidHostedMirrorMarker(String),
     #[error("The selected folder is not a registered collection copy: {0}")]
     NotARegisteredCollectionCopy(String),
     #[error("Unsupported collection operation: {0}")]
@@ -79,6 +87,8 @@ impl ConnectError {
             Self::CollectionInit(_) => "collection_init_failed",
             Self::CollectionOpen(_) => "collection_open_failed",
             Self::DuplicateCollectionIdentity { .. } => "duplicate_collection_identity",
+            Self::HostedMirrorCannotRegister { .. } => "hosted_mirror_cannot_register",
+            Self::InvalidHostedMirrorMarker(_) => "invalid_hosted_mirror_marker",
             Self::NotARegisteredCollectionCopy(_) => "not_a_registered_collection_copy",
             Self::UnsupportedOperation(_) => "unsupported_operation",
             Self::AccessDenied(_) => "access_denied",
@@ -341,6 +351,10 @@ impl CollectionRegistry {
         drop(statement);
         drop(connection);
         for collection in &mut collections {
+            if hosted_mirror_collection_id(Path::new(&collection.path))?.is_some() {
+                collection.enabled = false;
+                continue;
+            }
             let _ = self.refresh_summary_metadata(collection);
             if let Ok(description) = self.describe(collection.id) {
                 collection.contracts = description
@@ -377,6 +391,7 @@ impl CollectionRegistry {
             ));
         }
         let path = requested_path.canonicalize()?;
+        assert_local_authority_folder(&path)?;
         if !path.join("mdbase.yaml").is_file() {
             return Err(ConnectError::NotACollection(path.display().to_string()));
         }
@@ -440,6 +455,7 @@ impl CollectionRegistry {
             ));
         }
         let path = requested_path.canonicalize()?;
+        assert_local_authority_folder(&path)?;
         if !path.join("mdbase.yaml").is_file() {
             return Err(ConnectError::NotACollection(path.display().to_string()));
         }
@@ -573,6 +589,7 @@ impl CollectionRegistry {
         }
 
         let registered = self.get(id)?;
+        assert_local_authority_folder(Path::new(&registered.path))?;
         let config_path = Path::new(&registered.path).join("mdbase.yaml");
         let source = fs::read_to_string(&config_path)?;
         let mut config: serde_yaml::Value = serde_yaml::from_str(&source)?;
@@ -616,6 +633,10 @@ impl CollectionRegistry {
     }
 
     pub fn set_enabled(&self, id: Uuid, enabled: bool) -> Result<CollectionSummary, ConnectError> {
+        if enabled {
+            let registered = self.get(id)?;
+            assert_local_authority_folder(Path::new(&registered.path))?;
+        }
         let changed = self.connection()?.execute(
             "UPDATE collections SET enabled = ?2, updated_at = CURRENT_TIMESTAMP WHERE id = ?1",
             params![id.to_string(), enabled],
@@ -646,7 +667,11 @@ impl CollectionRegistry {
                 },
             )
             .optional()?;
-        row.ok_or(ConnectError::CollectionNotFound(id))
+        let mut collection = row.ok_or(ConnectError::CollectionNotFound(id))?;
+        if hosted_mirror_collection_id(Path::new(&collection.path))?.is_some() {
+            collection.enabled = false;
+        }
+        Ok(collection)
     }
 
     pub fn remove(&self, id: Uuid) -> Result<CollectionSummary, ConnectError> {
@@ -681,6 +706,7 @@ impl CollectionRegistry {
         synchronize: impl FnOnce(&CollectionInvalidation),
     ) -> Result<Value, ConnectError> {
         let registered = self.get(id)?;
+        assert_local_authority_folder(Path::new(&registered.path))?;
         if operation == "changes" {
             return serde_json::to_value(self.changes(id, input)?).map_err(ConnectError::from);
         }
@@ -999,6 +1025,7 @@ impl CollectionRegistry {
         &self,
         registered: &CollectionSummary,
     ) -> Result<Arc<FilesystemProvider>, ConnectError> {
+        assert_local_authority_folder(Path::new(&registered.path))?;
         let mut providers = self
             .providers
             .lock()
@@ -2092,6 +2119,61 @@ struct CollectionMetadata {
     description: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct HostedMirrorMarker {
+    version: u8,
+    role: String,
+    collection_id: Uuid,
+}
+
+fn assert_local_authority_folder(root: &Path) -> Result<(), ConnectError> {
+    if let Some(collection_id) = hosted_mirror_collection_id(root)? {
+        return Err(ConnectError::HostedMirrorCannotRegister { collection_id });
+    }
+    Ok(())
+}
+
+fn hosted_mirror_collection_id(root: &Path) -> Result<Option<Uuid>, ConnectError> {
+    let marker_directory = root.join(HOSTED_MIRROR_MARKER_DIRECTORY);
+    let directory_metadata = match fs::symlink_metadata(&marker_directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if directory_metadata.file_type().is_symlink() || !directory_metadata.is_dir() {
+        return Err(ConnectError::InvalidHostedMirrorMarker(format!(
+            "{} must be an ordinary directory.",
+            marker_directory.display()
+        )));
+    }
+    let marker_path = marker_directory.join(HOSTED_MIRROR_MARKER_FILE);
+    let marker_metadata = match fs::symlink_metadata(&marker_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if marker_metadata.file_type().is_symlink() || !marker_metadata.is_file() {
+        return Err(ConnectError::InvalidHostedMirrorMarker(format!(
+            "{} must be an ordinary file.",
+            marker_path.display()
+        )));
+    }
+    let marker: HostedMirrorMarker = serde_json::from_str(&fs::read_to_string(&marker_path)?)
+        .map_err(|error| {
+            ConnectError::InvalidHostedMirrorMarker(format!(
+                "{} could not be read: {error}",
+                marker_path.display()
+            ))
+        })?;
+    if marker.version != 1 || marker.role != "hosted_mirror" {
+        return Err(ConnectError::InvalidHostedMirrorMarker(format!(
+            "{} has an unsupported role or version.",
+            marker_path.display()
+        )));
+    }
+    Ok(Some(marker.collection_id))
+}
+
 fn ensure_collection_id(root: &Path) -> Result<Uuid, ConnectError> {
     if let Some(id) = read_collection_id(root)? {
         return Ok(id);
@@ -2522,6 +2604,21 @@ mod tests {
     use std::thread;
     use tempfile::tempdir;
 
+    fn mark_hosted_mirror(root: &Path, collection_id: Uuid) {
+        let directory = root.join(HOSTED_MIRROR_MARKER_DIRECTORY);
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(
+            directory.join(HOSTED_MIRROR_MARKER_FILE),
+            serde_json::to_vec_pretty(&json!({
+                "version": 1,
+                "role": "hosted_mirror",
+                "collection_id": collection_id,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn portable_mutation_results_produce_targeted_invalidations() {
         let output = serde_json::to_value(mdbase::v03::OperationResult {
@@ -2593,6 +2690,52 @@ mod tests {
             "unregistering must not delete collection files"
         );
         assert!(registry.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn hosted_mirror_cannot_be_registered_as_a_local_authority() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("hosted-mirror");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let hosted_collection_id = Uuid::new_v4();
+
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("mdbase.yaml"), "spec_version: 0.3.0\n").unwrap();
+        mark_hosted_mirror(&root, hosted_collection_id);
+
+        assert!(matches!(
+            registry.add(&root),
+            Err(ConnectError::HostedMirrorCannotRegister { collection_id })
+                if collection_id == hosted_collection_id
+        ));
+        assert_eq!(read_collection_id(&root).unwrap(), None);
+        assert!(registry.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_registered_folder_stops_being_available_when_it_becomes_a_hosted_mirror() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("notes");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let created = registry.create(&root, Some("Notes")).unwrap();
+        let hosted_collection_id = Uuid::new_v4();
+
+        mark_hosted_mirror(&root, hosted_collection_id);
+
+        assert!(!registry.get(created.id).unwrap().enabled);
+        assert!(!registry.list().unwrap()[0].enabled);
+        assert!(matches!(
+            registry.operation(created.id, "describe", &json!({})),
+            Err(ConnectError::HostedMirrorCannotRegister { collection_id })
+                if collection_id == hosted_collection_id
+        ));
+        assert!(matches!(
+            registry.set_enabled(created.id, true),
+            Err(ConnectError::HostedMirrorCannotRegister { collection_id })
+                if collection_id == hosted_collection_id
+        ));
     }
 
     #[test]

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -2739,6 +2739,67 @@ mod tests {
     }
 
     #[test]
+    fn a_malformed_hosted_mirror_marker_fails_closed() {
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let root = collection_parent.path().join("hosted-mirror");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+
+        fs::create_dir_all(root.join(HOSTED_MIRROR_MARKER_DIRECTORY)).unwrap();
+        fs::write(root.join("mdbase.yaml"), "spec_version: 0.3.0\n").unwrap();
+        fs::write(
+            root.join(HOSTED_MIRROR_MARKER_DIRECTORY)
+                .join(HOSTED_MIRROR_MARKER_FILE),
+            "{broken",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            registry.add(&root),
+            Err(ConnectError::InvalidHostedMirrorMarker(_))
+        ));
+        assert!(registry.list().unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_hosted_mirror_marker_fails_closed() {
+        use std::os::unix::fs::symlink;
+
+        let state = tempdir().unwrap();
+        let collection_parent = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let root = collection_parent.path().join("hosted-mirror");
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+
+        fs::create_dir_all(root.join(HOSTED_MIRROR_MARKER_DIRECTORY)).unwrap();
+        fs::write(root.join("mdbase.yaml"), "spec_version: 0.3.0\n").unwrap();
+        let target = outside.path().join(HOSTED_MIRROR_MARKER_FILE);
+        fs::write(
+            &target,
+            serde_json::to_vec(&json!({
+                "version": 1,
+                "role": "hosted_mirror",
+                "collection_id": Uuid::new_v4(),
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        symlink(
+            &target,
+            root.join(HOSTED_MIRROR_MARKER_DIRECTORY)
+                .join(HOSTED_MIRROR_MARKER_FILE),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            registry.add(&root),
+            Err(ConnectError::InvalidHostedMirrorMarker(_))
+        ));
+        assert!(registry.list().unwrap().is_empty());
+    }
+
+    #[test]
     fn collection_identity_survives_a_folder_move() {
         let state = tempdir().unwrap();
         let collection_parent = tempdir().unwrap();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,27 @@ the connector has proved that the selected path is a copy of a different,
 still-registered folder. It refuses the registered original, a moved folder,
 and a collection that can be registered normally.
 
+A physical folder has exactly one Connect storage role. A hosted mirror stores
+this non-secret device role in `.mdbase/connect-role.json`, outside the
+receive-only `mdbase.yaml` resource. The local connector refuses to register
+such a folder as a filesystem authority. If a folder was registered before it
+became a hosted mirror, the connector immediately reports it as unavailable and
+denies operations; it does not rely on the next control-plane heartbeat for
+safety.
+
+Mirror processes also take an exclusive device-local lease keyed by the
+folder's canonical path and filesystem identity. A long-running watcher holds
+the lease for its lifetime, so the desktop mirror and an Obsidian mirror plugin
+cannot manage the same physical folder concurrently. Custom mirror adapters
+must provide the equivalent lease when they cannot use the Node adapter.
+
+The control plane provides the final identity-level fence. If a connector
+publishes the ID of an active hosted collection, it is retained only as a
+disabled authority candidate until an approved authority transfer completes.
+This is defense in depth: the folder marker prevents a same-folder/different-ID
+mistake locally, while the server prevents two active authorities for the same
+ID.
+
 The browser SDK is multi-collection by default. `MdbaseConnect` manages the
 saved authorization set, `MdbaseConnection` is permanently bound to one
 collection, and `MdbaseBrowserLocation` owns bookmark selection and OAuth
@@ -266,6 +287,12 @@ Every collection has one write authority:
 - a local connector for a filesystem-backed collection;
 - a hosted collection provider for the managed service;
 - a self-hosted provider implementing the same Connect API.
+
+A hosted-authority folder may be mirrored into ordinary Markdown, but that
+folder cannot also be relayed by the local connector. Changing roles is an
+explicit authority transfer: converge and fence the current authority, verify
+the complete mirror, change the folder role, then activate the new authority.
+Rollback restores the hosted-mirror role before hosted writes resume.
 
 The hosted vertical slice implements stable IDs, pinned snapshots, ordered
 scoped changes, conditional replay-safe mutations, offline caches, conflicts,

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -390,6 +390,18 @@ Connect keeps replica state outside ordinary Markdown files:
 - pending local mutations and conflicts;
 - resource revisions for config and type files.
 
+Each physical mirror folder also contains the non-secret
+`.mdbase/connect-role.json` marker. It binds that folder to one hosted
+collection and prevents the local connector from exposing it as another write
+authority. Credentials, cursors, pending mutations, and conflicts remain in
+device-local state outside the collection.
+
+Before changing files, a Node mirror takes an exclusive device-local folder
+lease. `mdbase-mirror watch` holds it until the watcher stops; one-shot sync and
+conflict operations hold it for their complete critical section. Another
+desktop process receives `mirror_folder_in_use` rather than running a second
+engine over the same folder.
+
 Incoming documents use temporary files and atomic rename where the platform
 supports them. The watcher recognizes writes made by the mirror from the saved
 revision and avoids uploading them again.

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -38,6 +38,12 @@ collection-scoped access and renewal credentials are stored in the device's
 owner-only application-state directory, never inside the mirrored folder.
 Access tokens renew automatically until the mirror is revoked.
 
+The folder contains only a non-secret `.mdbase/connect-role.json` marker that
+identifies it as a hosted mirror. A local Connect agent will not register or
+relay that folder. Mirror operations also use an exclusive device-local lease;
+`watch` holds it for its lifetime, so a desktop mirror and an Obsidian mirror
+plugin cannot run over the same physical folder.
+
 `promote` requires a converged, full writable mirror and a running local
 `mdbase-connect` agent. It opens a browser confirmation, freezes hosted writes
 at a final sequence, proves that the directory is exact, and registers the

--- a/packages/sync/src/cli.ts
+++ b/packages/sync/src/cli.ts
@@ -8,14 +8,19 @@ import { parseArgs } from "node:util";
 import { HttpSyncTransport } from "./index.js";
 import {
   DirectoryMirror,
+  NodeMirrorLease,
   WritableDirectoryMirror,
+  type MirrorLease,
   type MirrorProgress,
   type MirrorStatus
 } from "./node.js";
 import {
+  assertHostedMirror,
+  clearHostedMirrorMarker,
   clearAuthorityPromotionCheckpoint,
   loadMirrorProfile,
   loadAuthorityPromotionCheckpoint,
+  markHostedMirror,
   readCollectionConfiguration,
   restoreCollectionConfiguration,
   retireMirrorAfterPromotion,
@@ -78,6 +83,7 @@ try {
     if (session.replica_id !== replicaId || session.mode !== mode) {
       throw new Error(`Replica is not the requested ${mode.replace("_", "-")} mirror capability.`);
     }
+    await markHostedMirror(root, collectionId);
     await saveMirrorProfile(
       root,
       {
@@ -121,25 +127,42 @@ try {
     if (!Number.isInteger(interval) || interval < 250) {
       throw new Error("--interval must be an integer of at least 250 milliseconds.");
     }
-    process.stdout.write(`Watching hosted collection into ${root}. Press Ctrl+C to stop.\n`);
-    let lastLine = "";
-    while (true) {
-      try {
-        await sync(root);
-        const status = await mirrorFor(root, await currentProfile(root)).status();
-        const line = statusLine(status);
-        if (line !== lastLine) {
-          process.stdout.write(`${line}\n`);
-          lastLine = line;
+    const acquiredLease = await new NodeMirrorLease(root).acquire();
+    let stopping = false;
+    const stop = () => { stopping = true; };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+    process.once("SIGHUP", stop);
+    try {
+      process.stdout.write(`Watching hosted collection into ${root}. Press Ctrl+C to stop.\n`);
+      let lastLine = "";
+      while (!stopping) {
+        try {
+          await sync(root, acquiredLease);
+          const status = await mirrorFor(
+            root,
+            await currentProfile(root),
+            acquiredLease
+          ).status();
+          const line = statusLine(status);
+          if (line !== lastLine) {
+            process.stdout.write(`${line}\n`);
+            lastLine = line;
+          }
+        } catch (error) {
+          const line = `Offline: ${error instanceof Error ? error.message : String(error)}`;
+          if (line !== lastLine) {
+            process.stderr.write(`${line}\n`);
+            lastLine = line;
+          }
         }
-      } catch (error) {
-        const line = `Offline: ${error instanceof Error ? error.message : String(error)}`;
-        if (line !== lastLine) {
-          process.stderr.write(`${line}\n`);
-          lastLine = line;
-        }
+        if (!stopping) await delay(interval);
       }
-      await delay(interval);
+    } finally {
+      process.removeListener("SIGINT", stop);
+      process.removeListener("SIGTERM", stop);
+      process.removeListener("SIGHUP", stop);
+      await acquiredLease.release();
     }
   }
 } catch (error) {
@@ -147,9 +170,9 @@ try {
   process.exitCode = 1;
 }
 
-async function sync(root: string): Promise<void> {
+async function sync(root: string, lease?: MirrorLease): Promise<void> {
   const configuration = await currentProfile(root);
-  await mirrorFor(root, configuration).sync();
+  await mirrorFor(root, configuration, lease).sync();
 }
 
 async function initialSync(root: string): Promise<void> {
@@ -179,13 +202,17 @@ async function initialSync(root: string): Promise<void> {
   await mirror.sync();
 }
 
-function mirrorFor(root: string, configuration: StoredMirrorProfile) {
+function mirrorFor(
+  root: string,
+  configuration: StoredMirrorProfile,
+  lease?: MirrorLease
+) {
   const transport = new HttpSyncTransport(
     configuration.profile.provider_url,
     configuration.profile.collection_id,
     configuration.credentials.access_token
   );
-  const options = { onProgress: mirrorProgressReporter() };
+  const options = { onProgress: mirrorProgressReporter(), ...(lease ? { lease } : {}) };
   return configuration.profile.mode === "read_write"
     ? new WritableDirectoryMirror(root, configuration.profile.replica_id, transport, options)
     : new DirectoryMirror(root, configuration.profile.replica_id, transport, options);
@@ -232,6 +259,8 @@ function mirrorProgressReporter(): (progress: MirrorProgress) => void {
 
 async function currentProfile(root: string): Promise<StoredMirrorProfile> {
   let stored = await loadMirrorProfile(root);
+  await markHostedMirror(root, stored.profile.collection_id);
+  await assertHostedMirror(root, stored.profile.collection_id);
   const expiry = stored.profile.access_token_expires_at;
   if (
     stored.profile.control_url
@@ -335,6 +364,7 @@ async function connect(root: string): Promise<void> {
       continue;
     }
     const exchanged = await responseJson<MirrorExchangeResponse>(response);
+    await markHostedMirror(root, exchanged.replica.collection_id);
     await saveMirrorProfile(
       root,
       {
@@ -383,6 +413,7 @@ async function promote(root: string): Promise<void> {
     }
     process.stdout.write("Resuming the materialized authority handoff.\n");
     await setHostedCollectionIdentity(root, unfinished.collection_id);
+    await clearHostedMirrorMarker(root, unfinished.collection_id);
     await registerPromotedCollection(root, unfinished.collection_id);
     await completePromotion(root, controlUrl, authentication, unfinished);
     return;
@@ -450,6 +481,7 @@ async function promote(root: string): Promise<void> {
     };
     await saveAuthorityPromotionCheckpoint(root, checkpoint);
     await setHostedCollectionIdentity(root, prepared.collection_id);
+    await clearHostedMirrorMarker(root, prepared.collection_id);
     const added = await runConnectCli(["collection", "add", root]);
     const registeredId = collectionIdFromControlResult(added);
     if (registeredId !== prepared.collection_id) {
@@ -464,6 +496,7 @@ async function promote(root: string): Promise<void> {
     const saved = await loadAuthorityPromotionCheckpoint(root);
     if (saved?.transfer_id === prepared.id) {
       await restoreCollectionConfiguration(root, saved.original_configuration).catch(() => undefined);
+      await markHostedMirror(root, saved.collection_id).catch(() => undefined);
       await clearAuthorityPromotionCheckpoint(root).catch(() => undefined);
     }
     await fetch(
@@ -560,6 +593,7 @@ async function rollbackMaterializedPromotion(
 ): Promise<void> {
   await runConnectCli(["collection", "remove", checkpoint.collection_id]);
   await restoreCollectionConfiguration(root, checkpoint.original_configuration);
+  await markHostedMirror(root, checkpoint.collection_id);
   await clearAuthorityPromotionCheckpoint(root);
 }
 

--- a/packages/sync/src/device.test.ts
+++ b/packages/sync/src/device.test.ts
@@ -3,8 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertHostedMirror,
+  clearHostedMirrorMarker,
   loadAuthorityPromotionCheckpoint,
+  loadHostedMirrorMarker,
   loadMirrorProfile,
+  markHostedMirror,
   mirrorProfileDirectory,
   restoreCollectionConfiguration,
   retireMirrorAfterPromotion,
@@ -12,9 +16,47 @@ import {
   saveMirrorProfile,
   setHostedCollectionIdentity
 } from "./device.js";
-import { NodeMirrorStateStore } from "./node.js";
+import { NodeMirrorLease, NodeMirrorStateStore } from "./node.js";
 
 describe("device-local mirror storage", () => {
+  it("marks a hosted mirror without putting device role state in hosted resources", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    const collectionId = crypto.randomUUID();
+    try {
+      await writeFile(join(root, "mdbase.yaml"), "spec_version: 0.3.0\n");
+      await markHostedMirror(root, collectionId);
+      await assertHostedMirror(root, collectionId);
+      expect(await loadHostedMirrorMarker(root)).toEqual({
+        version: 1,
+        role: "hosted_mirror",
+        collection_id: collectionId
+      });
+      expect(await readFile(join(root, "mdbase.yaml"), "utf8"))
+        .toBe("spec_version: 0.3.0\n");
+      await expect(markHostedMirror(root, crypto.randomUUID()))
+        .rejects.toMatchObject({ code: "hosted_mirror_identity_conflict" });
+      await clearHostedMirrorMarker(root, collectionId);
+      expect(await loadHostedMirrorMarker(root)).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requires an authority transfer before a local collection folder becomes a hosted mirror", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    try {
+      await writeFile(
+        join(root, "mdbase.yaml"),
+        `spec_version: 0.3.0\nx-mdbase-connect:\n  collection_id: ${crypto.randomUUID()}\n`
+      );
+      await expect(markHostedMirror(root, crypto.randomUUID()))
+        .rejects.toMatchObject({ code: "local_authority_requires_transfer" });
+      expect(await loadHostedMirrorMarker(root)).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("sets the hosted identity atomically and can restore the original collection config", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
     const collectionId = crypto.randomUUID();
@@ -140,6 +182,24 @@ describe("device-local mirror storage", () => {
       await expect(access(join(root, ".mdbase", "connect-mirror.json"))).rejects.toMatchObject({
         code: "ENOENT"
       });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("allows only one mirror process to own a physical folder", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+    try {
+      const first = new NodeMirrorLease(root, stateRoot);
+      const second = new NodeMirrorLease(root, stateRoot);
+      const acquired = await first.acquire();
+      await expect(second.acquire())
+        .rejects.toMatchObject({ code: "mirror_folder_in_use" });
+      await acquired.release();
+      const reacquired = await second.acquire();
+      await reacquired.release();
     } finally {
       await rm(root, { recursive: true, force: true });
       await rm(stateRoot, { recursive: true, force: true });

--- a/packages/sync/src/device.test.ts
+++ b/packages/sync/src/device.test.ts
@@ -1,4 +1,13 @@
-import { access, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -16,7 +25,11 @@ import {
   saveMirrorProfile,
   setHostedCollectionIdentity
 } from "./device.js";
-import { NodeMirrorLease, NodeMirrorStateStore } from "./node.js";
+import {
+  mirrorDeviceDirectory,
+  NodeMirrorLease,
+  NodeMirrorStateStore
+} from "./node.js";
 
 describe("device-local mirror storage", () => {
   it("marks a hosted mirror without putting device role state in hosted resources", async () => {
@@ -205,6 +218,86 @@ describe("device-local mirror storage", () => {
       await rm(stateRoot, { recursive: true, force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "uses one lease for aliases of the same physical folder",
+    async () => {
+      const parent = await mkdtemp(join(tmpdir(), "mdbase-mirror-parent-"));
+      const root = join(parent, "mirror");
+      const alias = join(parent, "mirror-alias");
+      const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+      try {
+        await mkdir(root);
+        await symlink(root, alias, "dir");
+        const acquired = await new NodeMirrorLease(root, stateRoot).acquire();
+        await expect(new NodeMirrorLease(alias, stateRoot).acquire())
+          .rejects.toMatchObject({ code: "mirror_folder_in_use" });
+        await acquired.release();
+      } finally {
+        await rm(parent, { recursive: true, force: true });
+        await rm(stateRoot, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it("recovers a lease left behind by a dead process", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+    try {
+      const directory = await mirrorDeviceDirectory(root, stateRoot);
+      await mkdir(directory, { recursive: true });
+      await writeFile(join(directory, "mirror.lock"), JSON.stringify({
+        version: 1,
+        owner_id: crypto.randomUUID(),
+        pid: 999_999_999,
+        acquired_at: new Date().toISOString()
+      }));
+      const acquired = await new NodeMirrorLease(root, stateRoot).acquire();
+      await acquired.release();
+      await expect(access(join(directory, "mirror.lock")))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the hosted mirror marker is malformed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+    try {
+      await mkdir(join(root, ".mdbase"));
+      await writeFile(join(root, ".mdbase", "connect-role.json"), "{broken");
+      await expect(loadHostedMirrorMarker(root))
+        .rejects.toMatchObject({ code: "invalid_hosted_mirror_marker" });
+      await expect(markHostedMirror(root, crypto.randomUUID()))
+        .rejects.toMatchObject({ code: "invalid_hosted_mirror_marker" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "refuses a symlinked hosted mirror marker",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
+      const outside = await mkdtemp(join(tmpdir(), "mdbase-mirror-outside-"));
+      try {
+        await mkdir(join(root, ".mdbase"));
+        const target = join(outside, "connect-role.json");
+        await writeFile(target, JSON.stringify({
+          version: 1,
+          role: "hosted_mirror",
+          collection_id: crypto.randomUUID()
+        }));
+        await symlink(target, join(root, ".mdbase", "connect-role.json"));
+        await expect(loadHostedMirrorMarker(root))
+          .rejects.toMatchObject({ code: "unsafe_hosted_mirror_marker" });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
+    }
+  );
 
   it("does not attach an old writable journal to a folder recreated at the same path", async () => {
     const parent = await mkdtemp(join(tmpdir(), "mdbase-mirror-parent-"));

--- a/packages/sync/src/device.ts
+++ b/packages/sync/src/device.ts
@@ -36,6 +36,12 @@ export interface StoredMirrorProfile {
   credentials: MirrorCredentials;
 }
 
+export interface HostedMirrorMarker {
+  version: 1;
+  role: "hosted_mirror";
+  collection_id: string;
+}
+
 export interface AuthorityPromotionReceipt {
   version: 1;
   collection_id: string;
@@ -108,6 +114,112 @@ export async function mirrorProfileDirectory(
   stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
 ): Promise<string> {
   return mirrorDeviceDirectory(root, stateRoot);
+}
+
+/**
+ * Persist the non-secret role of a hosted mirror inside the collection.
+ *
+ * The marker deliberately lives under `.mdbase` rather than in `mdbase.yaml`:
+ * the latter is a receive-only hosted resource, while this role belongs to the
+ * physical folder on this device. Local Connect treats the marker as a hard
+ * refusal to expose the same folder as a filesystem authority.
+ */
+export async function markHostedMirror(
+  root: string,
+  collectionId: string
+): Promise<void> {
+  const existing = await loadHostedMirrorMarker(root);
+  if (existing) {
+    if (existing.collection_id !== collectionId) {
+      throw new SyncError(
+        "hosted_mirror_identity_conflict",
+        "This folder already mirrors a different hosted collection."
+      );
+    }
+    return;
+  }
+  const localCollectionId = await readPortableCollectionId(root);
+  if (localCollectionId !== null) {
+    throw new SyncError(
+      "local_authority_requires_transfer",
+      "This folder already has a local Connect identity. Move authority explicitly before using it as a hosted mirror."
+    );
+  }
+  const markerPath = await hostedMirrorMarkerPath(root, true);
+  if (markerPath === null) {
+    throw new SyncError(
+      "hosted_mirror_marker_unavailable",
+      "The hosted mirror role marker could not be created."
+    );
+  }
+  await atomicWrite(
+    markerPath,
+    `${JSON.stringify({
+      version: 1,
+      role: "hosted_mirror",
+      collection_id: collectionId
+    } satisfies HostedMirrorMarker, null, 2)}\n`
+  );
+}
+
+export async function assertHostedMirror(
+  root: string,
+  collectionId: string
+): Promise<void> {
+  const marker = await loadHostedMirrorMarker(root);
+  if (!marker || marker.collection_id !== collectionId) {
+    throw new SyncError(
+      "hosted_mirror_marker_missing",
+      "This folder is not marked as the configured hosted collection mirror."
+    );
+  }
+}
+
+export async function loadHostedMirrorMarker(
+  root: string
+): Promise<HostedMirrorMarker | null> {
+  const markerPath = await hostedMirrorMarkerPath(root, false);
+  if (markerPath === null) return null;
+  const value = await readOptional(markerPath);
+  if (value === null) return null;
+  let marker: unknown;
+  try {
+    marker = JSON.parse(value);
+  } catch {
+    throw new SyncError(
+      "invalid_hosted_mirror_marker",
+      "The hosted mirror role marker is corrupt."
+    );
+  }
+  if (
+    !marker
+    || typeof marker !== "object"
+    || (marker as Partial<HostedMirrorMarker>).version !== 1
+    || (marker as Partial<HostedMirrorMarker>).role !== "hosted_mirror"
+    || typeof (marker as Partial<HostedMirrorMarker>).collection_id !== "string"
+  ) {
+    throw new SyncError(
+      "invalid_hosted_mirror_marker",
+      "The hosted mirror role marker is invalid."
+    );
+  }
+  return marker as HostedMirrorMarker;
+}
+
+export async function clearHostedMirrorMarker(
+  root: string,
+  collectionId: string
+): Promise<void> {
+  const marker = await loadHostedMirrorMarker(root);
+  if (marker === null) return;
+  if (marker.collection_id !== collectionId) {
+    throw new SyncError(
+      "hosted_mirror_identity_conflict",
+      "This folder mirrors a different hosted collection."
+    );
+  }
+  const markerPath = await hostedMirrorMarkerPath(root, false);
+  if (markerPath !== null) await unlinkOptional(markerPath);
 }
 
 export async function setHostedCollectionIdentity(
@@ -253,6 +365,76 @@ export async function clearAuthorityPromotionCheckpoint(
   const directory = await mirrorDeviceDirectory(root, stateRoot);
   await unlinkOptional(join(directory, "authority-promotion.json"));
 }
+
+async function hostedMirrorMarkerPath(
+  root: string,
+  createDirectory: boolean
+): Promise<string | null> {
+  const canonicalRoot = await realpath(root);
+  const directory = join(canonicalRoot, ".mdbase");
+  try {
+    const metadata = await lstat(directory);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      throw new SyncError(
+        "unsafe_hosted_mirror_marker",
+        ".mdbase must be an ordinary directory inside the mirrored folder."
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    if (!createDirectory) return null;
+    await mkdir(directory, { recursive: false, mode: 0o700 });
+  }
+  const markerPath = join(directory, "connect-role.json");
+  try {
+    const metadata = await lstat(markerPath);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) {
+      throw new SyncError(
+        "unsafe_hosted_mirror_marker",
+        "The hosted mirror role marker must be an ordinary file."
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return markerPath;
+}
+
+async function readPortableCollectionId(root: string): Promise<string | null> {
+  const configurationPath = join(await realpath(root), "mdbase.yaml");
+  let source: string;
+  try {
+    source = await readFile(configurationPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  const document = parseDocument(source);
+  if (document.errors.length || !isMap(document.contents)) {
+    throw new SyncError(
+      "invalid_collection_configuration",
+      "mdbase.yaml must contain a valid YAML mapping."
+    );
+  }
+  const extension = document.get("x-mdbase-connect", true);
+  if (extension === undefined) return null;
+  if (!isMap(extension)) {
+    throw new SyncError(
+      "invalid_collection_configuration",
+      "x-mdbase-connect must be a YAML mapping."
+    );
+  }
+  const collectionId = extension.get("collection_id");
+  if (collectionId === undefined) return null;
+  if (typeof collectionId !== "string") {
+    throw new SyncError(
+      "invalid_collection_configuration",
+      "x-mdbase-connect.collection_id must be a UUID string."
+    );
+  }
+  return collectionId;
+}
+
 async function readJson<Value>(path: string): Promise<Value | null> {
   const value = await readOptional(path);
   if (value === null) return null;

--- a/packages/sync/src/node.test.ts
+++ b/packages/sync/src/node.test.ts
@@ -6,6 +6,7 @@ import { MemoryHostedAuthority } from "./index.js";
 import {
   authorityManifestDigest,
   DirectoryMirror,
+  MemoryMirrorLease,
   MemoryMirrorStateStore,
   MirrorDivergenceError,
   WritableDirectoryMirror,
@@ -15,7 +16,10 @@ import {
 } from "./node.js";
 
 function deviceState(): DirectoryMirrorOptions {
-  return { stateStore: new MemoryMirrorStateStore() };
+  return {
+    stateStore: new MemoryMirrorStateStore(),
+    lease: new MemoryMirrorLease()
+  };
 }
 
 class MemoryMirrorFileSystem implements MirrorFileSystem {
@@ -264,7 +268,11 @@ describe("writable Markdown mirror", () => {
       "/virtual",
       replicaId,
       hosted.transport(replicaId),
-      { stateStore: new MemoryMirrorStateStore(), fileSystem }
+      {
+        stateStore: new MemoryMirrorStateStore(),
+        fileSystem,
+        lease: new MemoryMirrorLease()
+      }
     );
     await mirror.sync();
 
@@ -282,7 +290,11 @@ describe("writable Markdown mirror", () => {
       "/virtual",
       readOnlyId,
       hosted.transport(readOnlyId),
-      { stateStore: new MemoryMirrorStateStore(), fileSystem: new MemoryMirrorFileSystem() }
+      {
+        stateStore: new MemoryMirrorStateStore(),
+        fileSystem: new MemoryMirrorFileSystem(),
+        lease: new MemoryMirrorLease()
+      }
     );
     await readOnly.sync();
     await expect(readOnly.authorityPromotionManifest()).rejects.toMatchObject({
@@ -295,7 +307,11 @@ describe("writable Markdown mirror", () => {
       "/virtual",
       writableId,
       hosted.transport(writableId),
-      { stateStore: new MemoryMirrorStateStore(), fileSystem }
+      {
+        stateStore: new MemoryMirrorStateStore(),
+        fileSystem,
+        lease: new MemoryMirrorLease()
+      }
     );
     await writable.sync();
     fileSystem.files.set("unmanaged.md", "---\ntitle: Unmanaged\n---\n");

--- a/packages/sync/src/node.ts
+++ b/packages/sync/src/node.ts
@@ -50,9 +50,18 @@ export interface MirrorStateStore {
   write(state: MirrorState): Promise<void>;
 }
 
+export interface MirrorLease {
+  runExclusive<Value>(operation: () => Promise<Value>): Promise<Value>;
+}
+
+export interface AcquiredMirrorLease extends MirrorLease {
+  release(): Promise<void>;
+}
+
 export interface DirectoryMirrorOptions {
   stateStore?: MirrorStateStore;
   fileSystem?: MirrorFileSystem;
+  lease?: MirrorLease;
   onProgress?: (progress: MirrorProgress) => void;
 }
 
@@ -109,6 +118,26 @@ export class MemoryMirrorStateStore implements MirrorStateStore {
   }
 }
 
+/** In-process lease for filesystem-neutral adapters and deterministic tests. */
+export class MemoryMirrorLease implements MirrorLease {
+  private held = false;
+
+  async runExclusive<Value>(operation: () => Promise<Value>): Promise<Value> {
+    if (this.held) {
+      throw new SyncError(
+        "mirror_folder_in_use",
+        "Another mdbase mirror process is already using this folder."
+      );
+    }
+    this.held = true;
+    try {
+      return await operation();
+    } finally {
+      this.held = false;
+    }
+  }
+}
+
 export class NodeMirrorStateStore implements MirrorStateStore {
   private statePath: Promise<string> | null = null;
 
@@ -141,6 +170,77 @@ export class NodeMirrorStateStore implements MirrorStateStore {
     this.statePath ??= mirrorDeviceDirectory(this.root, this.stateRoot)
       .then((directory) => join(directory, "mirror-state.json"));
     return this.statePath;
+  }
+}
+
+interface MirrorLeaseRecord {
+  version: 1;
+  owner_id: string;
+  pid: number;
+  acquired_at: string;
+}
+
+/**
+ * Cross-process exclusion for a physical mirror folder.
+ *
+ * The lease is device-local and keyed by canonical path plus filesystem
+ * identity, just like mirror state. It therefore does not leak paths into the
+ * collection or travel through another file-sync product.
+ */
+export class NodeMirrorLease implements MirrorLease {
+  constructor(
+    private readonly root: string,
+    private readonly stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
+  ) {}
+
+  async acquire(): Promise<AcquiredMirrorLease> {
+    const directory = await mirrorDeviceDirectory(this.root, this.stateRoot);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const path = join(directory, "mirror.lock");
+    const record: MirrorLeaseRecord = {
+      version: 1,
+      owner_id: randomUUID(),
+      pid: process.pid,
+      acquired_at: new Date().toISOString()
+    };
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        await writeFile(path, `${JSON.stringify(record)}\n`, {
+          flag: "wx",
+          mode: 0o600
+        });
+        let released = false;
+        return {
+          runExclusive: async <Value>(operation: () => Promise<Value>) => operation(),
+          release: async () => {
+            if (released) return;
+            released = true;
+            const current = await readLeaseRecord(path);
+            if (current?.owner_id === record.owner_id) await unlinkOptional(path);
+          }
+        };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        if (attempt === 0 && await removeStaleLease(path)) continue;
+        throw new SyncError(
+          "mirror_folder_in_use",
+          "Another mdbase mirror process is already using this folder."
+        );
+      }
+    }
+    throw new SyncError(
+      "mirror_folder_in_use",
+      "Another mdbase mirror process is already using this folder."
+    );
+  }
+
+  async runExclusive<Value>(operation: () => Promise<Value>): Promise<Value> {
+    const acquired = await this.acquire();
+    try {
+      return await operation();
+    } finally {
+      await acquired.release();
+    }
   }
 }
 
@@ -265,6 +365,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
   private readonly root: string;
   private readonly stateStore: MirrorStateStore;
   private readonly fileSystem: MirrorFileSystem;
+  private readonly lease: MirrorLease;
   private readonly onProgress?: (progress: MirrorProgress) => void;
 
   constructor(
@@ -277,17 +378,22 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     this.root = resolve(root);
     this.stateStore = options.stateStore ?? new NodeMirrorStateStore(this.root);
     this.fileSystem = options.fileSystem ?? new NodeMirrorFileSystem(this.root);
+    this.lease = options.lease ?? new NodeMirrorLease(this.root);
     this.onProgress = options.onProgress;
   }
 
   async sync(): Promise<void> {
+    await this.lease.runExclusive(() => this.syncUnlocked());
+  }
+
+  private async syncUnlocked(): Promise<void> {
     const state = await this.readState();
     if (!state) {
       await this.rebuild();
       // A writable first sync is also the import path for an existing local
       // directory: rebuild establishes the remote baseline, then a normal
       // pass journals and conditionally uploads files that were not remote.
-      if (this.mode === "read_write") await this.sync();
+      if (this.mode === "read_write") await this.syncUnlocked();
       return;
     }
     if (this.mode === "read_write") {
@@ -387,6 +493,10 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
    * authority cursor. The digest contains no paths or record content.
    */
   async authorityPromotionManifest(): Promise<AuthorityPromotionManifest> {
+    return this.lease.runExclusive(() => this.authorityPromotionManifestUnlocked());
+  }
+
+  private async authorityPromotionManifestUnlocked(): Promise<AuthorityPromotionManifest> {
     if (this.mode !== "read_write") {
       throw new SyncError(
         "promotion_requires_writable_mirror",
@@ -673,6 +783,13 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
   }
 
   async resolveConflict(recordId: string, resolution: "local" | "remote"): Promise<void> {
+    await this.lease.runExclusive(() => this.resolveConflictUnlocked(recordId, resolution));
+  }
+
+  private async resolveConflictUnlocked(
+    recordId: string,
+    resolution: "local" | "remote"
+  ): Promise<void> {
     if (this.mode !== "read_write") {
       throw new SyncError("mirror_read_only", "Receive-only mirrors do not contain writable conflicts.");
     }
@@ -1193,6 +1310,59 @@ async function readOptional(path: string): Promise<string | null> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
+  }
+}
+
+async function readLeaseRecord(path: string): Promise<MirrorLeaseRecord | null> {
+  const source = await readOptional(path);
+  if (source === null) return null;
+  try {
+    const record = JSON.parse(source) as Partial<MirrorLeaseRecord>;
+    if (
+      record.version !== 1
+      || typeof record.owner_id !== "string"
+      || !Number.isSafeInteger(record.pid)
+      || record.pid! <= 0
+      || typeof record.acquired_at !== "string"
+    ) return null;
+    return record as MirrorLeaseRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function removeStaleLease(path: string): Promise<boolean> {
+  const record = await readLeaseRecord(path);
+  if (record === null || processIsAlive(record.pid)) return false;
+  const current = await readLeaseRecord(path);
+  if (
+    current === null
+    || current.owner_id !== record.owner_id
+    || current.pid !== record.pid
+  ) return false;
+  try {
+    await unlink(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+async function unlinkOptional(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }
 

--- a/packages/sync/src/node.ts
+++ b/packages/sync/src/node.ts
@@ -214,9 +214,9 @@ export class NodeMirrorLease implements MirrorLease {
           runExclusive: async <Value>(operation: () => Promise<Value>) => operation(),
           release: async () => {
             if (released) return;
-            released = true;
             const current = await readLeaseRecord(path);
             if (current?.owner_id === record.owner_id) await unlinkOptional(path);
+            released = true;
           }
         };
       } catch (error) {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1030,23 +1030,31 @@ schema:
   const symlinkOutsideRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-symlink-outside-"));
   try {
     await symlink(symlinkOutsideRoot, join(symlinkMirrorRoot, ".mdbase"), "dir");
-    await execute(process.execPath, [
-      join(repoRoot, "packages", "sync", "dist", "cli.js"),
-      "init",
-      symlinkMirrorRoot,
-      "--server", provider.url,
-      "--collection", collectionId,
-      "--replica", mirror.id
-    ], {
-      env: { ...process.env, MDBASE_CONNECT_REPLICA_TOKEN: mirror.token }
-    });
+    await assert.rejects(
+      () => execute(process.execPath, [
+        join(repoRoot, "packages", "sync", "dist", "cli.js"),
+        "init",
+        symlinkMirrorRoot,
+        "--server", provider.url,
+        "--collection", collectionId,
+        "--replica", mirror.id
+      ], {
+        env: { ...process.env, MDBASE_CONNECT_REPLICA_TOKEN: mirror.token }
+      }),
+      (error) => error.stderr.includes(
+        ".mdbase must be an ordinary directory inside the mirrored folder."
+      )
+    );
     await assert.rejects(
       () => readFile(join(symlinkOutsideRoot, "connect-mirror.json"), "utf8"),
       { code: "ENOENT" }
     );
-    assert.equal(
-      (await stat(join(await mirrorProfileDirectory(symlinkMirrorRoot), "credentials.json"))).mode & 0o777,
-      0o600
+    await assert.rejects(
+      async () => stat(join(
+        await mirrorProfileDirectory(symlinkMirrorRoot),
+        "credentials.json"
+      )),
+      { code: "ENOENT" }
     );
   } finally {
     await rm(symlinkMirrorRoot, { recursive: true, force: true });


### PR DESCRIPTION
## What changed

- mark physical hosted-mirror folders with a non-secret `.mdbase/connect-role.json` role binding
- make the local connector refuse registration and operations for hosted-mirror folders, including folders registered before the marker appeared
- stop watcher/runtime side effects when a registered folder becomes unavailable
- add a cross-process folder lease for mirror sync, conflict resolution, promotion verification, and long-running `watch`
- remove and restore the role marker transactionally during hosted-to-local authority promotion and rollback
- document the one-folder/one-role boundary

## Why

Server authority fencing already prevents two active authorities with the same collection ID, but it could not recognize the same physical folder if a local registration used another ID. Two mirror engines could also manage the same folder concurrently. This closes both local gaps and keeps the server fence as defense in depth.

## Impact

A hosted mirror cannot also be exposed as a local relay. Existing local-authority folders must use the explicit authority-transfer flow before becoming hosted mirrors. Competing mirror processes fail with `mirror_folder_in_use`.

## Validation

- `cargo test --workspace --locked`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- 42 sync tests, including marker lifecycle and exclusive lease coverage
- 25 Connect core tests, including pre-registered-folder fail-closed behavior
