### PR TITLE
Release mdbase connect 0.1.0-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "clap",
  "mdbase-connect-core",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-agent"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "clap",
  "directories",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "clap",
  "mdbase-connect-core",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-agent"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "clap",
  "directories",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "chrono",
  "mdbase",

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -1,6 +1,6 @@
 # Deploy an immutable mdbase connect release checkout. This value labels the
 # locally built images and must match the checked-out tag without the leading v.
-MDBASE_CONNECT_VERSION=0.1.0-beta.4
+MDBASE_CONNECT_VERSION=0.1.0-beta.5
 
 CONNECT_PUBLIC_URL=https://connect.example.com
 CONNECT_BIND_PORT=8787

--- a/docs/portable-apps.md
+++ b/docs/portable-apps.md
@@ -112,7 +112,7 @@ Use an exact package version, copy the SHA-384 value from that version's
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/npm/@mdbase/connect@0.1.0-beta.4/dist/browser/mdbase-connect.min.js"
+  src="https://cdn.jsdelivr.net/npm/@mdbase/connect@0.1.0-beta.5/dist/browser/mdbase-connect.min.js"
   integrity="sha384-6GTn5SRbBhjL6mSvjFUYGC+h7EV/Scj7NzxwbbmCFPWip8vc11F3EiZsOshUvLeP"
   crossorigin="anonymous"></script>
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -103,10 +103,10 @@ services require a branch reference; deploy tooling separately verifies and
 deploys the exact tag commit:
 
 ```bash
-pnpm version:check v0.1.0-beta.4
-git branch releases/v0.1.0-beta.4
-git tag -a v0.1.0-beta.4 -m "mdbase connect 0.1.0-beta.4"
-git push origin releases/v0.1.0-beta.4 v0.1.0-beta.4
+pnpm version:check v0.1.0-beta.5
+git branch releases/v0.1.0-beta.5
+git tag -a v0.1.0-beta.5 -m "mdbase connect 0.1.0-beta.5"
+git push origin releases/v0.1.0-beta.5 v0.1.0-beta.5
 ```
 
 When platform publisher configuration is wholly absent, the workflow publishes

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -17,8 +17,8 @@ Production deployments must use a signed or annotated release tag, never
 ```bash
 git clone https://github.com/mdbase-dev/mdbase-connect.git
 cd mdbase-connect
-git checkout v0.1.0-beta.4
-test "$(git describe --tags --exact-match)" = "v0.1.0-beta.4"
+git checkout v0.1.0-beta.5
+test "$(git describe --tags --exact-match)" = "v0.1.0-beta.5"
 ```
 
 Copy the production environment template:
@@ -163,7 +163,7 @@ and update `MDBASE_CONNECT_VERSION` to match it:
 
 ```bash
 git fetch --tags
-git checkout v0.1.0-beta.4
+git checkout v0.1.0-beta.5
 docker compose --env-file deploy/self-host/.env \
   -f deploy/self-host/compose.yml \
   --profile hosted --profile mcp \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.4" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.5" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- bump all Rust and JavaScript workspace versions to `0.1.0-beta.5`
- update immutable self-hosting and release examples
- prepare the hosted mirror/relay authority safety fix for staging deployment

## Validation

- `pnpm version:check v0.1.0-beta.5`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `cargo test --workspace --locked`
- prior change PR: full Server CI and 10,000-record hosted-provider stress run

## Deployment

This release will be tagged and pinned to the staging environment only after this PR and the release preflight pass. Production is unchanged.