### PR TITLE
Expose hosted collections and mirror control in desktop

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -16,9 +16,10 @@ need to understand relays, OAuth, or networking to control access.
 ## Product Purpose
 
 mdbase connect makes a user's local and hosted collections safely available to
-applications they choose. The local desktop client controls computer-owned
-collections; the account portal controls mdbase-hosted collections and shared
-application access. The hosted service supplies identity, short-lived
+applications they choose. The desktop client is the primary surface for both
+computer-owned and mdbase-hosted collections, application access, and optional
+local mirrors. The account portal handles sign-in, pairing, account recovery,
+and remote revocation. The hosted service supplies identity, short-lived
 authorization, routing, an outbound-only relay for local authorities, and a
 durable authority for hosted collections. Hosted collections are always mdbase
 collections—application contracts are optional consumers, never the storage

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ models, and interfaces live in their owning applications.
 - `crates/connect-runtime`: the small Connect adapter that compiles exact grant
   criteria into provider-neutral `mdbase-runtime` workflows.
 - `crates/connect-cli`: local administration and operation CLI.
-- `apps/desktop`: Electron controller for collection registration, application
-  metadata and availability, application access, browser pairing, local
-  activity, tray operation, and launch-at-login.
+- `apps/desktop`: Electron controller for local and hosted collections,
+  filesystem mirrors, application access, browser pairing, local activity,
+  tray operation, and launch-at-login.
 - `services/server`: Fastify control plane and transient, horizontally scalable
   relay backed by PostgreSQL and optional Core NATS request/reply. It also owns
   Web Push installations and a durable, privacy-minimal delivery outbox.
@@ -49,9 +49,9 @@ models, and interfaces live in their owning applications.
 - `crates/connect-hosted-provider`: encrypted PostgreSQL authority for hosted
   collections, with direct app operations and the versioned sync data plane.
 - `apps/portal`: deliberately small account, computer management, secure
-  pairing, remote approval, and grant-review surface. Routine collection
-  configuration stays in the local controller, and there is no developer
-  portal.
+  pairing, remote approval, and emergency grant-review surface. Routine
+  collection and mirror configuration stays in the desktop controller, and
+  there is no developer portal.
 - `packages/client`: browser SDK using authorization code or portable device
   authorization with PKCE, plus a dependency-free CDN/SRI browser build.
 - `packages/protocol`: shared versioned web/relay contracts.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,8 @@
   "main": "dist/main/main.js",
   "scripts": {
     "build": "pnpm build:main && pnpm build:renderer",
-    "build:main": "tsc -p tsconfig.main.json && node scripts/build-main.mjs",
+    "build:sync": "pnpm --filter @mdbase/connect-sync build",
+    "build:main": "pnpm build:sync && tsc -p tsconfig.main.json && node scripts/build-main.mjs",
     "build:renderer": "vite build",
     "dev:agent": "cargo build --manifest-path ../../Cargo.toml -p mdbase-connect-agent",
     "start": "pnpm dev:agent && pnpm build && electron .",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.3.0",
     "@fontsource/azeret-mono": "^5.3.0",
+    "@mdbase/connect-sync": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "scheduler": "^0.27.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,7 @@
   "main": "dist/main/main.js",
   "scripts": {
     "build": "pnpm build:main && pnpm build:renderer",
-    "build:main": "tsc -p tsconfig.main.json",
+    "build:main": "tsc -p tsconfig.main.json && node scripts/build-main.mjs",
     "build:renderer": "vite build",
     "dev:agent": "cargo build --manifest-path ../../Cargo.toml -p mdbase-connect-agent",
     "start": "pnpm dev:agent && pnpm build && electron .",
@@ -20,7 +20,6 @@
   "dependencies": {
     "@fontsource/atkinson-hyperlegible": "^5.3.0",
     "@fontsource/azeret-mono": "^5.3.0",
-    "@mdbase/connect-sync": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "scheduler": "^0.27.0"
@@ -33,12 +32,14 @@
     "@electron-forge/maker-rpm": "^7.11.2",
     "@electron-forge/maker-squirrel": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",
+    "@mdbase/connect-sync": "workspace:*",
     "@mdbase/connect-ui": "workspace:*",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "electron": "^43.1.1",
+    "esbuild": "^0.28.1",
     "lodash": "^4.18.1",
     "playwright-core": "^1.61.1",
     "typescript": "^7.0.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,7 @@
   "main": "dist/main/main.js",
   "scripts": {
     "build": "pnpm build:main && pnpm build:renderer",
-    "build:sync": "pnpm --filter @mdbase/connect-sync build",
+    "build:sync": "pnpm --filter @mdbase/connect-protocol build && pnpm --filter @mdbase/connect-sync build",
     "build:main": "pnpm build:sync && tsc -p tsconfig.main.json && node scripts/build-main.mjs",
     "build:renderer": "vite build",
     "dev:agent": "cargo build --manifest-path ../../Cargo.toml -p mdbase-connect-agent",

--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -1,0 +1,16 @@
+import { build } from "esbuild";
+
+await build({
+  entryPoints: [
+    "src/main/main.ts",
+    "src/main/preload.ts"
+  ],
+  bundle: true,
+  platform: "node",
+  target: "node22",
+  format: "cjs",
+  outdir: "dist/main",
+  external: ["electron"],
+  sourcemap: false,
+  logLevel: "info"
+});

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -15,7 +15,8 @@ const electronApp = await electron.launch({
   args: [".", `--user-data-dir=${userData}`],
   env: {
     ...process.env,
-    MDBASE_CONNECT_AGENT_BIN: executable
+    MDBASE_CONNECT_AGENT_BIN: executable,
+    MDBASE_CONNECT_USER_DATA_DIR: userData
   }
 });
 
@@ -24,14 +25,22 @@ try {
   await window.getByRole("heading", { name: "Your local connection." }).waitFor();
   await window.getByText("Local only").first().waitFor();
   await window.getByRole("button", { name: /Collections/ }).click();
-  await window.getByRole("heading", { name: "Your files stay here." }).waitFor();
+  await window.getByRole("heading", { name: "Your collections, in one place." }).waitFor();
+  await window.getByRole("heading", { name: "On this computer" }).waitFor();
+  await window.getByRole("heading", { name: "Hosted by mdbase" }).waitFor();
+  await window.getByRole("button", { name: "Create collection" }).click();
+  await window.getByRole("heading", { name: "Create an mdbase collection" }).waitFor();
+  const hostedAuthority = window.getByRole("radio", { name: "Hosted by mdbase" });
+  if (await hostedAuthority.isEnabled()) throw new Error("Hosted authority should require an account connection");
+  await window.getByText("Connect this computer to your account first.").waitFor();
+  const screenshot = process.env.MDBASE_CONNECT_SMOKE_SCREENSHOT;
+  if (screenshot) await window.screenshot({ path: screenshot, animations: "disabled" });
+  await window.getByRole("button", { name: "Cancel" }).click();
   await window.getByRole("button", { name: /App access/ }).click();
   await window.getByRole("heading", { name: "Connect this computer." }).waitFor();
   await window.getByRole("button", { name: /Overview/ }).click();
   const title = await window.title();
   if (title !== "mdbase connect") throw new Error(`Unexpected window title: ${title}`);
-  const screenshot = process.env.MDBASE_CONNECT_SMOKE_SCREENSHOT;
-  if (screenshot) await window.screenshot({ path: screenshot, animations: "disabled" });
   process.stdout.write("Electron smoke test passed\n");
 } finally {
   await electronApp.close();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -13,12 +13,12 @@ import {
 import { createHash } from "node:crypto";
 import { ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { hostname } from "node:os";
 import { AgentControlError, requestAgent } from "./control-client";
 import { relaunchAfterAgentStops } from "./agent-lifecycle";
-import { MirrorManager } from "./mirror-manager";
+import { MirrorManager, pathsOverlap } from "./mirror-manager";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
@@ -531,14 +531,20 @@ function registerIpc(): void {
     if (!["read_only", "read_write"].includes(String(value.mode))) {
       throw new Error("Choose receive-only or two-way synchronization.");
     }
+    const mirrorPath = await realpath(resolve(value.path));
     const registered = await requestReadyAgent<Array<{ path: string }>>("collections.list");
-    if (registered.some((collection) => pathsOverlap(collection.path, value.path as string))) {
+    const registeredPaths = await Promise.all(
+      registered.map(async (collection) =>
+        realpath(resolve(collection.path)).catch(() => resolve(collection.path))
+      )
+    );
+    if (registeredPaths.some((path) => pathsOverlap(path, mirrorPath))) {
       throw new Error("That folder overlaps a computer-owned collection. Choose another folder.");
     }
     const cloud = await requiredCloudConfig();
     return mirrors().connect({
       collectionId: value.collectionId,
-      path: value.path,
+      path: mirrorPath,
       mode: value.mode as "read_only" | "read_write",
       name: typeof value.name === "string" ? value.name : undefined,
       cloud
@@ -587,16 +593,6 @@ function registerIpc(): void {
 function asObject(value: unknown, message: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(message);
   return value as Record<string, unknown>;
-}
-
-function pathsOverlap(left: string, right: string): boolean {
-  const resolvedLeft = resolve(left);
-  const resolvedRight = resolve(right);
-  const fromLeft = relative(resolvedLeft, resolvedRight);
-  const fromRight = relative(resolvedRight, resolvedLeft);
-  return fromLeft === ""
-    || (!fromLeft.startsWith("..") && !isAbsolute(fromLeft))
-    || (!fromRight.startsWith("..") && !isAbsolute(fromRight));
 }
 
 function stringArray(value: unknown, message: string): string[] {
@@ -910,7 +906,9 @@ app.whenReady().then(async () => {
   registerIpc();
   createWindow();
   createTray();
-  await mirrors().start();
+  await mirrors().start().catch((error) => {
+    console.error("Hosted mirror settings could not be initialized", error);
+  });
   handleDeepLink(process.argv.find((value) => value.startsWith("mdbase-connect://")));
   try {
     await ensureAgent();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -14,15 +14,17 @@ import { createHash } from "node:crypto";
 import { ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { hostname } from "node:os";
 import { AgentControlError, requestAgent } from "./control-client";
 import { relaunchAfterAgentStops } from "./agent-lifecycle";
+import { MirrorManager } from "./mirror-manager";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let agentProcess: ChildProcess | null = null;
 let agentStartup: Promise<void> | null = null;
+let mirrorManager: MirrorManager | null = null;
 let quitting = false;
 const activePairings = new Map<string, { serverUrl: string; secret: string }>();
 
@@ -30,6 +32,9 @@ interface StoredCloudConfig {
   server_url: string;
   encrypted_token: string;
 }
+
+const userDataOverride = process.env.MDBASE_CONNECT_USER_DATA_DIR;
+if (userDataOverride) app.setPath("userData", resolve(userDataOverride));
 
 const singleInstance = app.requestSingleInstanceLock();
 if (!singleInstance) app.quit();
@@ -147,6 +152,11 @@ async function chooseFolder(): Promise<string | null> {
     ? await dialog.showOpenDialog(mainWindow, options)
     : await dialog.showOpenDialog(options);
   return result.canceled ? null : result.filePaths[0] ?? null;
+}
+
+function mirrors(): MirrorManager {
+  mirrorManager ??= new MirrorManager(app.getPath("userData"));
+  return mirrorManager;
 }
 
 function registerIpc(): void {
@@ -419,11 +429,174 @@ function registerIpc(): void {
     const value = typeof limit === "number" ? Math.max(1, Math.min(500, Math.floor(limit))) : 100;
     return requestReadyAgent("activity.list", { limit: value });
   });
+  ipcMain.handle("connect:hosted:snapshot", async (event) => {
+    trustedIpc(event);
+    return connectorRequest("GET", "/v1/connectors/hosted-control");
+  });
+  ipcMain.handle("connect:hosted:create", async (event, name: unknown) => {
+    trustedIpc(event);
+    if (typeof name !== "string" || name.trim().length === 0 || [...name.trim()].length > 200) {
+      throw new Error("Collection name must be between 1 and 200 characters.");
+    }
+    return connectorRequest("POST", "/v1/connectors/hosted/collections", {
+      display_name: name.trim(),
+      template: "mdbase"
+    });
+  });
+  ipcMain.handle("connect:hosted:rename", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid hosted collection details.");
+    if (typeof value.collectionId !== "string") throw new Error("Invalid collection ID.");
+    if (typeof value.name !== "string" || value.name.trim().length === 0 || [...value.name.trim()].length > 200) {
+      throw new Error("Collection name must be between 1 and 200 characters.");
+    }
+    return connectorRequest(
+      "PATCH",
+      `/v1/connectors/hosted/collections/${encodeURIComponent(value.collectionId)}`,
+      { display_name: value.name.trim() }
+    );
+  });
+  ipcMain.handle("connect:hosted:delete", async (event, collectionId: unknown) => {
+    trustedIpc(event);
+    if (typeof collectionId !== "string") throw new Error("Invalid collection ID.");
+    return connectorRequest(
+      "DELETE",
+      `/v1/connectors/hosted/collections/${encodeURIComponent(collectionId)}`
+    );
+  });
+  ipcMain.handle("connect:hosted:authorization-approve", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid authorization decision.");
+    if (typeof value.requestId !== "string" || typeof value.collectionId !== "string") {
+      throw new Error("Choose a hosted collection for this request.");
+    }
+    return connectorRequest(
+      "POST",
+      `/v1/connectors/hosted/authorization-requests/${encodeURIComponent(value.requestId)}/approve`,
+      {
+        collection_id: value.collectionId,
+        operations: stringArray(value.operations, "Choose at least one operation.")
+      }
+    );
+  });
+  ipcMain.handle("connect:hosted:grant-update", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid hosted application access.");
+    if (typeof value.grantId !== "string") throw new Error("Invalid grant ID.");
+    return connectorRequest(
+      "PATCH",
+      `/v1/connectors/hosted/grants/${encodeURIComponent(value.grantId)}`,
+      { operations: stringArray(value.operations, "Choose at least one operation.") }
+    );
+  });
+  ipcMain.handle("connect:hosted:grant-revoke", async (event, grantId: unknown) => {
+    trustedIpc(event);
+    if (typeof grantId !== "string") throw new Error("Invalid grant ID.");
+    return connectorRequest(
+      "DELETE",
+      `/v1/connectors/hosted/grants/${encodeURIComponent(grantId)}`
+    );
+  });
+  ipcMain.handle("connect:hosted:replica-revoke", async (event, replicaId: unknown) => {
+    trustedIpc(event);
+    if (typeof replicaId !== "string") throw new Error("Invalid mirror ID.");
+    return connectorRequest(
+      "DELETE",
+      `/v1/connectors/hosted/replicas/${encodeURIComponent(replicaId)}`
+    );
+  });
+  ipcMain.handle("connect:mirrors:list", async (event) => {
+    trustedIpc(event);
+    return mirrors().list();
+  });
+  ipcMain.handle("connect:mirrors:choose-folder", async (event) => {
+    trustedIpc(event);
+    const result = mainWindow
+      ? await dialog.showOpenDialog(mainWindow, {
+          title: "Choose a folder for this hosted collection",
+          properties: ["openDirectory", "createDirectory"]
+        })
+      : await dialog.showOpenDialog({
+          title: "Choose a folder for this hosted collection",
+          properties: ["openDirectory", "createDirectory"]
+        });
+    return result.canceled ? null : result.filePaths[0] ?? null;
+  });
+  ipcMain.handle("connect:mirrors:connect", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid mirror settings.");
+    if (typeof value.collectionId !== "string" || typeof value.path !== "string") {
+      throw new Error("Choose a hosted collection and folder.");
+    }
+    if (!["read_only", "read_write"].includes(String(value.mode))) {
+      throw new Error("Choose receive-only or two-way synchronization.");
+    }
+    const registered = await requestReadyAgent<Array<{ path: string }>>("collections.list");
+    if (registered.some((collection) => pathsOverlap(collection.path, value.path as string))) {
+      throw new Error("That folder overlaps a computer-owned collection. Choose another folder.");
+    }
+    const cloud = await requiredCloudConfig();
+    return mirrors().connect({
+      collectionId: value.collectionId,
+      path: value.path,
+      mode: value.mode as "read_only" | "read_write",
+      name: typeof value.name === "string" ? value.name : undefined,
+      cloud
+    });
+  });
+  ipcMain.handle("connect:mirrors:sync", async (event, replicaId: unknown) => {
+    trustedIpc(event);
+    if (typeof replicaId !== "string") throw new Error("Invalid mirror ID.");
+    return mirrors().syncNow(replicaId);
+  });
+  ipcMain.handle("connect:mirrors:resolve", async (event, input: unknown) => {
+    trustedIpc(event);
+    const value = asObject(input, "Invalid conflict resolution.");
+    if (
+      typeof value.replicaId !== "string"
+      || typeof value.recordId !== "string"
+      || !["local", "remote"].includes(String(value.resolution))
+    ) {
+      throw new Error("Choose the local or hosted version.");
+    }
+    return mirrors().resolveConflict(
+      value.replicaId,
+      value.recordId,
+      value.resolution as "local" | "remote"
+    );
+  });
+  ipcMain.handle("connect:mirrors:disconnect", async (event, replicaId: unknown) => {
+    trustedIpc(event);
+    if (typeof replicaId !== "string") throw new Error("Invalid mirror ID.");
+    await connectorRequest(
+      "DELETE",
+      `/v1/connectors/hosted/replicas/${encodeURIComponent(replicaId)}`
+    );
+    await mirrors().remove(replicaId);
+    return { ok: true };
+  });
+  ipcMain.handle("connect:mirrors:open", async (event, replicaId: unknown) => {
+    trustedIpc(event);
+    if (typeof replicaId !== "string") throw new Error("Invalid mirror ID.");
+    const path = mirrors().pathFor(replicaId);
+    if (!path) throw new Error("That mirror is not controlled by this computer.");
+    return shell.openPath(path);
+  });
 }
 
 function asObject(value: unknown, message: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(message);
   return value as Record<string, unknown>;
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const resolvedLeft = resolve(left);
+  const resolvedRight = resolve(right);
+  const fromLeft = relative(resolvedLeft, resolvedRight);
+  const fromRight = relative(resolvedRight, resolvedLeft);
+  return fromLeft === ""
+    || (!fromLeft.startsWith("..") && !isAbsolute(fromLeft))
+    || (!fromRight.startsWith("..") && !isAbsolute(fromRight));
 }
 
 function stringArray(value: unknown, message: string): string[] {
@@ -491,6 +664,36 @@ async function effectiveCloudConfig(): Promise<{ serverUrl: string; connectorTok
   return { serverUrl: validateServerUrl(serverUrl), connectorToken };
 }
 
+async function requiredCloudConfig(): Promise<{ serverUrl: string; connectorToken: string }> {
+  const cloud = await effectiveCloudConfig();
+  if (!cloud) throw new Error("Connect this computer to an account first.");
+  return cloud;
+}
+
+async function connectorRequest<Result = unknown>(
+  method: "GET" | "POST" | "PATCH" | "DELETE",
+  path: string,
+  body?: unknown
+): Promise<Result> {
+  const cloud = await requiredCloudConfig();
+  const response = await fetch(`${cloud.serverUrl}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${cloud.connectorToken}`,
+      ...(body === undefined ? {} : { "content-type": "application/json" })
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(30_000)
+  });
+  const value = await response.json().catch(() => null) as {
+    error?: { message?: string };
+  } | null;
+  if (!response.ok) {
+    throw new Error(value?.error?.message ?? `Account request failed with HTTP ${response.status}.`);
+  }
+  return value as Result;
+}
+
 async function writeCloudConfig(serverUrl: string, connectorToken: string): Promise<void> {
   const url = new URL(validateServerUrl(serverUrl));
   if (!connectorToken.startsWith("con_") || connectorToken.length < 24) {
@@ -553,6 +756,9 @@ function handleDeepLink(value: string | undefined): void {
       showRoute("access");
     } else if (url.hostname === "paired") {
       showRoute("overview");
+    } else if (url.hostname === "mirror") {
+      const collectionId = url.searchParams.get("collection");
+      showRoute(collectionId ? `collections:mirror:${collectionId}` : "collections");
     }
   } catch {
     // Ignore malformed protocol invocations.
@@ -704,6 +910,7 @@ app.whenReady().then(async () => {
   registerIpc();
   createWindow();
   createTray();
+  await mirrors().start();
   handleDeepLink(process.argv.find((value) => value.startsWith("mdbase-connect://")));
   try {
     await ensureAgent();
@@ -733,5 +940,6 @@ app.on("activate", () => {
 
 app.on("before-quit", () => {
   quitting = true;
+  mirrorManager?.stop();
   agentProcess?.kill();
 });

--- a/apps/desktop/src/main/mirror-manager.ts
+++ b/apps/desktop/src/main/mirror-manager.ts
@@ -1,0 +1,463 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+export interface MirrorCloudCredential {
+  serverUrl: string;
+  connectorToken: string;
+}
+
+export interface MirrorConflictSummary {
+  record_id: string;
+  path: string | null;
+  kind: "conflicted" | "rejected";
+  message: string;
+}
+
+export interface DesktopMirrorSummary {
+  collection_id: string;
+  replica_id: string;
+  name: string;
+  mode: "read_only" | "read_write";
+  path: string;
+  state: "not_initialized" | "up_to_date" | "changes_waiting" | "attention" | "offline";
+  pending: number;
+  conflicts: MirrorConflictSummary[];
+  cursor: number | null;
+  last_synced_at: string | null;
+  syncing: boolean;
+  progress?: {
+    phase: "uploading" | "applying";
+    completed: number;
+    total: number | null;
+  };
+  error?: string;
+}
+
+interface MirrorRegistryEntry {
+  collection_id: string;
+  replica_id: string;
+  name: string;
+  mode: "read_only" | "read_write";
+  path: string;
+  created_at: string;
+}
+
+interface MirrorRegistry {
+  version: 1;
+  mirrors: MirrorRegistryEntry[];
+}
+
+interface MirrorPairingResponse {
+  pairing_id: string;
+  pairing_secret: string;
+}
+
+interface MirrorExchangeResponse {
+  status: "paired";
+  replica: {
+    id: string;
+    collection_id: string;
+    name: string;
+    mode: "read_only" | "read_write";
+  };
+  token: string;
+  token_expires_at: string;
+  sync_url: string;
+}
+
+interface RuntimeState {
+  syncing: boolean;
+  progress?: DesktopMirrorSummary["progress"];
+  error?: string;
+}
+
+const SYNC_INTERVAL_MS = 5_000;
+const TOKEN_RENEWAL_WINDOW_MS = 24 * 60 * 60 * 1_000;
+
+export class MirrorManager {
+  private entries: MirrorRegistryEntry[] = [];
+  private readonly runtime = new Map<string, RuntimeState>();
+  private timer: NodeJS.Timeout | null = null;
+  private initialized = false;
+
+  constructor(private readonly userData: string) {}
+
+  async start(): Promise<void> {
+    if (this.initialized) return;
+    this.entries = await this.readRegistry();
+    this.initialized = true;
+    this.timer = setInterval(() => void this.syncAll(), SYNC_INTERVAL_MS);
+    this.timer.unref();
+    void this.syncAll();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async list(): Promise<DesktopMirrorSummary[]> {
+    await this.start();
+    return Promise.all(this.entries.map((entry) => this.summary(entry)));
+  }
+
+  async connect(input: {
+    collectionId: string;
+    path: string;
+    mode: "read_only" | "read_write";
+    name?: string;
+    cloud: MirrorCloudCredential;
+  }): Promise<DesktopMirrorSummary> {
+    await this.start();
+    const selectedPath = resolve(input.path);
+    await mkdir(selectedPath, { recursive: true });
+    const canonicalPath = await realpath(selectedPath);
+    if (this.entries.some((entry) => pathsOverlap(entry.path, canonicalPath))) {
+      throw new Error("That folder overlaps another hosted collection mirror.");
+    }
+    const name = input.name?.trim()
+      || `${hostname().trim() || "This computer"} mirror`;
+    const pairing = await jsonRequest<MirrorPairingResponse>(
+      `${input.cloud.serverUrl}/v1/mirror-pairing-requests`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          mirror_name: name,
+          mode: input.mode,
+          collection_id: input.collectionId
+        })
+      }
+    );
+    await jsonRequest(
+      `${input.cloud.serverUrl}/v1/connectors/mirror-pairing-requests/${pairing.pairing_id}/approve`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${input.cloud.connectorToken}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ collection_id: input.collectionId })
+      }
+    );
+    const exchanged = await jsonRequest<MirrorExchangeResponse>(
+      `${input.cloud.serverUrl}/v1/mirror-pairing-requests/${pairing.pairing_id}/exchange`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${pairing.pairing_secret}` }
+      }
+    );
+    const { saveMirrorProfile } = await import("@mdbase/connect-sync/device");
+    const entry: MirrorRegistryEntry = {
+      collection_id: exchanged.replica.collection_id,
+      replica_id: exchanged.replica.id,
+      name: exchanged.replica.name,
+      mode: exchanged.replica.mode,
+      path: canonicalPath,
+      created_at: new Date().toISOString()
+    };
+    try {
+      await saveMirrorProfile(
+        canonicalPath,
+        {
+          version: 1,
+          provider_url: canonicalOrigin(exchanged.sync_url),
+          control_url: canonicalOrigin(input.cloud.serverUrl),
+          collection_id: exchanged.replica.collection_id,
+          replica_id: exchanged.replica.id,
+          mode: exchanged.replica.mode,
+          name: exchanged.replica.name,
+          enrollment_id: pairing.pairing_id,
+          access_token_expires_at: exchanged.token_expires_at
+        },
+        {
+          access_token: exchanged.token,
+          refresh_token: pairing.pairing_secret
+        },
+        this.mirrorStateRoot()
+      );
+      this.entries.push(entry);
+      await this.writeRegistry();
+    } catch (error) {
+      this.entries = this.entries.filter(
+        (candidate) => candidate.replica_id !== exchanged.replica.id
+      );
+      await this.removeProfile(canonicalPath).catch(() => undefined);
+      await jsonRequest(
+        `${input.cloud.serverUrl}/v1/connectors/hosted/replicas/${encodeURIComponent(exchanged.replica.id)}`,
+        {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${input.cloud.connectorToken}` }
+        }
+      ).catch(() => undefined);
+      throw error;
+    }
+    await this.sync(entry);
+    return this.summary(entry);
+  }
+
+  async syncNow(replicaId: string): Promise<DesktopMirrorSummary> {
+    await this.start();
+    const entry = this.entry(replicaId);
+    await this.sync(entry);
+    return this.summary(entry);
+  }
+
+  async resolveConflict(
+    replicaId: string,
+    recordId: string,
+    resolution: "local" | "remote"
+  ): Promise<DesktopMirrorSummary> {
+    await this.start();
+    const entry = this.entry(replicaId);
+    if (entry.mode !== "read_write") {
+      throw new Error("Receive-only mirrors do not have writable conflicts.");
+    }
+    const mirror = await this.mirrorFor(entry);
+    await mirror.resolveConflict(recordId, resolution);
+    await this.sync(entry);
+    return this.summary(entry);
+  }
+
+  async remove(replicaId: string): Promise<void> {
+    await this.start();
+    const entry = this.entry(replicaId);
+    const previous = this.entries;
+    this.entries = this.entries.filter((candidate) => candidate.replica_id !== replicaId);
+    this.runtime.delete(replicaId);
+    try {
+      await this.writeRegistry();
+    } catch (error) {
+      this.entries = previous;
+      throw error;
+    }
+    await this.removeProfile(entry.path);
+  }
+
+  pathFor(replicaId: string): string | null {
+    return this.entries.find((entry) => entry.replica_id === replicaId)?.path ?? null;
+  }
+
+  private async syncAll(): Promise<void> {
+    if (!this.initialized) return;
+    await Promise.allSettled(this.entries.map((entry) => this.sync(entry)));
+  }
+
+  private async sync(entry: MirrorRegistryEntry): Promise<void> {
+    const current = this.runtime.get(entry.replica_id);
+    if (current?.syncing) return;
+    this.runtime.set(entry.replica_id, { syncing: true });
+    try {
+      const mirror = await this.mirrorFor(entry, (progress) => {
+        this.runtime.set(entry.replica_id, {
+          syncing: true,
+          progress: {
+            phase: progress.phase,
+            completed: progress.completed,
+            total: progress.total
+          }
+        });
+      });
+      const preview = await mirror.previewInitialization();
+      if (preview.collisions.length > 0) {
+        throw new Error(
+          `Existing Markdown differs from the hosted collection: ${preview.collisions.join(", ")}.`
+        );
+      }
+      await mirror.sync();
+      this.runtime.set(entry.replica_id, { syncing: false });
+    } catch (error) {
+      this.runtime.set(entry.replica_id, {
+        syncing: false,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      throw error;
+    }
+  }
+
+  private async summary(entry: MirrorRegistryEntry): Promise<DesktopMirrorSummary> {
+    const runtime = this.runtime.get(entry.replica_id) ?? { syncing: false };
+    try {
+      const status = await (await this.mirrorFor(entry)).status();
+      return {
+        collection_id: entry.collection_id,
+        replica_id: entry.replica_id,
+        name: entry.name,
+        path: entry.path,
+        ...status,
+        mode: entry.mode,
+        syncing: runtime.syncing,
+        ...(runtime.progress ? { progress: runtime.progress } : {}),
+        ...(runtime.error ? { error: runtime.error } : {})
+      };
+    } catch (error) {
+      return {
+        collection_id: entry.collection_id,
+        replica_id: entry.replica_id,
+        name: entry.name,
+        mode: entry.mode,
+        path: entry.path,
+        state: "offline",
+        pending: 0,
+        conflicts: [],
+        cursor: null,
+        last_synced_at: null,
+        syncing: runtime.syncing,
+        error: runtime.error ?? (error instanceof Error ? error.message : String(error))
+      };
+    }
+  }
+
+  private async mirrorFor(
+    entry: MirrorRegistryEntry,
+    onProgress?: (progress: {
+      phase: "uploading" | "applying";
+      completed: number;
+      total: number | null;
+      done: boolean;
+    }) => void
+  ) {
+    const { HttpSyncTransport } = await import("@mdbase/connect-sync");
+    const { DirectoryMirror, NodeMirrorStateStore, WritableDirectoryMirror } =
+      await import("@mdbase/connect-sync/node");
+    const stored = await this.currentProfile(entry);
+    const transport = new HttpSyncTransport(
+      stored.profile.provider_url,
+      stored.profile.collection_id,
+      stored.credentials.access_token
+    );
+    const options = {
+      stateStore: new NodeMirrorStateStore(entry.path, this.mirrorStateRoot()),
+      ...(onProgress ? { onProgress } : {})
+    };
+    return entry.mode === "read_write"
+      ? new WritableDirectoryMirror(entry.path, entry.replica_id, transport, options)
+      : new DirectoryMirror(entry.path, entry.replica_id, transport, options);
+  }
+
+  private async currentProfile(entry: MirrorRegistryEntry) {
+    const { loadMirrorProfile, updateMirrorCredentials } =
+      await import("@mdbase/connect-sync/device");
+    let stored = await loadMirrorProfile(entry.path, this.mirrorStateRoot());
+    const expiry = stored.profile.access_token_expires_at;
+    if (
+      stored.profile.control_url
+      && stored.profile.enrollment_id
+      && stored.credentials.refresh_token
+      && expiry
+      && Date.parse(expiry) - Date.now() < TOKEN_RENEWAL_WINDOW_MS
+    ) {
+      const renewed = await jsonRequest<MirrorExchangeResponse>(
+        `${stored.profile.control_url}/v1/mirror-pairing-requests/${stored.profile.enrollment_id}/renew`,
+        {
+          method: "POST",
+          headers: { authorization: `Bearer ${stored.credentials.refresh_token}` }
+        }
+      );
+      stored = await updateMirrorCredentials(
+        entry.path,
+        {
+          access_token: renewed.token,
+          refresh_token: stored.credentials.refresh_token
+        },
+        renewed.token_expires_at,
+        this.mirrorStateRoot()
+      );
+    }
+    return stored;
+  }
+
+  private async removeProfile(path: string): Promise<void> {
+    const { mirrorProfileDirectory } = await import("@mdbase/connect-sync/device");
+    const profileDirectory = await mirrorProfileDirectory(path, this.mirrorStateRoot());
+    await rm(profileDirectory, { recursive: true, force: true });
+  }
+
+  private entry(replicaId: string): MirrorRegistryEntry {
+    const entry = this.entries.find((candidate) => candidate.replica_id === replicaId);
+    if (!entry) throw new Error("That mirror is not controlled by this computer.");
+    return entry;
+  }
+
+  private registryPath(): string {
+    return join(this.userData, "mirrors.json");
+  }
+
+  private mirrorStateRoot(): string {
+    return join(this.userData, "mirror-state");
+  }
+
+  private async readRegistry(): Promise<MirrorRegistryEntry[]> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(this.registryPath(), "utf8"));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw new Error("Hosted mirror settings could not be read.");
+    }
+    if (!isMirrorRegistry(parsed)) {
+      throw new Error("Hosted mirror settings are invalid.");
+    }
+    return parsed.mirrors.map((entry) => ({ ...entry, path: resolve(entry.path) }));
+  }
+
+  private async writeRegistry(): Promise<void> {
+    const path = this.registryPath();
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    const temporary = `${path}.${randomUUID()}.tmp`;
+    const registry: MirrorRegistry = { version: 1, mirrors: this.entries };
+    await writeFile(temporary, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
+    await rename(temporary, path);
+  }
+}
+
+function isMirrorRegistry(value: unknown): value is MirrorRegistry {
+  if (!value || typeof value !== "object") return false;
+  const registry = value as Partial<MirrorRegistry>;
+  return registry.version === 1
+    && Array.isArray(registry.mirrors)
+    && registry.mirrors.every((entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      const candidate = entry as Partial<MirrorRegistryEntry>;
+      return typeof candidate.collection_id === "string"
+        && typeof candidate.replica_id === "string"
+        && typeof candidate.name === "string"
+        && ["read_only", "read_write"].includes(candidate.mode ?? "")
+        && typeof candidate.path === "string"
+        && isAbsolute(candidate.path)
+        && typeof candidate.created_at === "string";
+    });
+}
+
+function canonicalOrigin(value: string): string {
+  const url = new URL(value);
+  const loopback = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error("Hosted mirror services must use HTTPS outside local development.");
+  }
+  return url.origin;
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const fromLeft = relative(left, right);
+  const fromRight = relative(right, left);
+  return fromLeft === ""
+    || (!fromLeft.startsWith("..") && !isAbsolute(fromLeft))
+    || (!fromRight.startsWith("..") && !isAbsolute(fromRight));
+}
+
+async function jsonRequest<Result = unknown>(
+  url: string,
+  init: RequestInit
+): Promise<Result> {
+  const response = await fetch(url, { ...init, signal: AbortSignal.timeout(30_000) });
+  const value = await response.json().catch(() => null) as {
+    error?: { message?: string };
+  } | null;
+  if (!response.ok) {
+    throw new Error(value?.error?.message ?? `Hosted mirror request failed with HTTP ${response.status}.`);
+  }
+  return value as Result;
+}

--- a/apps/desktop/src/main/mirror-manager.ts
+++ b/apps/desktop/src/main/mirror-manager.ts
@@ -440,7 +440,7 @@ function canonicalOrigin(value: string): string {
   return url.origin;
 }
 
-function pathsOverlap(left: string, right: string): boolean {
+export function pathsOverlap(left: string, right: string): boolean {
   const fromLeft = relative(left, right);
   const fromRight = relative(right, left);
   return fromLeft === ""

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -45,6 +45,40 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
     ipcRenderer.invoke("connect:authorizations:approve", input),
   denyAuthorization: (requestId: string) => ipcRenderer.invoke("connect:authorizations:deny", requestId),
   listActivity: (limit = 100) => ipcRenderer.invoke("connect:activity:list", limit),
+  hostedSnapshot: () => ipcRenderer.invoke("connect:hosted:snapshot"),
+  createHostedCollection: (name: string) => ipcRenderer.invoke("connect:hosted:create", name),
+  renameHostedCollection: (input: { collectionId: string; name: string }) =>
+    ipcRenderer.invoke("connect:hosted:rename", input),
+  deleteHostedCollection: (collectionId: string) =>
+    ipcRenderer.invoke("connect:hosted:delete", collectionId),
+  approveHostedAuthorization: (input: {
+    requestId: string;
+    collectionId: string;
+    operations: string[];
+  }) => ipcRenderer.invoke("connect:hosted:authorization-approve", input),
+  updateHostedGrant: (input: { grantId: string; operations: string[] }) =>
+    ipcRenderer.invoke("connect:hosted:grant-update", input),
+  revokeHostedGrant: (grantId: string) =>
+    ipcRenderer.invoke("connect:hosted:grant-revoke", grantId),
+  revokeHostedReplica: (replicaId: string) =>
+    ipcRenderer.invoke("connect:hosted:replica-revoke", replicaId),
+  listMirrors: () => ipcRenderer.invoke("connect:mirrors:list"),
+  chooseMirrorFolder: () => ipcRenderer.invoke("connect:mirrors:choose-folder"),
+  connectMirror: (input: {
+    collectionId: string;
+    path: string;
+    mode: "read_only" | "read_write";
+    name?: string;
+  }) => ipcRenderer.invoke("connect:mirrors:connect", input),
+  syncMirror: (replicaId: string) => ipcRenderer.invoke("connect:mirrors:sync", replicaId),
+  resolveMirrorConflict: (input: {
+    replicaId: string;
+    recordId: string;
+    resolution: "local" | "remote";
+  }) => ipcRenderer.invoke("connect:mirrors:resolve", input),
+  disconnectMirror: (replicaId: string) =>
+    ipcRenderer.invoke("connect:mirrors:disconnect", replicaId),
+  openMirror: (replicaId: string) => ipcRenderer.invoke("connect:mirrors:open", replicaId),
   onNavigate: (listener: (route: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, route: string) => listener(route);
     ipcRenderer.on("connect:navigate", handler);

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -24,6 +24,8 @@ interface ContractRequirement {
 
 interface ApplicationRequirements {
   contracts: ContractRequirement[];
+  access?: "contract" | "full_collection";
+  collection_kind?: "hosted";
 }
 
 interface TypeProvision {
@@ -79,6 +81,7 @@ interface ConnectorAccount {
 interface GrantSummary {
   id: string;
   application_id: string;
+  application_family_id?: string;
   application_name: string;
   application_distribution: "web" | "portable";
   application_homepage: string;
@@ -87,6 +90,7 @@ interface GrantSummary {
   application_icon?: string;
   collection_id: string;
   collection_name: string;
+  collection_kind?: "local" | "hosted";
   operations: string[];
   scope: GrantScope;
   created_at: string;
@@ -119,6 +123,67 @@ interface AccessSnapshot {
   grants: GrantSummary[];
   pending_authorizations: PendingAuthorization[];
   authority_conflicts: AuthorityConflict[];
+}
+
+interface HostedReplicaSummary {
+  id: string;
+  name: string;
+  mode: "read_only" | "read_write";
+  allowed_types: string[];
+  revoked_at: string | null;
+  created_at: string;
+  sync_status: {
+    head: number;
+    acknowledged_sequence: number;
+    last_seen_at: string | null;
+    token_expires_at: string;
+  } | null;
+}
+
+interface HostedCollectionSummary {
+  id: string;
+  display_name: string;
+  template: "mdbase";
+  provider_url: string;
+  spec_version: string;
+  contracts: ContractRequirement[];
+  authority_state: "active" | "transferring" | "transferred";
+  authority_epoch: number;
+  transferred_collection_id: string | null;
+  created_at: string;
+  replicas: HostedReplicaSummary[];
+}
+
+interface HostedControlSnapshot {
+  online: boolean;
+  hosted_collections: HostedCollectionSummary[];
+  grants: GrantSummary[];
+  pending_authorizations: PendingAuthorization[];
+}
+
+interface DesktopMirrorSummary {
+  collection_id: string;
+  replica_id: string;
+  name: string;
+  mode: "read_only" | "read_write";
+  path: string;
+  state: "not_initialized" | "up_to_date" | "changes_waiting" | "attention" | "offline";
+  pending: number;
+  conflicts: Array<{
+    record_id: string;
+    path: string | null;
+    kind: "conflicted" | "rejected";
+    message: string;
+  }>;
+  cursor: number | null;
+  last_synced_at: string | null;
+  syncing: boolean;
+  progress?: {
+    phase: "uploading" | "applying";
+    completed: number;
+    total: number | null;
+  };
+  error?: string;
 }
 
 interface AuthorityConflict {
@@ -179,6 +244,21 @@ interface Window {
     approveAuthorization(input: { requestId: string; collectionId: string; operations: string[] }): Promise<unknown>;
     denyAuthorization(requestId: string): Promise<unknown>;
     listActivity(limit?: number): Promise<ActivityEntry[]>;
+    hostedSnapshot(): Promise<HostedControlSnapshot>;
+    createHostedCollection(name: string): Promise<{ collection: HostedCollectionSummary }>;
+    renameHostedCollection(input: { collectionId: string; name: string }): Promise<{ collection: { id: string; display_name: string } }>;
+    deleteHostedCollection(collectionId: string): Promise<{ ok: true }>;
+    approveHostedAuthorization(input: { requestId: string; collectionId: string; operations: string[] }): Promise<{ ok: true }>;
+    updateHostedGrant(input: { grantId: string; operations: string[] }): Promise<unknown>;
+    revokeHostedGrant(grantId: string): Promise<unknown>;
+    revokeHostedReplica(replicaId: string): Promise<{ ok: true }>;
+    listMirrors(): Promise<DesktopMirrorSummary[]>;
+    chooseMirrorFolder(): Promise<string | null>;
+    connectMirror(input: { collectionId: string; path: string; mode: "read_only" | "read_write"; name?: string }): Promise<DesktopMirrorSummary>;
+    syncMirror(replicaId: string): Promise<DesktopMirrorSummary>;
+    resolveMirrorConflict(input: { replicaId: string; recordId: string; resolution: "local" | "remote" }): Promise<DesktopMirrorSummary>;
+    disconnectMirror(replicaId: string): Promise<{ ok: true }>;
+    openMirror(replicaId: string): Promise<string>;
     onNavigate(listener: (route: string) => void): () => void;
   };
 }

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -21,8 +21,16 @@ import { presentConnection, type ConnectionDotState } from "./connection-state.m
 import "./styles.css";
 
 type Route = "overview" | "collections" | "access" | "activity" | "settings";
+interface AuthorizationCollection {
+  id: string;
+  display_name: string;
+  spec_version: string;
+  contracts: ContractRequirement[];
+  kind: "local" | "hosted";
+  provisionable: boolean;
+}
 
-const allOperations = ["read", "query", "list_views", "execute_view", "read_view_source", "create", "update", "rename", "delete", "create_view_source", "update_view_source", "delete_view_source", "validate", "read_type", "create_type", "update_type", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"];
+const allOperations = ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "create", "update", "rename", "delete", "create_view_source", "update_view_source", "delete_view_source", "validate", "read_type", "create_type", "update_type", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"];
 const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }> = {
   overview: {
     eyebrow: "This computer",
@@ -30,9 +38,9 @@ const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }>
     lede: "Collections, application access, and connection status in one place."
   },
   collections: {
-    eyebrow: "Local collections",
-    title: "Your files stay here.",
-    lede: "Choose which mdbase folders this computer can make available."
+    eyebrow: "Collection authority",
+    title: "Your collections, in one place.",
+    lede: "Manage folders owned by this computer and collections hosted by mdbase."
   },
   access: {
     eyebrow: "Application access",
@@ -58,6 +66,8 @@ function App() {
   const [startup, setStartup] = useState<StartupSetting>({ enabled: false, available: false });
   const [cloud, setCloud] = useState<CloudSetting | null>(null);
   const [access, setAccess] = useState<AccessSnapshot>({ configured: false, online: false, grants: [], pending_authorizations: [], authority_conflicts: [] });
+  const [hosted, setHosted] = useState<HostedControlSnapshot>({ online: false, hosted_collections: [], grants: [], pending_authorizations: [] });
+  const [mirrors, setMirrors] = useState<DesktopMirrorSummary[]>([]);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -66,6 +76,8 @@ function App() {
   const [copiedCollectionPath, setCopiedCollectionPath] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
   const [newPath, setNewPath] = useState("");
+  const [newAuthority, setNewAuthority] = useState<"local" | "hosted">("local");
+  const [mirrorTarget, setMirrorTarget] = useState<string | null>(null);
 
   const refresh = useCallback(async (quiet = false) => {
     try {
@@ -75,7 +87,11 @@ function App() {
         window.mdbaseConnect.getLaunchAtLogin().then(setStartup),
         window.mdbaseConnect.getCloudConfig().then(setCloud),
         window.mdbaseConnect.accessSnapshot().then(setAccess),
-        window.mdbaseConnect.listActivity(100).then(setActivity)
+        window.mdbaseConnect.listActivity(100).then(setActivity),
+        window.mdbaseConnect.hostedSnapshot().then(setHosted).catch(() => {
+          setHosted((current) => ({ ...current, online: false }));
+        }),
+        window.mdbaseConnect.listMirrors().then(setMirrors)
       ]);
       const failed = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
       if (failed) throw failed.reason;
@@ -89,6 +105,11 @@ function App() {
     void refresh();
     const timer = window.setInterval(() => void refresh(true), 5_000);
     const removeNavigation = window.mdbaseConnect.onNavigate((next) => {
+      if (next.startsWith("collections:mirror:")) {
+        setMirrorTarget(next.slice("collections:mirror:".length));
+        setRoute("collections");
+        return;
+      }
       if (["overview", "collections", "access", "activity", "settings"].includes(next)) {
         setRoute(next as Route);
       }
@@ -143,16 +164,40 @@ function App() {
 
   async function createCollection() {
     await act(async () => {
-      const created = await window.mdbaseConnect.createCollection({ path: newPath, name: newName });
+      if (newAuthority === "hosted") {
+        const result = await window.mdbaseConnect.createHostedCollection(newName);
+        setNotice(`${result.collection.display_name} is now hosted by mdbase.`);
+      } else {
+        const created = await window.mdbaseConnect.createCollection({ path: newPath, name: newName });
+        setNotice(`${created.display_name} was created on this computer.`);
+      }
       setCreateOpen(false);
       setNewName("");
       setNewPath("");
-      setNotice(`${created.display_name} was created and registered.`);
+      setNewAuthority("local");
     });
   }
 
   const copy = routeCopy[route];
   const connection = presentConnection(status, cloud);
+  const combinedAccess = useMemo<AccessSnapshot>(() => {
+    const grants = new Map<string, GrantSummary>();
+    for (const grant of access.grants) grants.set(grant.id, {
+      ...grant,
+      collection_kind: grant.collection_kind ?? "local"
+    });
+    for (const grant of hosted.grants) grants.set(grant.id, grant);
+    const pending = new Map<string, PendingAuthorization>();
+    for (const request of hosted.pending_authorizations) pending.set(request.id, request);
+    for (const request of access.pending_authorizations) pending.set(request.id, request);
+    return {
+      ...access,
+      online: access.online || hosted.online,
+      grants: [...grants.values()],
+      pending_authorizations: [...pending.values()]
+    };
+  }, [access, hosted]);
+  const collectionCount = collections.length + hosted.hosted_collections.length;
 
   return (
     <div className="shell">
@@ -161,7 +206,7 @@ function App() {
           <Brand />
           <div className="product-header-meta" role="status" aria-live="polite">
             <StatusDot state={connection.dot} />
-            <div className="product-header-meta-copy"><strong>{connection.label}</strong><small>{access.account?.connector_name ?? "This computer"} · {status ? `${status.registered_collections} registered` : "Checking local connector"}</small></div>
+            <div className="product-header-meta-copy"><strong>{connection.label}</strong><small>{access.account?.connector_name ?? "This computer"} · {collectionCount} {plural(collectionCount, "collection", "collections")}</small></div>
           </div>
         </div>
       </header>
@@ -169,8 +214,8 @@ function App() {
       <nav className="view-tabs" aria-label="mdbase connect views">
         <div className="view-tabs-inner">
           <NavButton route="overview" current={route} label="Overview" onSelect={setRoute} />
-          <NavButton route="collections" current={route} label="Collections" count={collections.length} onSelect={setRoute} />
-          <NavButton route="access" current={route} label="App access" attention={access.pending_authorizations.length} onSelect={setRoute} />
+          <NavButton route="collections" current={route} label="Collections" count={collectionCount} onSelect={setRoute} />
+          <NavButton route="access" current={route} label="App access" attention={combinedAccess.pending_authorizations.length} onSelect={setRoute} />
           <NavButton route="activity" current={route} label="Activity" onSelect={setRoute} />
           <NavButton route="settings" current={route} label="Settings" onSelect={setRoute} />
         </div>
@@ -190,8 +235,8 @@ function App() {
           <Overview
             status={status}
             cloud={cloud}
-            access={access}
-            collections={collections}
+            access={combinedAccess}
+            collectionCount={collectionCount}
             busy={busy}
             onNavigate={setRoute}
             onPause={(paused) => void act(async () => {
@@ -202,6 +247,10 @@ function App() {
         ) : route === "collections" ? (
           <Collections
             collections={collections}
+            hosted={hosted}
+            cloudConfigured={cloud.configured}
+            mirrors={mirrors}
+            mirrorTarget={mirrorTarget}
             authorityConflicts={access.authority_conflicts}
             busy={busy}
             copiedCollectionPath={copiedCollectionPath}
@@ -209,14 +258,16 @@ function App() {
             onCancelCopy={() => setCopiedCollectionPath(null)}
             onCreate={() => setCreateOpen(true)}
             onRegisterCopy={() => void registerCopiedCollection()}
+            onMirrorTargetHandled={() => setMirrorTarget(null)}
             onAct={act}
             onNotice={setNotice}
           />
         ) : route === "access" ? (
           <Access
             cloud={cloud}
-            access={access}
+            access={combinedAccess}
             collections={collections}
+            hostedCollections={hosted.hosted_collections}
             busy={busy}
             onAct={act}
             onNotice={setNotice}
@@ -237,14 +288,25 @@ function App() {
       {createOpen && (
         <div className="modal-backdrop" role="presentation" onMouseDown={() => !busy && setCreateOpen(false)}>
           <section className="modal" role="dialog" aria-modal="true" aria-labelledby="create-title" onMouseDown={(event) => event.stopPropagation()}>
-            <p className="eyebrow">New local collection</p>
+            <p className="eyebrow">New collection</p>
             <h2 id="create-title">Create an mdbase collection</h2>
-            <p>mdbase connect will add a canonical <code>mdbase.yaml</code> and type folder. Existing files are left alone.</p>
+            <p>Choose the authority deliberately. You can mirror a hosted collection onto this computer after creating it.</p>
+            <fieldset className="authority-choice">
+              <legend>Collection authority</legend>
+              <label className={newAuthority === "local" ? "selected" : ""}>
+                <input type="radio" name="authority" value="local" checked={newAuthority === "local"} onChange={() => setNewAuthority("local")} />
+                <span><strong>On this computer</strong><small>A folder here is the final authority.</small></span>
+              </label>
+              <label className={`${newAuthority === "hosted" ? "selected" : ""} ${cloud?.configured ? "" : "disabled"}`}>
+                <input type="radio" name="authority" value="hosted" checked={newAuthority === "hosted"} disabled={!cloud?.configured} onChange={() => setNewAuthority("hosted")} />
+                <span><strong>Hosted by mdbase</strong><small>{cloud?.configured ? "Available while this computer is offline; optional local mirror." : "Connect this computer to your account first."}</small></span>
+              </label>
+            </fieldset>
             <label><span>Collection name</span><input autoFocus value={newName} onChange={(event) => setNewName(event.target.value)} placeholder="Workouts" /></label>
-            <label><span>Folder</span><button className="folder-picker" onClick={() => void chooseCreateFolder()}>{newPath || "Choose a folder…"}</button></label>
+            {newAuthority === "local" && <label><span>Folder</span><button className="folder-picker" onClick={() => void chooseCreateFolder()}>{newPath || "Choose a folder…"}</button></label>}
             <div className="modal-actions">
               <button className="button secondary" disabled={busy} onClick={() => setCreateOpen(false)}>Cancel</button>
-              <button className="button primary" disabled={busy || !newName.trim() || !newPath} onClick={() => void createCollection()}>Create collection</button>
+              <button className="button primary" disabled={busy || !newName.trim() || (newAuthority === "local" && !newPath)} onClick={() => void createCollection()}>Create collection</button>
             </div>
           </section>
         </div>
@@ -260,11 +322,11 @@ function ConnectionProgress() {
   </div>;
 }
 
-function Overview({ status, cloud, access, collections, busy, onNavigate, onPause }: {
+function Overview({ status, cloud, access, collectionCount, busy, onNavigate, onPause }: {
   status: AgentStatus | null;
   cloud: CloudSetting;
   access: AccessSnapshot;
-  collections: CollectionSummary[];
+  collectionCount: number;
   busy: boolean;
   onNavigate(route: Route): void;
   onPause(paused: boolean): void;
@@ -277,7 +339,7 @@ function Overview({ status, cloud, access, collections, busy, onNavigate, onPaus
       {access.pending_authorizations.length > 0 && (
         <button className="pending-banner" onClick={() => onNavigate("access")}>
           <span>{access.pending_authorizations.length}</span>
-          <div><strong>{plural(access.pending_authorizations.length, "application is", "applications are")} waiting for a decision</strong><small>Review the requested collection operations on this computer.</small></div>
+          <div><strong>{plural(access.pending_authorizations.length, "application is", "applications are")} waiting for a decision</strong><small>Review the requested collection and operations.</small></div>
           <b>Review requests</b>
         </button>
       )}
@@ -298,7 +360,7 @@ function Overview({ status, cloud, access, collections, busy, onNavigate, onPaus
         />
       </section>
       <section className="overview-list" aria-label="Connector summary">
-        <OverviewRow label="Collections" value={`${collections.length} registered`} detail="Only enabled local folders can be reached" action="Manage" onClick={() => onNavigate("collections")} />
+        <OverviewRow label="Collections" value={`${collectionCount} managed`} detail="Computer-owned and hosted authorities stay explicit" action="Manage" onClick={() => onNavigate("collections")} />
         <OverviewRow label="Application access" value={`${access.grants.length} active`} detail="Each grant is limited to one collection" action="Manage" onClick={() => onNavigate("access")} />
         <OverviewRow label="Portal" value={access.account?.user_email ?? cloud.serverUrl ?? "Configured"} detail={access.account?.connector_name ?? "Cloud identity unavailable while offline"} action="Settings" onClick={() => onNavigate("settings")} />
       </section>
@@ -310,8 +372,28 @@ function OverviewRow({ label, value, detail, action, onClick }: { label: string;
   return <div className="overview-row"><span>{label}</span><div><strong>{value}</strong><small>{detail}</small></div><button className="quiet-action" onClick={onClick}>{action}</button></div>;
 }
 
-function Collections({ collections, authorityConflicts, busy, copiedCollectionPath, onAdd, onCancelCopy, onCreate, onRegisterCopy, onAct, onNotice }: {
+function Collections({
+  collections,
+  hosted,
+  cloudConfigured,
+  mirrors,
+  mirrorTarget,
+  authorityConflicts,
+  busy,
+  copiedCollectionPath,
+  onAdd,
+  onCancelCopy,
+  onCreate,
+  onRegisterCopy,
+  onMirrorTargetHandled,
+  onAct,
+  onNotice
+}: {
   collections: CollectionSummary[];
+  hosted: HostedControlSnapshot;
+  cloudConfigured: boolean;
+  mirrors: DesktopMirrorSummary[];
+  mirrorTarget: string | null;
   authorityConflicts: AuthorityConflict[];
   busy: boolean;
   copiedCollectionPath: string | null;
@@ -319,12 +401,13 @@ function Collections({ collections, authorityConflicts, busy, copiedCollectionPa
   onCancelCopy(): void;
   onCreate(): void;
   onRegisterCopy(): void;
+  onMirrorTargetHandled(): void;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
 }) {
   return (
     <section className="collection-section">
-      <SectionHeading title="Collections" note="Removing a collection never deletes its files.">
+      <SectionHeading title="Collections" note="Authority and local copies are shown separately.">
         <button className="button secondary" disabled={busy} onClick={onAdd}>Add existing</button>
         <button className="button primary" disabled={busy} onClick={onCreate}>Create collection</button>
       </SectionHeading>
@@ -364,13 +447,45 @@ function Collections({ collections, authorityConflicts, busy, copiedCollectionPa
           </div>
         </section>
       ))}
-      {collections.length === 0 ? (
-        <Empty title="No collections registered" text="Add a folder with an existing mdbase.yaml, or create a new collection." action="Create the first collection" onAction={onCreate} />
-      ) : (
-        <div className="collection-list">
-          {collections.map((collection) => <CollectionRow key={collection.id} collection={collection} busy={busy} onAct={onAct} onNotice={onNotice} />)}
-        </div>
-      )}
+      <div className="collection-authority-group">
+        <SectionHeading title="On this computer" note="These folders are authoritative here." count={collections.length} />
+        {collections.length === 0 ? (
+          <Empty title="No computer-owned collections" text="Add a folder with an existing mdbase.yaml, or create one here." />
+        ) : (
+          <div className="collection-list">
+            {collections.map((collection) => <CollectionRow key={collection.id} collection={collection} busy={busy} onAct={onAct} onNotice={onNotice} />)}
+          </div>
+        )}
+      </div>
+      <div className="collection-authority-group">
+        <SectionHeading
+          title="Hosted by mdbase"
+          note={!cloudConfigured
+            ? "Connect this computer to manage hosted collections."
+            : hosted.online
+              ? "Available to approved apps without this computer."
+              : "Hosted controls are offline; last known state is shown."}
+          count={hosted.hosted_collections.length}
+        />
+        {hosted.hosted_collections.length === 0 ? (
+          <Empty title="No hosted collections" text="Create one to keep its authority online, with an optional folder mirror here." />
+        ) : (
+          <div className="collection-list">
+            {hosted.hosted_collections.map((collection) => (
+              <HostedCollectionRow
+                key={collection.id}
+                collection={collection}
+                mirrors={mirrors}
+                openMirror={mirrorTarget === collection.id}
+                busy={busy}
+                onTargetHandled={onMirrorTargetHandled}
+                onAct={onAct}
+                onNotice={onNotice}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     </section>
   );
 }
@@ -437,10 +552,171 @@ function CollectionRow({ collection, busy, onAct, onNotice }: {
   );
 }
 
-function Access({ cloud, access, collections, busy, onAct, onNotice }: {
+function HostedCollectionRow({
+  collection,
+  mirrors,
+  openMirror,
+  busy,
+  onTargetHandled,
+  onAct,
+  onNotice
+}: {
+  collection: HostedCollectionSummary;
+  mirrors: DesktopMirrorSummary[];
+  openMirror: boolean;
+  busy: boolean;
+  onTargetHandled(): void;
+  onAct(action: () => Promise<void>): Promise<void>;
+  onNotice(value: string): void;
+}) {
+  const [editing, setEditing] = useState(openMirror);
+  const [name, setName] = useState(collection.display_name);
+  const [path, setPath] = useState("");
+  const [mode, setMode] = useState<"read_only" | "read_write">("read_write");
+  const mirror = mirrors.find((candidate) => candidate.collection_id === collection.id);
+  const activeReplicas = collection.replicas.filter((replica) => replica.revoked_at === null);
+
+  useEffect(() => {
+    if (openMirror) {
+      setEditing(true);
+      onTargetHandled();
+    }
+  }, [onTargetHandled, openMirror]);
+  useEffect(() => {
+    if (!editing) setName(collection.display_name);
+  }, [collection.display_name, editing]);
+
+  async function chooseMirrorFolder() {
+    const selected = await window.mdbaseConnect.chooseMirrorFolder();
+    if (selected) setPath(selected);
+  }
+
+  const state = mirrorState(mirror);
+  return (
+    <article className={`collection-card hosted-collection ${editing ? "editing" : ""}`}>
+      <div className="collection-summary">
+        <div className="collection-copy">
+          <div className="collection-title-row">
+            <h3>{collection.display_name}</h3>
+            <span className="version">v{collection.spec_version}</span>
+          </div>
+          <span className="authority-label">Hosted authority · {activeReplicas.length} {plural(activeReplicas.length, "mirror", "mirrors")}</span>
+        </div>
+        <div className="collection-status"><StatusDot state={collection.authority_state === "active" ? "connected" : "idle"} />{collection.authority_state === "active" ? "Available" : collection.authority_state}</div>
+        <div className="row-actions">
+          <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : mirror ? "Mirror" : "Details"}</button>
+        </div>
+      </div>
+      {editing && <div className="collection-editor hosted-editor">
+        <form className="collection-editor-form" onSubmit={(event) => {
+          event.preventDefault();
+          void onAct(async () => {
+            await window.mdbaseConnect.renameHostedCollection({ collectionId: collection.id, name });
+            onNotice(`${name.trim()} was renamed.`);
+          });
+        }}>
+          <section className="collection-editor-section">
+            <div><strong>Details</strong><small>The name is stored with the hosted authority.</small></div>
+            <div className="collection-fields">
+              <label><span>Name</span><input value={name} maxLength={200} required onChange={(event) => setName(event.target.value)} /></label>
+              <button className="button secondary" disabled={busy || !name.trim() || name.trim() === collection.display_name}>Save name</button>
+            </div>
+          </section>
+        </form>
+        <section className="collection-editor-section mirror-section">
+          <div>
+            <strong>Mirror on this computer</strong>
+            <small>A mirror is a local copy. The hosted collection remains authoritative.</small>
+          </div>
+          {mirror ? (
+            <div className="mirror-control">
+              <div className="mirror-state-row">
+                <StatusDot state={state.dot} />
+                <div><strong>{state.label}</strong><button className="path" title={mirror.path} onClick={() => void window.mdbaseConnect.openMirror(mirror.replica_id)}>{mirror.path}</button></div>
+                <code>{mirror.mode === "read_write" ? "two-way" : "receive-only"}</code>
+              </div>
+              {mirror.progress && <small>{mirror.progress.phase === "uploading" ? "Uploading" : "Applying"} {mirror.progress.completed}{mirror.progress.total === null ? "" : ` of ${mirror.progress.total}`} changes…</small>}
+              {mirror.error && <div className="message error-message compact-message">{mirror.error}</div>}
+              {mirror.conflicts.length > 0 && (
+                <div className="mirror-conflicts">
+                  {mirror.conflicts.map((conflict) => <div key={conflict.record_id}>
+                    <div><strong>{conflict.path ?? conflict.record_id}</strong><small>{conflict.message}</small></div>
+                    <div className="row-actions">
+                      <button className="quiet-action" disabled={busy} onClick={() => void onAct(async () => {
+                        await window.mdbaseConnect.resolveMirrorConflict({ replicaId: mirror.replica_id, recordId: conflict.record_id, resolution: "local" });
+                        onNotice("The local version was kept and synchronized.");
+                      })}>Keep local</button>
+                      <button className="quiet-action" disabled={busy} onClick={() => void onAct(async () => {
+                        await window.mdbaseConnect.resolveMirrorConflict({ replicaId: mirror.replica_id, recordId: conflict.record_id, resolution: "remote" });
+                        onNotice("The hosted version was applied.");
+                      })}>Use hosted</button>
+                    </div>
+                  </div>)}
+                </div>
+              )}
+              <div className="mirror-actions">
+                <button className="quiet-action" disabled={busy || mirror.syncing} onClick={() => void onAct(async () => {
+                  await window.mdbaseConnect.syncMirror(mirror.replica_id);
+                  onNotice(`${collection.display_name} is synchronized.`);
+                })}>{mirror.syncing ? "Synchronizing…" : "Sync now"}</button>
+                <button className="quiet-action" disabled={busy} onClick={() => void window.mdbaseConnect.openMirror(mirror.replica_id)}>Open folder</button>
+                <button className="quiet-action danger" disabled={busy} onClick={() => {
+                  if (!window.confirm(`Stop mirroring ${collection.display_name} on this computer? The folder and its files will remain.`)) return;
+                  void onAct(async () => {
+                    await window.mdbaseConnect.disconnectMirror(mirror.replica_id);
+                    onNotice(`The mirror was disconnected. Files remain at ${mirror.path}.`);
+                  });
+                }}>Stop mirror</button>
+              </div>
+            </div>
+          ) : (
+            <div className="mirror-setup">
+              <label><span>Folder</span><button type="button" className="folder-picker" onClick={() => void chooseMirrorFolder()}>{path || "Choose a folder…"}</button></label>
+              <label><span>Synchronization</span><select value={mode} onChange={(event) => setMode(event.target.value as "read_only" | "read_write")}><option value="read_write">Two-way</option><option value="read_only">Receive-only</option></select></label>
+              <small>Two-way mirrors upload local edits. Receive-only mirrors replace their local view with hosted changes.</small>
+              <button className="button primary" disabled={busy || !path} onClick={() => void onAct(async () => {
+                await window.mdbaseConnect.connectMirror({ collectionId: collection.id, path, mode });
+                setPath("");
+                onNotice(`${collection.display_name} is now mirrored on this computer.`);
+              })}>Start mirror</button>
+            </div>
+          )}
+        </section>
+        {activeReplicas.some((replica) => replica.id !== mirror?.replica_id) && (
+          <section className="collection-editor-section">
+            <div><strong>Other mirrors</strong><small>Mirrors connected from another installation or through the command line.</small></div>
+            <div className="replica-list">{activeReplicas.filter((replica) => replica.id !== mirror?.replica_id).map((replica) => (
+              <div key={replica.id}><span>{replica.name}</span><code>{replica.mode === "read_write" ? "two-way" : "receive-only"}</code><small>{replica.sync_status?.last_seen_at ? `Seen ${relativeTime(replica.sync_status.last_seen_at)}` : "Not synchronized yet"}</small><button className="quiet-action danger" disabled={busy} onClick={() => {
+                if (!window.confirm(`Revoke ${replica.name}? Its local files will remain, but it will no longer synchronize.`)) return;
+                void onAct(async () => {
+                  await window.mdbaseConnect.revokeHostedReplica(replica.id);
+                  onNotice(`${replica.name} was revoked.`);
+                });
+              }}>Revoke</button></div>
+            ))}</div>
+          </section>
+        )}
+        <div className="collection-danger-row">
+          <small>Deleting a hosted collection permanently removes its hosted records. Local mirror files remain.</small>
+          <button className="quiet-action danger" disabled={busy} onClick={() => {
+            if (!window.confirm(`Permanently delete the hosted collection ${collection.display_name}? This cannot be undone.`)) return;
+            void onAct(async () => {
+              if (mirror) await window.mdbaseConnect.disconnectMirror(mirror.replica_id);
+              await window.mdbaseConnect.deleteHostedCollection(collection.id);
+              onNotice(`${collection.display_name} was deleted. Any local mirror files remain.`);
+            });
+          }}>Delete hosted collection</button>
+        </div>
+      </div>}
+    </article>
+  );
+}
+
+function Access({ cloud, access, collections, hostedCollections, busy, onAct, onNotice }: {
   cloud: CloudSetting;
   access: AccessSnapshot;
   collections: CollectionSummary[];
+  hostedCollections: HostedCollectionSummary[];
   busy: boolean;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
@@ -452,10 +728,10 @@ function Access({ cloud, access, collections, busy, onAct, onNotice }: {
       <section>
         <SectionHeading title="Pending requests" note="An application cannot continue until you decide here." count={access.pending_authorizations.length} />
         {access.pending_authorizations.length === 0 ? (
-          <Empty title="No applications are waiting" text="New connection requests from websites and downloaded files will appear here while this computer is online." />
+          <Empty title="No applications are waiting" text="New connection requests from websites and downloaded files will appear here." />
         ) : (
           <div className="request-list">
-            {access.pending_authorizations.map((request) => <AuthorizationRequest key={request.id} request={request} collections={collections} busy={busy} onAct={onAct} onNotice={onNotice} />)}
+            {access.pending_authorizations.map((request) => <AuthorizationRequest key={request.id} request={request} collections={collections} hostedCollections={hostedCollections} busy={busy} onAct={onAct} onNotice={onNotice} />)}
           </div>
         )}
       </section>
@@ -495,34 +771,72 @@ function ApplicationGrantGroup({ group, busy, onAct, onNotice }: {
           <GrantEditor key={grant.id} grant={grant} busy={busy} onAct={onAct} onNotice={onNotice} />
         ))}</div>
         <div className="application-grant-actions">
-          <small>Revokes this application from every collection on this computer.</small>
+          <small>Revokes this application from every collection listed above.</small>
           <button className="quiet-action danger" disabled={busy} onClick={() => {
-            if (!window.confirm(`Revoke all ${group.applicationName} access from this computer?`)) return;
+            if (!window.confirm(`Revoke all ${group.applicationName} collection access?`)) return;
             void onAct(async () => {
-              for (const grant of group.grants) await window.mdbaseConnect.revokeGrant(grant.id);
-              onNotice(`${group.applicationName} access from this computer was revoked.`);
+              for (const grant of group.grants) {
+                if (grant.collection_kind === "hosted") {
+                  await window.mdbaseConnect.revokeHostedGrant(grant.id);
+                } else {
+                  await window.mdbaseConnect.revokeGrant(grant.id);
+                }
+              }
+              onNotice(`${group.applicationName} collection access was revoked.`);
             });
-          }}>Revoke from this computer</button>
+          }}>Revoke all access</button>
         </div>
       </div>
     </details>
   );
 }
 
-function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
+function AuthorizationRequest({ request, collections, hostedCollections, busy, onAct, onNotice }: {
   request: PendingAuthorization;
   collections: CollectionSummary[];
+  hostedCollections: HostedCollectionSummary[];
   busy: boolean;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
 }) {
-  const available = useMemo(
-    () => collections.filter((collection) =>
-      request.compatible_collection_ids.includes(collection.id)
-      || request.provisionable_collection_ids.includes(collection.id)
-    ),
-    [collections, request.compatible_collection_ids, request.provisionable_collection_ids]
-  );
+  const available = useMemo<AuthorizationCollection[]>(() => [
+    ...collections
+      .filter((collection) =>
+        request.requirements.collection_kind !== "hosted"
+        && (
+          request.compatible_collection_ids.includes(collection.id)
+          || request.provisionable_collection_ids.includes(collection.id)
+        )
+      )
+      .map((collection) => ({
+        ...collection,
+        kind: "local" as const,
+        provisionable: request.provisionable_collection_ids.includes(collection.id)
+      })),
+    ...hostedCollections
+      .filter((collection) =>
+        collection.authority_state === "active"
+        && hostedCollectionCompatible(request, collection)
+      )
+      .map((collection) => ({
+        id: collection.id,
+        display_name: collection.display_name,
+        spec_version: collection.spec_version,
+        contracts: collection.contracts,
+        kind: "hosted" as const,
+        provisionable: request.requirements.contracts.some(
+          (requirement) => !hasContract(collection.contracts, requirement)
+        )
+      }))
+  ], [
+    collections,
+    hostedCollections,
+    request.compatible_collection_ids,
+    request.provisionable_collection_ids,
+    request.requirements,
+    request.provisions,
+    request.requested_operations
+  ]);
   const [collectionId, setCollectionId] = useState(
     available.some((collection) => collection.id === request.collection_hint)
       ? request.collection_hint!
@@ -530,7 +844,7 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
   );
   const [operations, setOperations] = useState(request.requested_operations);
   const selected = available.find((collection) => collection.id === collectionId);
-  const setup = selected && request.provisionable_collection_ids.includes(selected.id)
+  const setup = selected?.provisionable
     ? neededProvisions(request.requirements, request.provisions, selected)
     : [];
   const permissionGroups = useMemo(
@@ -549,8 +863,8 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
         <section className="request-section">
           <div><strong>Collection</strong><small>Choose where {request.application_name} can work.</small></div>
           <div className="request-section-content">
-            <label><span>Collection on this computer</span><select value={collectionId} disabled={available.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{available.length === 0 && <option value="">No compatible collection</option>}{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name}{request.provisionable_collection_ids.includes(collection.id) ? " · setup required" : ""}</option>)}</select></label>
-            {available.length === 0 && <small>No registered collection supports all requested operations and contracts.</small>}
+            <label><span>Collection</span><select value={collectionId} disabled={available.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{available.length === 0 && <option value="">No compatible collection</option>}{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name} · {collection.kind === "hosted" ? "hosted" : "this computer"}{collection.provisionable ? " · setup required" : ""}</option>)}</select></label>
+            {available.length === 0 && <small>No available local or hosted collection supports all requested operations and contracts.</small>}
             {setup.length > 0 && <small>Setup needed: allowing access will add {provisionNames(setup)} to this collection.</small>}
           </div>
         </section>
@@ -561,11 +875,18 @@ function AuthorizationRequest({ request, collections, busy, onAct, onNotice }: {
         <NotificationAccess notifications={request.notifications} />
         <footer className="request-footer">
           <p>{selected
-            ? `${request.application_name} will use ${selected.display_name} on this computer until you revoke access.`
+            ? `${request.application_name} will use ${selected.display_name}, ${selected.kind === "hosted" ? "hosted by mdbase" : "on this computer"}, until you revoke access.`
             : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
           <div className="decision-actions">
             <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
-            <button className="button primary" disabled={busy || !collectionId || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.approveAuthorization({ requestId: request.id, collectionId, operations }); onNotice(`${request.application_name} can now use the selected operations.`); })}>Allow {request.application_name}</button>
+            <button className="button primary" disabled={busy || !selected || operations.length === 0} onClick={() => void onAct(async () => {
+              if (selected?.kind === "hosted") {
+                await window.mdbaseConnect.approveHostedAuthorization({ requestId: request.id, collectionId, operations });
+              } else {
+                await window.mdbaseConnect.approveAuthorization({ requestId: request.id, collectionId, operations });
+              }
+              onNotice(`${request.application_name} can now use the selected operations.`);
+            })}>Allow {request.application_name}</button>
           </div>
         </footer>
       </div>
@@ -637,9 +958,10 @@ function GrantEditor({ grant, busy, onAct, onNotice }: { grant: GrantSummary; bu
   );
   const changed = useMemo(() => [...operations].sort().join(",") !== [...grant.operations].sort().join(","), [operations, grant.operations]);
   useEffect(() => setOperations(grant.operations), [grant.operations]);
+  const authority = grant.collection_kind === "hosted" ? "Hosted by mdbase" : "On this computer";
   return (
     <article className="grant-review">
-      <div className="grant-identity"><p className="eyebrow">Collection access</p><h3>{grant.collection_name}</h3><code>{grant.application_distribution === "portable" ? "Downloaded file · encrypted local access" : host(grant.application_origin || grant.application_homepage)}</code><small>Connected {relativeTime(grant.created_at)}</small>{grant.scope.contracts.length > 0 && <small>{scopeDescription(grant.scope.contracts)}</small>}</div>
+      <div className="grant-identity"><p className="eyebrow">{authority}</p><h3>{grant.collection_name}</h3><code>{grant.application_distribution === "portable" ? "Downloaded file · encrypted access" : host(grant.application_origin || grant.application_homepage)}</code><small>Connected {relativeTime(grant.created_at)}</small>{grant.scope.contracts.length > 0 && <small>{scopeDescription(grant.scope.contracts)}</small>}</div>
       <div className="request-decision">
         <section className="request-section">
           <div><strong>Permissions</strong><small>{allowedOperations.length} available actions across {permissionGroups.length} {plural(permissionGroups.length, "category", "categories")}.</small></div>
@@ -648,8 +970,16 @@ function GrantEditor({ grant, busy, onAct, onNotice }: { grant: GrantSummary; bu
         <footer className="request-footer">
           <p>{grant.application_name} can use the selected actions on {grant.collection_name} until you revoke access.</p>
           <div className="decision-actions">
-            <button className="button secondary danger-text" disabled={busy} onClick={() => { if (window.confirm(`Revoke ${grant.application_name} access to ${grant.collection_name}?`)) void onAct(async () => { await window.mdbaseConnect.revokeGrant(grant.id); onNotice(`${grant.application_name} access was revoked.`); }); }}>Revoke</button>
-            <button className="button primary" disabled={busy || !changed || operations.length === 0} onClick={() => void onAct(async () => { await window.mdbaseConnect.updateGrant({ grantId: grant.id, operations }); onNotice(`${grant.application_name} permissions were updated.`); })}>Save changes</button>
+            <button className="button secondary danger-text" disabled={busy} onClick={() => { if (window.confirm(`Revoke ${grant.application_name} access to ${grant.collection_name}?`)) void onAct(async () => {
+              if (grant.collection_kind === "hosted") await window.mdbaseConnect.revokeHostedGrant(grant.id);
+              else await window.mdbaseConnect.revokeGrant(grant.id);
+              onNotice(`${grant.application_name} access was revoked.`);
+            }); }}>Revoke</button>
+            <button className="button primary" disabled={busy || !changed || operations.length === 0} onClick={() => void onAct(async () => {
+              if (grant.collection_kind === "hosted") await window.mdbaseConnect.updateHostedGrant({ grantId: grant.id, operations });
+              else await window.mdbaseConnect.updateGrant({ grantId: grant.id, operations });
+              onNotice(`${grant.application_name} permissions were updated.`);
+            })}>Save changes</button>
           </div>
         </footer>
       </div>
@@ -731,7 +1061,7 @@ function Settings({ startup, cloud, access, status, busy, onAct, onNotice }: {
           </div>
         </div>
       </section>
-      <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Local paths are never synchronized.</strong><p>The portal receives collection names, versions, stable identifiers, and grant metadata. Same-computer apps connect directly when allowed; remote operations remain end-to-end encrypted through the relay.</p></div></section>
+      <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Folder locations are never synchronized.</strong><p>Computer-owned collection content stays on this computer. Hosted Markdown is stored by the encrypted hosted provider and optional mirrors synchronize directly with it; the account portal receives only collection and access metadata.</p></div></section>
     </div>
   );
 }
@@ -899,12 +1229,52 @@ function SettingSwitch({ className, label, description, checked, disabled, state
 function neededProvisions(
   requirements: ApplicationRequirements,
   provisions: ApplicationProvisions | undefined,
-  collection: CollectionSummary
+  collection: Pick<AuthorizationCollection, "contracts">
 ): TypeProvision[] {
   const missing = requirements.contracts.filter((requirement) => !hasContract(collection.contracts, requirement));
   return (provisions?.types ?? []).filter((provision) =>
     provision.provides.some((provided) => missing.some((requirement) => sameContract(provided, requirement)))
   );
+}
+
+const MDBASE_03_OPERATIONS = new Set([
+  "query",
+  "list_views",
+  "execute_view",
+  "read_type",
+  "create_type",
+  "update_type"
+]);
+
+function hostedCollectionCompatible(
+  request: PendingAuthorization,
+  collection: HostedCollectionSummary
+): boolean {
+  if (
+    request.requested_operations.some((operation) => MDBASE_03_OPERATIONS.has(operation))
+    && !/^0\.3(?:\.|$)/.test(collection.spec_version)
+  ) {
+    return false;
+  }
+  return request.requirements.contracts.every((required) =>
+    hasContract(collection.contracts, required)
+    || request.provisions.types.some((provision) =>
+      provision.provides.some((provided) => sameContract(provided, required))
+    )
+  );
+}
+
+function mirrorState(mirror: DesktopMirrorSummary | undefined): {
+  dot: ConnectionDotState;
+  label: string;
+} {
+  if (!mirror) return { dot: "idle", label: "Not mirrored" };
+  if (mirror.syncing) return { dot: "connecting", label: "Synchronizing" };
+  if (mirror.error || mirror.state === "offline") return { dot: "danger", label: "Mirror needs attention" };
+  if (mirror.conflicts.length > 0 || mirror.state === "attention") return { dot: "paused", label: "Conflicts need a decision" };
+  if (mirror.state === "changes_waiting" || mirror.pending > 0) return { dot: "connecting", label: "Changes waiting" };
+  if (mirror.state === "not_initialized") return { dot: "idle", label: "Not synchronized yet" };
+  return { dot: "connected", label: "Up to date" };
 }
 
 function hasContract(contracts: ContractRequirement[], required: ContractRequirement) { return contracts.some((contract) => sameContract(contract, required)); }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -77,6 +77,8 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .overview-row small { color: var(--muted); font-size: var(--type-supporting); }
 
 .collection-section, .activity-section { margin-top: 30px; }
+.collection-authority-group { margin-top: 40px; }
+.collection-authority-group + .collection-authority-group { margin-top: 52px; }
 .collection-list, .grant-list, .activity-list { display: grid; margin-top: 10px; }
 .application-access-list { margin-top: 10px; border-top: 1px solid var(--line); }
 .application-grant-group { border-bottom: 1px solid var(--line); }
@@ -101,6 +103,7 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .collection-title-row { display: flex; align-items: center; gap: 8px; }
 .collection-title-row h3 { margin: 0; overflow: hidden; font-size: var(--type-row-title); font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
 .collection-copy > p { max-width: 62ch; margin: 4px 0 0; color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.authority-label { display: block; margin-top: 5px; color: var(--muted); font-family: var(--mono); font-size: var(--type-action); }
 .version { color: var(--faint); font-family: var(--mono); font-size: var(--type-metadata); }
 .path { display: block; max-width: 100%; margin: 5px 0 0; padding: 0; overflow: hidden; border: 0; color: var(--muted); background: transparent; font-family: var(--mono); font-size: var(--type-action); text-align: left; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
 .path:hover { color: var(--ink); }
@@ -113,6 +116,28 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .collection-editor-section > div:first-child > small { color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
 .collection-fields { display: grid; grid-template-columns: minmax(160px, 0.7fr) minmax(260px, 1.3fr); gap: 14px; }
 .collection-editor label { display: grid; align-content: start; gap: 5px; }
+.hosted-editor .collection-fields { grid-template-columns: minmax(220px, 1fr) auto; align-items: end; }
+.mirror-section { align-items: start; }
+.mirror-control, .mirror-setup { display: grid; gap: 11px; min-width: 0; }
+.mirror-state-row { display: grid !important; grid-template-columns: 7px minmax(0, 1fr) auto; align-items: center; gap: 12px; }
+.mirror-state-row > div { display: grid; gap: 1px; min-width: 0; }
+.mirror-state-row > div > strong { font-size: var(--type-body); }
+.mirror-state-row > code { color: var(--muted); font-size: var(--type-metadata); }
+.mirror-control > small, .mirror-setup > small { color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.mirror-setup { grid-template-columns: minmax(220px, 1fr) minmax(140px, 0.45fr) auto; align-items: end; }
+.mirror-setup > small { grid-column: 1 / -1; }
+.mirror-setup .button { align-self: end; }
+.mirror-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 3px; padding-top: 4px; border-top: 1px solid var(--line); }
+.mirror-conflicts { display: grid; border-top: 1px solid var(--line); }
+.mirror-conflicts > div { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 0; border-bottom: 1px solid var(--line); }
+.mirror-conflicts > div > div:first-child { display: grid; gap: 2px; min-width: 0; }
+.mirror-conflicts strong { overflow: hidden; font-size: var(--type-supporting); text-overflow: ellipsis; white-space: nowrap; }
+.mirror-conflicts small { color: var(--muted); font-size: var(--type-action); }
+.compact-message { margin-top: 0; }
+.replica-list { display: grid; border-top: 1px solid var(--line); }
+.replica-list > div { display: grid; grid-template-columns: minmax(160px, 1fr) auto minmax(130px, auto) auto; align-items: center; gap: 14px; min-height: 42px; border-bottom: 1px solid var(--line); }
+.replica-list span { font-size: var(--type-body); font-weight: 700; }
+.replica-list code, .replica-list small { color: var(--muted); font-size: var(--type-action); }
 .collection-editor textarea { min-height: 58px; padding: 8px 10px; resize: vertical; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font: inherit; font-size: var(--type-body); line-height: 1.45; }
 .collection-config-actions { display: flex; align-items: center; justify-content: flex-start; gap: 8px; }
 .collection-editor-footer { padding: 14px 0; }
@@ -221,6 +246,15 @@ fieldset legend { margin-bottom: 6px; }
 .modal h2 { margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.025em; }
 .modal > p:not(.eyebrow) { margin: 8px 0 20px; color: var(--muted); font-size: var(--type-body); line-height: 1.5; }
 .modal label { display: grid; gap: 6px; margin-top: 14px; }
+.authority-choice { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.authority-choice > legend { grid-column: 1 / -1; }
+.authority-choice > label { display: flex; align-items: flex-start; gap: 9px; min-height: 68px; margin: 0; padding: 10px; border: 1px solid var(--line); border-radius: 3px; cursor: pointer; }
+.authority-choice > label.selected { border-color: var(--line-strong); background: var(--hover); }
+.authority-choice > label.disabled { opacity: 0.55; cursor: not-allowed; }
+.authority-choice input { width: 14px; min-height: 14px; flex: 0 0 auto; margin: 2px 0 0; padding: 0; accent-color: var(--accent); }
+.authority-choice label > span { display: grid; gap: 3px; color: var(--ink); }
+.authority-choice label strong { font-size: var(--type-supporting); }
+.authority-choice label small { color: var(--muted); font-size: var(--type-action); font-weight: 400; line-height: 1.35; }
 .folder-picker { width: 100%; min-height: 36px; padding: 0 10px; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--muted); background: var(--paper); font-family: var(--mono); font-size: var(--type-action); text-align: left; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 22px; padding-top: 15px; border-top: 1px solid var(--line); }
 
@@ -237,6 +271,10 @@ fieldset legend { margin-bottom: 6px; }
   .request-section { gap: 8px; }
   .collection-editor-section { gap: 10px; }
   .collection-fields { grid-template-columns: 1fr; }
+  .hosted-editor .collection-fields, .mirror-setup { grid-template-columns: 1fr; }
+  .mirror-setup > small { grid-column: 1; }
+  .replica-list > div { grid-template-columns: 1fr auto auto; }
+  .replica-list small { grid-column: 1 / -1; }
   .request-footer { align-items: flex-start; flex-direction: column; }
   .readiness-panel, .pairing-panel { grid-template-columns: 1fr; gap: 24px; }
   .application-grant-group > summary { grid-template-columns: minmax(0, 1fr) auto; gap: 8px 16px; padding: 10px 0; }

--- a/apps/desktop/test/mirror-manager.test.mjs
+++ b/apps/desktop/test/mirror-manager.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { pathsOverlap } from "../dist/main/mirror-manager.js";
+
+test("hosted mirrors reject the same folder and nested folders", () => {
+  assert.equal(pathsOverlap("/vault/hosted", "/vault/hosted"), true);
+  assert.equal(pathsOverlap("/vault/hosted", "/vault/hosted/nested"), true);
+  assert.equal(pathsOverlap("/vault/hosted/nested", "/vault/hosted"), true);
+});
+
+test("hosted mirrors allow sibling folders with similar names", () => {
+  assert.equal(pathsOverlap("/vault/hosted", "/vault/hosted-copy"), false);
+  assert.equal(pathsOverlap("/vault/one", "/vault/two"), false);
+});

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -477,7 +477,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
       </span>
       <span className="replica-count">{activeReplicas.length} {activeReplicas.length === 1 ? "mirror" : "mirrors"}</span>
       <div className="computer-actions">
-        {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Sync folder</button>}
+        {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Mirror</button>}
         {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button>}
         <button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button>
       </div>
@@ -512,16 +512,11 @@ function mirrorStatus(replica: HostedCollection["replicas"][number]): string {
 }
 
 function MirrorSetup({ collectionId }: { collectionId: string }) {
-  const command = `mdbase-mirror connect ./collection --server ${location.origin} --collection ${collectionId}`;
-  const [copied, setCopied] = useState(false);
-  async function copy(value: string) {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-  }
+  const desktopUrl = `mdbase-connect://mirror?collection=${encodeURIComponent(collectionId)}`;
   return <div className="mirror-setup" aria-live="polite">
-    <p><strong>Run this on the computer that owns the folder.</strong> Your browser will ask you to approve this collection. No credential is displayed or saved inside the folder.</p>
-    <div className="copy-row"><code>{command}</code><button className="quiet-action" type="button" onClick={() => void copy(command)}>{copied ? "Copied" : "Copy command"}</button></div>
-    <p>Existing Markdown is reviewed against the hosted collection before upload. Path collisions stop for an explicit decision.</p>
+    <p><strong>Choose the folder in mdbase connect.</strong> The desktop app controls synchronization and keeps mirror credentials in private application storage.</p>
+    <div className="mirror-setup-actions"><a className="button primary" href={desktopUrl}>Open mdbase connect</a></div>
+    <p>Existing Markdown is reviewed before upload. Path collisions stop for an explicit decision, and the hosted collection remains authoritative.</p>
   </div>;
 }
 

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -273,6 +273,11 @@ h1 {
   color: var(--ink-soft);
 }
 
+.mirror-setup-actions {
+  display: flex;
+  align-items: center;
+}
+
 .copy-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -49,7 +49,10 @@ reference path through a real HTTP server:
   an offline client for optimistic create, update, rename, and delete;
 - contract discovery from each hosted sync session, a generic offline replica,
   and receive-only or writable Markdown directory mirrors with atomic writes,
-  durable journals, and explicit conflict resolution.
+  durable journals, and explicit conflict resolution;
+- hosted collection and mirror controls in the Electron app, including folder
+  selection, background sync state, conflict decisions, and revocation without
+  a command-line onboarding step.
 
 The network end-to-end test creates a hosted collection, queues a record
 offline, synchronizes two clients, materializes Markdown, returns a stale-write
@@ -537,7 +540,7 @@ Markdown records and type definitions.
 - materialize a full hosted collection as Markdown;
 - preserve identity, paths, resources, and cursor state locally;
 - detect local divergence and pause before replacement;
-- approve enrollment in the account portal without copying a credential;
+- approve enrollment from the Electron controller without copying a credential;
 - verify complete rebuild after replica metadata loss.
 
 ### 5. Writable Connect mirror

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@fontsource/azeret-mono':
         specifier: ^5.3.0
         version: 5.3.0
-      '@mdbase/connect-sync':
-        specifier: workspace:*
-        version: link:../../packages/sync
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -61,6 +58,9 @@ importers:
       '@electron-forge/maker-zip':
         specifier: ^7.11.2
         version: 7.11.2(supports-color@8.1.1)
+      '@mdbase/connect-sync':
+        specifier: workspace:*
+        version: link:../../packages/sync
       '@mdbase/connect-ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -79,6 +79,9 @@ importers:
       electron:
         specifier: ^43.1.1
         version: 43.1.1(supports-color@8.1.1)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       lodash:
         specifier: ^4.18.1
         version: 4.18.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@fontsource/azeret-mono':
         specifier: ^5.3.0
         version: 5.3.0
+      '@mdbase/connect-sync':
+        specifier: workspace:*
+        version: link:../../packages/sync
       react:
         specifier: ^19.2.7
         version: 19.2.7

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -38,6 +38,8 @@ const promotionMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-promot
 const promotionToolRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-promotion-tool-"));
 const mirrorStateRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-mirror-state-"));
 const portableRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-portable-"));
+const desktopMirrorRoot = await mkdtemp(join(tmpdir(), "mdbase-provider-desktop-mirror-"));
+const desktopMirrorData = await mkdtemp(join(tmpdir(), "mdbase-provider-desktop-data-"));
 process.env.MDBASE_CONNECT_MIRROR_STATE_DIR = mirrorStateRoot;
 const children = new Set();
 let postgresStarted = false;
@@ -63,6 +65,7 @@ const { MdbaseConnect, MemoryGrantKeyStore } = await import("../packages/client/
 const { buildApp } = await import("../services/server/dist/app.js");
 const { createDatabase } = await import("../services/server/dist/db.js");
 const { HostedProviderClient } = await import("../services/server/dist/hosted-provider.js");
+const { MirrorManager } = await import("../apps/desktop/dist/main/mirror-manager.js");
 
 try {
   phase("starting disposable PostgreSQL 18");
@@ -543,6 +546,50 @@ try {
     ).status,
     421
   );
+
+  phase("controlling a writable mirror through the Electron mirror engine");
+  const connector = await controlRequest(controlUrl, "/v1/connectors", cookie, {
+    method: "POST",
+    body: { name: "Desktop mirror controller" }
+  });
+  const desktopMirrors = new MirrorManager(desktopMirrorData);
+  const desktopMirror = await desktopMirrors.connect({
+    collectionId,
+    path: desktopMirrorRoot,
+    mode: "read_write",
+    name: "Desktop-managed mirror",
+    cloud: {
+      serverUrl: controlUrl,
+      connectorToken: connector.token
+    }
+  });
+  assert.equal(desktopMirror.collection_id, collectionId);
+  assert.equal(desktopMirror.mode, "read_write");
+  assert.equal(desktopMirror.state, "up_to_date");
+  assert.match(await readFile(join(desktopMirrorRoot, "mdbase.yaml"), "utf8"), /spec_version: 0\.3\.0/);
+  assert.equal((await stat(join(desktopMirrorData, "mirrors.json"))).mode & 0o777, 0o600);
+  await mkdir(join(desktopMirrorRoot, "tasks"), { recursive: true });
+  await writeFile(
+    join(desktopMirrorRoot, "tasks", "desktop-managed.md"),
+    "---\ntype: task\ntitle: Desktop managed\nstatus: open\n---\n"
+  );
+  await desktopMirrors.syncNow(desktopMirror.replica_id);
+  const desktopRecord = (
+    await snapshotAll(
+      transport(provider.url, collectionId, writer),
+      await transport(provider.url, collectionId, writer).openSession()
+    )
+  ).find((record) => record.path === "tasks/desktop-managed.md");
+  assert.equal(desktopRecord?.frontmatter.title, "Desktop managed");
+  const desktopRevoked = await rawRequest(
+    controlUrl,
+    `/v1/connectors/hosted/replicas/${desktopMirror.replica_id}`,
+    { method: "DELETE", token: connector.token }
+  );
+  assert.equal(desktopRevoked.status, 200);
+  await desktopMirrors.remove(desktopMirror.replica_id);
+  assert.deepEqual(await desktopMirrors.list(), []);
+  desktopMirrors.stop();
 
   phase("exercising hosted lifecycle and writable enrollment in a real browser");
   await portalLifecycleE2E(controlUrl, browserMirrorRoot);
@@ -1664,6 +1711,8 @@ schema:
   await rm(promotionToolRoot, { recursive: true, force: true });
   await rm(mirrorStateRoot, { recursive: true, force: true });
   await rm(portableRoot, { recursive: true, force: true });
+  await rm(desktopMirrorRoot, { recursive: true, force: true });
+  await rm(desktopMirrorData, { recursive: true, force: true });
 }
 
 function phase(message) {
@@ -1890,10 +1939,11 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     const collectionId = dashboard.hosted_collections.find(
       (collection) => collection.display_name === "Browser E2E collection"
     ).id;
-    await row.getByRole("button", { name: "Sync folder" }).click();
-    await expect(row.locator("code").filter({ hasText: "mdbase-mirror connect" }))
-      .toContainText(`--collection ${collectionId}`);
-    await expect(row).toContainText("No credential is displayed or saved inside the folder");
+    await row.getByRole("button", { name: "Mirror" }).click();
+    await expect(row.getByRole("link", { name: "Open mdbase connect" }))
+      .toHaveAttribute("href", `mdbase-connect://mirror?collection=${collectionId}`);
+    await expect(row).toContainText("Choose the folder in mdbase connect");
+    await expect(row).not.toContainText("mdbase-mirror connect");
 
     const mirrorCli = join(repoRoot, "packages", "sync", "dist", "cli.js");
     connector = spawn(process.execPath, [

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1187,6 +1187,170 @@ describe("mdbase connect server", () => {
     });
   });
 
+  it("lets a paired desktop manage only its owner's hosted collections and mirrors", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const hostedProvider = {
+      url: "https://sync.example",
+      ready: vi.fn(),
+      createCollection: vi.fn(),
+      renameCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      provisionTypes: vi.fn(),
+      registerReplica: vi.fn(),
+      updateApplicationReplica: vi.fn(),
+      revokeReplica: vi.fn(),
+      replicaStatuses: vi.fn().mockResolvedValue([]),
+      upsertNotificationGrant: vi.fn(),
+      revokeNotificationGrant: vi.fn(),
+      rotateReplicaToken: vi.fn(),
+      compactThrough: vi.fn()
+    } as unknown as HostedProviderClient;
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedProvider,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+
+    const ownerSession = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Desktop owner", email: "desktop-owner@example.com" }
+    });
+    const ownerCookieHeader = ownerSession.headers["set-cookie"]!;
+    const ownerCookie = (Array.isArray(ownerCookieHeader) ? ownerCookieHeader[0] : ownerCookieHeader)
+      .split(";")[0];
+    const ownerConnector = await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie: ownerCookie },
+      payload: { name: "Owner desktop" }
+    });
+    const ownerToken = ownerConnector.json().token as string;
+
+    const created = await app.inject({
+      method: "POST",
+      url: "/v1/connectors/hosted/collections",
+      headers: { authorization: `Bearer ${ownerToken}` },
+      payload: { display_name: "Desktop notes", template: "mdbase" }
+    });
+    expect(created.statusCode, JSON.stringify(created.json())).toBe(201);
+    const collectionId = created.json().collection.id as string;
+    expect(hostedProvider.createCollection).toHaveBeenCalledWith(
+      collectionId,
+      "mdbase",
+      "Desktop notes"
+    );
+
+    const snapshot = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/hosted-control",
+      headers: { authorization: `Bearer ${ownerToken}` }
+    });
+    expect(snapshot.statusCode, JSON.stringify(snapshot.json())).toBe(200);
+    expect(snapshot.json().hosted_collections).toEqual([
+      expect.objectContaining({
+        id: collectionId,
+        display_name: "Desktop notes",
+        authority_state: "active",
+        replicas: []
+      })
+    ]);
+
+    const renamed = await app.inject({
+      method: "PATCH",
+      url: `/v1/connectors/hosted/collections/${collectionId}`,
+      headers: { authorization: `Bearer ${ownerToken}` },
+      payload: { display_name: "Desktop journal" }
+    });
+    expect(renamed.statusCode).toBe(200);
+    expect(hostedProvider.renameCollection).toHaveBeenCalledWith(
+      collectionId,
+      "Desktop journal"
+    );
+
+    const otherSession = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Other owner", email: "desktop-other@example.com" }
+    });
+    const otherCookieHeader = otherSession.headers["set-cookie"]!;
+    const otherCookie = (Array.isArray(otherCookieHeader) ? otherCookieHeader[0] : otherCookieHeader)
+      .split(";")[0];
+    const otherConnector = await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie: otherCookie },
+      payload: { name: "Other desktop" }
+    });
+    const forbiddenRename = await app.inject({
+      method: "PATCH",
+      url: `/v1/connectors/hosted/collections/${collectionId}`,
+      headers: { authorization: `Bearer ${otherConnector.json().token}` },
+      payload: { display_name: "Stolen" }
+    });
+    expect(forbiddenRename.statusCode).toBe(404);
+
+    const pairing = await app.inject({
+      method: "POST",
+      url: "/v1/mirror-pairing-requests",
+      payload: {
+        mirror_name: "Owner desktop mirror",
+        mode: "read_write",
+        collection_id: collectionId
+      }
+    });
+    const approved = await app.inject({
+      method: "POST",
+      url: `/v1/connectors/mirror-pairing-requests/${pairing.json().pairing_id}/approve`,
+      headers: { authorization: `Bearer ${ownerToken}` },
+      payload: { collection_id: collectionId }
+    });
+    expect(approved.statusCode).toBe(200);
+    const exchanged = await app.inject({
+      method: "POST",
+      url: `/v1/mirror-pairing-requests/${pairing.json().pairing_id}/exchange`,
+      headers: { authorization: `Bearer ${pairing.json().pairing_secret}` }
+    });
+    expect(exchanged.statusCode, JSON.stringify(exchanged.json())).toBe(200);
+    expect(exchanged.json()).toMatchObject({
+      status: "paired",
+      sync_url: "https://sync.example",
+      replica: {
+        collection_id: collectionId,
+        name: "Owner desktop mirror",
+        mode: "read_write"
+      }
+    });
+    expect(hostedProvider.registerReplica).toHaveBeenCalledWith(
+      collectionId,
+      expect.objectContaining({
+        id: exchanged.json().replica.id,
+        name: "Owner desktop mirror",
+        mode: "read_write"
+      })
+    );
+
+    const revoked = await app.inject({
+      method: "DELETE",
+      url: `/v1/connectors/hosted/replicas/${exchanged.json().replica.id}`,
+      headers: { authorization: `Bearer ${ownerToken}` }
+    });
+    expect(revoked.statusCode).toBe(200);
+    expect(hostedProvider.revokeReplica).toHaveBeenCalledWith(exchanged.json().replica.id);
+
+    const removed = await app.inject({
+      method: "DELETE",
+      url: `/v1/connectors/hosted/collections/${collectionId}`,
+      headers: { authorization: `Bearer ${ownerToken}` }
+    });
+    expect(removed.statusCode).toBe(200);
+    expect(hostedProvider.deleteCollection).toHaveBeenCalledWith(collectionId);
+  });
+
   it("provisions and reconciles contract-free hosted application access as unrestricted", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());
@@ -1290,6 +1454,14 @@ describe("mdbase connect server", () => {
       headers: { authorization: `Bearer ${connector.token}` }
     });
     expect(connectorControl.json().pending_authorizations).toEqual([]);
+    const hostedControl = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/hosted-control",
+      headers: { authorization: `Bearer ${connector.token}` }
+    });
+    expect(hostedControl.json().pending_authorizations).toEqual([
+      expect.objectContaining({ id: requestId, application_name: "Writing Editor" })
+    ]);
     const localApproval = await app.inject({
       method: "POST",
       url: `/v1/authorization-requests/${requestId}/approve`,
@@ -1302,8 +1474,8 @@ describe("mdbase connect server", () => {
     expect(localApproval.statusCode).toBe(404);
     const approved = await app.inject({
       method: "POST",
-      url: `/v1/authorization-requests/${requestId}/approve`,
-      headers: { cookie },
+      url: `/v1/connectors/hosted/authorization-requests/${requestId}/approve`,
+      headers: { authorization: `Bearer ${connector.token}` },
       payload: {
         collection_id: collectionId,
         operations: ["describe", "query", "create", "update"]
@@ -1344,6 +1516,39 @@ describe("mdbase connect server", () => {
       [provisioned.rows[0].id]
     );
     expect(reconciled.rows[0].allowed_types).toEqual([]);
+
+    const activeControl = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/hosted-control",
+      headers: { authorization: `Bearer ${connector.token}` }
+    });
+    const grantId = activeControl.json().grants[0].id as string;
+    const narrowed = await app.inject({
+      method: "PATCH",
+      url: `/v1/connectors/hosted/grants/${grantId}`,
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: { operations: ["describe", "query"] }
+    });
+    expect(narrowed.statusCode, JSON.stringify(narrowed.json())).toBe(200);
+    expect(narrowed.json().grant.operations).toEqual(["describe", "query"]);
+    expect(hostedProvider.updateApplicationReplica).toHaveBeenLastCalledWith(
+      provisioned.rows[0].id,
+      expect.objectContaining({ mode: "read_only", allowedOperations: ["describe", "query"] })
+    );
+    const broadened = await app.inject({
+      method: "PATCH",
+      url: `/v1/connectors/hosted/grants/${grantId}`,
+      headers: { authorization: `Bearer ${connector.token}` },
+      payload: { operations: ["describe", "query", "create"] }
+    });
+    expect(broadened.statusCode).toBe(400);
+    const revoked = await app.inject({
+      method: "DELETE",
+      url: `/v1/connectors/hosted/grants/${grantId}`,
+      headers: { authorization: `Bearer ${connector.token}` }
+    });
+    expect(revoked.statusCode).toBe(200);
+    expect(hostedProvider.revokeReplica).toHaveBeenCalledWith(provisioned.rows[0].id);
   });
 
   it("provisions required types before creating a full-collection grant", async () => {

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -2190,6 +2190,204 @@ export async function buildApp(options: BuildOptions) {
     return { ok: true };
   });
 
+  app.get("/v1/connectors/hosted-control", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    return hostedControlSnapshot(options, hostedReference, publicUrl, connector.user_id);
+  });
+
+  app.post("/v1/connectors/hosted/collections", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const input = z.object({
+      display_name: z.string().trim().min(1).max(200),
+      template: z.literal("mdbase").default("mdbase")
+    }).strict().parse(request.body);
+    const collection = await createHostedCollectionForUser(
+      options,
+      hostedReference,
+      publicUrl,
+      connector.user_id,
+      input.display_name,
+      input.template
+    );
+    return reply.code(201).send({ collection });
+  });
+
+  app.patch("/v1/connectors/hosted/collections/:collectionId", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
+    const input = z.object({
+      display_name: z.string().trim().min(1).max(200)
+    }).strict().parse(request.body);
+    const collection = await renameHostedCollectionForUser(
+      options,
+      connector.user_id,
+      collectionId,
+      input.display_name
+    );
+    if (!collection) {
+      return reply.code(404).send(apiError(
+        "hosted_collection_not_found",
+        "Hosted collection not found."
+      ));
+    }
+    return { collection };
+  });
+
+  app.delete("/v1/connectors/hosted/collections/:collectionId", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
+    if (!await deleteHostedCollectionForUser(
+      options,
+      hostedReference,
+      connector.user_id,
+      collectionId
+    )) {
+      return reply.code(404).send(apiError(
+        "hosted_collection_not_found",
+        "Hosted collection not found."
+      ));
+    }
+    return { ok: true };
+  });
+
+  app.post(
+    "/v1/connectors/mirror-pairing-requests/:pairingId/approve",
+    async (request, reply) => {
+      const connector = await requireConnector(request, reply, options.db);
+      if (!connector) return;
+      const { pairingId } = z.object({ pairingId: z.uuid() }).parse(request.params);
+      const input = z.object({ collection_id: z.uuid() }).strict().parse(request.body);
+      const approved = await options.db.query<{
+        id: string;
+        mode: "read_only" | "read_write";
+      }>(
+        `UPDATE mirror_pairing_requests
+         SET user_id = $2, collection_id = $3, approved_at = now()
+         WHERE id = $1 AND approved_at IS NULL AND consumed_at IS NULL
+           AND expires_at > now()
+           AND EXISTS (
+             SELECT 1 FROM hosted_collections
+             WHERE id = $3 AND user_id = $2 AND authority_state = 'active'
+           )
+         RETURNING id, mode`,
+        [pairingId, connector.user_id, input.collection_id]
+      );
+      if (!approved.rows[0]) {
+        return reply.code(404).send(apiError(
+          "mirror_pairing_not_found",
+          "Mirror setup expired, was already used, or the collection was not found."
+        ));
+      }
+      await audit(options.db, connector.user_id, "hosted_replica.pairing_approved", pairingId, {
+        collection_id: input.collection_id,
+        connector_id: connector.id,
+        mode: approved.rows[0].mode,
+        source: "desktop"
+      });
+      return { ok: true };
+    }
+  );
+
+  app.delete("/v1/connectors/hosted/replicas/:replicaId", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { replicaId } = z.object({ replicaId: z.uuid() }).parse(request.params);
+    if (!await revokeHostedReplicaForUser(
+      options,
+      hostedReference,
+      connector.user_id,
+      replicaId
+    )) {
+      return reply.code(404).send(apiError("replica_not_found", "Active mirror not found."));
+    }
+    return { ok: true };
+  });
+
+  app.post(
+    "/v1/connectors/hosted/authorization-requests/:requestId/approve",
+    async (request, reply) => {
+      const connector = await requireConnector(request, reply, options.db);
+      if (!connector) return;
+      const { requestId } = z.object({ requestId: z.uuid() }).parse(request.params);
+      const input = z.object({
+        collection_id: z.uuid(),
+        operations: z.array(operationSchema).min(1)
+      }).strict().parse(request.body);
+      if (!options.hostedProvider) {
+        return reply.code(503).send(apiError(
+          "hosted_provider_unavailable",
+          "Hosted application access is temporarily unavailable."
+        ));
+      }
+      const hosted = await options.db.query<{
+        id: string;
+        template: HostedTemplate;
+        display_name: string;
+        contracts: CollectionContractDescriptor[];
+      }>(
+        `SELECT id, template, display_name, contracts FROM hosted_collections
+         WHERE id = $1 AND user_id = $2 AND authority_state = 'active'`,
+        [input.collection_id, connector.user_id]
+      );
+      const collection = hosted.rows[0];
+      if (!collection) {
+        return reply.code(404).send(apiError(
+          "hosted_collection_not_found",
+          "Hosted collection not found."
+        ));
+      }
+      const approved = await approveHostedAuthorization(options.db, options.hostedProvider, {
+        requestId,
+        userId: connector.user_id,
+        collectionId: collection.id,
+        operations: input.operations,
+        template: collection.template,
+        displayName: collection.display_name,
+        contracts: collection.contracts
+      });
+      if (!approved) {
+        return reply.code(404).send(apiError(
+          "authorization_not_found",
+          "Authorization request expired or was not found."
+        ));
+      }
+      return { ok: true };
+    }
+  );
+
+  app.patch("/v1/connectors/hosted/grants/:grantId", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { grantId } = z.object({ grantId: z.uuid() }).parse(request.params);
+    const input = z.object({
+      operations: z.array(operationSchema).min(1)
+    }).strict().parse(request.body);
+    const grant = await narrowHostedGrantForUser(
+      options,
+      connector.user_id,
+      grantId,
+      input.operations
+    );
+    if (!grant) {
+      return reply.code(404).send(apiError("grant_not_found", "Active hosted grant not found."));
+    }
+    return { grant };
+  });
+
+  app.delete("/v1/connectors/hosted/grants/:grantId", async (request, reply) => {
+    const connector = await requireConnector(request, reply, options.db);
+    if (!connector) return;
+    const { grantId } = z.object({ grantId: z.uuid() }).parse(request.params);
+    if (!await revokeHostedGrantForUser(options, connector.user_id, grantId)) {
+      return reply.code(404).send(apiError("grant_not_found", "Active hosted grant not found."));
+    }
+    return { ok: true };
+  });
+
   app.post("/v1/hosted/collections", async (request, reply) => {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
@@ -5353,6 +5551,390 @@ function authorityTransferResponse(
       Math.floor((new Date(transfer.expires_at).getTime() - Date.now()) / 1_000)
     )
   };
+}
+
+async function hostedControlSnapshot(
+  options: BuildOptions,
+  hostedReference: HostedAuthorityRegistry | undefined,
+  publicUrl: string,
+  userId: string
+): Promise<Record<string, unknown>> {
+  if (!options.hostedCollections) {
+    return {
+      online: true,
+      hosted_collections: [],
+      grants: [],
+      pending_authorizations: []
+    };
+  }
+  await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+  const collections = await options.db.query<{
+    id: string;
+    display_name: string;
+    template: HostedTemplate;
+    contracts: CollectionContractDescriptor[];
+    provider_url: string | null;
+    authority_state: "active" | "transferring" | "transferred";
+    authority_epoch: string | number;
+    transferred_collection_id: string | null;
+    created_at: string;
+  }>(
+    `SELECT id, display_name, template, provider_url, contracts, authority_state,
+            authority_epoch, transferred_collection_id, created_at
+     FROM hosted_collections WHERE user_id = $1 ORDER BY display_name`,
+    [userId]
+  );
+  const replicas = collections.rows.length
+    ? await options.db.query<{
+        id: string;
+        collection_id: string;
+        name: string;
+        mode: "read_only" | "read_write";
+        allowed_types: string[];
+        revoked_at: string | null;
+        created_at: string;
+      }>(
+        `SELECT replica.id, replica.collection_id, replica.name, replica.mode,
+                replica.allowed_types, replica.revoked_at, replica.created_at
+         FROM hosted_replicas replica
+         JOIN hosted_collections collection ON collection.id = replica.collection_id
+         WHERE collection.user_id = $1 AND replica.purpose = 'mirror'
+         ORDER BY replica.created_at`,
+        [userId]
+      )
+    : { rows: [] };
+  const statuses = new Map<string, {
+    head: number;
+    acknowledged_sequence: number;
+    last_seen_at: string | null;
+    token_expires_at: string;
+  }>();
+  if (options.hostedProvider) {
+    const groups = await Promise.all(collections.rows.map(async (collection) => {
+      try {
+        return await options.hostedProvider!.replicaStatuses(collection.id);
+      } catch {
+        return [];
+      }
+    }));
+    for (const status of groups.flat()) statuses.set(status.id, status);
+  }
+  const grants = await options.db.query(
+    `SELECT g.id, g.application_id, a.family_identity AS application_family_id,
+            a.name AS application_name,
+            a.distribution AS application_distribution,
+            a.homepage AS application_homepage,
+            a.project_url AS application_project_url,
+            CASE WHEN g.application_origin = '' THEN a.homepage
+                 ELSE g.application_origin END AS application_origin,
+            a.icon AS application_icon,
+            h.id AS collection_id, h.display_name AS collection_name,
+            'hosted' AS collection_kind,
+            g.operations, g.scope, g.notification_criteria, g.created_at
+     FROM grants g
+     JOIN applications a ON a.id = g.application_id
+     JOIN hosted_collections h ON h.id = g.hosted_collection_id
+     WHERE g.user_id = $1 AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL
+     ORDER BY a.name, h.display_name`,
+    [userId]
+  );
+  const pending = await options.db.query(
+    `SELECT ar.id, ar.application_id,
+            a.name AS application_name,
+            a.distribution AS application_distribution,
+            a.homepage AS application_homepage,
+            a.project_url AS application_project_url,
+            a.icon AS application_icon,
+            ar.flow, ar.user_code, ar.requested_operations,
+            ar.collection_hint, ar.expires_at,
+            a.requirements, a.provisions, a.notifications
+     FROM authorization_requests ar
+     JOIN applications a ON a.id = ar.application_id
+     WHERE ar.user_id = $1 AND ar.completed_at IS NULL
+       AND ar.denied_at IS NULL AND ar.expires_at > now()
+     ORDER BY ar.expires_at`,
+    [userId]
+  );
+  return {
+    online: true,
+    hosted_collections: collections.rows.map((collection) => ({
+      ...collection,
+      provider_url: collection.provider_url ?? publicUrl,
+      spec_version: "0.3.0",
+      authority_epoch: Number(collection.authority_epoch),
+      contracts: contractRequirements(
+        effectiveHostedContractDescriptors(collection.contracts, collection.template)
+      ),
+      replicas: replicas.rows
+        .filter((replica) => replica.collection_id === collection.id)
+        .map((replica) => ({
+          ...replica,
+          sync_status: statuses.get(replica.id) ?? null
+        }))
+    })),
+    grants: grants.rows.map((grant) => ({
+      ...grant,
+      application_origin: normalizedApplicationOrigin(grant.application_origin)
+    })),
+    pending_authorizations: pending.rows.map((authorization) => ({
+      ...authorization,
+      compatible_collection_ids: [],
+      provisionable_collection_ids: []
+    }))
+  };
+}
+
+async function createHostedCollectionForUser(
+  options: BuildOptions,
+  hostedReference: HostedAuthorityRegistry | undefined,
+  publicUrl: string,
+  userId: string,
+  displayName: string,
+  template: HostedTemplate
+): Promise<Record<string, unknown>> {
+  if (!options.hostedCollections) {
+    throw new RequestValidationError("Hosted collections are not enabled.");
+  }
+  const collectionId = randomUUID();
+  try {
+    if (options.hostedProvider) {
+      await options.hostedProvider.createCollection(collectionId, template, displayName);
+    } else {
+      await hostedReference!.create(collectionId, template);
+    }
+    await options.db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, provider_url, contracts)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+      [
+        collectionId,
+        userId,
+        displayName,
+        template,
+        options.hostedProvider?.url ?? null,
+        JSON.stringify(hostedContractDescriptors(template))
+      ]
+    );
+  } catch (error) {
+    if (options.hostedProvider) {
+      await options.hostedProvider.deleteCollection(collectionId).catch(() => undefined);
+    } else {
+      await hostedReference?.delete(collectionId).catch(() => undefined);
+    }
+    throw error;
+  }
+  await audit(options.db, userId, "hosted_collection.created", collectionId, {
+    template,
+    source: "desktop"
+  });
+  return {
+    id: collectionId,
+    display_name: displayName,
+    template,
+    provider_url: options.hostedProvider?.url ?? publicUrl,
+    spec_version: "0.3.0",
+    contracts: contractRequirements(hostedContractDescriptors(template)),
+    authority_state: "active",
+    authority_epoch: 1,
+    transferred_collection_id: null,
+    created_at: new Date().toISOString(),
+    replicas: []
+  };
+}
+
+async function renameHostedCollectionForUser(
+  options: BuildOptions,
+  userId: string,
+  collectionId: string,
+  displayName: string
+): Promise<{ id: string; display_name: string } | null> {
+  if (!await ownsHostedCollection(options.db, userId, collectionId)) return null;
+  if (options.hostedProvider) {
+    await options.hostedProvider.renameCollection(collectionId, displayName);
+  }
+  const renamed = await options.db.query<{ id: string; display_name: string }>(
+    `UPDATE hosted_collections SET display_name = $3
+     WHERE id = $1 AND user_id = $2 RETURNING id, display_name`,
+    [collectionId, userId, displayName]
+  );
+  await audit(options.db, userId, "hosted_collection.renamed", collectionId, {
+    display_name: displayName,
+    source: "desktop"
+  });
+  return renamed.rows[0] ?? null;
+}
+
+async function deleteHostedCollectionForUser(
+  options: BuildOptions,
+  hostedReference: HostedAuthorityRegistry | undefined,
+  userId: string,
+  collectionId: string
+): Promise<boolean> {
+  if (!await ownsHostedCollection(options.db, userId, collectionId)) return false;
+  if (options.hostedProvider) await options.hostedProvider.deleteCollection(collectionId);
+  else await hostedReference!.delete(collectionId);
+  const connection = await options.db.connect();
+  try {
+    await connection.query("BEGIN");
+    await connection.query(
+      "DELETE FROM grants WHERE hosted_collection_id = $1 AND user_id = $2",
+      [collectionId, userId]
+    );
+    await connection.query(
+      "DELETE FROM hosted_collections WHERE id = $1 AND user_id = $2",
+      [collectionId, userId]
+    );
+    await audit(connection, userId, "hosted_collection.deleted", collectionId, {
+      source: "desktop"
+    });
+    await connection.query("COMMIT");
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+  return true;
+}
+
+async function revokeHostedReplicaForUser(
+  options: BuildOptions,
+  hostedReference: HostedAuthorityRegistry | undefined,
+  userId: string,
+  replicaId: string
+): Promise<boolean> {
+  const found = await options.db.query<{
+    collection_id: string;
+    revoked_at: string | null;
+  }>(
+    `SELECT replica.collection_id, replica.revoked_at FROM hosted_replicas replica
+     JOIN hosted_collections collection ON collection.id = replica.collection_id
+     WHERE replica.id = $1 AND replica.purpose = 'mirror'
+       AND collection.user_id = $2`,
+    [replicaId, userId]
+  );
+  const replica = found.rows[0];
+  if (!replica) return false;
+  if (replica.revoked_at) return true;
+  if (options.hostedProvider) await options.hostedProvider.revokeReplica(replicaId);
+  else await hostedReference!.revokeReplica(replica.collection_id, replicaId);
+  await options.db.query(
+    "UPDATE hosted_replicas SET revoked_at = now(), token_hash = NULL WHERE id = $1",
+    [replicaId]
+  );
+  await options.db.query("DELETE FROM mirror_pairing_requests WHERE replica_id = $1", [replicaId]);
+  await audit(options.db, userId, "hosted_replica.revoked", replicaId, {
+    source: "desktop"
+  });
+  return true;
+}
+
+async function narrowHostedGrantForUser(
+  options: BuildOptions,
+  userId: string,
+  grantId: string,
+  requestedOperations: string[]
+): Promise<{ id: string; operations: string[] } | null> {
+  const active = await options.db.query<{
+    id: string;
+    hosted_replica_id: string;
+    operations: string[];
+    scope: GrantScope;
+    requirements: ApplicationRequirements;
+    template: HostedTemplate;
+    hosted_contracts: CollectionContractDescriptor[];
+  }>(
+    `SELECT g.id, g.hosted_replica_id, g.operations, g.scope,
+            a.requirements, h.template,
+            h.contracts AS hosted_contracts
+     FROM grants g
+     JOIN applications a ON a.id = g.application_id
+     JOIN hosted_collections h ON h.id = g.hosted_collection_id
+     WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL`,
+    [grantId, userId]
+  );
+  const current = active.rows[0];
+  if (!current) return null;
+  const operations = [...new Set(requestedOperations)];
+  if (operations.some((operation) => !current.operations.includes(operation))) {
+    throw new RequestValidationError(
+      "Existing access can be narrowed here, but broader access requires a new application request."
+    );
+  }
+  assertOperationsAllowedByRequirements(operations, current.requirements);
+  if (!options.hostedProvider) {
+    throw new RequestValidationError("Hosted application access is temporarily unavailable.");
+  }
+  const write = operations.some((operation) => [
+    "create",
+    "update",
+    "delete",
+    "rename",
+    "create_type",
+    "update_type",
+    "create_view_source",
+    "update_view_source",
+    "delete_view_source",
+    "put_timer",
+    "cancel_timer",
+    "reconcile_timers"
+  ].includes(operation));
+  await options.hostedProvider.updateApplicationReplica(current.hosted_replica_id, {
+    grantId,
+    mode: write ? "read_write" : "read_only",
+    allowedTypes: typesForContracts(
+      effectiveHostedContractDescriptors(current.hosted_contracts, current.template),
+      current.scope.contracts
+    ),
+    fullCollection: current.scope.access === "full_collection",
+    allowedOperations: operations
+  });
+  const updated = await options.db.query<{ id: string; operations: string[] }>(
+    "UPDATE grants SET operations = $2::jsonb WHERE id = $1 RETURNING id, operations",
+    [grantId, JSON.stringify(operations)]
+  );
+  await audit(options.db, userId, "grant.narrowed", grantId, {
+    previous_operations: current.operations,
+    operations,
+    source: "desktop"
+  });
+  return updated.rows[0] ?? null;
+}
+
+async function revokeHostedGrantForUser(
+  options: BuildOptions,
+  userId: string,
+  grantId: string
+): Promise<boolean> {
+  const active = await options.db.query<{
+    hosted_collection_id: string;
+    hosted_replica_id: string;
+  }>(
+    `SELECT g.hosted_collection_id, g.hosted_replica_id
+     FROM grants g
+     JOIN hosted_collections h ON h.id = g.hosted_collection_id
+     WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL
+       AND g.activated_at IS NOT NULL`,
+    [grantId, userId]
+  );
+  const current = active.rows[0];
+  if (!current) return false;
+  if (!options.hostedProvider) {
+    throw new RequestValidationError("Hosted application access is temporarily unavailable.");
+  }
+  await options.hostedProvider.revokeReplica(current.hosted_replica_id);
+  await options.hostedProvider.revokeNotificationGrant(current.hosted_collection_id, grantId);
+  await options.db.query(
+    "UPDATE hosted_replicas SET revoked_at = now() WHERE id = $1",
+    [current.hosted_replica_id]
+  );
+  await options.db.query("UPDATE grants SET revoked_at = now() WHERE id = $1", [grantId]);
+  await options.db.query("UPDATE access_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
+  await options.db.query("UPDATE refresh_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
+  await audit(options.db, userId, "grant.revoked", grantId, { source: "desktop" });
+  return true;
 }
 
 async function ownsHostedCollection(


### PR DESCRIPTION
## Summary
- expose local and hosted collections in one Electron control surface
- let the desktop create, rename, delete, authorize, narrow, revoke, and mirror hosted collections
- replace the portal CLI instruction with an mdbase-connect deep link
- embed the sync runtime in packaged desktop builds and reserve beta.6 compatibility

## Test plan
- pnpm install --frozen-lockfile
- pnpm test
- pnpm typecheck
- pnpm version:check v0.1.0-beta.6
- cargo fmt --all -- --check
- cargo test --workspace (against pinned mdbase-rs a8a3972)
- cargo clippy --workspace --all-targets -- -D warnings (against pinned mdbase-rs a8a3972)
- pnpm e2e
- pnpm e2e:sync
- pnpm e2e:relay
- pnpm e2e:provider (PostgreSQL, real browser, Electron mirror engine, writable conflicts)
- pnpm package:audit
- pnpm --filter @mdbase/connect-desktop package
- isolated Electron Playwright smoke under Xvfb