### PR TITLE
Share mirror leases across client state roots

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,8 +54,10 @@ safety.
 Mirror processes also take an exclusive device-local lease keyed by the
 folder's canonical path and filesystem identity. A long-running watcher holds
 the lease for its lifetime, so the desktop mirror and an Obsidian mirror plugin
-cannot manage the same physical folder concurrently. Custom mirror adapters
-must provide the equivalent lease when they cannot use the Node adapter.
+cannot manage the same physical folder concurrently even when the clients keep
+separate application-state directories. The Node adapter uses one fixed
+OS-user-wide lease namespace; custom mirror adapters must provide equivalent
+cross-application exclusion when they cannot use it.
 
 The control plane provides the final identity-level fence. If a connector
 publishes the ID of an active hosted collection, it is retained only as a

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -400,7 +400,9 @@ Before changing files, a Node mirror takes an exclusive device-local folder
 lease. `mdbase-mirror watch` holds it until the watcher stops; one-shot sync and
 conflict operations hold it for their complete critical section. Another
 desktop process receives `mirror_folder_in_use` rather than running a second
-engine over the same folder.
+engine over the same folder. Lease files use one OS-user-wide namespace that
+cannot be redirected with `MDBASE_CONNECT_MIRROR_STATE_DIR`, so clients with
+separate credential/state roots still contend for the same physical folder.
 
 Incoming documents use temporary files and atomic rename where the platform
 supports them. The watcher recognizes writes made by the mirror from the saved

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -42,7 +42,8 @@ The folder contains only a non-secret `.mdbase/connect-role.json` marker that
 identifies it as a hosted mirror. A local Connect agent will not register or
 relay that folder. Mirror operations also use an exclusive device-local lease;
 `watch` holds it for its lifetime, so a desktop mirror and an Obsidian mirror
-plugin cannot run over the same physical folder.
+plugin cannot run over the same physical folder. The lock namespace is shared
+per OS user and is independent of each client's credential/state directory.
 
 `promote` requires a converged, full writable mirror and a running local
 `mdbase-connect` agent. It opens a browser confirmation, freezes hosted writes

--- a/packages/sync/src/device.test.ts
+++ b/packages/sync/src/device.test.ts
@@ -27,6 +27,7 @@ import {
 } from "./device.js";
 import {
   mirrorDeviceDirectory,
+  mirrorLeaseDirectory,
   NodeMirrorLease,
   NodeMirrorStateStore
 } from "./node.js";
@@ -203,10 +204,14 @@ describe("device-local mirror storage", () => {
 
   it("allows only one mirror process to own a physical folder", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
-    const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+    const firstStateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-a-"));
+    const secondStateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-b-"));
+    const leaseDirectory = await mirrorLeaseDirectory(root);
     try {
-      const first = new NodeMirrorLease(root, stateRoot);
-      const second = new NodeMirrorLease(root, stateRoot);
+      expect(await mirrorDeviceDirectory(root, firstStateRoot))
+        .not.toBe(await mirrorDeviceDirectory(root, secondStateRoot));
+      const first = new NodeMirrorLease(root);
+      const second = new NodeMirrorLease(root);
       const acquired = await first.acquire();
       await expect(second.acquire())
         .rejects.toMatchObject({ code: "mirror_folder_in_use" });
@@ -215,7 +220,9 @@ describe("device-local mirror storage", () => {
       await reacquired.release();
     } finally {
       await rm(root, { recursive: true, force: true });
-      await rm(stateRoot, { recursive: true, force: true });
+      await rm(firstStateRoot, { recursive: true, force: true });
+      await rm(secondStateRoot, { recursive: true, force: true });
+      await rm(leaseDirectory, { recursive: true, force: true });
     }
   });
 
@@ -225,26 +232,26 @@ describe("device-local mirror storage", () => {
       const parent = await mkdtemp(join(tmpdir(), "mdbase-mirror-parent-"));
       const root = join(parent, "mirror");
       const alias = join(parent, "mirror-alias");
-      const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+      let leaseDirectory: string | null = null;
       try {
         await mkdir(root);
         await symlink(root, alias, "dir");
-        const acquired = await new NodeMirrorLease(root, stateRoot).acquire();
-        await expect(new NodeMirrorLease(alias, stateRoot).acquire())
+        leaseDirectory = await mirrorLeaseDirectory(root);
+        const acquired = await new NodeMirrorLease(root).acquire();
+        await expect(new NodeMirrorLease(alias).acquire())
           .rejects.toMatchObject({ code: "mirror_folder_in_use" });
         await acquired.release();
       } finally {
         await rm(parent, { recursive: true, force: true });
-        await rm(stateRoot, { recursive: true, force: true });
+        if (leaseDirectory) await rm(leaseDirectory, { recursive: true, force: true });
       }
     }
   );
 
   it("recovers a lease left behind by a dead process", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-mirror-folder-"));
-    const stateRoot = await mkdtemp(join(tmpdir(), "mdbase-mirror-device-"));
+    const directory = await mirrorLeaseDirectory(root);
     try {
-      const directory = await mirrorDeviceDirectory(root, stateRoot);
       await mkdir(directory, { recursive: true });
       await writeFile(join(directory, "mirror.lock"), JSON.stringify({
         version: 1,
@@ -252,13 +259,13 @@ describe("device-local mirror storage", () => {
         pid: 999_999_999,
         acquired_at: new Date().toISOString()
       }));
-      const acquired = await new NodeMirrorLease(root, stateRoot).acquire();
+      const acquired = await new NodeMirrorLease(root).acquire();
       await acquired.release();
       await expect(access(join(directory, "mirror.lock")))
         .rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await rm(root, { recursive: true, force: true });
-      await rm(stateRoot, { recursive: true, force: true });
+      await rm(directory, { recursive: true, force: true });
     }
   });
 

--- a/packages/sync/src/node.ts
+++ b/packages/sync/src/node.ts
@@ -184,17 +184,15 @@ interface MirrorLeaseRecord {
  * Cross-process exclusion for a physical mirror folder.
  *
  * The lease is device-local and keyed by canonical path plus filesystem
- * identity, just like mirror state. It therefore does not leak paths into the
- * collection or travel through another file-sync product.
+ * identity. Unlike credentials and mirror state, its base directory cannot be
+ * overridden per client: Electron and Obsidian must contend in the same
+ * OS-user-wide namespace even when they keep separate application state.
  */
 export class NodeMirrorLease implements MirrorLease {
-  constructor(
-    private readonly root: string,
-    private readonly stateRoot = process.env.MDBASE_CONNECT_MIRROR_STATE_DIR
-  ) {}
+  constructor(private readonly root: string) {}
 
   async acquire(): Promise<AcquiredMirrorLease> {
-    const directory = await mirrorDeviceDirectory(this.root, this.stateRoot);
+    const directory = await mirrorLeaseDirectory(this.root);
     await mkdir(directory, { recursive: true, mode: 0o700 });
     const path = join(directory, "mirror.lock");
     const record: MirrorLeaseRecord = {
@@ -245,14 +243,7 @@ export class NodeMirrorLease implements MirrorLease {
 }
 
 export async function mirrorDeviceDirectory(root: string, stateRoot?: string): Promise<string> {
-  const resolvedRoot = resolve(root);
-  const canonicalRoot = await realpath(resolvedRoot);
-  const rootIdentity = await stat(canonicalRoot);
-  const digest = createHash("sha256")
-    .update(canonicalRoot)
-    .update("\0")
-    .update(`${rootIdentity.dev}:${rootIdentity.ino}:${rootIdentity.birthtimeMs}`)
-    .digest("hex");
+  const { resolvedRoot, canonicalRoot, digest } = await mirrorFolderIdentity(root);
   const base = stateRoot
     ? resolve(stateRoot)
     : process.platform === "darwin"
@@ -277,6 +268,39 @@ export async function mirrorDeviceDirectory(root: string, stateRoot?: string): P
     );
   }
   return join(base, "mirrors", digest);
+}
+
+/**
+ * Return the one per-user lease directory for a physical folder.
+ *
+ * This deliberately ignores MDBASE_CONNECT_MIRROR_STATE_DIR, XDG_STATE_HOME,
+ * and LOCALAPPDATA. Those are valid per-application state choices, but allowing
+ * them to choose the lock namespace would let two clients bypass exclusion.
+ */
+export async function mirrorLeaseDirectory(root: string): Promise<string> {
+  const { digest } = await mirrorFolderIdentity(root);
+  const base = process.platform === "darwin"
+    ? join(homedir(), "Library", "Application Support", "mdbase-connect")
+    : process.platform === "win32"
+      ? join(homedir(), "AppData", "Local", "mdbase-connect")
+      : join(homedir(), ".local", "state", "mdbase-connect");
+  return join(base, "mirror-leases", digest);
+}
+
+async function mirrorFolderIdentity(root: string): Promise<{
+  resolvedRoot: string;
+  canonicalRoot: string;
+  digest: string;
+}> {
+  const resolvedRoot = resolve(root);
+  const canonicalRoot = await realpath(resolvedRoot);
+  const rootIdentity = await stat(canonicalRoot);
+  const digest = createHash("sha256")
+    .update(canonicalRoot)
+    .update("\0")
+    .update(`${rootIdentity.dev}:${rootIdentity.ino}:${rootIdentity.birthtimeMs}`)
+    .digest("hex");
+  return { resolvedRoot, canonicalRoot, digest };
 }
 
 function isWithinDirectory(candidate: string, directory: string): boolean {


### PR DESCRIPTION
## Summary
- move physical-folder mirror leases into one fixed OS-user-wide namespace
- keep credentials and mirror state configurable per application
- prove distinct Electron/Obsidian-style state roots and symlink aliases still contend
- document the cross-application exclusion contract

## Why
Staging abuse testing found that two clients could manage the same physical mirror folder concurrently when each supplied a different mirror state directory. That is exactly the expected Electron plus Obsidian-plugin arrangement.

## Validation
- pnpm build
- pnpm typecheck
- pnpm test
- cargo test --workspace --locked against the pinned mdbase-rs revision
- pnpm e2e:provider
- 12-process cross-state-root and symlink-alias contention attack
- SIGKILL stale-lease recovery