### PR TITLE
Return client errors for malformed and oversized bodies

### DIFF
--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -42,6 +42,38 @@ describe("mdbase MCP gateway", () => {
     await db.end();
   });
 
+  it("keeps malformed and oversized request bodies out of the server-error path", async () => {
+    const db = await createDatabase("memory");
+    const { app } = await buildApp({ db, config: testConfig() });
+
+    const malformed = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      headers: { "content-type": "application/json" },
+      payload: "{"
+    });
+    expect(malformed.statusCode).toBe(400);
+    expect(malformed.json()).toEqual({
+      error: "invalid_request",
+      error_description: "The request body is invalid."
+    });
+
+    const oversized = await app.inject({
+      method: "POST",
+      url: "/oauth/register",
+      headers: { "content-type": "application/json" },
+      payload: JSON.stringify({ padding: "x".repeat(2 * 1024 * 1024 + 1) })
+    });
+    expect(oversized.statusCode).toBe(413);
+    expect(oversized.json()).toEqual({
+      error: "invalid_request",
+      error_description: "The request body exceeds the allowed size."
+    });
+
+    await app.close();
+    await db.end();
+  });
+
   it("authorizes a host, adds multiple collections, and routes MCP tools by connection ID", async () => {
     const upstream = await fakeUpstream(globalThis.fetch);
     vi.stubGlobal("fetch", upstream.fetch);

--- a/services/mcp/src/app.ts
+++ b/services/mcp/src/app.ts
@@ -76,6 +76,19 @@ export async function buildApp(options: BuildOptions) {
         issues: error.issues.map((issue) => ({ path: issue.path.join("."), message: issue.message }))
       });
     }
+    const statusCode = httpErrorStatus(error);
+    if (statusCode === 413) {
+      return reply.code(413).send({
+        error: "invalid_request",
+        error_description: "The request body exceeds the allowed size."
+      });
+    }
+    if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+      return reply.code(statusCode).send({
+        error: "invalid_request",
+        error_description: "The request body is invalid."
+      });
+    }
     request.log.error({ err: error }, "MCP gateway request failed");
     return reply.code(500).send({ error: "server_error", error_description: "The MCP gateway request failed." });
   });
@@ -201,6 +214,14 @@ export async function buildApp(options: BuildOptions) {
 async function authenticateRequest(authorization: string | undefined, oauth: OAuthService) {
   if (!authorization?.startsWith("Bearer ")) return null;
   return oauth.authenticate(authorization.slice(7));
+}
+
+function httpErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null || !("statusCode" in error)) {
+    return undefined;
+  }
+  const statusCode = (error as { statusCode?: unknown }).statusCode;
+  return typeof statusCode === "number" ? statusCode : undefined;
 }
 
 function unauthorized(reply: any, resourceMetadataUrl: string) {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -48,6 +48,45 @@ describe("mdbase connect server", () => {
     });
   });
 
+  it("keeps malformed and oversized request bodies out of the server-error path", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+
+    const malformed = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      headers: { "content-type": "application/json" },
+      payload: "{"
+    });
+    expect(malformed.statusCode).toBe(400);
+    expect(malformed.json()).toEqual({
+      error: {
+        code: "invalid_request",
+        message: "The request body is invalid."
+      }
+    });
+
+    const oversized = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      headers: { "content-type": "application/json" },
+      payload: JSON.stringify({ padding: "x".repeat(2 * 1024 * 1024 + 1) })
+    });
+    expect(oversized.statusCode).toBe(413);
+    expect(oversized.json()).toEqual({
+      error: {
+        code: "payload_too_large",
+        message: "The request body exceeds the allowed size."
+      }
+    });
+  });
+
   it("registers exact bundled declarations as immutable application identities", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -357,6 +357,19 @@ export async function buildApp(options: BuildOptions) {
         "Google sign-in could not be completed. Please try again."
       ));
     }
+    const statusCode = httpErrorStatus(error);
+    if (statusCode === 413) {
+      return reply.code(413).send(apiError(
+        "payload_too_large",
+        "The request body exceeds the allowed size."
+      ));
+    }
+    if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+      return reply.code(statusCode).send(apiError(
+        "invalid_request",
+        "The request body is invalid."
+      ));
+    }
     request.log.error(error);
     return reply.code(500).send(apiError("internal_error", "The request could not be completed."));
   });
@@ -5548,6 +5561,14 @@ async function audit(
 
 function apiError(code: string, message: string) {
   return { error: { code, message } };
+}
+
+function httpErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null || !("statusCode" in error)) {
+    return undefined;
+  }
+  const statusCode = (error as { statusCode?: unknown }).statusCode;
+  return typeof statusCode === "number" ? statusCode : undefined;
 }
 
 function oauthError(error: string, errorDescription: string) {


### PR DESCRIPTION
## Summary
- preserve Fastify 4xx parser and body-limit statuses in Connect and MCP
- return deliberately generic client-safe error payloads
- add regression coverage for malformed JSON and requests over the 2 MiB limit

## Why
The pre-release staging abuse harness found that malformed JSON and oversized bodies were being converted into HTTP 500 responses by both custom error handlers.

## Validation
- full pnpm build
- full pnpm typecheck
- full pnpm test
- pnpm package:audit
- reproduced against staging before the fix: Connect and MCP each returned 500 for malformed and oversized JSON