### PR TITLE
Serialize desktop dependency build before workspace tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "profile:connect": "cargo run --release -p mdbase-connect-core --bin connect-profile --",
     "profile:rs": "cargo run --release --manifest-path ../mdbase-rs/Cargo.toml --bin mdb-profile -- --scenario queries",
     "profile:views:rs": "cargo run --release --manifest-path ../mdbase-rs/Cargo.toml --bin mdb-profile -- --scenario views",
-    "test": "pnpm -r test",
+    "test": "pnpm --filter @mdbase/connect-desktop test && pnpm --filter '!@mdbase/connect-desktop' -r test",
     "typecheck": "pnpm -r typecheck",
     "version:check": "node scripts/check-release-version.mjs"
   },


### PR DESCRIPTION
## Summary
- run the desktop test target before the rest of the recursive workspace tests
- keep the remaining package tests parallel
- prevent desktop dependency rebuilds from deleting protocol output while server tests import it

## Validation
- clean `packages/protocol/dist` and `packages/sync/dist`, then `pnpm test`
- `pnpm typecheck`
- `pnpm version:check v0.1.0-beta.7`
- `git diff --check`

This fixes the macOS Apple Silicon release-preflight race observed in run 30202323084.