### PR TITLE
Fix nondeterministic workspace build race

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,12 +9,13 @@
   "scripts": {
     "build": "pnpm build:main && pnpm build:renderer",
     "build:sync": "pnpm --filter @mdbase/connect-protocol build && pnpm --filter @mdbase/connect-sync build",
-    "build:main": "pnpm build:sync && tsc -p tsconfig.main.json && node scripts/build-main.mjs",
+    "build:main": "tsc -p tsconfig.main.json && node scripts/build-main.mjs",
     "build:renderer": "vite build",
+    "build:standalone": "pnpm build:sync && pnpm build",
     "dev:agent": "cargo build --manifest-path ../../Cargo.toml -p mdbase-connect-agent",
-    "start": "pnpm dev:agent && pnpm build && electron .",
-    "make": "pnpm dev:agent --release && pnpm build && electron-forge make",
-    "package": "pnpm dev:agent --release && pnpm build && electron-forge package && node scripts/verify-package.mjs",
+    "start": "pnpm dev:agent && pnpm build:standalone && electron .",
+    "make": "pnpm dev:agent --release && pnpm build:standalone && electron-forge make",
+    "package": "pnpm dev:agent --release && pnpm build:standalone && electron-forge package && node scripts/verify-package.mjs",
     "test": "pnpm build:main && node --test test/*.test.mjs",
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit"
   },


### PR DESCRIPTION
## Summary
- stop the desktop recursive build/test lifecycle from rebuilding shared workspace dependencies
- keep start, package, and make self-contained through an explicit standalone build
- prevent protocol/sync dist directories being deleted while server and MCP tests read them

## Verification
- pnpm install --frozen-lockfile
- pnpm build
- pnpm typecheck
- pnpm test
- pnpm package:audit
- pnpm version:check v0.1.0-beta.7
- 20 consecutive full pnpm test runs
- pnpm --filter @mdbase/connect-desktop build:standalone
- pnpm --filter @mdbase/connect-desktop test