### PR TITLE
Add inline hosted collection creation

### DIFF
--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -156,6 +156,7 @@ interface HostedCollectionSummary {
 
 interface HostedControlSnapshot {
   online: boolean;
+  hosted_collections_available?: boolean;
   hosted_collections: HostedCollectionSummary[];
   grants: GrantSummary[];
   pending_authorizations: PendingAuthorization[];

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -66,7 +66,7 @@ function App() {
   const [startup, setStartup] = useState<StartupSetting>({ enabled: false, available: false });
   const [cloud, setCloud] = useState<CloudSetting | null>(null);
   const [access, setAccess] = useState<AccessSnapshot>({ configured: false, online: false, grants: [], pending_authorizations: [], authority_conflicts: [] });
-  const [hosted, setHosted] = useState<HostedControlSnapshot>({ online: false, hosted_collections: [], grants: [], pending_authorizations: [] });
+  const [hosted, setHosted] = useState<HostedControlSnapshot>({ online: false, hosted_collections_available: false, hosted_collections: [], grants: [], pending_authorizations: [] });
   const [mirrors, setMirrors] = useState<DesktopMirrorSummary[]>([]);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
   const [busy, setBusy] = useState(false);
@@ -268,6 +268,7 @@ function App() {
             access={combinedAccess}
             collections={collections}
             hostedCollections={hosted.hosted_collections}
+            canCreateHosted={hosted.hosted_collections_available !== false}
             busy={busy}
             onAct={act}
             onNotice={setNotice}
@@ -297,9 +298,9 @@ function App() {
                 <input type="radio" name="authority" value="local" checked={newAuthority === "local"} onChange={() => setNewAuthority("local")} />
                 <span><strong>On this computer</strong><small>A folder here is the final authority.</small></span>
               </label>
-              <label className={`${newAuthority === "hosted" ? "selected" : ""} ${cloud?.configured ? "" : "disabled"}`}>
-                <input type="radio" name="authority" value="hosted" checked={newAuthority === "hosted"} disabled={!cloud?.configured} onChange={() => setNewAuthority("hosted")} />
-                <span><strong>Hosted by mdbase</strong><small>{cloud?.configured ? "Available while this computer is offline; optional local mirror." : "Connect this computer to your account first."}</small></span>
+              <label className={`${newAuthority === "hosted" ? "selected" : ""} ${cloud?.configured && hosted.hosted_collections_available !== false ? "" : "disabled"}`}>
+                <input type="radio" name="authority" value="hosted" checked={newAuthority === "hosted"} disabled={!cloud?.configured || hosted.hosted_collections_available === false} onChange={() => setNewAuthority("hosted")} />
+                <span><strong>Hosted by mdbase</strong><small>{!cloud?.configured ? "Connect this computer to your account first." : hosted.hosted_collections_available !== false ? "Available while this computer is offline; optional local mirror." : "Hosted collections are not enabled for this Connect service."}</small></span>
               </label>
             </fieldset>
             <label><span>Collection name</span><input autoFocus value={newName} onChange={(event) => setNewName(event.target.value)} placeholder="Workouts" /></label>
@@ -712,11 +713,12 @@ function HostedCollectionRow({
   );
 }
 
-function Access({ cloud, access, collections, hostedCollections, busy, onAct, onNotice }: {
+function Access({ cloud, access, collections, hostedCollections, canCreateHosted, busy, onAct, onNotice }: {
   cloud: CloudSetting;
   access: AccessSnapshot;
   collections: CollectionSummary[];
   hostedCollections: HostedCollectionSummary[];
+  canCreateHosted: boolean;
   busy: boolean;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
@@ -731,7 +733,7 @@ function Access({ cloud, access, collections, hostedCollections, busy, onAct, on
           <Empty title="No applications are waiting" text="New connection requests from websites and downloaded files will appear here." />
         ) : (
           <div className="request-list">
-            {access.pending_authorizations.map((request) => <AuthorizationRequest key={request.id} request={request} collections={collections} hostedCollections={hostedCollections} busy={busy} onAct={onAct} onNotice={onNotice} />)}
+            {access.pending_authorizations.map((request) => <AuthorizationRequest key={request.id} request={request} collections={collections} hostedCollections={hostedCollections} canCreateHosted={canCreateHosted} busy={busy} onAct={onAct} onNotice={onNotice} />)}
           </div>
         )}
       </section>
@@ -791,14 +793,25 @@ function ApplicationGrantGroup({ group, busy, onAct, onNotice }: {
   );
 }
 
-function AuthorizationRequest({ request, collections, hostedCollections, busy, onAct, onNotice }: {
+function AuthorizationRequest({ request, collections, hostedCollections, canCreateHosted, busy, onAct, onNotice }: {
   request: PendingAuthorization;
   collections: CollectionSummary[];
   hostedCollections: HostedCollectionSummary[];
+  canCreateHosted: boolean;
   busy: boolean;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
 }) {
+  const [creatingHosted, setCreatingHosted] = useState(false);
+  const [hostedName, setHostedName] = useState("");
+  const [createdHostedCollection, setCreatedHostedCollection] = useState<HostedCollectionSummary | null>(null);
+  const authorizationHostedCollections = useMemo(() => {
+    const combined = new Map(hostedCollections.map((collection) => [collection.id, collection]));
+    if (createdHostedCollection && !combined.has(createdHostedCollection.id)) {
+      combined.set(createdHostedCollection.id, createdHostedCollection);
+    }
+    return [...combined.values()];
+  }, [createdHostedCollection, hostedCollections]);
   const available = useMemo<AuthorizationCollection[]>(() => [
     ...collections
       .filter((collection) =>
@@ -813,7 +826,7 @@ function AuthorizationRequest({ request, collections, hostedCollections, busy, o
         kind: "local" as const,
         provisionable: request.provisionable_collection_ids.includes(collection.id)
       })),
-    ...hostedCollections
+    ...authorizationHostedCollections
       .filter((collection) =>
         collection.authority_state === "active"
         && hostedCollectionCompatible(request, collection)
@@ -830,7 +843,7 @@ function AuthorizationRequest({ request, collections, hostedCollections, busy, o
       }))
   ], [
     collections,
-    hostedCollections,
+    authorizationHostedCollections,
     request.compatible_collection_ids,
     request.provisionable_collection_ids,
     request.requirements,
@@ -856,6 +869,22 @@ function AuthorizationRequest({ request, collections, hostedCollections, busy, o
       setCollectionId(available[0]?.id ?? "");
     }
   }, [collectionId, available]);
+  async function createHostedCollection(event: React.FormEvent) {
+    event.preventDefault();
+    const displayName = hostedName.trim();
+    if (!displayName) return;
+    let created: HostedCollectionSummary | undefined;
+    await onAct(async () => {
+      const result = await window.mdbaseConnect.createHostedCollection(displayName);
+      created = result.collection;
+    });
+    if (!created) return;
+    setCreatedHostedCollection(created);
+    setCollectionId(created.id);
+    setCreatingHosted(false);
+    setHostedName("");
+    onNotice(`${created.display_name} was created and selected. Application access is not allowed yet.`);
+  }
   return (
     <article className="request-panel">
       <div className="request-identity"><p className="eyebrow">Access request</p><h3>{request.application_name}</h3><code>{request.application_distribution === "portable" ? `Downloaded HTML file${request.application_project_url ? ` · ${host(request.application_project_url)}` : ""}` : host(request.application_homepage)}</code>{request.application_distribution === "portable" && <small className="portable-request-warning">Unverified file origin. Only allow it if you intentionally opened the file{request.user_code ? ` and it shows ${request.user_code}` : ""}.</small>}<small>Expires {relativeTime(request.expires_at)}</small>{request.requirements.contracts.length > 0 && <small>{scopeDescription(request.requirements.contracts)}</small>}</div>
@@ -863,8 +892,45 @@ function AuthorizationRequest({ request, collections, hostedCollections, busy, o
         <section className="request-section">
           <div><strong>Collection</strong><small>Choose where {request.application_name} can work.</small></div>
           <div className="request-section-content">
-            <label><span>Collection</span><select value={collectionId} disabled={available.length === 0} onChange={(event) => setCollectionId(event.target.value)}>{available.length === 0 && <option value="">No compatible collection</option>}{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name} · {collection.kind === "hosted" ? "hosted" : "this computer"}{collection.provisionable ? " · setup required" : ""}</option>)}</select></label>
+            <label><span>Collection</span><select value={collectionId} disabled={available.length === 0 || busy} onChange={(event) => setCollectionId(event.target.value)}>{available.length === 0 && <option value="">No compatible collection</option>}{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name} · {collection.kind === "hosted" ? "Hosted by mdbase" : "on this computer"}{collection.provisionable ? " · setup required" : ""}</option>)}</select></label>
             {available.length === 0 && <small>No available local or hosted collection supports all requested operations and contracts.</small>}
+            {canCreateHosted && (creatingHosted ? (
+              <form
+                className="request-collection-create"
+                id={`create-hosted-${request.id}`}
+                onSubmit={(event) => void createHostedCollection(event)}
+              >
+                <label>
+                  <span>New collection name</span>
+                  <input
+                    autoFocus
+                    maxLength={200}
+                    value={hostedName}
+                    disabled={busy}
+                    placeholder="Workouts"
+                    onChange={(event) => setHostedName(event.target.value)}
+                  />
+                </label>
+                <p>Creates a plain mdbase collection hosted by mdbase. Application access is still approved separately below.</p>
+                <div>
+                  <button className="quiet-action" type="button" disabled={busy} onClick={() => {
+                    setCreatingHosted(false);
+                    setHostedName("");
+                  }}>Cancel</button>
+                  <button className="button secondary" disabled={busy || !hostedName.trim()}>{busy ? "Creating…" : "Create collection"}</button>
+                </div>
+              </form>
+            ) : (
+              <div className="request-collection-action">
+                <button
+                  className="button secondary"
+                  type="button"
+                  aria-controls={`create-hosted-${request.id}`}
+                  disabled={busy}
+                  onClick={() => setCreatingHosted(true)}
+                >Create hosted collection</button>
+              </div>
+            ))}
             {setup.length > 0 && <small>Setup needed: allowing access will add {provisionNames(setup)} to this collection.</small>}
           </div>
         </section>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -171,6 +171,11 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .request-section > div:first-child > strong { font-size: var(--type-body); }
 .request-section > div:first-child > small, .request-section-content > small, .request-permission-review summary small, .notification-request summary small { color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
 .request-section-content { display: grid; gap: 7px; min-width: 0; }
+.request-collection-action { display: flex; justify-content: flex-start; }
+.request-collection-create { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 10px; padding-top: 9px; border-top: 1px solid var(--line); }
+.request-collection-create > label { grid-column: 1; grid-row: 1; display: grid; gap: 5px; min-width: 0; }
+.request-collection-create > p { grid-column: 1 / -1; grid-row: 2; margin: 0 0 2px; color: var(--muted); font-size: var(--type-action); line-height: 1.45; }
+.request-collection-create > div { grid-column: 2; grid-row: 1; display: flex; align-items: center; gap: 3px; }
 label > span, fieldset > legend { color: var(--muted); font-size: var(--type-supporting); font-weight: 700; }
 input, select { width: 100%; min-height: 36px; padding: 0 10px; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font-size: var(--type-body); }
 .request-section-content > label, .manual-app label, .manual-grant > label, .pairing-form label { display: grid; gap: 5px; }
@@ -267,6 +272,9 @@ fieldset legend { margin-bottom: 6px; }
 @media (max-width: 780px) {
   .content { padding-inline: 24px; }
   .request-panel, .grant-review, .request-section, .collection-editor-section { grid-template-columns: 1fr; }
+  .request-collection-create { grid-template-columns: 1fr; }
+  .request-collection-create > label, .request-collection-create > p, .request-collection-create > div { grid-column: 1; grid-row: auto; }
+  .request-collection-create > div { justify-content: flex-end; }
   .request-panel, .grant-review { gap: 16px; }
   .request-section { gap: 8px; }
   .collection-editor-section { gap: 10px; }

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -21,6 +21,7 @@ export class ApiError extends Error {
 
 export interface DashboardData {
   user: { id: string; name: string; email: string | null; login: string | null };
+  hosted_collections_available?: boolean;
   authentication: {
     provider: "google" | "github" | "tailscale" | "session";
     registration: "closed" | "open";

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -54,6 +54,7 @@ function Login() {
   const [email, setEmail] = useState("callum@example.com");
   const [config, setConfig] = useState<AuthConfig | null>(null);
   const [error, setError] = useState("");
+  const continuingAuthorization = isAuthorizationReturnTarget();
 
   useEffect(() => {
     async function identify() {
@@ -106,11 +107,13 @@ function Login() {
     <main className="center-page">
       <PageBrand label="connect" />
       <section className="auth-panel">
-        <p className="eyebrow">{config.registration === "open" ? "Account access" : "Private preview"}</p>
-        <h1>Sign in to mdbase connect</h1>
-        <p>{config.registration === "open"
-          ? "Choose an identity provider to create or open your account."
-          : "Access is currently limited to invited accounts."}</p>
+        <p className="eyebrow">{continuingAuthorization ? "Choose a collection" : config.registration === "open" ? "Account access" : "Private preview"}</p>
+        <h1>{continuingAuthorization ? "Sign in to continue" : "Sign in to mdbase connect"}</h1>
+        <p>{continuingAuthorization
+          ? `After you choose a collection and approve access, you’ll return to the app.${config.registration === "open" ? "" : " Sign-in is currently limited to invited accounts."}`
+          : config.registration === "open"
+            ? "Choose an identity provider to create or open your account."
+            : "Access is currently limited to invited accounts."}</p>
         {error && <div className="message error" role="alert">{error}</div>}
         <div className="auth-providers">
           {providers.map((provider, index) => <React.Fragment key={provider.id}>
@@ -309,6 +312,7 @@ function Dashboard() {
                 <RequestIdentity request={request} />
                 <ApprovalForm
                   request={request}
+                  canCreateHosted={data.hosted_collections_available !== false}
                   collections={[
                     ...(request.available_collections ?? []),
                     ...data.hosted_collections
@@ -327,7 +331,12 @@ function Dashboard() {
             ))}</div></>}
         </section>
         <section id="hosted">
-          <HostedCollections collections={data.hosted_collections} onChanged={refresh} onError={setError} />
+          <HostedCollections
+            collections={data.hosted_collections}
+            canCreate={data.hosted_collections_available !== false}
+            onChanged={refresh}
+            onError={setError}
+          />
         </section>
         <section id="permissions">
           <SectionHeading title="Application access" note="Applications are grouped here; expand one to review its collection access." count={applicationAccess.length} />
@@ -366,8 +375,9 @@ function Dashboard() {
   );
 }
 
-function HostedCollections({ collections, onChanged, onError }: {
+function HostedCollections({ collections, canCreate, onChanged, onError }: {
   collections: HostedCollection[];
+  canCreate: boolean;
   onChanged(): Promise<void>;
   onError(value: string): void;
 }) {
@@ -401,15 +411,20 @@ function HostedCollections({ collections, onChanged, onError }: {
       count={collections.length}
     />
     {collections.length === 0 && !creating
-      ? <Empty title="No hosted collections" text="Create an mdbase collection whose source of truth stays available without a connected computer." />
+      ? <Empty
+          title="No hosted collections"
+          text={canCreate
+            ? "Create an mdbase collection whose source of truth stays available without a connected computer."
+            : "Hosted collections are not enabled for this Connect service."}
+        />
       : <div className="hosted-list">{collections.map((collection) => (
           <HostedCollectionRow key={collection.id} collection={collection} onChanged={onChanged} onError={onError} />
         ))}</div>}
-    {creating ? <form className="inline-create" onSubmit={(event) => void create(event)}>
+    {canCreate && (creating ? <form className="inline-create" onSubmit={(event) => void create(event)}>
       <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
       <p>Starts as a clean mdbase 0.3 collection. Add Markdown through compatible apps, with an optional exact local mirror.</p>
       <div><button type="button" className="quiet-action" disabled={busy} onClick={() => setCreating(false)}>Cancel</button><button className="button primary" disabled={busy || !name.trim()}>{busy ? "Creating…" : "Create collection"}</button></div>
-    </form> : <button className="button secondary" onClick={() => setCreating(true)}>Create hosted collection</button>}
+    </form> : <button className="button secondary" onClick={() => setCreating(true)}>Create hosted collection</button>)}
   </>;
 }
 
@@ -1033,6 +1048,7 @@ function Authorization({ requestId }: { requestId: string }) {
   const [request, setRequest] = useState<{
     authorization: PendingAuthorization;
     collections: AvailableCollection[];
+    hosted_collections_available?: boolean;
     unavailable_connectors: UnavailableConnector[];
   } | null>(null);
   const [status, setStatus] = useState<"pending" | "approved" | "denied">("pending");
@@ -1047,6 +1063,7 @@ function Authorization({ requestId }: { requestId: string }) {
         const next = await api<{
           authorization: PendingAuthorization;
           collections: AvailableCollection[];
+          hosted_collections_available?: boolean;
           unavailable_connectors: UnavailableConnector[];
         }>(`/v1/authorization-requests/${requestId}`);
         if (active) {
@@ -1104,12 +1121,15 @@ function Authorization({ requestId }: { requestId: string }) {
           {error && <div className="message error">{error}</div>}
           <ApprovalForm
             request={authorization}
+            canCreateHosted={request.hosted_collections_available !== false}
             collections={request.collections}
             unavailableConnectors={request.unavailable_connectors}
             onDecision={(decision) => setStatus(decision)}
             onCollectionCreated={(collection) => setRequest((current) => current ? {
               ...current,
-              collections: [...current.collections, collection]
+              collections: current.collections.some((existing) => existing.id === collection.id)
+                ? current.collections
+                : [...current.collections, collection]
             } : current)}
           />
         </> : status === "approved" ? <><p className="eyebrow outcome-label">Access approved</p><h2>{authorization.distribution === "portable" ? "Return to the downloaded application." : "Returning to the application…"}</h2><p>{authorization.distribution === "portable" ? "The file will finish connecting with its one-time device code. You can close this window." : "Your approved collection and permissions will follow you back."}</p></> : <><p className="eyebrow outcome-label">Access denied</p><h2>{authorization.distribution === "portable" ? "Return to the downloaded application." : "Returning to the application…"}</h2><p>{authorization.distribution === "portable" ? "The file will learn that access was not granted. You can close this window." : "The application will show that access was not granted."}</p></>}
@@ -1134,7 +1154,7 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
           <small>{scopeDescription(request.requirements.contracts)}</small>
         )}
         {request.requirements.collection_kind === "hosted" && (
-          <small>Requires an mdbase cloud collection</small>
+          <small>Requires a collection hosted by mdbase</small>
         )}
       </div>
     </div>
@@ -1144,20 +1164,29 @@ function RequestIdentity({ request, large = false }: { request: PendingAuthoriza
 function ApprovalForm({
   request,
   collections,
+  canCreateHosted,
   unavailableConnectors = [],
   onDecision,
   onCollectionCreated
 }: {
   request: PendingAuthorization;
   collections: AvailableCollection[];
+  canCreateHosted: boolean;
   unavailableConnectors?: UnavailableConnector[];
   onDecision(decision: "approved" | "denied"): void | Promise<void>;
   onCollectionCreated(collection: AvailableCollection): void;
 }) {
-  const choices = useMemo(() => collections.map((collection) => ({
-    collection,
-    compatibility: collectionCompatibility(request, collection)
-  })), [collections, request]);
+  const [createdCollections, setCreatedCollections] = useState<AvailableCollection[]>([]);
+  const choices = useMemo(() => {
+    const combined = new Map(collections.map((collection) => [collection.id, collection]));
+    for (const collection of createdCollections) {
+      if (!combined.has(collection.id)) combined.set(collection.id, collection);
+    }
+    return [...combined.values()].map((collection) => ({
+      collection,
+      compatibility: collectionCompatibility(request, collection)
+    }));
+  }, [collections, createdCollections, request]);
   const compatible = useMemo(
     () => choices.filter((choice) => choice.compatibility.compatible),
     [choices]
@@ -1173,6 +1202,8 @@ function ApprovalForm({
   );
   const [operations, setOperations] = useState(() => new Set(request.requested_operations));
   const [submitting, setSubmitting] = useState<"approved" | "denied" | "creating" | null>(null);
+  const [creatingHosted, setCreatingHosted] = useState(false);
+  const [collectionName, setCollectionName] = useState("");
   const [error, setError] = useState("");
   const selected = compatible.find((choice) => choice.collection.id === collectionId)?.collection;
   const setup = selected ? neededProvisions(request, selected) : [];
@@ -1217,27 +1248,33 @@ function ApprovalForm({
     }
   }
 
-  async function createCloudCollection() {
+  async function createHostedCollection(event: React.FormEvent) {
+    event.preventDefault();
+    const displayName = collectionName.trim();
+    if (!displayName) return;
     setSubmitting("creating");
     setError("");
     try {
       const created = await api<{ collection: HostedCollection }>("/v1/hosted/collections", {
         method: "POST",
         body: JSON.stringify({
-          display_name: "My collection",
+          display_name: displayName,
           template: "mdbase"
         })
       });
       const collection: AvailableCollection = {
         id: created.collection.id,
         display_name: created.collection.display_name,
-        connector_name: "mdbase cloud",
+        connector_name: "Hosted by mdbase",
         spec_version: created.collection.spec_version ?? "0.3.0",
         contracts: [],
         kind: "hosted"
       };
+      setCreatedCollections((current) => [...current, collection]);
       onCollectionCreated(collection);
       setCollectionId(collection.id);
+      setCollectionName("");
+      setCreatingHosted(false);
     } catch (creationError) {
       setError(message(creationError));
     } finally {
@@ -1263,13 +1300,26 @@ function ApprovalForm({
           <small>Choose where {request.application_name} can work.</small>
         </div>
         <div className="approval-section-content">
-          <label className="collection-field" htmlFor={`collection-${request.id}`}>
-            <span>Collection and location</span>
-            <select id={`collection-${request.id}`} value={collectionId} onChange={(event) => setCollectionId(event.target.value)} disabled={submitting !== null || compatible.length === 0}>
-              {compatible.length === 0 && <option value="">No compatible collection</option>}
-              {choices.map(({ collection, compatibility }) => <option value={collection.id} key={collection.id} disabled={!compatibility.compatible}>{collection.display_name} · {collection.connector_name}{compatibility.compatible ? (neededProvisions(request, collection).length ? " · setup required" : "") : ` · ${compatibility.label}`}</option>)}
-            </select>
-          </label>
+          {compatible.length > 0 && <fieldset className="collection-choice-field">
+            <legend>Collection and location</legend>
+            <div className="collection-choice-list">
+              {compatible.map(({ collection }) => {
+                const provisions = neededProvisions(request, collection);
+                return <label className={collection.id === collectionId ? "selected" : undefined} key={collection.id}>
+                  <input
+                    type="radio"
+                    name={`collection-${request.id}`}
+                    value={collection.id}
+                    checked={collection.id === collectionId}
+                    disabled={submitting !== null}
+                    onChange={() => setCollectionId(collection.id)}
+                  />
+                  <span><strong>{collection.display_name}</strong><small>{collection.connector_name}</small></span>
+                  {provisions.length > 0 && <b>Setup needed</b>}
+                </label>;
+              })}
+            </div>
+          </fieldset>}
           {unavailable.length > 0 && <details className="collection-compatibility">
             <summary>{compatible.length > 0
               ? `${unavailable.length} other ${unavailable.length === 1 ? "collection is" : "collections are"} unavailable`
@@ -1281,15 +1331,56 @@ function ApprovalForm({
               ? `${connector.connector_name} has remote access paused.`
               : `${connector.connector_name} is offline.`).join(" ")} Those local collections cannot be selected until their computer is available.
           </div>}
-          {compatible.length === 0 && <div className="authorization-empty-collection">
-            <p className="field-note">No compatible collection is ready.</p>
-            <button
-              className="button secondary"
-              type="button"
-              disabled={submitting !== null}
-              onClick={() => void createCloudCollection()}
-            >{submitting === "creating" ? "Creating…" : "Create an mdbase cloud collection"}</button>
-          </div>}
+          {canCreateHosted && (creatingHosted ? (
+            <form
+              className="authorization-collection-create"
+              id={`create-hosted-${request.id}`}
+              onSubmit={(event) => void createHostedCollection(event)}
+            >
+              <label>
+                <span>New collection name</span>
+                <input
+                  autoFocus
+                  maxLength={200}
+                  value={collectionName}
+                  disabled={submitting !== null}
+                  placeholder="Workouts"
+                  onChange={(event) => setCollectionName(event.target.value)}
+                />
+              </label>
+              <p>Creates a plain mdbase collection hosted by mdbase. Application access is still approved separately below.</p>
+              <div>
+                <button
+                  className="quiet-action"
+                  type="button"
+                  disabled={submitting !== null}
+                  onClick={() => {
+                    setCreatingHosted(false);
+                    setCollectionName("");
+                    setError("");
+                  }}
+                >Cancel</button>
+                <button className="button secondary" disabled={submitting !== null || !collectionName.trim()}>
+                  {submitting === "creating" ? "Creating…" : "Create collection"}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div className="authorization-collection-action">
+              {compatible.length === 0 && <p className="field-note">No compatible collection is ready.</p>}
+              <button
+                className="button secondary"
+                type="button"
+                aria-controls={`create-hosted-${request.id}`}
+                disabled={submitting !== null}
+                onClick={() => {
+                  setCreatingHosted(true);
+                  setError("");
+                }}
+              >Create hosted collection</button>
+            </div>
+          ))}
+          {!canCreateHosted && compatible.length === 0 && <p className="field-note">No compatible collection is ready.</p>}
           {setup.length > 0 && <p className="field-note">Setup needed: allowing access will add {provisionNames(setup)} to this collection through its live authority.</p>}
         </div>
       </section>
@@ -1309,7 +1400,7 @@ function ApprovalForm({
       {error && <div className="message error compact">{error}</div>}
       <footer className="approval-footer">
         <p>{selected
-          ? `${request.application_name} will use ${selected.display_name} through ${selected.connector_name}. Every operation is checked against this grant, and access lasts until you revoke it.`
+          ? `${request.application_name} will work in ${selected.display_name} at ${selected.connector_name}. You can revoke access at any time in mdbase connect.`
           : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
         <div className="approval-actions">
           <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
@@ -1439,6 +1530,13 @@ function returnTarget() {
   if (!requested) return "/";
   const target = new URL(requested, location.origin);
   return target.origin === location.origin ? target.href : "/";
+}
+function isAuthorizationReturnTarget() {
+  try {
+    return new URL(returnTarget(), location.origin).pathname.startsWith("/authorize/");
+  } catch {
+    return false;
+  }
 }
 function identityLabel(user: { email: string | null; login: string | null }) {
   return user.login ? `@${user.login}` : user.email ?? "Identity unavailable";

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -714,10 +714,125 @@ h1 {
   min-width: 0;
 }
 
+.authorization-collection-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.authorization-collection-create {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--line);
+}
+
+.authorization-collection-create label {
+  grid-column: 1;
+  grid-row: 1;
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.authorization-collection-create label > span {
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.authorization-collection-create > p {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  margin: 0 0 0.15rem;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.authorization-collection-create > div {
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .collection-field {
   display: grid;
   gap: 0.4rem;
   min-width: 0;
+}
+
+.collection-choice-field {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+}
+
+.collection-choice-field > legend {
+  margin-bottom: 0.4rem;
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.collection-choice-list {
+  display: grid;
+  border-top: 1px solid var(--line);
+}
+
+.collection-choice-list > label {
+  min-height: 3.4rem;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+  transition: background 160ms ease-out;
+}
+
+.collection-choice-list > label:hover,
+.collection-choice-list > label.selected {
+  background: var(--paper-hover);
+}
+
+.collection-choice-list input {
+  accent-color: var(--accent);
+}
+
+.collection-choice-list label > span {
+  min-width: 0;
+  display: grid;
+  gap: 0.15rem;
+}
+
+.collection-choice-list strong,
+.collection-choice-list small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.collection-choice-list strong {
+  color: var(--ink);
+  font-size: 0.8rem;
+}
+
+.collection-choice-list small {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+}
+
+.collection-choice-list b {
+  color: var(--warning);
+  font-size: 0.68rem;
+  white-space: nowrap;
 }
 
 .collection-field > span,
@@ -1294,8 +1409,21 @@ select {
 
   .hosted-rename,
   .inline-create,
-  .mirror-form {
+  .mirror-form,
+  .authorization-collection-create {
     grid-template-columns: 1fr;
+  }
+
+  .authorization-collection-create > div {
+    grid-column: 1;
+    grid-row: auto;
+    justify-content: flex-end;
+  }
+
+  .authorization-collection-create > label,
+  .authorization-collection-create > p {
+    grid-column: 1;
+    grid-row: auto;
   }
 
   .transfer-consequences > div {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2454,10 +2454,13 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     await page.goto(authorizationUrl);
     await expect(page.getByRole("heading", { name: "Hosted SDK E2E" })).toBeVisible();
     await expect(page.getByText("Hosted SDK E2E is asking to use one collection. Choose where it can work and review what it can do.")).toBeVisible();
-    const collection = page.getByLabel("Collection and location");
-    await expect(collection.locator(`option[value="${collectionId}"]`)).toHaveCount(1);
-    await collection.selectOption(collectionId);
-    await expect(collection.locator("option:checked")).toHaveText("Hosted writing · Hosted by mdbase");
+    const collection = page.getByRole("radio", {
+      name: /Hosted writing.*Hosted by mdbase/
+    });
+    await expect(collection).toHaveAttribute("value", collectionId);
+    await collection.check();
+    await expect(collection).toBeChecked();
+    await expect(page.getByRole("button", { name: "Create hosted collection" })).toBeVisible();
     await page.getByRole("button", { name: "Allow Hosted SDK E2E" }).click();
     const outcome = await Promise.race([
       page.waitForURL(
@@ -2488,17 +2491,17 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, ca
     const page = await context.newPage();
     await page.goto(authorizationUrl);
     await expect(page.getByRole("heading", { name: "Workout Inline E2E" })).toBeVisible();
-    const collection = page.getByLabel("Collection and location");
-    await expect(collection.locator("option")).toHaveCount(1);
-    await expect(collection.locator("option:checked")).toHaveText("No compatible collection");
-    await expect(collection).toBeDisabled();
-    await page.getByRole("button", { name: "Create an mdbase cloud collection" }).click();
-    await expect(collection.locator("option")).toHaveCount(1);
-    await expect(collection.locator("option:checked")).toHaveText(
-      "My collection · mdbase cloud · setup required"
-    );
+    await expect(page.getByText("No compatible collection is ready.")).toBeVisible();
+    await expect(page.getByRole("group", { name: "Collection and location" })).toHaveCount(0);
+    await page.getByRole("button", { name: "Create hosted collection" }).click();
+    await page.getByLabel("New collection name").fill("Workout records");
+    await page.getByRole("button", { name: "Create collection" }).click();
+    const collection = page.getByRole("radio", {
+      name: /Workout records.*Hosted by mdbase.*Setup needed/
+    });
+    await expect(collection).toBeVisible();
+    await expect(collection).toBeChecked();
     await expect(page.getByText("allowing access will add Workout")).toBeVisible();
-    await expect(collection).toBeEnabled();
     await page.getByRole("button", { name: "Allow Workout Inline E2E" }).click();
     await page.waitForURL((url) => url.origin === callbackOrigin && url.searchParams.has("code"));
     return page.url();

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1290,6 +1290,7 @@ describe("mdbase connect server", () => {
       headers: { authorization: `Bearer ${ownerToken}` }
     });
     expect(snapshot.statusCode, JSON.stringify(snapshot.json())).toBe(200);
+    expect(snapshot.json().hosted_collections_available).toBe(true);
     expect(snapshot.json().hosted_collections).toEqual([
       expect.objectContaining({
         id: collectionId,
@@ -1484,6 +1485,7 @@ describe("mdbase connect server", () => {
       access: "full_collection",
       collection_kind: "hosted"
     });
+    expect(pending.json().hosted_collections_available).toBe(true);
     expect(pending.json().collections).toEqual([
       expect.objectContaining({ id: collectionId, kind: "hosted" })
     ]);

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -1540,6 +1540,7 @@ export async function buildApp(options: BuildOptions) {
     );
     return {
       user,
+      hosted_collections_available: options.hostedCollections === true,
       authentication: {
         provider: authenticationProvider ?? (options.tailscaleAuth ? "tailscale" : "session"),
         registration
@@ -3101,6 +3102,7 @@ export async function buildApp(options: BuildOptions) {
     ];
     return {
       authorization: authorization.rows[0],
+      hosted_collections_available: options.hostedCollections === true,
       unavailable_connectors: local.unavailable_connectors,
       collections: requiresHostedCollection(authorization.rows[0].requirements)
         ? availableCollections.filter((collection) => collection.kind === "hosted")
@@ -5575,6 +5577,7 @@ async function hostedControlSnapshot(
   if (!options.hostedCollections) {
     return {
       online: true,
+      hosted_collections_available: false,
       hosted_collections: [],
       grants: [],
       pending_authorizations: []
@@ -5671,6 +5674,7 @@ async function hostedControlSnapshot(
   );
   return {
     online: true,
+    hosted_collections_available: true,
     hosted_collections: collections.rows.map((collection) => ({
       ...collection,
       provider_url: collection.provider_url ?? publicUrl,

--- a/services/server/src/production-auth.test.ts
+++ b/services/server/src/production-auth.test.ts
@@ -179,6 +179,18 @@ describe("production GitHub authentication", () => {
       payload: { display_name: "Private" }
     });
     expect(response.statusCode).toBe(404);
+    const login = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Local user", email: "local-only@example.com" }
+    });
+    const cookie = cookiePair(responseCookies(login)[0]);
+    const dashboard = await app.inject({
+      method: "GET",
+      url: "/v1/me",
+      headers: { cookie }
+    });
+    expect(dashboard.json().hosted_collections_available).toBe(false);
   });
 
   it("manages the complete hosted collection and receive-only mirror lifecycle", async () => {


### PR DESCRIPTION
## What changed

- add a named, inline hosted-collection creation flow to portal and desktop application approval screens
- keep creation separate from approval, auto-select the new collection, and disclose any setup still required
- advertise hosted-collection availability so self-hosted instances do not show an unusable action
- add responsive styling and extend browser/server coverage

## Why

Users should be able to choose a fresh hosted collection at the point where they decide where an application may work. Requiring a portal detour interrupts authorization and prevents users from deliberately isolating an app from existing collections.

## Impact

When hosted collections are enabled, users can create and name one from the collection picker even when compatible collections already exist. The application still receives no access until the user separately chooses **Allow**.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:provider`
- portal and desktop production builds
