### PR TITLE
Expose hosted-to-local authority transfer in Electron

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -601,6 +601,44 @@ function registerIpc(): void {
       value.resolution as "local" | "remote"
     );
   });
+  ipcMain.handle("connect:mirrors:promote", async (event, replicaId: unknown) => {
+    trustedIpc(event);
+    if (typeof replicaId !== "string") throw new Error("Invalid mirror ID.");
+    return mirrors().promoteAuthority(replicaId, {
+      registeredCollectionPath: async (collectionId) => {
+        const registered = await requestReadyAgent<Array<{ id: string; path: string }>>(
+          "collections.list"
+        );
+        const existing = registered.find(
+          (collection) => collection.id === collectionId
+        );
+        return existing?.path ?? null;
+      },
+      registerCollection: async (path) => {
+        const added = await requestReadyAgent<{ id: string }>(
+          "collections.add",
+          { path },
+          10_000
+        );
+        return added.id;
+      },
+      validateCollection: async (collectionId) => {
+        await requestReadyAgent(
+          "collections.validate",
+          { collection_id: collectionId },
+          10_000
+        );
+      },
+      removeCollection: async (collectionId) => {
+        await requestReadyAgent(
+          "collections.remove",
+          { collection_id: collectionId },
+          10_000
+        );
+      },
+      onVerification: (verificationUri) => shell.openExternal(verificationUri)
+    });
+  });
   ipcMain.handle("connect:mirrors:disconnect", async (event, replicaId: unknown) => {
     trustedIpc(event);
     if (typeof replicaId !== "string") throw new Error("Invalid mirror ID.");

--- a/apps/desktop/src/main/mirror-manager.ts
+++ b/apps/desktop/src/main/mirror-manager.ts
@@ -32,6 +32,18 @@ export interface DesktopMirrorSummary {
   cursor: number | null;
   last_synced_at: string | null;
   syncing: boolean;
+  promotion_pending: boolean;
+  promotion?: {
+    phase:
+      | "synchronizing"
+      | "awaiting_approval"
+      | "verifying"
+      | "registering"
+      | "registered"
+      | "activating"
+      | "completed"
+      | "resuming";
+  };
   progress?: {
     phase: "uploading" | "applying";
     completed: number;
@@ -74,8 +86,24 @@ interface MirrorExchangeResponse {
 
 interface RuntimeState {
   syncing: boolean;
+  promoting?: boolean;
+  promotionPhase?: NonNullable<DesktopMirrorSummary["promotion"]>["phase"];
   progress?: DesktopMirrorSummary["progress"];
   error?: string;
+}
+
+export interface DesktopAuthorityPromotionOptions {
+  registeredCollectionPath(collectionId: string): Promise<string | null>;
+  registerCollection(path: string, collectionId: string): Promise<string>;
+  validateCollection(collectionId: string): Promise<void>;
+  removeCollection(collectionId: string): Promise<void>;
+  onVerification(verificationUri: string): void | Promise<void>;
+}
+
+export interface DesktopAuthorityPromotionResult {
+  collection_id: string;
+  authority_epoch: number;
+  path: string;
 }
 
 const SYNC_INTERVAL_MS = 5_000;
@@ -245,6 +273,79 @@ export class MirrorManager {
     return this.summary(entry);
   }
 
+  async promoteAuthority(
+    replicaId: string,
+    options: DesktopAuthorityPromotionOptions
+  ): Promise<DesktopAuthorityPromotionResult> {
+    await this.start();
+    const entry = this.entry(replicaId);
+    if (entry.mode !== "read_write") {
+      throw new Error("Authority can move only from a two-way mirror.");
+    }
+    const runtime = this.runtime.get(replicaId);
+    if (runtime?.syncing || runtime?.promoting) {
+      throw new Error("Wait for the current mirror operation to finish.");
+    }
+    this.runtime.set(replicaId, {
+      syncing: false,
+      promoting: true,
+      promotionPhase: "synchronizing"
+    });
+    try {
+      const { promoteMirrorAuthority } = await import("@mdbase/connect-sync/promotion");
+      const result = await promoteMirrorAuthority(entry.path, {
+        stateRoot: this.mirrorStateRoot(),
+        registeredCollectionPath: options.registeredCollectionPath,
+        registerCollection: options.registerCollection,
+        validateCollection: options.validateCollection,
+        removeCollection: options.removeCollection,
+        onVerification: options.onVerification,
+        onPhase: (phase) => {
+          this.runtime.set(replicaId, {
+            syncing: false,
+            promoting: true,
+            promotionPhase: phase
+          });
+        },
+        onProgress: (progress) => {
+          const current = this.runtime.get(replicaId);
+          this.runtime.set(replicaId, {
+            syncing: false,
+            promoting: true,
+            promotionPhase: current?.promotionPhase ?? "synchronizing",
+            progress: {
+              phase: progress.phase,
+              completed: progress.completed,
+              total: progress.total
+            }
+          });
+        }
+      });
+      const previous = this.entries;
+      this.entries = this.entries.filter(
+        (candidate) => candidate.replica_id !== replicaId
+      );
+      try {
+        await this.writeRegistry();
+      } catch (error) {
+        this.entries = previous;
+        throw error;
+      }
+      this.runtime.delete(replicaId);
+      return {
+        collection_id: result.collectionId,
+        authority_epoch: result.authorityEpoch,
+        path: result.path
+      };
+    } catch (error) {
+      this.runtime.set(replicaId, {
+        syncing: false,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      throw error;
+    }
+  }
+
   async remove(replicaId: string): Promise<void> {
     await this.start();
     const entry = this.entry(replicaId);
@@ -271,9 +372,10 @@ export class MirrorManager {
 
   private async sync(entry: MirrorRegistryEntry): Promise<void> {
     const current = this.runtime.get(entry.replica_id);
-    if (current?.syncing) return;
-    this.runtime.set(entry.replica_id, { syncing: true });
+    if (current?.syncing || current?.promoting) return;
     try {
+      if (await this.promotionPending(entry)) return;
+      this.runtime.set(entry.replica_id, { syncing: true });
       const mirror = await this.mirrorFor(entry, (progress) => {
         this.runtime.set(entry.replica_id, {
           syncing: true,
@@ -303,6 +405,50 @@ export class MirrorManager {
 
   private async summary(entry: MirrorRegistryEntry): Promise<DesktopMirrorSummary> {
     const runtime = this.runtime.get(entry.replica_id) ?? { syncing: false };
+    let promotionPending: boolean;
+    try {
+      promotionPending = await this.promotionPending(entry);
+    } catch (error) {
+      return {
+        collection_id: entry.collection_id,
+        replica_id: entry.replica_id,
+        name: entry.name,
+        mode: entry.mode,
+        path: entry.path,
+        state: "attention",
+        pending: 0,
+        conflicts: [],
+        local_issues: [],
+        cursor: null,
+        last_synced_at: null,
+        syncing: false,
+        promotion_pending: false,
+        error: `Authority transfer recovery data could not be read: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      };
+    }
+    if (runtime.promoting) {
+      return {
+        collection_id: entry.collection_id,
+        replica_id: entry.replica_id,
+        name: entry.name,
+        mode: entry.mode,
+        path: entry.path,
+        state: "up_to_date",
+        pending: 0,
+        conflicts: [],
+        local_issues: [],
+        cursor: null,
+        last_synced_at: null,
+        syncing: false,
+        promotion_pending: promotionPending,
+        promotion: {
+          phase: runtime.promotionPhase ?? "synchronizing"
+        },
+        ...(runtime.progress ? { progress: runtime.progress } : {})
+      };
+    }
     try {
       const status = await (await this.mirrorFor(entry)).status();
       return {
@@ -313,6 +459,7 @@ export class MirrorManager {
         ...status,
         mode: entry.mode,
         syncing: runtime.syncing,
+        promotion_pending: promotionPending,
         ...(runtime.progress ? { progress: runtime.progress } : {}),
         ...(runtime.error ? { error: runtime.error } : {})
       };
@@ -330,9 +477,18 @@ export class MirrorManager {
         cursor: null,
         last_synced_at: null,
         syncing: runtime.syncing,
+        promotion_pending: promotionPending,
         error: runtime.error ?? (error instanceof Error ? error.message : String(error))
       };
     }
+  }
+
+  private async promotionPending(entry: MirrorRegistryEntry): Promise<boolean> {
+    const { loadAuthorityPromotionCheckpoint } =
+      await import("@mdbase/connect-sync/device");
+    return Boolean(
+      await loadAuthorityPromotionCheckpoint(entry.path, this.mirrorStateRoot())
+    );
   }
 
   private async mirrorFor(

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -78,6 +78,8 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
     recordId: string;
     resolution: "local" | "remote";
   }) => ipcRenderer.invoke("connect:mirrors:resolve", input),
+  promoteMirrorAuthority: (replicaId: string) =>
+    ipcRenderer.invoke("connect:mirrors:promote", replicaId),
   disconnectMirror: (replicaId: string) =>
     ipcRenderer.invoke("connect:mirrors:disconnect", replicaId),
   openMirror: (replicaId: string) => ipcRenderer.invoke("connect:mirrors:open", replicaId),

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -184,6 +184,18 @@ interface DesktopMirrorSummary {
   cursor: number | null;
   last_synced_at: string | null;
   syncing: boolean;
+  promotion_pending: boolean;
+  promotion?: {
+    phase:
+      | "synchronizing"
+      | "awaiting_approval"
+      | "verifying"
+      | "registering"
+      | "registered"
+      | "activating"
+      | "completed"
+      | "resuming";
+  };
   progress?: {
     phase: "uploading" | "applying";
     completed: number;
@@ -267,6 +279,11 @@ interface Window {
     connectMirror(input: { collectionId: string; path: string; mode: "read_only" | "read_write"; name?: string }): Promise<DesktopMirrorSummary>;
     syncMirror(replicaId: string): Promise<DesktopMirrorSummary>;
     resolveMirrorConflict(input: { replicaId: string; recordId: string; resolution: "local" | "remote" }): Promise<DesktopMirrorSummary>;
+    promoteMirrorAuthority(replicaId: string): Promise<{
+      collection_id: string;
+      authority_epoch: number;
+      path: string;
+    }>;
     disconnectMirror(replicaId: string): Promise<{ ok: true }>;
     openMirror(replicaId: string): Promise<string>;
     onNavigate(listener: (route: string) => void): () => void;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -615,6 +615,7 @@ function HostedCollectionRow({
   const [name, setName] = useState(collection.display_name);
   const [path, setPath] = useState("");
   const [mode, setMode] = useState<"read_only" | "read_write">("read_write");
+  const [promotionStarting, setPromotionStarting] = useState(false);
   const mirror = mirrors.find((candidate) => candidate.collection_id === collection.id);
   const activeReplicas = collection.replicas.filter((replica) => replica.revoked_at === null);
 
@@ -634,6 +635,7 @@ function HostedCollectionRow({
   }
 
   const state = mirrorState(mirror);
+  const promotion = authorityPromotionState(collection, mirror, promotionStarting);
   return (
     <article className={`collection-card hosted-collection ${editing ? "editing" : ""}`}>
       <div className="collection-summary">
@@ -642,9 +644,22 @@ function HostedCollectionRow({
             <h3>{collection.display_name}</h3>
             <span className="version">v{collection.spec_version}</span>
           </div>
-          <span className="authority-label">Hosted authority · {activeReplicas.length} {plural(activeReplicas.length, "mirror", "mirrors")}</span>
+          <span className="authority-label">
+            {collection.authority_state === "transferred"
+              ? "Retired hosted copy · authority moved"
+              : collection.authority_state === "transferring"
+                ? "Authority transfer in progress"
+                : `Hosted authority · ${activeReplicas.length} ${plural(activeReplicas.length, "mirror", "mirrors")}`}
+          </span>
         </div>
-        <div className="collection-status"><StatusDot state={collection.authority_state === "active" ? "connected" : "idle"} />{collection.authority_state === "active" ? "Available" : collection.authority_state}</div>
+        <div className="collection-status">
+          <StatusDot state={collection.authority_state === "active" ? "connected" : "idle"} />
+          {collection.authority_state === "active"
+            ? "Available"
+            : collection.authority_state === "transferred"
+              ? "Moved"
+              : "Moving"}
+        </div>
         <div className="row-actions">
           <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : mirror ? "Mirror" : "Details"}</button>
         </div>
@@ -665,7 +680,7 @@ function HostedCollectionRow({
             </div>
           </section>
         </form>
-        <section className="collection-editor-section mirror-section">
+        {collection.authority_state !== "transferred" && <section className="collection-editor-section mirror-section">
           <div>
             <strong>Mirror on this computer</strong>
             <small>A mirror is a local copy. The hosted collection remains authoritative.</small>
@@ -733,7 +748,72 @@ function HostedCollectionRow({
               })}>Start mirror</button>
             </div>
           )}
-        </section>
+        </section>}
+        {collection.authority_state === "transferred" ? (
+          <section className="collection-editor-section">
+            <div>
+              <strong>Authority</strong>
+              <small>This hosted copy is retained for recovery but no longer accepts changes.</small>
+            </div>
+            <div className="authority-transfer-control">
+              <div>
+                <strong>Source of truth moved to this computer</strong>
+                <small>The collection now appears under On this computer. Applications need fresh access to the computer-owned collection.</small>
+              </div>
+            </div>
+          </section>
+        ) : mirror && (
+          <section className="collection-editor-section">
+            <div>
+              <strong>Authority</strong>
+              <small>Make this synchronized folder the source of truth.</small>
+            </div>
+            <div className="authority-transfer-control">
+              <div>
+                <strong>{promotion.title}</strong>
+                <small>{promotion.detail}</small>
+              </div>
+              <button
+                type="button"
+                className="button secondary"
+                disabled={busy || !promotion.enabled}
+                onClick={() => {
+                  if (
+                    !mirror.promotion_pending
+                    && !window.confirm(
+                      `Move ${collection.display_name} authority to this computer? `
+                      + `${mirror.path} will become the source of truth. Hosted writes will stop, `
+                      + "and existing application access and other mirrors will be revoked. "
+                      + "You will confirm this change in your browser."
+                    )
+                  ) return;
+                  setPromotionStarting(true);
+                  void onAct(async () => {
+                    onNotice(
+                      mirror.promotion_pending
+                        ? "Resuming the authority transfer. Keep mdbase connect open."
+                        : "Confirm the authority transfer in your browser, then return to mdbase connect."
+                    );
+                    try {
+                      const result = await window.mdbaseConnect.promoteMirrorAuthority(
+                        mirror.replica_id
+                      );
+                      setEditing(false);
+                      onNotice(
+                        `${collection.display_name} now uses this computer as its authority at epoch `
+                        + `${result.authority_epoch}. Applications need fresh access.`
+                      );
+                    } finally {
+                      setPromotionStarting(false);
+                    }
+                  });
+                }}
+              >
+                {promotion.button}
+              </button>
+            </div>
+          </section>
+        )}
         {activeReplicas.some((replica) => replica.id !== mirror?.replica_id) && (
           <section className="collection-editor-section">
             <div><strong>Other mirrors</strong><small>Mirrors connected from another installation or through the command line.</small></div>
@@ -1386,6 +1466,12 @@ function mirrorState(mirror: DesktopMirrorSummary | undefined): {
   label: string;
 } {
   if (!mirror) return { dot: "idle", label: "Not mirrored" };
+  if (mirror.promotion) {
+    return {
+      dot: "connecting",
+      label: authorityPromotionPhaseLabel(mirror.promotion.phase)
+    };
+  }
   if (mirror.syncing) return { dot: "connecting", label: "Synchronizing" };
   if (mirror.error || mirror.state === "offline") return { dot: "danger", label: "Mirror needs attention" };
   if (mirror.conflicts.length > 0) return { dot: "paused", label: "Conflicts need a decision" };
@@ -1393,6 +1479,112 @@ function mirrorState(mirror: DesktopMirrorSummary | undefined): {
   if (mirror.state === "changes_waiting" || mirror.pending > 0) return { dot: "connecting", label: "Changes waiting" };
   if (mirror.state === "not_initialized") return { dot: "idle", label: "Not synchronized yet" };
   return { dot: "connected", label: "Up to date" };
+}
+
+function authorityPromotionState(
+  collection: HostedCollectionSummary,
+  mirror: DesktopMirrorSummary | undefined,
+  starting: boolean
+): { enabled: boolean; title: string; detail: string; button: string } {
+  if (!mirror) {
+    return {
+      enabled: false,
+      title: "A two-way mirror is required",
+      detail: "Create and synchronize a two-way mirror on this computer first.",
+      button: "Move authority to this computer"
+    };
+  }
+  if (starting && !mirror.promotion) {
+    return {
+      enabled: false,
+      title: "Preparing authority transfer",
+      detail: "Checking the folder before opening browser confirmation.",
+      button: "Preparing transfer…"
+    };
+  }
+  if (mirror.promotion) {
+    const label = authorityPromotionPhaseLabel(mirror.promotion.phase);
+    return {
+      enabled: false,
+      title: label,
+      detail: mirror.promotion.phase === "awaiting_approval"
+        ? "Approve the move in your browser. Hosted writes continue until approval."
+        : "Keep mdbase connect open while the handoff finishes.",
+      button: `${label}…`
+    };
+  }
+  if (mirror.promotion_pending) {
+    return {
+      enabled: true,
+      title: "Authority transfer ready to resume",
+      detail: "The folder was already verified. Finish activating it as the source of truth.",
+      button: "Resume authority move"
+    };
+  }
+  if (mirror.mode !== "read_write") {
+    return {
+      enabled: false,
+      title: "A two-way mirror is required",
+      detail: "Receive-only folders cannot become authoritative. Recreate this mirror as two-way.",
+      button: "Move authority to this computer"
+    };
+  }
+  if (collection.authority_state !== "active") {
+    return {
+      enabled: false,
+      title: "Authority transfer already in progress",
+      detail: "Return to the browser confirmation or wait for the current request to expire.",
+      button: "Move authority to this computer"
+    };
+  }
+  if (mirror.syncing) {
+    return {
+      enabled: false,
+      title: "Mirror is synchronizing",
+      detail: "Authority can move after the current synchronization finishes.",
+      button: "Move authority to this computer"
+    };
+  }
+  if (
+    mirror.error
+    || mirror.state === "offline"
+    || mirror.conflicts.length > 0
+    || mirror.local_issues.length > 0
+    || mirror.state === "attention"
+  ) {
+    return {
+      enabled: false,
+      title: "Mirror needs attention",
+      detail: "Resolve mirror errors and file conflicts before moving authority.",
+      button: "Move authority to this computer"
+    };
+  }
+  if (mirror.state !== "up_to_date" || mirror.pending > 0) {
+    return {
+      enabled: false,
+      title: "Synchronize this mirror first",
+      detail: "The folder must match the hosted collection before it can become authoritative.",
+      button: "Move authority to this computer"
+    };
+  }
+  return {
+    enabled: true,
+    title: "Move authority to this computer",
+    detail: "Browser confirmation will pause hosted writes, verify this folder, and revoke existing application access.",
+    button: "Move authority to this computer"
+  };
+}
+
+function authorityPromotionPhaseLabel(
+  phase: NonNullable<DesktopMirrorSummary["promotion"]>["phase"]
+): string {
+  if (phase === "synchronizing") return "Synchronizing mirror";
+  if (phase === "awaiting_approval") return "Waiting for browser approval";
+  if (phase === "verifying") return "Verifying exact folder contents";
+  if (phase === "registering") return "Registering local authority";
+  if (phase === "registered" || phase === "activating") return "Activating local authority";
+  if (phase === "resuming") return "Resuming authority transfer";
+  return "Finishing authority transfer";
 }
 
 function hasContract(contracts: ContractRequirement[], required: ContractRequirement) { return contracts.some((contract) => sameContract(contract, required)); }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -140,6 +140,12 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .replica-list code, .replica-list small { color: var(--muted); font-size: var(--type-action); }
 .collection-editor textarea { min-height: 58px; padding: 8px 10px; resize: vertical; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font: inherit; font-size: var(--type-body); line-height: 1.45; }
 .collection-config-actions { display: flex; align-items: center; justify-content: flex-start; gap: 8px; }
+.authority-transfer-control { display: flex; align-items: center; justify-content: space-between; gap: 18px; min-width: 0; }
+.authority-transfer-control > div { display: grid; gap: 3px; min-width: 0; }
+.authority-transfer-control > strong { display: block; }
+.authority-transfer-control strong { font-size: var(--type-body); }
+.authority-transfer-control small { display: block; max-width: 68ch; margin-top: 3px; color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.authority-transfer-control .button { flex: 0 0 auto; }
 .collection-editor-footer { padding: 14px 0; }
 .collection-danger-row { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 12px 0 14px; }
 .collection-danger-row small { color: var(--muted); font-size: var(--type-action); }
@@ -290,6 +296,7 @@ fieldset legend { margin-bottom: 6px; }
   .application-grant-group > summary > b { grid-column: 2; grid-row: 1; }
   .application-grant-actions { align-items: flex-start; flex-direction: column; }
   .collection-danger-row { align-items: flex-start; flex-direction: column; }
+  .authority-transfer-control { align-items: flex-start; flex-direction: column; }
   .overview-row { grid-template-columns: 95px minmax(0, 1fr) auto; }
   .pairing-form { grid-template-columns: 1fr; }
   .pairing-form .button { grid-column: 1; }

--- a/apps/desktop/test/mirror-manager.test.mjs
+++ b/apps/desktop/test/mirror-manager.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import { pathsOverlap } from "../dist/main/mirror-manager.js";
+import { mirrorProfileDirectory } from "@mdbase/connect-sync/device";
+import { MirrorManager, pathsOverlap } from "../dist/main/mirror-manager.js";
 
 test("hosted mirrors reject the same folder and nested folders", () => {
   assert.equal(pathsOverlap("/vault/hosted", "/vault/hosted"), true);
@@ -11,4 +15,49 @@ test("hosted mirrors reject the same folder and nested folders", () => {
 test("hosted mirrors allow sibling folders with similar names", () => {
   assert.equal(pathsOverlap("/vault/hosted", "/vault/hosted-copy"), false);
   assert.equal(pathsOverlap("/vault/one", "/vault/two"), false);
+});
+
+test("a corrupt authority checkpoint is isolated to its mirror summary", async () => {
+  const userData = await mkdtemp(join(tmpdir(), "mdbase-desktop-user-data-"));
+  const root = await mkdtemp(join(tmpdir(), "mdbase-desktop-mirror-"));
+  const manager = new MirrorManager(userData);
+  const collectionId = "11111111-1111-4111-8111-111111111111";
+  const replicaId = "22222222-2222-4222-8222-222222222222";
+  try {
+    await writeFile(join(userData, "mirrors.json"), JSON.stringify({
+      version: 1,
+      mirrors: [{
+        collection_id: collectionId,
+        replica_id: replicaId,
+        name: "Recovery test",
+        mode: "read_write",
+        path: root,
+        created_at: new Date().toISOString()
+      }]
+    }));
+    const profileDirectory = await mirrorProfileDirectory(
+      root,
+      join(userData, "mirror-state")
+    );
+    await mkdir(profileDirectory, { recursive: true });
+    await writeFile(
+      join(profileDirectory, "authority-promotion.json"),
+      "{\"version\":1,\"transfer_id\":false}\n"
+    );
+
+    const summaries = await manager.list();
+
+    assert.equal(summaries.length, 1);
+    assert.equal(summaries[0].replica_id, replicaId);
+    assert.equal(summaries[0].state, "attention");
+    assert.equal(summaries[0].promotion_pending, false);
+    assert.match(
+      summaries[0].error,
+      /Authority transfer recovery data could not be read/
+    );
+  } finally {
+    manager.stop();
+    await rm(userData, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -34,6 +34,10 @@
     "./enrollment": {
       "types": "./dist/enrollment.d.ts",
       "import": "./dist/enrollment.js"
+    },
+    "./promotion": {
+      "types": "./dist/promotion.d.ts",
+      "import": "./dist/promotion.js"
     }
   },
   "files": [

--- a/packages/sync/src/cli.ts
+++ b/packages/sync/src/cli.ts
@@ -16,19 +16,10 @@ import {
 } from "./node.js";
 import {
   assertMirror,
-  clearMirrorMarker,
-  clearAuthorityPromotionCheckpoint,
   loadMirrorProfile,
-  loadAuthorityPromotionCheckpoint,
   markMirror,
-  readCollectionConfiguration,
-  restoreCollectionConfiguration,
-  retireMirrorAfterPromotion,
   saveMirrorProfile,
-  saveAuthorityPromotionCheckpoint,
-  setCollectionIdentity,
   updateMirrorCredentials,
-  type AuthorityPromotionCheckpoint,
   type StoredMirrorProfile
 } from "./device.js";
 import {
@@ -36,6 +27,7 @@ import {
   canonicalConnectOrigin,
   type MirrorEnrollment
 } from "./enrollment.js";
+import { promoteMirrorAuthority } from "./promotion.js";
 
 const parsed = parseArgs({
   allowPositionals: true,
@@ -287,33 +279,6 @@ async function currentProfile(root: string): Promise<StoredMirrorProfile> {
   return stored;
 }
 
-interface AuthorityTransfer {
-  id: string;
-  collection_id: string;
-  replica_id: string;
-  state: "requested" | "approved" | "prepared" | "completed" | "cancelled" | "expired";
-  final_head: number | null;
-  authority_epoch: number | null;
-  manifest_digest: string | null;
-  expires_at: string;
-  verification_uri: string;
-  local_collection_id?: string;
-}
-
-interface AuthorityTransferResponse {
-  transfer: AuthorityTransfer;
-  verification_uri?: string;
-  expires_in?: number;
-}
-
-interface AuthorityTransferCompletion {
-  status: "completed" | "waiting_for_connector";
-  collection_id?: string;
-  local_collection_id?: string;
-  authority_epoch?: number;
-  message?: string;
-}
-
 async function connect(root: string): Promise<void> {
   await mkdir(root, { recursive: true });
   const controlUrl = canonicalConnectOrigin(required(parsed.values.server, "--server"));
@@ -350,210 +315,41 @@ async function connect(root: string): Promise<void> {
 }
 
 async function promote(root: string): Promise<void> {
-  const unfinished = await loadAuthorityPromotionCheckpoint(root);
-  // A committed provider has already revoked the mirror access token. Resume
-  // from the durable proof without attempting ordinary token renewal.
-  const stored = unfinished ? await loadMirrorProfile(root) : await currentProfile(root);
-  if (
-    stored.profile.mode !== "read_write"
-    || !stored.profile.control_url
-    || !stored.profile.enrollment_id
-    || !stored.credentials.refresh_token
-  ) {
-    throw new Error(
-      "Authority can move only from a browser-paired, two-way full collection mirror."
-    );
-  }
-  const controlUrl = canonicalConnectOrigin(stored.profile.control_url);
-  const authentication = { authorization: `Bearer ${stored.credentials.refresh_token}` };
-  if (unfinished) {
-    if (unfinished.collection_id !== stored.profile.collection_id) {
-      throw new Error("The saved authority promotion belongs to another collection.");
-    }
-    process.stdout.write("Resuming the materialized authority handoff.\n");
-    await setCollectionIdentity(root, unfinished.collection_id);
-    await clearMirrorMarker(root, unfinished.collection_id);
-    await registerPromotedCollection(root, unfinished.collection_id);
-    await completePromotion(root, controlUrl, authentication, unfinished);
-    return;
-  }
-
-  await initialSync(root);
-  const requested = await jsonRequest<AuthorityTransferResponse>(
-    `${controlUrl}/v1/mirror-pairing-requests/${encodeURIComponent(stored.profile.enrollment_id)}/authority-transfers`,
-    {
-      method: "POST",
-      headers: { ...authentication, "content-type": "application/json" },
-      body: "{}"
-    }
-  );
-  const verificationUri = requested.verification_uri ?? requested.transfer.verification_uri;
-  process.stdout.write(
-    `Confirm moving the source of truth to this computer:\n${verificationUri}\n`
-  );
-  if (!parsed.values["no-open"]) openBrowser(verificationUri);
-  const deadline = new Date(requested.transfer.expires_at).getTime();
-  let prepared = requested.transfer;
-  while (prepared.state !== "prepared" && Date.now() < deadline) {
-    const response = await fetch(
-      `${controlUrl}/v1/authority-transfers/${encodeURIComponent(prepared.id)}/prepare`,
-      { method: "POST", headers: { ...authentication, "content-type": "application/json" }, body: "{}" }
-    );
-    if (response.status === 202) {
-      await delay(1_500);
-      continue;
-    }
-    prepared = (await responseJson<AuthorityTransferResponse>(response)).transfer;
-  }
-  if (
-    prepared.state !== "prepared"
-    || prepared.final_head === null
-    || prepared.authority_epoch === null
-    || !prepared.manifest_digest
-  ) {
-    throw new Error("Authority transfer approval expired. Run the promote command again.");
-  }
-
-  let localRegistered = false;
-  let checkpoint: Omit<AuthorityPromotionCheckpoint, "version"> | null = null;
-  try {
-    const configuration = await currentProfile(root);
-    const mirror = mirrorFor(root, configuration);
-    await mirror.sync();
-    const manifest = await mirror.authorityPromotionManifest();
-    if (
-      manifest.cursor !== prepared.final_head
-      || manifest.digest !== prepared.manifest_digest
-    ) {
-      throw new Error(
-        "The local folder does not exactly match the fenced collection authority."
+  const result = await promoteMirrorAuthority(root, {
+    registeredCollectionPath: async (collectionId) => {
+      const collections = await runConnectCli(["collection", "list"]);
+      return collectionPathFromControlResult(collections, collectionId);
+    },
+    registerCollection: async (path) => {
+      const added = await runConnectCli(["collection", "add", path]);
+      return collectionIdFromControlResult(added) ?? "";
+    },
+    validateCollection: async (collectionId) => {
+      await runConnectCli(["collection", "validate", collectionId]);
+    },
+    removeCollection: async (collectionId) => {
+      await runConnectCli(["collection", "remove", collectionId]);
+    },
+    onVerification: (verificationUri) => {
+      process.stdout.write(
+        `Confirm moving the source of truth to this computer:\n${verificationUri}\n`
       );
-    }
-    const originalConfiguration = await readCollectionConfiguration(root);
-    checkpoint = {
-      transfer_id: prepared.id,
-      collection_id: prepared.collection_id,
-      manifest_digest: prepared.manifest_digest,
-      authority_epoch: prepared.authority_epoch,
-      expires_at: prepared.expires_at,
-      original_configuration: originalConfiguration
-    };
-    await saveAuthorityPromotionCheckpoint(root, checkpoint);
-    await setCollectionIdentity(root, prepared.collection_id);
-    await clearMirrorMarker(root, prepared.collection_id);
-    const added = await runConnectCli(["collection", "add", root]);
-    const registeredId = collectionIdFromControlResult(added);
-    if (registeredId !== prepared.collection_id) {
-      throw new Error("The local agent registered a different collection identity.");
-    }
-    localRegistered = true;
-    await runConnectCli(["collection", "validate", prepared.collection_id]);
-  } catch (error) {
-    if (localRegistered) {
-      await runConnectCli(["collection", "remove", prepared.collection_id]).catch(() => undefined);
-    }
-    const saved = await loadAuthorityPromotionCheckpoint(root);
-    if (saved?.transfer_id === prepared.id) {
-      await restoreCollectionConfiguration(root, saved.original_configuration).catch(() => undefined);
-      await markMirror(root, saved.collection_id).catch(() => undefined);
-      await clearAuthorityPromotionCheckpoint(root).catch(() => undefined);
-    }
-    await fetch(
-      `${controlUrl}/v1/authority-transfers/${encodeURIComponent(prepared.id)}`,
-      { method: "DELETE", headers: authentication }
-    ).catch(() => undefined);
-    throw error;
-  }
-
-  if (!checkpoint) throw new Error("Authority promotion checkpoint was not created.");
-  process.stdout.write("Local collection registered. Waiting for this computer to publish it.\n");
-  await completePromotion(root, controlUrl, authentication, checkpoint);
-}
-
-async function registerPromotedCollection(root: string, collectionId: string): Promise<void> {
-  const added = await runConnectCli(["collection", "add", root]);
-  const registeredId = collectionIdFromControlResult(added);
-  if (registeredId !== collectionId) {
-    throw new Error("The local agent registered a different collection identity.");
-  }
-  await runConnectCli(["collection", "validate", collectionId]);
-}
-
-async function completePromotion(
-  root: string,
-  controlUrl: string,
-  authentication: { authorization: string },
-  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">
-): Promise<void> {
-  const deadline = new Date(checkpoint.expires_at).getTime();
-  let attempted = false;
-  while (!attempted || Date.now() < deadline) {
-    attempted = true;
-    let response: Response;
-    try {
-      response = await fetch(
-        `${controlUrl}/v1/authority-transfers/${encodeURIComponent(checkpoint.transfer_id)}/complete`,
-        {
-          method: "POST",
-          headers: { ...authentication, "content-type": "application/json" },
-          body: JSON.stringify({ manifest_digest: checkpoint.manifest_digest })
-        }
-      );
-    } catch {
-      if (Date.now() >= deadline) break;
-      await delay(2_000);
-      continue;
-    }
-    if (response.status === 202) {
-      if (Date.now() >= deadline) break;
-      await delay(2_000);
-      continue;
-    }
-    let completed: AuthorityTransferCompletion;
-    try {
-      completed = await responseJson<AuthorityTransferCompletion>(response);
-    } catch (error) {
-      if (
-        error instanceof ApiRequestError
-        && error.status === 409
-        && ["authority_transfer_expired", "authority_transfer_inactive"].includes(error.code)
-      ) {
-        await rollbackMaterializedPromotion(root, checkpoint);
+      if (!parsed.values["no-open"]) openBrowser(verificationUri);
+    },
+    onPhase: (phase) => {
+      if (phase === "resuming") {
+        process.stdout.write("Resuming the materialized authority handoff.\n");
+      } else if (phase === "registered") {
+        process.stdout.write(
+          "Local collection registered. Waiting for this computer to publish it.\n"
+        );
       }
-      throw error;
-    }
-    if (
-      completed.status !== "completed"
-      || completed.collection_id !== checkpoint.collection_id
-      || completed.authority_epoch !== checkpoint.authority_epoch
-    ) {
-      if (Date.now() >= deadline) break;
-      await delay(2_000);
-      continue;
-    }
-    await retireMirrorAfterPromotion(root, {
-      collection_id: checkpoint.collection_id,
-      authority_epoch: completed.authority_epoch
-    });
-    process.stdout.write(
-      `Authority moved to ${root}. Remote writes are retired at epoch ${completed.authority_epoch}.\n`
-    );
-    return;
-  }
-  throw new Error(
-    "The local collection is ready, but activation did not finish. "
-    + "Leave the folder and local agent running, then run promote again."
+    },
+    onProgress: mirrorProgressReporter()
+  });
+  process.stdout.write(
+    `Authority moved to ${result.path}. Remote writes are retired at epoch ${result.authorityEpoch}.\n`
   );
-}
-
-async function rollbackMaterializedPromotion(
-  root: string,
-  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">
-): Promise<void> {
-  await runConnectCli(["collection", "remove", checkpoint.collection_id]);
-  await restoreCollectionConfiguration(root, checkpoint.original_configuration);
-  await markMirror(root, checkpoint.collection_id);
-  await clearAuthorityPromotionCheckpoint(root);
 }
 
 async function runConnectCli(args: string[]): Promise<unknown> {
@@ -599,31 +395,23 @@ function collectionIdFromControlResult(result: unknown): string | null {
   return typeof id === "string" ? id : null;
 }
 
-async function jsonRequest<Result>(url: string, init: RequestInit): Promise<Result> {
-  return responseJson<Result>(await fetch(url, init));
-}
-
-async function responseJson<Result>(response: Response): Promise<Result> {
-  const value = await response.json().catch(() => null);
-  if (!response.ok) {
-    const error = value as { error?: { code?: string; message?: string } } | null;
-    throw new ApiRequestError(
-      response.status,
-      error?.error?.code ?? "request_failed",
-      error?.error?.message ?? `Request failed with status ${response.status}.`
-    );
+function collectionPathFromControlResult(
+  result: unknown,
+  collectionId: string
+): string | null {
+  if (!Array.isArray(result)) {
+    throw new Error("The local mdbase connect agent returned an invalid collection list.");
   }
-  return value as Result;
-}
-
-class ApiRequestError extends Error {
-  constructor(
-    readonly status: number,
-    readonly code: string,
-    message: string
-  ) {
-    super(message);
+  const collection = result.find((candidate) =>
+    candidate
+    && typeof candidate === "object"
+    && (candidate as Record<string, unknown>).id === collectionId
+  ) as Record<string, unknown> | undefined;
+  if (!collection) return null;
+  if (typeof collection.path !== "string") {
+    throw new Error("The local mdbase connect agent returned an invalid collection path.");
   }
+  return collection.path;
 }
 
 function openBrowser(url: string): void {

--- a/packages/sync/src/promotion.fault-injection.test.ts
+++ b/packages/sync/src/promotion.fault-injection.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ids = vi.hoisted(() => ({
+  collection: "11111111-1111-4111-8111-111111111111",
+  otherCollection: "22222222-2222-4222-8222-222222222222",
+  replica: "33333333-3333-4333-8333-333333333333",
+  transfer: "44444444-4444-4444-8444-444444444444"
+}));
+
+const state = vi.hoisted(() => ({
+  calls: [] as string[],
+  checkpoint: null as null | Record<string, unknown>,
+  registeredPath: null as string | null,
+  registrationLookupUnavailable: false,
+  manifest: {
+    cursor: 7,
+    digest: "a".repeat(64)
+  },
+  profile: {
+    profile: {
+      version: 1 as const,
+      sync_url: `https://connect.test/v1/authorities/${ids.collection}/sync`,
+      control_url: "https://connect.test",
+      collection_id: ids.collection,
+      replica_id: ids.replica,
+      mode: "read_write" as const,
+      enrollment_id: "55555555-5555-4555-8555-555555555555",
+      access_token_expires_at: "2099-01-01T00:00:00.000Z"
+    },
+    credentials: {
+      access_token: "access-token",
+      refresh_token: "refresh-token"
+    }
+  }
+}));
+
+vi.mock("./index.js", () => ({
+  HttpSyncTransport: class HttpSyncTransport {}
+}));
+
+vi.mock("./node.js", () => ({
+  NodeMirrorStateStore: class NodeMirrorStateStore {},
+  WritableDirectoryMirror: class WritableDirectoryMirror {
+    async previewInitialization() {
+      return {
+        collisions: [],
+        already_initialized: true,
+        download_documents: 0,
+        upload_documents: 0,
+        unchanged_documents: 0
+      };
+    }
+    async sync() {
+      state.calls.push("sync");
+    }
+    async authorityPromotionManifest() {
+      state.calls.push("manifest");
+      return state.manifest;
+    }
+  }
+}));
+
+vi.mock("./device.js", () => ({
+  loadAuthorityPromotionCheckpoint: async () => state.checkpoint,
+  loadMirrorProfile: async () => state.profile,
+  markMirror: async () => {
+    state.calls.push("mark-mirror");
+  },
+  clearMirrorMarker: async () => {
+    state.calls.push("clear-marker");
+  },
+  readCollectionConfiguration: async () => "name: Original\n",
+  restoreCollectionConfiguration: async () => {
+    state.calls.push("restore-config");
+  },
+  retireMirrorAfterPromotion: async () => {
+    state.calls.push("retire-mirror");
+  },
+  saveAuthorityPromotionCheckpoint: async (
+    _root: string,
+    checkpoint: Record<string, unknown>
+  ) => {
+    state.calls.push("save-checkpoint");
+    state.checkpoint = { version: 1, ...checkpoint };
+  },
+  clearAuthorityPromotionCheckpoint: async () => {
+    state.calls.push("clear-checkpoint");
+    state.checkpoint = null;
+  },
+  setCollectionIdentity: async (_root: string, collectionId: string) => {
+    state.calls.push(`set-identity:${collectionId}`);
+  },
+  updateMirrorCredentials: async () => state.profile
+}));
+
+vi.mock("./enrollment.js", () => ({
+  canonicalConnectOrigin: (value: string) => new URL(value).origin,
+  MirrorEnrollmentClient: class MirrorEnrollmentClient {}
+}));
+
+import { promoteMirrorAuthority } from "./promotion.js";
+
+beforeEach(() => {
+  state.calls.length = 0;
+  state.checkpoint = null;
+  state.registeredPath = null;
+  state.registrationLookupUnavailable = false;
+  state.manifest = {
+    cursor: 7,
+    digest: "a".repeat(64)
+  };
+});
+
+describe("authority promotion fault injection", () => {
+  it("cancels before local materialization when the fenced manifest differs", async () => {
+    state.manifest = { cursor: 7, digest: "b".repeat(64) };
+    const fetch = scenarioFetch();
+
+    await expect(promoteMirrorAuthority("/mirror", options(fetch))).rejects.toThrow(
+      "does not exactly match"
+    );
+
+    expect(state.calls).toContain("cancel-transfer");
+    expect(state.calls).not.toContain("save-checkpoint");
+    expect(state.calls.some((call) => call.startsWith("set-identity:"))).toBe(false);
+  });
+
+  it("rolls back the folder and registration when local validation fails", async () => {
+    const fetch = scenarioFetch();
+    const callbacks = options(fetch);
+    callbacks.validateCollection = async () => {
+      state.calls.push("validate");
+      throw new Error("validation failed");
+    };
+
+    await expect(promoteMirrorAuthority("/mirror", callbacks)).rejects.toThrow(
+      "validation failed"
+    );
+
+    expect(state.calls).toEqual(expect.arrayContaining([
+      "remove-registration",
+      "restore-config",
+      "mark-mirror",
+      "clear-checkpoint",
+      "cancel-transfer"
+    ]));
+  });
+
+  it("retries an outcome-uncertain completion without repeating materialization", async () => {
+    const fetch = scenarioFetch({ failFirstCompletion: true });
+
+    const result = await promoteMirrorAuthority("/mirror", {
+      ...options(fetch),
+      pollIntervalMs: 0
+    });
+
+    expect(result).toMatchObject({
+      collectionId: ids.collection,
+      authorityEpoch: 2
+    });
+    expect(state.calls.filter((call) => call === "register")).toHaveLength(1);
+    expect(state.calls.filter((call) => call === "complete-transfer")).toHaveLength(2);
+    expect(state.calls).toContain("retire-mirror");
+  });
+
+  it("rolls back a materialized folder when the server declares the transfer inactive", async () => {
+    const fetch = scenarioFetch({ inactiveCompletion: true });
+
+    await expect(promoteMirrorAuthority("/mirror", options(fetch))).rejects.toThrow(
+      "Transfer is inactive"
+    );
+
+    expect(state.calls).toEqual(expect.arrayContaining([
+      "remove-registration",
+      "restore-config",
+      "mark-mirror",
+      "clear-checkpoint"
+    ]));
+  });
+
+  it("rejects a same-origin response that substitutes another collection identity", async () => {
+    const fetch = scenarioFetch({ collectionId: ids.otherCollection });
+    const callbacks = options(fetch);
+    callbacks.registerCollection = async (_path, collectionId) => {
+      state.calls.push("register");
+      return collectionId;
+    };
+
+    await expect(promoteMirrorAuthority("/mirror", callbacks)).rejects.toThrow(
+      "does not match this mirrored collection"
+    );
+
+    expect(state.calls.some((call) =>
+      call === `set-identity:${ids.otherCollection}`
+    )).toBe(false);
+    expect(state.calls).not.toContain("open-verification");
+  });
+
+  it("rejects identity substitution after browser approval but before materialization", async () => {
+    const fetch = scenarioFetch({ preparedCollectionId: ids.otherCollection });
+
+    await expect(
+      promoteMirrorAuthority("/mirror", options(fetch))
+    ).rejects.toThrow("does not match this mirrored collection");
+
+    expect(state.calls).toContain("open-verification");
+    expect(state.calls).not.toContain("save-checkpoint");
+    expect(state.calls.some((call) => call.startsWith("set-identity:"))).toBe(false);
+  });
+
+  it("preserves recovery state when completion returns another identity", async () => {
+    const fetch = scenarioFetch({ completionCollectionId: ids.otherCollection });
+
+    await expect(
+      promoteMirrorAuthority("/mirror", options(fetch))
+    ).rejects.toThrow("does not match the local recovery checkpoint");
+
+    expect(state.checkpoint).toMatchObject({
+      collection_id: ids.collection,
+      transfer_id: ids.transfer
+    });
+    expect(state.calls).not.toContain("retire-mirror");
+  });
+
+  it("reconciles a local registration that committed before its reply timed out", async () => {
+    const fetch = scenarioFetch();
+    const callbacks = options(fetch);
+    callbacks.registerCollection = async () => {
+      state.calls.push("agent-committed-registration");
+      state.registeredPath = "/mirror";
+      throw new Error("local agent reply timed out");
+    };
+
+    const result = await promoteMirrorAuthority("/mirror", callbacks);
+
+    expect(result.collectionId).toBe(ids.collection);
+    expect(state.calls).toContain("validate");
+    expect(state.calls).not.toContain("remove-registration");
+    expect(state.calls).toContain("retire-mirror");
+  });
+
+  it("preserves and resumes recovery when a timed-out registration cannot be queried", async () => {
+    const fetch = scenarioFetch();
+    const callbacks = options(fetch);
+    callbacks.registerCollection = async () => {
+      state.calls.push("agent-registration-outcome-unknown");
+      state.registeredPath = "/mirror";
+      state.registrationLookupUnavailable = true;
+      throw new Error("local agent reply timed out");
+    };
+
+    await expect(promoteMirrorAuthority("/mirror", callbacks)).rejects.toThrow(
+      "may have registered this collection"
+    );
+
+    expect(state.checkpoint).toMatchObject({
+      collection_id: ids.collection,
+      transfer_id: ids.transfer
+    });
+    expect(state.calls).not.toContain("restore-config");
+    expect(state.calls).not.toContain("clear-checkpoint");
+    expect(state.calls).not.toContain("cancel-transfer");
+
+    state.registrationLookupUnavailable = false;
+    const result = await promoteMirrorAuthority("/mirror", callbacks);
+
+    expect(result.collectionId).toBe(ids.collection);
+    expect(
+      state.calls.filter((call) => call === "agent-registration-outcome-unknown")
+    ).toHaveLength(1);
+    expect(state.calls).toContain("retire-mirror");
+  });
+
+  it("does not claim an already registered local collection", async () => {
+    state.registeredPath = "/mirror";
+
+    await expect(
+      promoteMirrorAuthority("/mirror", options(scenarioFetch()))
+    ).rejects.toThrow("already registered as a local collection");
+
+    expect(state.calls).not.toContain("request-transfer");
+  });
+});
+
+function options(fetch: typeof globalThis.fetch) {
+  return {
+    fetch,
+    pollIntervalMs: 0,
+    registeredCollectionPath: async () => {
+      state.calls.push("lookup-registration");
+      if (state.registrationLookupUnavailable) {
+        throw new Error("local agent unavailable");
+      }
+      return state.registeredPath;
+    },
+    registerCollection: async () => {
+      state.calls.push("register");
+      return ids.collection;
+    },
+    validateCollection: async () => {
+      state.calls.push("validate");
+    },
+    removeCollection: async () => {
+      state.calls.push("remove-registration");
+    },
+    onVerification: async () => {
+      state.calls.push("open-verification");
+    }
+  };
+}
+
+function scenarioFetch(input: {
+  collectionId?: string;
+  preparedCollectionId?: string;
+  completionCollectionId?: string;
+  failFirstCompletion?: boolean;
+  inactiveCompletion?: boolean;
+} = {}): typeof globalThis.fetch {
+  const collectionId = input.collectionId ?? ids.collection;
+  const preparedCollectionId = input.preparedCollectionId ?? collectionId;
+  const completionCollectionId = input.completionCollectionId ?? collectionId;
+  let completionAttempts = 0;
+  return (async (request: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(request));
+    if (
+      init?.method === "POST"
+      && url.pathname.endsWith("/authority-transfers")
+    ) {
+      state.calls.push("request-transfer");
+      return jsonResponse({
+        transfer: transfer("requested", collectionId),
+        verification_uri: `https://connect.test/transfer/${ids.transfer}`
+      }, 201);
+    }
+    if (url.pathname.endsWith("/prepare")) {
+      state.calls.push("prepare-transfer");
+      return jsonResponse({
+        transfer: transfer("prepared", preparedCollectionId)
+      });
+    }
+    if (url.pathname.endsWith("/complete")) {
+      state.calls.push("complete-transfer");
+      completionAttempts += 1;
+      if (input.failFirstCompletion && completionAttempts === 1) {
+        throw new TypeError("connection reset after commit");
+      }
+      if (input.inactiveCompletion) {
+        return jsonResponse({
+          error: {
+            code: "authority_transfer_inactive",
+            message: "Transfer is inactive"
+          }
+        }, 409);
+      }
+      return jsonResponse({
+        status: "completed",
+        collection_id: completionCollectionId,
+        authority_epoch: 2
+      });
+    }
+    if (init?.method === "DELETE") {
+      state.calls.push("cancel-transfer");
+      return jsonResponse({ ok: true });
+    }
+    throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+}
+
+function transfer(
+  status: "requested" | "prepared",
+  collectionId: string
+) {
+  return {
+    id: ids.transfer,
+    collection_id: collectionId,
+    replica_id: ids.replica,
+    state: status,
+    final_head: status === "prepared" ? 7 : null,
+    authority_epoch: status === "prepared" ? 2 : null,
+    manifest_digest: status === "prepared" ? "a".repeat(64) : null,
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    verification_uri: `https://connect.test/transfer/${ids.transfer}`
+  };
+}
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}

--- a/packages/sync/src/promotion.test.ts
+++ b/packages/sync/src/promotion.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { trustedVerificationUri } from "./promotion.js";
+
+describe("authority promotion confirmation", () => {
+  it("accepts confirmation pages from the configured Connect origin", () => {
+    expect(
+      trustedVerificationUri(
+        "https://connect.example",
+        "https://connect.example/transfer/123?source=desktop"
+      )
+    ).toBe("https://connect.example/transfer/123?source=desktop");
+  });
+
+  it("rejects a confirmation page from another origin", () => {
+    expect(() =>
+      trustedVerificationUri(
+        "https://connect.example",
+        "https://accounts.example/transfer/123"
+      )
+    ).toThrow("untrusted confirmation address");
+  });
+});

--- a/packages/sync/src/promotion.ts
+++ b/packages/sync/src/promotion.ts
@@ -1,0 +1,581 @@
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
+import { HttpSyncTransport } from "./index.js";
+import {
+  clearAuthorityPromotionCheckpoint,
+  clearMirrorMarker,
+  loadAuthorityPromotionCheckpoint,
+  loadMirrorProfile,
+  markMirror,
+  readCollectionConfiguration,
+  restoreCollectionConfiguration,
+  retireMirrorAfterPromotion,
+  saveAuthorityPromotionCheckpoint,
+  setCollectionIdentity,
+  updateMirrorCredentials,
+  type AuthorityPromotionCheckpoint,
+  type StoredMirrorProfile
+} from "./device.js";
+import {
+  canonicalConnectOrigin,
+  MirrorEnrollmentClient,
+  type MirrorEnrollment
+} from "./enrollment.js";
+import {
+  NodeMirrorStateStore,
+  WritableDirectoryMirror,
+  type MirrorProgress
+} from "./node.js";
+
+const TOKEN_RENEWAL_WINDOW_MS = 24 * 60 * 60 * 1_000;
+
+export type AuthorityPromotionPhase =
+  | "synchronizing"
+  | "awaiting_approval"
+  | "verifying"
+  | "registering"
+  | "registered"
+  | "activating"
+  | "completed"
+  | "resuming";
+
+export interface AuthorityPromotionResult {
+  collectionId: string;
+  authorityEpoch: number;
+  path: string;
+}
+
+export interface AuthorityPromotionOptions {
+  stateRoot?: string;
+  registeredCollectionPath(collectionId: string): Promise<string | null>;
+  registerCollection(path: string, collectionId: string): Promise<string>;
+  validateCollection(collectionId: string): Promise<void>;
+  removeCollection(collectionId: string): Promise<void>;
+  onVerification?(verificationUri: string): void | Promise<void>;
+  onPhase?(phase: AuthorityPromotionPhase): void;
+  onProgress?(progress: MirrorProgress): void;
+  pollIntervalMs?: number;
+  fetch?: typeof globalThis.fetch;
+}
+
+interface AuthorityTransfer {
+  id: string;
+  collection_id: string;
+  replica_id: string;
+  state: "requested" | "approved" | "prepared" | "completed" | "cancelled" | "expired";
+  final_head: number | null;
+  authority_epoch: number | null;
+  manifest_digest: string | null;
+  expires_at: string;
+  verification_uri: string;
+  local_collection_id?: string;
+}
+
+interface AuthorityTransferResponse {
+  transfer: AuthorityTransfer;
+  verification_uri?: string;
+  expires_in?: number;
+}
+
+interface AuthorityTransferCompletion {
+  status: "completed" | "waiting_for_connector";
+  collection_id?: string;
+  local_collection_id?: string;
+  authority_epoch?: number;
+  message?: string;
+}
+
+interface MirrorExchangeResponse {
+  status: "paired";
+  replica: {
+    id: string;
+    collection_id: string;
+    name: string;
+    mode: "read_only" | "read_write";
+  };
+  token: string;
+  token_expires_at: string;
+  sync_url: string;
+}
+
+export async function promoteMirrorAuthority(
+  root: string,
+  options: AuthorityPromotionOptions
+): Promise<AuthorityPromotionResult> {
+  const fetchRequest = options.fetch ?? globalThis.fetch;
+  const pollIntervalMs = options.pollIntervalMs ?? 1_500;
+  const unfinished = await loadAuthorityPromotionCheckpoint(root, options.stateRoot);
+  // A committed provider may already have revoked the mirror access token.
+  // Resume from the durable proof without attempting ordinary token renewal.
+  const stored = unfinished
+    ? await loadMirrorProfile(root, options.stateRoot)
+    : await currentProfile(root, options, fetchRequest);
+  assertPromotableProfile(stored);
+  const controlUrl = canonicalConnectOrigin(stored.profile.control_url);
+  const authentication = { authorization: `Bearer ${stored.credentials.refresh_token}` };
+
+  if (unfinished) {
+    if (unfinished.collection_id !== stored.profile.collection_id) {
+      throw new Error("The saved authority transfer belongs to another collection.");
+    }
+    options.onPhase?.("resuming");
+    await setCollectionIdentity(root, unfinished.collection_id);
+    await clearMirrorMarker(root, unfinished.collection_id);
+    await ensurePromotedCollectionRegistered(root, unfinished.collection_id, options);
+    await options.validateCollection(unfinished.collection_id);
+    return completePromotion(
+      root,
+      controlUrl,
+      authentication,
+      unfinished,
+      options,
+      fetchRequest
+    );
+  }
+
+  await assertCollectionIsNotRegistered(root, stored.profile.collection_id, options);
+  options.onPhase?.("synchronizing");
+  await synchronizeMirror(root, stored, options);
+  const requested = await jsonRequest<AuthorityTransferResponse>(
+    fetchRequest,
+    `${controlUrl}/v1/mirror-pairing-requests/${encodeURIComponent(stored.profile.enrollment_id)}/authority-transfers`,
+    {
+      method: "POST",
+      headers: { ...authentication, "content-type": "application/json" },
+      body: "{}"
+    }
+  );
+  assertTransferIdentity(requested.transfer, stored);
+  const verificationUri = trustedVerificationUri(
+    controlUrl,
+    requested.verification_uri ?? requested.transfer.verification_uri
+  );
+  options.onPhase?.("awaiting_approval");
+  await options.onVerification?.(verificationUri);
+
+  const deadline = new Date(requested.transfer.expires_at).getTime();
+  let prepared = requested.transfer;
+  while (prepared.state !== "prepared" && Date.now() < deadline) {
+    const response = await fetchRequest(
+      `${controlUrl}/v1/authority-transfers/${encodeURIComponent(prepared.id)}/prepare`,
+      {
+        method: "POST",
+        headers: { ...authentication, "content-type": "application/json" },
+        body: "{}"
+      }
+    );
+    if (response.status === 202) {
+      await delay(pollIntervalMs);
+      continue;
+    }
+    prepared = (await responseJson<AuthorityTransferResponse>(response)).transfer;
+    try {
+      assertTransferIdentity(prepared, stored, requested.transfer.id);
+    } catch (error) {
+      await fetchRequest(
+        `${controlUrl}/v1/authority-transfers/${encodeURIComponent(requested.transfer.id)}`,
+        { method: "DELETE", headers: authentication }
+      ).catch(() => undefined);
+      throw error;
+    }
+  }
+  if (
+    prepared.state !== "prepared"
+    || prepared.final_head === null
+    || prepared.authority_epoch === null
+    || !prepared.manifest_digest
+  ) {
+    throw new Error("Authority transfer approval expired. Start the transfer again.");
+  }
+
+  let localRegistered = false;
+  let checkpoint: Omit<AuthorityPromotionCheckpoint, "version"> | null = null;
+  try {
+    options.onPhase?.("verifying");
+    const configuration = await currentProfile(root, options, fetchRequest);
+    const mirror = writableMirror(root, configuration, options);
+    await mirror.sync();
+    const manifest = await mirror.authorityPromotionManifest();
+    if (
+      manifest.cursor !== prepared.final_head
+      || manifest.digest !== prepared.manifest_digest
+    ) {
+      throw new Error(
+        "The local folder does not exactly match the fenced collection authority."
+      );
+    }
+    const originalConfiguration = await readCollectionConfiguration(root);
+    checkpoint = {
+      transfer_id: prepared.id,
+      collection_id: prepared.collection_id,
+      manifest_digest: prepared.manifest_digest,
+      authority_epoch: prepared.authority_epoch,
+      expires_at: prepared.expires_at,
+      original_configuration: originalConfiguration
+    };
+    await saveAuthorityPromotionCheckpoint(root, checkpoint, options.stateRoot);
+    await setCollectionIdentity(root, prepared.collection_id);
+    await clearMirrorMarker(root, prepared.collection_id);
+    options.onPhase?.("registering");
+    await ensurePromotedCollectionRegistered(root, prepared.collection_id, options);
+    localRegistered = true;
+    await options.validateCollection(prepared.collection_id);
+  } catch (error) {
+    if (error instanceof LocalRegistrationOutcomeUncertainError) {
+      throw error;
+    }
+    if (localRegistered) {
+      await options.removeCollection(prepared.collection_id).catch(() => undefined);
+    }
+    const saved = await loadAuthorityPromotionCheckpoint(root, options.stateRoot);
+    if (saved?.transfer_id === prepared.id) {
+      await restoreCollectionConfiguration(root, saved.original_configuration).catch(
+        () => undefined
+      );
+      await markMirror(root, saved.collection_id).catch(() => undefined);
+      await clearAuthorityPromotionCheckpoint(root, options.stateRoot).catch(
+        () => undefined
+      );
+    }
+    await fetchRequest(
+      `${controlUrl}/v1/authority-transfers/${encodeURIComponent(prepared.id)}`,
+      { method: "DELETE", headers: authentication }
+    ).catch(() => undefined);
+    throw error;
+  }
+
+  if (!checkpoint) throw new Error("Authority transfer checkpoint was not created.");
+  options.onPhase?.("registered");
+  return completePromotion(
+    root,
+    controlUrl,
+    authentication,
+    checkpoint,
+    options,
+    fetchRequest
+  );
+}
+
+export function trustedVerificationUri(controlUrl: string, value: string): string {
+  const controlOrigin = new URL(canonicalConnectOrigin(controlUrl)).origin;
+  const verification = new URL(value);
+  if (verification.origin !== controlOrigin) {
+    throw new Error("The authority returned an untrusted confirmation address.");
+  }
+  return verification.toString();
+}
+
+async function synchronizeMirror(
+  root: string,
+  stored: StoredMirrorProfile,
+  options: AuthorityPromotionOptions
+): Promise<void> {
+  const mirror = writableMirror(root, stored, options);
+  const preview = await mirror.previewInitialization();
+  if (preview.collisions.length > 0) {
+    throw new Error(
+      `Existing files differ from the authority: ${preview.collisions.join(", ")}. `
+      + "Reconcile them before moving authority."
+    );
+  }
+  await mirror.sync();
+}
+
+function writableMirror(
+  root: string,
+  stored: StoredMirrorProfile,
+  options: AuthorityPromotionOptions
+): WritableDirectoryMirror {
+  if (stored.profile.mode !== "read_write") {
+    throw new Error("Authority can move only from a two-way collection mirror.");
+  }
+  const transport = new HttpSyncTransport(
+    stored.profile.sync_url,
+    stored.credentials.access_token
+  );
+  return new WritableDirectoryMirror(root, stored.profile.replica_id, transport, {
+    stateStore: new NodeMirrorStateStore(root, options.stateRoot),
+    ...(options.onProgress ? { onProgress: options.onProgress } : {})
+  });
+}
+
+async function currentProfile(
+  root: string,
+  options: AuthorityPromotionOptions,
+  fetchRequest: typeof globalThis.fetch
+): Promise<StoredMirrorProfile> {
+  let stored = await loadMirrorProfile(root, options.stateRoot);
+  await markMirror(root, stored.profile.collection_id);
+  const expiry = stored.profile.access_token_expires_at;
+  const controlUrl = stored.profile.control_url;
+  const enrollmentId = stored.profile.enrollment_id;
+  const refreshToken = stored.credentials.refresh_token;
+  if (
+    controlUrl
+    && enrollmentId
+    && refreshToken
+    && expiry
+    && Date.parse(expiry) - Date.now() < TOKEN_RENEWAL_WINDOW_MS
+  ) {
+    const renewed = await jsonRequest<MirrorExchangeResponse>(
+      fetchRequest,
+      `${canonicalConnectOrigin(controlUrl)}/v1/mirror-pairing-requests/${encodeURIComponent(enrollmentId)}/renew`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${refreshToken}` }
+      }
+    );
+    stored = await updateMirrorCredentials(
+      root,
+      {
+        access_token: renewed.token,
+        refresh_token: refreshToken
+      },
+      renewed.token_expires_at,
+      options.stateRoot
+    );
+  }
+  return stored;
+}
+
+function assertPromotableProfile(
+  stored: StoredMirrorProfile
+): asserts stored is StoredMirrorProfile & {
+  profile: StoredMirrorProfile["profile"] & {
+    control_url: string;
+    enrollment_id: string;
+  };
+  credentials: StoredMirrorProfile["credentials"] & { refresh_token: string };
+} {
+  if (
+    stored.profile.mode !== "read_write"
+    || !stored.profile.control_url
+    || !stored.profile.enrollment_id
+    || !stored.credentials.refresh_token
+  ) {
+    throw new Error(
+      "Authority can move only from a browser-paired, two-way full collection mirror."
+    );
+  }
+}
+
+function assertTransferIdentity(
+  transfer: AuthorityTransfer,
+  stored: StoredMirrorProfile,
+  expectedTransferId?: string
+): void {
+  if (
+    transfer.collection_id !== stored.profile.collection_id
+    || transfer.replica_id !== stored.profile.replica_id
+    || (expectedTransferId !== undefined && transfer.id !== expectedTransferId)
+  ) {
+    throw new Error(
+      "The authority transfer response does not match this mirrored collection."
+    );
+  }
+}
+
+async function assertCollectionIsNotRegistered(
+  root: string,
+  collectionId: string,
+  options: AuthorityPromotionOptions
+): Promise<void> {
+  const registeredPath = await options.registeredCollectionPath(collectionId);
+  if (registeredPath === null) return;
+  if (await pathsReferToSameFolder(root, registeredPath)) {
+    throw new Error(
+      "This folder is already registered as a local collection. "
+      + "Remove that registration before moving authority."
+    );
+  }
+  throw new Error(
+    "This collection identity is already registered to another folder."
+  );
+}
+
+async function ensurePromotedCollectionRegistered(
+  root: string,
+  collectionId: string,
+  options: AuthorityPromotionOptions
+): Promise<void> {
+  const existingPath = await options.registeredCollectionPath(collectionId);
+  if (existingPath !== null) {
+    if (!(await pathsReferToSameFolder(root, existingPath))) {
+      throw new Error(
+        "This collection identity is already registered to another folder."
+      );
+    }
+    return;
+  }
+
+  let registeredId: string;
+  try {
+    registeredId = await options.registerCollection(root, collectionId);
+  } catch (registrationError) {
+    let reconciledPath: string | null;
+    try {
+      reconciledPath = await options.registeredCollectionPath(collectionId);
+    } catch {
+      throw new LocalRegistrationOutcomeUncertainError(registrationError);
+    }
+    if (reconciledPath === null) throw registrationError;
+    if (!(await pathsReferToSameFolder(root, reconciledPath))) {
+      throw new Error(
+        "This collection identity is already registered to another folder."
+      );
+    }
+    return;
+  }
+  if (registeredId !== collectionId) {
+    throw new Error("The local agent registered a different collection identity.");
+  }
+}
+
+async function pathsReferToSameFolder(left: string, right: string): Promise<boolean> {
+  const [canonicalLeft, canonicalRight] = await Promise.all([
+    realpath(resolve(left)).catch(() => resolve(left)),
+    realpath(resolve(right)).catch(() => resolve(right))
+  ]);
+  return canonicalLeft === canonicalRight;
+}
+
+async function completePromotion(
+  root: string,
+  controlUrl: string,
+  authentication: { authorization: string },
+  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">,
+  options: AuthorityPromotionOptions,
+  fetchRequest: typeof globalThis.fetch
+): Promise<AuthorityPromotionResult> {
+  options.onPhase?.("activating");
+  const deadline = new Date(checkpoint.expires_at).getTime();
+  const pollIntervalMs = options.pollIntervalMs ?? 2_000;
+  let attempted = false;
+  while (!attempted || Date.now() < deadline) {
+    attempted = true;
+    let response: Response;
+    try {
+      response = await fetchRequest(
+        `${controlUrl}/v1/authority-transfers/${encodeURIComponent(checkpoint.transfer_id)}/complete`,
+        {
+          method: "POST",
+          headers: { ...authentication, "content-type": "application/json" },
+          body: JSON.stringify({ manifest_digest: checkpoint.manifest_digest })
+        }
+      );
+    } catch {
+      if (Date.now() >= deadline) break;
+      await delay(pollIntervalMs);
+      continue;
+    }
+    if (response.status === 202) {
+      if (Date.now() >= deadline) break;
+      await delay(pollIntervalMs);
+      continue;
+    }
+    let completed: AuthorityTransferCompletion;
+    try {
+      completed = await responseJson<AuthorityTransferCompletion>(response);
+    } catch (error) {
+      if (
+        error instanceof AuthorityPromotionRequestError
+        && error.status === 409
+        && ["authority_transfer_expired", "authority_transfer_inactive"].includes(error.code)
+      ) {
+        await rollbackMaterializedPromotion(root, checkpoint, options);
+      }
+      throw error;
+    }
+    if (
+      completed.status === "completed"
+      && (
+        completed.collection_id !== checkpoint.collection_id
+        || completed.authority_epoch !== checkpoint.authority_epoch
+      )
+    ) {
+      throw new Error(
+        "The completed authority transfer does not match the local recovery checkpoint."
+      );
+    }
+    if (completed.status !== "completed") {
+      if (Date.now() >= deadline) break;
+      await delay(pollIntervalMs);
+      continue;
+    }
+    await retireMirrorAfterPromotion(
+      root,
+      {
+        collection_id: checkpoint.collection_id,
+        authority_epoch: checkpoint.authority_epoch
+      },
+      options.stateRoot
+    );
+    options.onPhase?.("completed");
+    return {
+      collectionId: checkpoint.collection_id,
+      authorityEpoch: checkpoint.authority_epoch,
+      path: root
+    };
+  }
+  throw new Error(
+    "The local collection is ready, but activation did not finish. "
+    + "Keep this computer running, then resume the authority transfer."
+  );
+}
+
+async function rollbackMaterializedPromotion(
+  root: string,
+  checkpoint: Omit<AuthorityPromotionCheckpoint, "version">,
+  options: AuthorityPromotionOptions
+): Promise<void> {
+  await options.removeCollection(checkpoint.collection_id);
+  await restoreCollectionConfiguration(root, checkpoint.original_configuration);
+  await markMirror(root, checkpoint.collection_id);
+  await clearAuthorityPromotionCheckpoint(root, options.stateRoot);
+}
+
+async function jsonRequest<Result>(
+  fetchRequest: typeof globalThis.fetch,
+  url: string,
+  init: RequestInit
+): Promise<Result> {
+  return responseJson<Result>(await fetchRequest(url, init));
+}
+
+async function responseJson<Result>(response: Response): Promise<Result> {
+  const value = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error = value as { error?: { code?: string; message?: string } } | null;
+    throw new AuthorityPromotionRequestError(
+      response.status,
+      error?.error?.code ?? "request_failed",
+      error?.error?.message ?? `Request failed with status ${response.status}.`
+    );
+  }
+  return value as Result;
+}
+
+class AuthorityPromotionRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+class LocalRegistrationOutcomeUncertainError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "The local agent may have registered this collection, but its response "
+      + "could not be confirmed. Keep the recovery data and resume the authority "
+      + "transfer when the local agent is available.",
+      { cause }
+    );
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2234,7 +2234,7 @@ process.stdout.write(JSON.stringify({
   id: crypto.randomUUID(),
   protocol_version: 1,
   ok: true,
-  result: action === "add" ? { id } : { valid: true }
+  result: action === "list" ? [] : action === "add" ? { id } : { valid: true }
 }) + "\\n");
 `, { mode: 0o700 });
 


### PR DESCRIPTION
## What changed

- expose hosted-to-local collection authority transfer in the Electron collection view
- extract the CLI authority-promotion workflow into a shared sync-package API
- pause mirror sync during materialization and support durable resume after interruption
- bind request, prepare, and completion responses to the expected collection, replica, transfer, epoch, and manifest
- reconcile timed-out local registrations by exact collection identity and canonical folder path
- isolate corrupt promotion checkpoints to an actionable mirror state instead of breaking mirror refresh

## Why

Hosted collections with a writable local mirror could already transfer authority through the CLI, but Electron did not expose the workflow. The shared path also needed stronger failure handling for same-origin identity substitution, ambiguous agent replies, and corrupt recovery data.

## User impact

A user can now move a hosted collection’s source of truth to its synchronized folder from the Electron app, confirm the consequential action in the browser, observe progress, and safely resume an interrupted handoff.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- `pnpm e2e:provider`
- adversarial fault injection for identity substitution, manifest mismatch, validation rollback, registration reply loss, unavailable-agent resume, completion uncertainty, and corrupt checkpoints