### PR TITLE
Require effective frontmatter in saved views

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -576,8 +576,18 @@ export interface ExecuteViewInput {
   render?: boolean;
 }
 
+/**
+ * A saved-view row always includes the canonical frontmatter used to evaluate
+ * the view. Empty-frontmatter Markdown is represented by an empty object.
+ */
+export interface SavedViewRecord<Frontmatter extends JsonObject = JsonObject>
+  extends Omit<QueryRecord<Frontmatter>, "effective_frontmatter"> {
+  effective_frontmatter: Frontmatter;
+  values?: JsonObject;
+}
+
 export interface SavedViewExecution<Frontmatter extends JsonObject = JsonObject> {
-  results: Array<QueryRecord<Frontmatter> & { values?: JsonObject }>;
+  results: Array<SavedViewRecord<Frontmatter>>;
   meta: {
     total_count: number;
     has_more: boolean;


### PR DESCRIPTION
## What changed

- Added a dedicated `SavedViewRecord` protocol type.
- Made `effective_frontmatter` required for every saved-view result.
- Documented `{}` as the representation for Markdown documents without frontmatter.

## Why

TaskNotes was consuming saved-view rows through an ambiguous optional projection and could silently parse every task from an empty object. Saved views are evaluated against canonical effective frontmatter, so their wire contract should expose that representation unconditionally. File paths remain separate in `path`/`file.path`.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
