### PR TITLE
feat(desktop): add transactional signed updates

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -59,6 +59,7 @@ jobs:
       WINDOWS_STORE_IDENTITY_NAME: ${{ vars.WINDOWS_STORE_IDENTITY_NAME }}
       WINDOWS_STORE_PUBLISHER: ${{ vars.WINDOWS_STORE_PUBLISHER }}
       WINDOWS_STORE_PUBLISHER_DISPLAY_NAME: ${{ vars.WINDOWS_STORE_PUBLISHER_DISPLAY_NAME }}
+      WINDOWS_STORE_PRODUCT_ID: ${{ vars.WINDOWS_STORE_PRODUCT_ID }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -172,7 +173,8 @@ jobs:
           $identityValues = @(
             $env:WINDOWS_STORE_IDENTITY_NAME,
             $env:WINDOWS_STORE_PUBLISHER,
-            $env:WINDOWS_STORE_PUBLISHER_DISPLAY_NAME
+            $env:WINDOWS_STORE_PUBLISHER_DISPLAY_NAME,
+            $env:WINDOWS_STORE_PRODUCT_ID
           )
           $configured = @($identityValues | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count
           if ($configured -eq 0) {
@@ -181,7 +183,7 @@ jobs:
             exit 0
           }
           if ($configured -ne $identityValues.Count) {
-            throw "Microsoft Store identity is partially configured; provide all three Partner Center values or remove them."
+            throw "Microsoft Store identity is partially configured; provide all four Partner Center values or remove them."
           }
 
           $build = [int]$env:GITHUB_RUN_NUMBER
@@ -273,11 +275,28 @@ jobs:
               "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}-UNSIGNED.dmg"
             cp "$portable" \
               "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}-UNSIGNED.zip"
-            cp docs/macos-unsigned-preview.txt release-artifacts/
+            cp docs/macos-unsigned-preview.txt \
+              "release-artifacts/macos-${{ matrix.arch }}-unsigned-preview.txt"
           else
-            find apps/desktop/out/make -type f \
-              \( -name '*.dmg' -o -name '*.zip' -o -name '*.deb' -o -name '*.rpm' \) \
-              -exec cp '{}' release-artifacts/ ';'
+            if [ "${{ matrix.platform }}" = "macos" ]; then
+              dmg="$(find apps/desktop/out/make -type f -name '*.dmg' -print -quit)"
+              portable="$(find apps/desktop/out/make -type f -name '*.zip' -print -quit)"
+              test -n "$dmg"
+              test -n "$portable"
+              cp "$dmg" \
+                "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}.dmg"
+              cp "$portable" \
+                "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}.zip"
+            else
+              deb="$(find apps/desktop/out/make -type f -name '*.deb' -print -quit)"
+              rpm="$(find apps/desktop/out/make -type f -name '*.rpm' -print -quit)"
+              test -n "$deb"
+              test -n "$rpm"
+              cp "$deb" \
+                "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-linux-${{ matrix.arch }}.deb"
+              cp "$rpm" \
+                "release-artifacts/mdbase-connect-${{ steps.version.outputs.value }}-linux-${{ matrix.arch }}.rpm"
+            fi
           fi
           test -n "$(find release-artifacts -type f -print -quit)"
 
@@ -306,6 +325,53 @@ jobs:
           else
             sha256sum * > "SHA256SUMS-${{ matrix.platform }}-${{ matrix.arch }}"
           fi
+
+      - name: Describe platform update
+        shell: bash
+        run: |
+          arguments=(
+            --directory release-artifacts
+            --platform "${{ matrix.platform }}"
+            --arch "${{ matrix.arch }}"
+          )
+          if [ "${{ matrix.platform }}" = "macos" ]; then
+            if [ "$MACOS_RELEASE_MODE" = "signed" ]; then
+              arguments+=(
+                --mode automatic
+                --action-url '$RELEASE_URL'
+                --artifact "mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}.zip"
+              )
+            else
+              arguments+=(
+                --mode manual
+                --action-url '$RELEASE_URL'
+                --artifact "mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}-UNSIGNED.dmg"
+                --artifact "mdbase-connect-${{ steps.version.outputs.value }}-macos-${{ matrix.arch }}-UNSIGNED.zip"
+              )
+            fi
+          elif [ "${{ matrix.platform }}" = "windows" ]; then
+            if [ "$WINDOWS_STORE_MODE" = "store" ]; then
+              arguments+=(
+                --mode store
+                --action-url "https://apps.microsoft.com/detail/$WINDOWS_STORE_PRODUCT_ID"
+              )
+            else
+              arguments+=(
+                --mode manual
+                --action-url '$RELEASE_URL'
+                --artifact "mdbase-connect-${{ steps.version.outputs.value }}-windows-${{ matrix.arch }}-UNSIGNED-Setup.exe"
+                --artifact "mdbase-connect-${{ steps.version.outputs.value }}-windows-${{ matrix.arch }}-UNSIGNED-portable.zip"
+              )
+            fi
+          else
+            arguments+=(
+              --mode manual
+              --action-url '$RELEASE_URL'
+              --artifact "mdbase-connect-${{ steps.version.outputs.value }}-linux-${{ matrix.arch }}.deb"
+              --artifact "mdbase-connect-${{ steps.version.outputs.value }}-linux-${{ matrix.arch }}.rpm"
+            )
+          fi
+          node scripts/write-update-input.mjs "${arguments[@]}"
 
       - name: Sign and verify Microsoft Store submission provenance
         if: matrix.platform == 'windows' && env.WINDOWS_STORE_MODE == 'store'
@@ -344,11 +410,46 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: desktop-*
           path: release-artifacts
           merge-multiple: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Create and verify signed update manifest
+        shell: bash
+        env:
+          UPDATE_ROLLOUT_PERCENTAGE: ${{ vars.UPDATE_ROLLOUT_PERCENTAGE }}
+          UPDATE_BLOCKED_VERSIONS: ${{ vars.UPDATE_BLOCKED_VERSIONS }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          rollout="${UPDATE_ROLLOUT_PERCENTAGE:-100}"
+          node scripts/generate-update-manifest.mjs \
+            --directory release-artifacts \
+            --output release-artifacts/mdbase-connect-update.json \
+            --version "$version" \
+            --repository "$GITHUB_REPOSITORY" \
+            --rollout "$rollout" \
+            --blocked-versions "${UPDATE_BLOCKED_VERSIONS:-}"
+          find release-artifacts -maxdepth 1 -type f -name 'update-input-*.json' -delete
+          cosign sign-blob \
+            --yes \
+            --bundle release-artifacts/mdbase-connect-update.json.sigstore.json \
+            release-artifacts/mdbase-connect-update.json
+          cosign verify-blob \
+            --bundle release-artifacts/mdbase-connect-update.json.sigstore.json \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/desktop-release.yml@${GITHUB_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            release-artifacts/mdbase-connect-update.json
+          sha256sum \
+            release-artifacts/mdbase-connect-update.json \
+            release-artifacts/mdbase-connect-update.json.sigstore.json \
+            > release-artifacts/SHA256SUMS-update
 
       - name: Publish prerelease
         env:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ pnpm --filter @mdbase/connect-desktop package
 This builds the release Rust daemon/CLI, embeds it beside the Electron application,
 and fails if either the application archive or connector binary is absent. See
 [`docs/releasing.md`](docs/releasing.md) for signing and beta-release gates.
+Installed builds expose one signed update experience: notarized macOS releases
+stage automatically, while Windows Store and Linux packages hand replacement
+back to their platform trust channel. See
+[`docs/desktop-updates.md`](docs/desktop-updates.md) for rollout, daemon handoff,
+and recovery behavior.
 
 ## Use the CLI and daemon
 

--- a/apps/desktop/forge.config.cjs
+++ b/apps/desktop/forge.config.cjs
@@ -127,6 +127,11 @@ module.exports = {
     executableName: "mdbase-connect",
     icon: platformIcon,
     protocols: [{ name: "mdbase connect", schemes: ["mdbase-connect"] }],
+    extendInfo: {
+      NSAppTransportSecurity: {
+        NSAllowsLocalNetworking: true
+      }
+    },
     ...macSigning,
     extraResource: fs.existsSync(connector)
       ? [connector]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -42,6 +42,7 @@
     "esbuild": "^0.28.1",
     "lodash": "^4.18.1",
     "playwright-core": "^1.61.1",
+    "sigstore": "4.1.1",
     "typescript": "^7.0.2",
     "vite": "^8.1.5"
   }

--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -5,7 +5,13 @@ await rm("dist/main", { recursive: true, force: true });
 await build({
   entryPoints: [
     "src/main/main.ts",
-    "src/main/preload.ts"
+    "src/main/preload.ts",
+    "src/main/electron-update-backend.ts",
+    "src/main/release-source.ts",
+    "src/main/update-coordinator.ts",
+    "src/main/update-download.ts",
+    "src/main/update-policy.ts",
+    "src/main/update-state.ts"
   ],
   bundle: true,
   platform: "node",

--- a/apps/desktop/src/main/electron-update-backend.ts
+++ b/apps/desktop/src/main/electron-update-backend.ts
@@ -1,0 +1,444 @@
+import { autoUpdater, shell } from "electron";
+import { execFile as execFileCallback } from "node:child_process";
+import { createReadStream } from "node:fs";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  rename,
+  rm,
+  stat
+} from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { findLatestRelease, verifyArtifactBundle } from "./release-source";
+import type {
+  PreparedDaemonHandoff,
+  RecoveryResult,
+  UpdateBackend
+} from "./update-coordinator";
+import {
+  channelForVersion,
+  type UpdateManifest,
+  type UpdateTarget
+} from "./update-policy";
+import type { UpdateTransaction } from "./update-state";
+import { artifactMatches, downloadArtifact, downloadBytes } from "./update-download";
+
+const execFile = promisify(execFileCallback);
+const AUTO_UPDATER_TIMEOUT_MS = 180_000;
+const MAX_BUNDLE_BYTES = 4 * 1024 * 1024;
+
+export interface ElectronUpdateBackendOptions {
+  currentVersion: string;
+  packaged: boolean;
+  platform: NodeJS.Platform;
+  arch: string;
+  userDataDirectory: string;
+  binaryPath: () => string;
+  stateDirectory: () => string;
+  endpoint: () => string;
+}
+
+export class ElectronUpdateBackend implements UpdateBackend {
+  readonly currentVersion: string;
+  readonly channel;
+  readonly platformKey: string;
+  readonly packaged: boolean;
+  private readonly options: ElectronUpdateBackendOptions;
+
+  constructor(options: ElectronUpdateBackendOptions) {
+    this.options = options;
+    this.currentVersion = options.currentVersion;
+    this.channel = channelForVersion(options.currentVersion);
+    this.platformKey = `${options.platform}-${options.arch}`;
+    this.packaged = options.packaged;
+  }
+
+  async reconcileInstalledRuntime(): Promise<string | null> {
+    if (!this.packaged) return null;
+    const status = await this.daemonStatus();
+    const needsReconciliation = runtimeNeedsReconciliation(status, this.currentVersion);
+    if (!needsReconciliation) return null;
+    await this.activateRuntime(
+      this.options.binaryPath(),
+      this.currentVersion,
+      status.installed
+    );
+    return `Connector runtime ${this.currentVersion} was reconciled with this application.`;
+  }
+
+  async findLatest(): Promise<{ manifest: UpdateManifest } | null> {
+    return findLatestRelease({
+      channel: this.channel,
+      trustCacheDirectory: join(this.options.userDataDirectory, "updates", "sigstore")
+    });
+  }
+
+  async stageAutomatic(
+    manifest: UpdateManifest,
+    target: UpdateTarget,
+    onProgress: (progress: number) => void
+  ): Promise<void> {
+    if (this.options.platform !== "darwin" || target.mode !== "automatic") {
+      throw new Error("Automatic installation is only enabled for signed macOS releases.");
+    }
+    const artifact = target.artifacts.find((candidate) => candidate.kind === "zip");
+    if (!artifact) throw new Error("The macOS update does not contain a ZIP artifact.");
+    const directory = join(this.options.userDataDirectory, "updates", "downloads", manifest.version);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700).catch(() => undefined);
+    const archive = join(directory, artifact.name);
+    const bundleBytes = await downloadBytes(artifact.sigstore_url, MAX_BUNDLE_BYTES);
+    const cached = await artifactMatches(archive, artifact);
+    if (!cached) {
+      await rm(archive, { force: true });
+      await downloadArtifact(artifact, archive, (progress) => onProgress(Math.min(90, progress * 0.9)));
+    } else {
+      onProgress(90);
+    }
+    await verifyArtifactBundle({
+      bundleBytes,
+      artifactPath: archive,
+      tag: manifest.tag,
+      trustCacheDirectory: join(this.options.userDataDirectory, "updates", "sigstore")
+    }).catch(async (error) => {
+      await rm(archive, { force: true });
+      throw error;
+    });
+    onProgress(94);
+    await stageMacUpdate(archive, manifest, onProgress);
+  }
+
+  async prepareDaemonHandoff(previousVersion: string): Promise<PreparedDaemonHandoff> {
+    const status = await this.daemonStatus();
+    const source = this.options.binaryPath();
+    const directory = join(
+      this.options.userDataDirectory,
+      "updates",
+      "runtimes",
+      previousVersion
+    );
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700).catch(() => undefined);
+    const extension = this.options.platform === "win32" ? ".exe" : "";
+    const destination = join(directory, `mdbase-connect${extension}`);
+    const temporary = `${destination}.tmp-${process.pid}`;
+    await rm(temporary, { force: true });
+    try {
+      await copyFile(source, temporary);
+      if (this.options.platform !== "win32") await chmod(temporary, 0o700);
+      await rm(destination, { force: true });
+      await rename(temporary, destination);
+    } catch (error) {
+      await rm(temporary, { force: true });
+      throw error;
+    }
+    return {
+      serviceInstalled: status.installed,
+      previousRuntime: destination
+    };
+  }
+
+  async stopDaemon(): Promise<void> {
+    const status = await this.daemonStatus();
+    if (!status.running) return;
+    await this.runCli(this.options.binaryPath(), ["daemon", "stop"], 35_000);
+  }
+
+  installAutomatic(): void {
+    autoUpdater.quitAndInstall();
+  }
+
+  async openExternal(url: string): Promise<void> {
+    await shell.openExternal(url);
+  }
+
+  async recover(transaction: UpdateTransaction): Promise<RecoveryResult> {
+    if (transaction.previous_runtime) {
+      const extension = this.options.platform === "win32" ? ".exe" : "";
+      const expected = join(
+        this.options.userDataDirectory,
+        "updates",
+        "runtimes",
+        transaction.previous_version,
+        `mdbase-connect${extension}`
+      );
+      if (transaction.previous_runtime !== expected) {
+        throw new Error("The recorded recovery runtime is outside the private update directory.");
+      }
+    }
+    const runningTarget = this.currentVersion === transaction.target_version;
+    const runningPrevious = this.currentVersion === transaction.previous_version;
+    if (runningTarget) {
+      try {
+        await this.activateRuntime(
+          this.options.binaryPath(),
+          transaction.target_version,
+          transaction.service_installed
+        );
+        return {
+          healthy: true,
+          rolledBack: false,
+          message: `Updated to version ${transaction.target_version}; the connector is healthy.`
+        };
+      } catch (error) {
+        if (!transaction.previous_runtime) throw error;
+        await this.activateRuntime(
+          transaction.previous_runtime,
+          transaction.previous_version,
+          transaction.service_installed
+        );
+        return {
+          healthy: true,
+          rolledBack: true,
+          message:
+            `Version ${transaction.target_version} could not start its connector. ` +
+            `The last-known-good ${transaction.previous_version} connector was restored.`
+        };
+      }
+    }
+    if (runningPrevious) {
+      await this.activateRuntime(
+        this.options.binaryPath(),
+        transaction.previous_version,
+        transaction.service_installed
+      );
+      return {
+        healthy: true,
+        rolledBack: true,
+        message: "The interrupted update was cancelled and the connector was restored."
+      };
+    }
+    if (!transaction.previous_runtime) {
+      throw new Error(
+        `The application is version ${this.currentVersion}, but the interrupted update expected ` +
+          `${transaction.previous_version} or ${transaction.target_version}.`
+      );
+    }
+    await this.activateRuntime(
+      transaction.previous_runtime,
+      transaction.previous_version,
+      transaction.service_installed
+    );
+    return {
+      healthy: true,
+      rolledBack: true,
+      message: `An unexpected application version was detected; connector ${transaction.previous_version} was restored.`
+    };
+  }
+
+  private async activateRuntime(
+    binary: string,
+    expectedVersion: string,
+    serviceInstalled: boolean
+  ): Promise<void> {
+    const current = await this.daemonStatus().catch(() => ({ installed: serviceInstalled, running: false }));
+    if (current.running) {
+      await this.runCli(binary, ["daemon", "stop"], 35_000).catch(() => undefined);
+    }
+    await this.runCli(binary, ["daemon", serviceInstalled ? "install" : "start"], 35_000);
+    const deadline = Date.now() + 30_000;
+    let lastVersion: string | undefined;
+    while (Date.now() < deadline) {
+      const status = await this.daemonStatus(binary).catch(() => null);
+      lastVersion = status?.binaryVersion;
+      if (status?.running && status.binaryVersion === expectedVersion) return;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    throw new Error(
+      lastVersion
+        ? `Connector ${lastVersion} started when ${expectedVersion} was required.`
+        : `Connector ${expectedVersion} did not become healthy.`
+    );
+  }
+
+  private async daemonStatus(binary = this.options.binaryPath()): Promise<{
+    installed: boolean;
+    running: boolean;
+    binaryVersion?: string;
+  }> {
+    const value = await this.runCli(binary, ["daemon", "status"], 10_000);
+    return {
+      installed: value.installed === true,
+      running: value.running === true,
+      binaryVersion:
+        value.status &&
+        typeof value.status === "object" &&
+        !Array.isArray(value.status) &&
+        typeof (value.status as Record<string, unknown>).binary_version === "string"
+          ? ((value.status as Record<string, unknown>).binary_version as string)
+          : undefined
+    };
+  }
+
+  private async runCli(
+    binary: string,
+    command: string[],
+    timeout: number
+  ): Promise<Record<string, unknown>> {
+    const { stdout } = await execFile(
+      binary,
+      [
+        "--state-dir",
+        this.options.stateDirectory(),
+        "--endpoint",
+        this.options.endpoint(),
+        "--json",
+        ...command
+      ],
+      { env: process.env, timeout, windowsHide: true }
+    );
+    const parsed = JSON.parse(stdout) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("The connector returned an invalid lifecycle result.");
+    }
+    return parsed as Record<string, unknown>;
+  }
+}
+
+export function runtimeNeedsReconciliation(
+  status: { installed: boolean; running: boolean; binaryVersion?: string },
+  currentVersion: string
+): boolean {
+  return (
+    (status.running && status.binaryVersion !== currentVersion) ||
+    (!status.running && status.installed)
+  );
+}
+
+async function stageMacUpdate(
+  archive: string,
+  manifest: UpdateManifest,
+  onProgress: (progress: number) => void
+): Promise<void> {
+  const server = await localUpdateServer(archive, manifest);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Could not create the local verified update feed.");
+  }
+  const feedUrl = `http://127.0.0.1:${address.port}/feed`;
+  try {
+    autoUpdater.setFeedURL({ url: feedUrl, serverType: "json" });
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => finish(new Error("The platform updater did not stage the release in time.")),
+        AUTO_UPDATER_TIMEOUT_MS
+      );
+      const onDownloaded = () => finish();
+      const onUnavailable = () => finish(new Error("The platform updater rejected the newer release."));
+      const onError = (error: Error) => finish(error);
+      const finish = (error?: Error) => {
+        clearTimeout(timeout);
+        autoUpdater.removeListener("update-downloaded", onDownloaded);
+        autoUpdater.removeListener("update-not-available", onUnavailable);
+        autoUpdater.removeListener("error", onError);
+        error ? reject(error) : resolve();
+      };
+      autoUpdater.once("update-downloaded", onDownloaded);
+      autoUpdater.once("update-not-available", onUnavailable);
+      autoUpdater.once("error", onError);
+      try {
+        autoUpdater.checkForUpdates();
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+    onProgress(100);
+  } finally {
+    await closeServer(server);
+  }
+}
+
+export async function localUpdateServer(archive: string, manifest: UpdateManifest): Promise<Server> {
+  const details = await stat(archive);
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.url === "/feed") {
+        if (request.method !== "GET" && request.method !== "HEAD") {
+          response.writeHead(405, { allow: "GET, HEAD" }).end();
+          return;
+        }
+        const address = server.address();
+        if (!address || typeof address === "string") throw new Error("Local update feed is unavailable.");
+        const payload = Buffer.from(
+          JSON.stringify({
+            url: `http://127.0.0.1:${address.port}/artifact`,
+            name: manifest.version,
+            notes: manifest.notes,
+            pub_date: manifest.published_at
+          })
+        );
+        response.writeHead(200, {
+          "content-type": "application/json",
+          "content-length": payload.length,
+          "cache-control": "no-store"
+        });
+        response.end(request.method === "HEAD" ? undefined : payload);
+        return;
+      }
+      if (request.url !== "/artifact") {
+        response.writeHead(404).end();
+        return;
+      }
+      if (request.method !== "GET" && request.method !== "HEAD") {
+        response.writeHead(405, { allow: "GET, HEAD" }).end();
+        return;
+      }
+      let range;
+      try {
+        range = parseRange(request.headers.range, details.size);
+      } catch {
+        response.writeHead(416, { "content-range": `bytes */${details.size}` }).end();
+        return;
+      }
+      const start = range?.start ?? 0;
+      const end = range?.end ?? details.size - 1;
+      response.writeHead(range ? 206 : 200, {
+        "content-type": "application/zip",
+        "content-length": end - start + 1,
+        "accept-ranges": "bytes",
+        ...(range ? { "content-range": `bytes ${start}-${end}/${details.size}` } : {})
+      });
+      if (request.method === "HEAD") {
+        response.end();
+        return;
+      }
+      createReadStream(archive, { start, end })
+        .on("error", () => response.destroy())
+        .pipe(response);
+    } catch {
+      response.writeHead(500).end();
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+export function parseRange(
+  value: string | undefined,
+  size: number
+): { start: number; end: number } | null {
+  if (!value) return null;
+  const match = /^bytes=(\d+)-(\d*)$/.exec(value);
+  if (!match) throw new Error("Invalid update range.");
+  const start = Number(match[1]);
+  const end = match[2] ? Number(match[2]) : size - 1;
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 0 || end < start || end >= size) {
+    throw new Error("Invalid update range.");
+  }
+  return { start, end };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,5 +1,6 @@
 import {
   app,
+  autoUpdater,
   BrowserWindow,
   dialog,
   ipcMain,
@@ -16,11 +17,15 @@ import { join, resolve } from "node:path";
 import { hostname } from "node:os";
 import { promisify } from "node:util";
 import { AgentControlError, requestAgent } from "./control-client";
+import { ElectronUpdateBackend } from "./electron-update-backend";
+import { UpdateCoordinator } from "./update-coordinator";
+import { UpdateStateStore } from "./update-state";
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let agentStartup: Promise<void> | null = null;
 let daemonPaths: { stateDir: string; endpoint: string } | null = null;
+let updater: UpdateCoordinator | null = null;
 let quitting = false;
 const activePairings = new Map<string, { serverUrl: string; secret: string }>();
 const execFile = promisify(execFileCallback);
@@ -30,6 +35,10 @@ if (userDataOverride) app.setPath("userData", resolve(userDataOverride));
 
 const singleInstance = app.requestSingleInstanceLock();
 if (!singleInstance) app.quit();
+
+autoUpdater.on("before-quit-for-update", () => {
+  quitting = true;
+});
 
 function stateDirectory(): string {
   if (!daemonPaths) throw new Error("The connector runtime has not been initialized.");
@@ -171,6 +180,21 @@ function registerIpc(): void {
   ipcMain.handle("connect:status", async (event) => {
     trustedIpc(event);
     return requestReadyAgent("status");
+  });
+  ipcMain.handle("connect:updates:status", (event) => {
+    trustedIpc(event);
+    if (!updater) throw new Error("The updater has not been initialized.");
+    return updater.status();
+  });
+  ipcMain.handle("connect:updates:check", async (event) => {
+    trustedIpc(event);
+    if (!updater) throw new Error("The updater has not been initialized.");
+    return updater.check(true);
+  });
+  ipcMain.handle("connect:updates:install", async (event) => {
+    trustedIpc(event);
+    if (!updater) throw new Error("The updater has not been initialized.");
+    return updater.install();
   });
   ipcMain.handle("connect:collections:list", async (event) => {
     trustedIpc(event);
@@ -834,11 +858,40 @@ function createTray(): void {
   const image = createTrayImage();
   tray = new Tray(image);
   tray.setToolTip("mdbase connect");
+  refreshTrayMenu();
+  tray.on("double-click", () => mainWindow?.show());
+}
+
+function refreshTrayMenu(): void {
+  if (!tray) return;
+  const update = updater?.status();
+  const updateReady = update?.can_install === true;
   tray.setContextMenu(
     Menu.buildFromTemplate([
       { label: "Show mdbase connect", click: () => mainWindow?.show() },
       { type: "separator" },
       { label: "Local connector running", enabled: false },
+      {
+        label: updateReady
+          ? update?.phase === "ready"
+            ? `Install ${update.target_version}`
+            : `Open ${update?.target_version ?? "update"}`
+          : "Check for updates",
+        enabled: update?.can_check === true || updateReady,
+        click: () => {
+          if (!updater) return;
+          if (updateReady) {
+            void updater.install().catch((error) => {
+              dialog.showErrorBox(
+                "mdbase connect could not install the update",
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+          } else {
+            void updater.check(true);
+          }
+        }
+      },
       { type: "separator" },
       {
         label: "Quit mdbase connect",
@@ -849,7 +902,6 @@ function createTray(): void {
       }
     ])
   );
-  tray.on("double-click", () => mainWindow?.show());
 }
 
 function createTrayImage(): Electron.NativeImage {
@@ -906,11 +958,30 @@ app.whenReady().then(async () => {
     app.quit();
     return;
   }
+  updater = new UpdateCoordinator(
+    new UpdateStateStore(join(app.getPath("userData"), "updates", "state.json")),
+    new ElectronUpdateBackend({
+      currentVersion: app.getVersion(),
+      packaged: app.isPackaged,
+      platform: process.platform,
+      arch: process.arch,
+      userDataDirectory: app.getPath("userData"),
+      binaryPath: connectBinary,
+      stateDirectory,
+      endpoint: controlEndpoint
+    })
+  );
+  const recoveryStatus = await updater.initialize();
+  updater.subscribe((status) => {
+    mainWindow?.webContents.send("connect:update-status", status);
+    refreshTrayMenu();
+  });
   registerIpc();
   createWindow();
   createTray();
   handleDeepLink(process.argv.find((value) => value.startsWith("mdbase-connect://")));
   try {
+    if (recoveryStatus.phase === "failed") throw new Error(recoveryStatus.message);
     await ensureAgent();
   } catch (error) {
     dialog.showErrorBox(
@@ -918,6 +989,10 @@ app.whenReady().then(async () => {
       error instanceof Error ? error.message : String(error)
     );
   }
+  const initialUpdateCheck = setTimeout(() => void updater?.check(false), 30_000);
+  initialUpdateCheck.unref();
+  const updateChecks = setInterval(() => void updater?.check(false), 6 * 60 * 60 * 1000);
+  updateChecks.unref();
 });
 
 app.on("second-instance", (_event, argv) => {

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -1,7 +1,11 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { DesktopUpdateStatus } from "./update-coordinator";
 
 contextBridge.exposeInMainWorld("mdbaseConnect", {
   status: () => ipcRenderer.invoke("connect:status"),
+  updateStatus: () => ipcRenderer.invoke("connect:updates:status"),
+  checkForUpdates: () => ipcRenderer.invoke("connect:updates:check"),
+  installUpdate: () => ipcRenderer.invoke("connect:updates:install"),
   listCollections: () => ipcRenderer.invoke("connect:collections:list"),
   addCollection: () => ipcRenderer.invoke("connect:collections:add"),
   addCopiedCollection: (path: string) =>
@@ -87,5 +91,11 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
     const handler = (_event: Electron.IpcRendererEvent, route: string) => listener(route);
     ipcRenderer.on("connect:navigate", handler);
     return () => ipcRenderer.removeListener("connect:navigate", handler);
+  },
+  onUpdateStatus: (listener: (status: DesktopUpdateStatus) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, status: DesktopUpdateStatus) =>
+      listener(status);
+    ipcRenderer.on("connect:update-status", handler);
+    return () => ipcRenderer.removeListener("connect:update-status", handler);
   }
 });

--- a/apps/desktop/src/main/release-source.ts
+++ b/apps/desktop/src/main/release-source.ts
@@ -1,0 +1,239 @@
+import { verify, type Bundle } from "sigstore";
+import {
+  channelForVersion,
+  compareVersions,
+  parseUpdateManifest,
+  type UpdateChannel,
+  type UpdateManifest
+} from "./update-policy";
+
+const GITHUB_API = "https://api.github.com";
+const REPOSITORY = "mdbase-dev/mdbase-connect";
+const WORKFLOW_IDENTITY_PREFIX =
+  "https://github.com/mdbase-dev/mdbase-connect/.github/workflows/desktop-release.yml@refs/tags/";
+const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
+const MANIFEST_NAME = "mdbase-connect-update.json";
+const MANIFEST_BUNDLE_NAME = `${MANIFEST_NAME}.sigstore.json`;
+const MAX_RELEASE_INDEX_BYTES = 2 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_BUNDLE_BYTES = 4 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 15_000;
+const responseTimeouts = new WeakMap<Response, ReturnType<typeof setTimeout>>();
+
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+interface GitHubRelease {
+  draft: boolean;
+  prerelease: boolean;
+  tag_name: string;
+  html_url: string;
+  assets: GitHubAsset[];
+}
+
+export interface ReleaseCandidate {
+  manifest: UpdateManifest;
+  manifestBytes: Buffer;
+  release: {
+    tag: string;
+    url: string;
+  };
+}
+
+export interface ReleaseSourceOptions {
+  channel: UpdateChannel;
+  trustCacheDirectory: string;
+  fetchImpl?: typeof fetch;
+  verifyBundle?: (
+    bundle: unknown,
+    payload: Buffer,
+    identity: string,
+    trustCacheDirectory: string
+  ) => Promise<void>;
+}
+
+export async function findLatestRelease(options: ReleaseSourceOptions): Promise<ReleaseCandidate | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const indexUrl = `${GITHUB_API}/repos/${REPOSITORY}/releases?per_page=20`;
+  const response = await request(fetchImpl, indexUrl);
+  const releases = parseReleaseIndex(
+    JSON.parse((await readLimited(response, MAX_RELEASE_INDEX_BYTES)).toString("utf8"))
+  );
+  const matching = releases.filter(
+    (release) =>
+      !release.draft &&
+      (options.channel === "beta" ? release.prerelease : !release.prerelease) &&
+      /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(release.tag_name)
+  );
+  let best: ReleaseCandidate | null = null;
+  for (const release of matching) {
+    const manifestAsset = release.assets.find((asset) => asset.name === MANIFEST_NAME);
+    const bundleAsset = release.assets.find((asset) => asset.name === MANIFEST_BUNDLE_NAME);
+    if (!manifestAsset || !bundleAsset) continue;
+    const [manifestResponse, bundleResponse] = await Promise.all([
+      request(fetchImpl, manifestAsset.browser_download_url),
+      request(fetchImpl, bundleAsset.browser_download_url)
+    ]);
+    const [manifestBytes, bundleBytes] = await Promise.all([
+      readLimited(manifestResponse, MAX_MANIFEST_BYTES),
+      readLimited(bundleResponse, MAX_BUNDLE_BYTES)
+    ]);
+    const identity = `${WORKFLOW_IDENTITY_PREFIX}${release.tag_name}`;
+    const verifyBundle = options.verifyBundle ?? verifyReleaseBundle;
+    await verifyBundle(JSON.parse(bundleBytes.toString("utf8")), manifestBytes, identity, options.trustCacheDirectory);
+    const manifest = parseUpdateManifest(JSON.parse(manifestBytes.toString("utf8")));
+    if (manifest.tag !== release.tag_name) throw new Error("Signed update manifest does not match its release tag.");
+    if (manifest.release_url !== new URL(release.html_url).href) {
+      throw new Error("Signed update manifest does not match its release page.");
+    }
+    if (manifest.channel !== options.channel || channelForVersion(manifest.version) !== options.channel) {
+      throw new Error("Signed update manifest is published on the wrong channel.");
+    }
+    if (!best || compareVersions(manifest.version, best.manifest.version) > 0) {
+      best = { manifest, manifestBytes, release: { tag: release.tag_name, url: release.html_url } };
+    }
+  }
+  return best;
+}
+
+export async function verifyArtifactBundle(input: {
+  bundleBytes: Buffer;
+  artifactBytes?: Buffer;
+  artifactPath?: string;
+  tag: string;
+  trustCacheDirectory: string;
+}): Promise<void> {
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(input.tag)) {
+    throw new Error("Cannot verify an artifact from an invalid release tag.");
+  }
+  let payload = input.artifactBytes;
+  if (!payload && input.artifactPath) {
+    const { readFile } = await import("node:fs/promises");
+    payload = await readFile(input.artifactPath);
+  }
+  if (!payload) throw new Error("Artifact bytes are required for signature verification.");
+  await verifyReleaseBundle(
+    JSON.parse(input.bundleBytes.toString("utf8")),
+    payload,
+    `${WORKFLOW_IDENTITY_PREFIX}${input.tag}`,
+    input.trustCacheDirectory
+  );
+}
+
+async function verifyReleaseBundle(
+  bundle: unknown,
+  payload: Buffer,
+  identity: string,
+  trustCacheDirectory: string
+): Promise<void> {
+  await verify(bundle as Bundle, payload, {
+    certificateIssuer: OIDC_ISSUER,
+    certificateIdentityURI: identity,
+    tlogThreshold: 1,
+    ctLogThreshold: 1,
+    tufCachePath: trustCacheDirectory,
+    timeout: 10_000,
+    retry: { retries: 2 }
+  });
+}
+
+async function request(fetchImpl: typeof fetch, url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const response = await fetchImpl(url, {
+    headers: {
+      accept: "application/vnd.github+json, application/octet-stream",
+      "user-agent": "mdbase-connect-updater"
+    },
+    redirect: "follow",
+    signal: controller.signal
+  }).catch((error) => {
+    clearTimeout(timeout);
+    throw error;
+  });
+  if (!response.ok) {
+    clearTimeout(timeout);
+    throw new Error(`Update service returned HTTP ${response.status}.`);
+  }
+  if (!response.url.startsWith("https://")) {
+    clearTimeout(timeout);
+    throw new Error("Update service redirected to an insecure URL.");
+  }
+  responseTimeouts.set(response, timeout);
+  return response;
+}
+
+async function readLimited(response: Response, maximum: number): Promise<Buffer> {
+  try {
+    const lengthHeader = response.headers.get("content-length");
+    const declared = lengthHeader === null ? null : Number(lengthHeader);
+    if (declared !== null && Number.isFinite(declared) && declared > maximum) {
+      throw new Error("Update response exceeds its size limit.");
+    }
+    if (!response.body) return Buffer.alloc(0);
+    const chunks: Buffer[] = [];
+    let length = 0;
+    for await (const chunk of response.body) {
+      const bytes = Buffer.from(chunk);
+      length += bytes.length;
+      if (length > maximum) throw new Error("Update response exceeds its size limit.");
+      chunks.push(bytes);
+    }
+    return Buffer.concat(chunks, length);
+  } finally {
+    const timeout = responseTimeouts.get(response);
+    if (timeout) clearTimeout(timeout);
+    responseTimeouts.delete(response);
+  }
+}
+
+function parseReleaseIndex(value: unknown): GitHubRelease[] {
+  if (!Array.isArray(value)) throw new Error("Update service returned an invalid release index.");
+  return value.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error("Update service returned an invalid release.");
+    }
+    const release = entry as Record<string, unknown>;
+    if (
+      typeof release.draft !== "boolean" ||
+      typeof release.prerelease !== "boolean" ||
+      typeof release.tag_name !== "string" ||
+      typeof release.html_url !== "string" ||
+      !release.html_url.startsWith("https://") ||
+      !Array.isArray(release.assets)
+    ) {
+      throw new Error("Update service returned an invalid release.");
+    }
+    const assets = release.assets.map((asset) => {
+      if (!asset || typeof asset !== "object" || Array.isArray(asset)) {
+        throw new Error("Update service returned an invalid release asset.");
+      }
+      const value = asset as Record<string, unknown>;
+      if (
+        typeof value.name !== "string" ||
+        typeof value.browser_download_url !== "string" ||
+        !value.browser_download_url.startsWith("https://") ||
+        typeof value.size !== "number" ||
+        !Number.isSafeInteger(value.size) ||
+        value.size < 0
+      ) {
+        throw new Error("Update service returned an invalid release asset.");
+      }
+      return {
+        name: value.name,
+        browser_download_url: value.browser_download_url,
+        size: value.size
+      };
+    });
+    return {
+      draft: release.draft,
+      prerelease: release.prerelease,
+      tag_name: release.tag_name,
+      html_url: new URL(release.html_url).href,
+      assets
+    };
+  });
+}

--- a/apps/desktop/src/main/update-coordinator.ts
+++ b/apps/desktop/src/main/update-coordinator.ts
@@ -1,0 +1,423 @@
+import { randomUUID } from "node:crypto";
+import {
+  compareVersions,
+  decideUpdate,
+  type UpdateChannel,
+  type UpdateManifest,
+  type UpdateTarget
+} from "./update-policy";
+import { UpdateStateStore, type UpdateTransaction } from "./update-state";
+
+export type UpdatePhase =
+  | "unavailable"
+  | "idle"
+  | "checking"
+  | "deferred"
+  | "downloading"
+  | "ready"
+  | "external"
+  | "installing"
+  | "recovery"
+  | "failed";
+
+export interface DesktopUpdateStatus {
+  phase: UpdatePhase;
+  current_version: string;
+  channel: UpdateChannel;
+  target_version?: string;
+  checked_at?: string;
+  progress?: number;
+  message: string;
+  release_url?: string;
+  can_check: boolean;
+  can_install: boolean;
+}
+
+export interface PreparedDaemonHandoff {
+  serviceInstalled: boolean;
+  previousRuntime: string | null;
+}
+
+export interface RecoveryResult {
+  healthy: boolean;
+  rolledBack: boolean;
+  message: string;
+}
+
+export interface UpdateBackend {
+  currentVersion: string;
+  channel: UpdateChannel;
+  platformKey: string;
+  packaged: boolean;
+  reconcileInstalledRuntime(): Promise<string | null>;
+  findLatest(): Promise<{ manifest: UpdateManifest } | null>;
+  stageAutomatic(
+    manifest: UpdateManifest,
+    target: UpdateTarget,
+    onProgress: (progress: number) => void
+  ): Promise<void>;
+  prepareDaemonHandoff(previousVersion: string): Promise<PreparedDaemonHandoff>;
+  stopDaemon(): Promise<void>;
+  installAutomatic(): void;
+  openExternal(url: string): Promise<void>;
+  recover(transaction: UpdateTransaction): Promise<RecoveryResult>;
+}
+
+export class UpdateCoordinator {
+  private readonly store: UpdateStateStore;
+  private readonly backend: UpdateBackend;
+  private readonly listeners = new Set<(status: DesktopUpdateStatus) => void>();
+  private statusValue: DesktopUpdateStatus;
+  private candidate: { manifest: UpdateManifest; target: UpdateTarget } | null = null;
+  private operation: Promise<DesktopUpdateStatus> | null = null;
+
+  constructor(store: UpdateStateStore, backend: UpdateBackend) {
+    this.store = store;
+    this.backend = backend;
+    this.statusValue = {
+      phase: backend.packaged ? "idle" : "unavailable",
+      current_version: backend.currentVersion,
+      channel: backend.channel,
+      message: backend.packaged
+        ? "Updates have not been checked yet."
+        : "Updates are available in installed builds.",
+      can_check: backend.packaged,
+      can_install: false
+    };
+  }
+
+  status(): DesktopUpdateStatus {
+    return structuredClone(this.statusValue);
+  }
+
+  subscribe(listener: (status: DesktopUpdateStatus) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.status());
+    return () => this.listeners.delete(listener);
+  }
+
+  async initialize(): Promise<DesktopUpdateStatus> {
+    const persisted = await this.store.load();
+    if (persisted.last_checked_at) {
+      this.statusValue.checked_at = persisted.last_checked_at;
+    }
+    if (!persisted.transaction) {
+      try {
+        const message = await this.backend.reconcileInstalledRuntime();
+        if (message) {
+          this.setStatus({
+            phase: "idle",
+            message,
+            can_check: this.backend.packaged,
+            can_install: false
+          });
+        }
+      } catch (error) {
+        this.setStatus({
+          phase: "failed",
+          message: `Could not reconcile the installed connector runtime: ${message(error)}`,
+          can_check: false,
+          can_install: false
+        });
+      }
+      return this.status();
+    }
+    this.setStatus({
+      phase: "recovery",
+      target_version: persisted.transaction.target_version,
+      message: "Finishing the application and connector upgrade.",
+      can_check: false,
+      can_install: false
+    });
+    await this.store.update((state) => {
+      if (state.transaction) state.transaction.phase = "recovering";
+    });
+    try {
+      const result = await this.backend.recover(persisted.transaction);
+      await this.store.update((state) => {
+        if (result.healthy && !result.rolledBack) {
+          state.highest_trusted_version = maxVersion(
+            state.highest_trusted_version,
+            persisted.transaction?.target_version
+          );
+          if (persisted.transaction?.previous_runtime) {
+            state.last_known_good_runtime = {
+              version: persisted.transaction.previous_version,
+              path: persisted.transaction.previous_runtime
+            };
+          }
+        }
+        delete state.transaction;
+      });
+      this.setStatus({
+        phase: result.healthy && !result.rolledBack ? "idle" : "recovery",
+        message: result.message,
+        can_check: this.backend.packaged,
+        can_install: false
+      });
+    } catch (error) {
+      await this.store.update((state) => {
+        if (state.transaction) state.transaction.error = message(error);
+      });
+      this.setStatus({
+        phase: "failed",
+        target_version: persisted.transaction.target_version,
+        message: `Update recovery needs attention: ${message(error)}`,
+        can_check: false,
+        can_install: false
+      });
+    }
+    return this.status();
+  }
+
+  check(manual = false): Promise<DesktopUpdateStatus> {
+    if (this.operation) return this.operation;
+    if (
+      ["ready", "installing"].includes(this.statusValue.phase) ||
+      !this.statusValue.can_check
+    ) {
+      return Promise.resolve(this.status());
+    }
+    this.operation = this.checkExclusive(manual).finally(() => {
+      this.operation = null;
+    });
+    return this.operation;
+  }
+
+  async install(): Promise<DesktopUpdateStatus> {
+    if (!this.candidate) throw new Error("No update is ready to install.");
+    if (this.candidate.target.mode !== "automatic") {
+      if (this.statusValue.phase !== "external" || !this.statusValue.can_install) {
+        throw new Error("The external update is not ready to open.");
+      }
+      await this.backend.openExternal(this.candidate.target.action_url);
+      return this.status();
+    }
+    if (this.statusValue.phase !== "ready") throw new Error("The update has not finished downloading.");
+    const persisted = await this.store.load();
+    const transaction = persisted.transaction;
+    if (
+      !transaction ||
+      transaction.phase !== "prepared" ||
+      transaction.target_version !== this.candidate.manifest.version ||
+      transaction.previous_version !== this.backend.currentVersion
+    ) {
+      throw new Error("The prepared app and daemon update transaction is missing.");
+    }
+    this.setStatus({
+      phase: "installing",
+      target_version: transaction.target_version,
+      message: "Stopping the connector and installing the update.",
+      can_check: false,
+      can_install: false
+    });
+    try {
+      await this.backend.stopDaemon();
+      await this.store.update((state) => {
+        if (state.transaction?.id === transaction.id) state.transaction.phase = "installing";
+      });
+      this.backend.installAutomatic();
+    } catch (error) {
+      const recovered = await this.backend.recover(transaction).catch(() => null);
+      await this.store.update((state) => {
+        delete state.transaction;
+      });
+      this.candidate = null;
+      this.setStatus({
+        phase: "failed",
+        target_version: transaction.target_version,
+        message: recovered?.healthy
+          ? `The update was not installed; the connector was restored. ${message(error)}`
+          : `The update was not installed and connector recovery failed: ${message(error)}`,
+        can_check: this.backend.packaged,
+        can_install: false
+      });
+      throw error;
+    }
+    return this.status();
+  }
+
+  private async checkExclusive(manual: boolean): Promise<DesktopUpdateStatus> {
+    if (!this.backend.packaged) return this.status();
+    this.setStatus({
+      phase: "checking",
+      message: "Checking the signed release channel…",
+      can_check: false,
+      can_install: false
+    });
+    try {
+      const persisted = await this.store.load();
+      const release = await this.backend.findLatest();
+      const checkedAt = new Date().toISOString();
+      if (!release) {
+        await this.store.update((state) => {
+          state.last_checked_at = checkedAt;
+        });
+        this.candidate = null;
+        this.setStatus({
+          phase: "idle",
+          checked_at: checkedAt,
+          message: "This is the newest release on the selected channel.",
+          can_check: true,
+          can_install: false
+        });
+        return this.status();
+      }
+      const decision = decideUpdate({
+        manifest: release.manifest,
+        currentVersion: this.backend.currentVersion,
+        channel: this.backend.channel,
+        platformKey: this.backend.platformKey,
+        installationId: persisted.installation_id,
+        highestTrustedVersion: persisted.highest_trusted_version,
+        manual
+      });
+      await this.store.update((state) => {
+        state.last_checked_at = checkedAt;
+        state.highest_trusted_version = maxVersion(
+          state.highest_trusted_version,
+          release.manifest.version
+        );
+      });
+      if (decision.kind === "blocked") {
+        this.candidate = null;
+        this.setStatus({
+          phase: "failed",
+          checked_at: checkedAt,
+          target_version: release.manifest.version,
+          release_url: release.manifest.release_url,
+          message: decision.reason,
+          can_check: true,
+          can_install: false
+        });
+      } else if (decision.kind === "current") {
+        this.candidate = null;
+        this.setStatus({
+          phase: "idle",
+          checked_at: checkedAt,
+          message: "This is the newest release on the selected channel.",
+          can_check: true,
+          can_install: false
+        });
+      } else if (decision.kind === "deferred") {
+        this.candidate = null;
+        this.setStatus({
+          phase: "deferred",
+          checked_at: checkedAt,
+          target_version: release.manifest.version,
+          release_url: release.manifest.release_url,
+          message: `Version ${release.manifest.version} is rolling out to ${decision.percentage}% of installations.`,
+          can_check: true,
+          can_install: false
+        });
+      } else {
+        this.candidate = { manifest: release.manifest, target: decision.target };
+        if (decision.target.mode === "automatic") {
+          this.setStatus({
+            phase: "downloading",
+            checked_at: checkedAt,
+            target_version: release.manifest.version,
+            release_url: release.manifest.release_url,
+            progress: 0,
+            message: `Downloading verified version ${release.manifest.version}…`,
+            can_check: false,
+            can_install: false
+          });
+          const handoff = await this.backend.prepareDaemonHandoff(this.backend.currentVersion);
+          const transaction: UpdateTransaction = {
+            id: randomUUID(),
+            phase: "prepared",
+            target_version: release.manifest.version,
+            previous_version: this.backend.currentVersion,
+            service_installed: handoff.serviceInstalled,
+            previous_runtime: handoff.previousRuntime,
+            started_at: new Date().toISOString()
+          };
+          await this.store.update((state) => {
+            state.transaction = transaction;
+          });
+          try {
+            await this.backend.stageAutomatic(release.manifest, decision.target, (progress) => {
+              this.setStatus({
+                phase: "downloading",
+                progress,
+                message: `Downloading verified version ${release.manifest.version}…`,
+                can_check: false,
+                can_install: false
+              });
+            });
+          } catch (error) {
+            await this.store.update((state) => {
+              if (state.transaction?.id === transaction.id) delete state.transaction;
+            });
+            throw error;
+          }
+          this.setStatus({
+            phase: "ready",
+            checked_at: checkedAt,
+            target_version: release.manifest.version,
+            release_url: release.manifest.release_url,
+            progress: 100,
+            message: `Version ${release.manifest.version} is verified and ready to install.`,
+            can_check: true,
+            can_install: true
+          });
+        } else {
+          this.setStatus({
+            phase: "external",
+            checked_at: checkedAt,
+            target_version: release.manifest.version,
+            release_url: release.manifest.release_url,
+            message:
+              decision.target.mode === "store"
+                ? `Version ${release.manifest.version} is available through the Microsoft Store.`
+                : `Version ${release.manifest.version} is available through the signed package channel.`,
+            can_check: true,
+            can_install: true
+          });
+        }
+      }
+      return this.status();
+    } catch (error) {
+      this.setStatus({
+        phase: "failed",
+        message: `Could not verify updates: ${message(error)}`,
+        can_check: true,
+        can_install: false
+      });
+      return this.status();
+    }
+  }
+
+  private setStatus(patch: Partial<DesktopUpdateStatus> & Pick<DesktopUpdateStatus, "phase" | "message">): void {
+    const base =
+      patch.phase === this.statusValue.phase
+        ? this.statusValue
+        : {
+            phase: patch.phase,
+            current_version: this.backend.currentVersion,
+            channel: this.backend.channel,
+            checked_at: this.statusValue.checked_at,
+            message: patch.message,
+            can_check: false,
+            can_install: false
+          };
+    this.statusValue = {
+      ...base,
+      ...patch,
+      current_version: this.backend.currentVersion,
+      channel: this.backend.channel
+    };
+    for (const listener of this.listeners) listener(this.status());
+  }
+}
+
+function maxVersion(left: string | undefined, right: string | undefined): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  return compareVersions(left, right) >= 0 ? left : right;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/src/main/update-download.ts
+++ b/apps/desktop/src/main/update-download.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import { rename, rm, stat } from "node:fs/promises";
+import { Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { UpdateArtifact } from "./update-policy";
+
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
+const responseTimeouts = new WeakMap<Response, ReturnType<typeof setTimeout>>();
+
+export async function downloadBytes(
+  url: string,
+  maximum: number,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = DEFAULT_DOWNLOAD_TIMEOUT_MS
+): Promise<Buffer> {
+  const response = await secureFetch(url, fetchImpl, timeoutMs);
+  try {
+    const declared = contentLength(response);
+    if (declared !== null && declared > maximum) {
+      throw new Error("Update signature is too large.");
+    }
+    if (!response.body) throw new Error("Update signature is empty.");
+    const chunks: Buffer[] = [];
+    let length = 0;
+    for await (const chunk of response.body) {
+      const bytes = Buffer.from(chunk);
+      length += bytes.length;
+      if (length > maximum) throw new Error("Update signature is too large.");
+      chunks.push(bytes);
+    }
+    return Buffer.concat(chunks, length);
+  } finally {
+    clearResponseTimeout(response);
+  }
+}
+
+export async function downloadArtifact(
+  artifact: UpdateArtifact,
+  destination: string,
+  onProgress: (progress: number) => void,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = DEFAULT_DOWNLOAD_TIMEOUT_MS
+): Promise<void> {
+  const response = await secureFetch(artifact.url, fetchImpl, timeoutMs);
+  const temporary = `${destination}.part-${process.pid}`;
+  try {
+    const declared = contentLength(response);
+    if (declared !== null && declared !== artifact.size) {
+      throw new Error("Update artifact size does not match the signed manifest.");
+    }
+    if (!response.body) throw new Error("Update artifact is empty.");
+    await rm(destination, { force: true });
+    await rm(temporary, { force: true });
+    const hash = createHash("sha256");
+    let received = 0;
+    const inspect = new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        received += chunk.length;
+        if (received > artifact.size) {
+          callback(new Error("Update artifact exceeds its signed size."));
+          return;
+        }
+        hash.update(chunk);
+        onProgress((received / artifact.size) * 100);
+        callback(null, chunk);
+      }
+    });
+    await pipeline(
+      response.body as unknown as NodeJS.ReadableStream,
+      inspect,
+      createWriteStream(temporary, { flags: "wx", mode: 0o600 })
+    );
+    if (received !== artifact.size || hash.digest("hex") !== artifact.sha256) {
+      throw new Error("Update artifact does not match its signed digest.");
+    }
+    await rename(temporary, destination);
+  } catch (error) {
+    await rm(temporary, { force: true });
+    throw error;
+  } finally {
+    clearResponseTimeout(response);
+  }
+}
+
+export async function artifactMatches(path: string, artifact: UpdateArtifact): Promise<boolean> {
+  try {
+    const details = await stat(path);
+    if (!details.isFile() || details.size !== artifact.size) return false;
+    const hash = createHash("sha256");
+    for await (const chunk of createReadStream(path)) hash.update(chunk);
+    return hash.digest("hex") === artifact.sha256;
+  } catch {
+    return false;
+  }
+}
+
+async function secureFetch(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number
+): Promise<Response> {
+  if (!url.startsWith("https://")) throw new Error("Update downloads must use HTTPS.");
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const response = await fetchImpl(url, {
+    headers: { "user-agent": "mdbase-connect-updater" },
+    redirect: "follow",
+    signal: controller.signal
+  }).catch((error) => {
+    clearTimeout(timeout);
+    throw error;
+  });
+  if (!response.ok) {
+    clearTimeout(timeout);
+    throw new Error(`Update download returned HTTP ${response.status}.`);
+  }
+  if (!response.url.startsWith("https://")) {
+    clearTimeout(timeout);
+    throw new Error("Update download redirected to an insecure URL.");
+  }
+  responseTimeouts.set(response, timeout);
+  return response;
+}
+
+function clearResponseTimeout(response: Response): void {
+  const timeout = responseTimeouts.get(response);
+  if (timeout) clearTimeout(timeout);
+  responseTimeouts.delete(response);
+}
+
+function contentLength(response: Response): number | null {
+  const value = response.headers.get("content-length");
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}

--- a/apps/desktop/src/main/update-policy.ts
+++ b/apps/desktop/src/main/update-policy.ts
@@ -1,0 +1,321 @@
+import { createHash } from "node:crypto";
+
+export const UPDATE_MANIFEST_SCHEMA_VERSION = 1;
+export const UPDATE_CHANNELS = ["stable", "beta"] as const;
+export type UpdateChannel = (typeof UPDATE_CHANNELS)[number];
+export type UpdateMode = "automatic" | "store" | "manual";
+
+export interface UpdateArtifact {
+  name: string;
+  url: string;
+  sigstore_url: string;
+  sha256: string;
+  size: number;
+  kind: "zip" | "dmg" | "exe" | "deb" | "rpm";
+}
+
+export interface UpdateTarget {
+  mode: UpdateMode;
+  action_url: string;
+  artifacts: UpdateArtifact[];
+}
+
+export interface UpdateManifest {
+  schema_version: 1;
+  version: string;
+  tag: string;
+  channel: UpdateChannel;
+  published_at: string;
+  release_url: string;
+  notes: string;
+  rollout: {
+    percentage: number;
+    seed: string;
+  };
+  blocked_versions: string[];
+  targets: Record<string, UpdateTarget>;
+}
+
+export type UpdateDecision =
+  | { kind: "current" }
+  | { kind: "blocked"; reason: string }
+  | { kind: "deferred"; percentage: number }
+  | { kind: "available"; target: UpdateTarget };
+
+const VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const TAG_PATTERN = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const HTTPS_URL_PATTERN = /^https:\/\//;
+const MAX_ARTIFACT_SIZE = 512 * 1024 * 1024;
+
+interface ParsedVersion {
+  main: [bigint, bigint, bigint];
+  prerelease: Array<bigint | string>;
+}
+
+export function compareVersions(left: string, right: string): number {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < a.main.length; index += 1) {
+    if (a.main[index] !== b.main[index]) return a.main[index] < b.main[index] ? -1 : 1;
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    return a.prerelease.length === b.prerelease.length ? 0 : a.prerelease.length === 0 ? 1 : -1;
+  }
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const aPart = a.prerelease[index];
+    const bPart = b.prerelease[index];
+    if (aPart === undefined || bPart === undefined) return aPart === undefined ? -1 : 1;
+    if (aPart === bPart) continue;
+    if (typeof aPart === "bigint" && typeof bPart === "bigint") return aPart < bPart ? -1 : 1;
+    if (typeof aPart === "bigint") return -1;
+    if (typeof bPart === "bigint") return 1;
+    return aPart < bPart ? -1 : 1;
+  }
+  return 0;
+}
+
+export function channelForVersion(version: string): UpdateChannel {
+  return parseVersion(version).prerelease.length === 0 ? "stable" : "beta";
+}
+
+export function rolloutBucket(installationId: string, seed: string): number {
+  if (!installationId || !seed) throw new Error("Rollout identity and seed are required.");
+  const digest = createHash("sha256").update(`${seed}\0${installationId}`, "utf8").digest();
+  return digest.readUInt32BE(0) % 10_000;
+}
+
+export function decideUpdate(input: {
+  manifest: UpdateManifest;
+  currentVersion: string;
+  channel: UpdateChannel;
+  platformKey: string;
+  installationId: string;
+  highestTrustedVersion?: string;
+  manual?: boolean;
+}): UpdateDecision {
+  const {
+    manifest,
+    currentVersion,
+    channel,
+    platformKey,
+    installationId,
+    highestTrustedVersion,
+    manual = false
+  } = input;
+  parseVersion(currentVersion);
+  if (manifest.channel !== channel) return { kind: "current" };
+  if (highestTrustedVersion && compareVersions(manifest.version, highestTrustedVersion) < 0) {
+    return { kind: "blocked", reason: "The release manifest is older than the last trusted release." };
+  }
+  if (manifest.blocked_versions.includes(manifest.version)) {
+    return { kind: "blocked", reason: "The target release has been withdrawn." };
+  }
+  if (compareVersions(manifest.version, currentVersion) <= 0) return { kind: "current" };
+  const target = manifest.targets[platformKey];
+  if (!target) return { kind: "blocked", reason: `No update is published for ${platformKey}.` };
+  const threshold = Math.round(manifest.rollout.percentage * 100);
+  const currentVersionIsBlocked = manifest.blocked_versions.includes(currentVersion);
+  if (!manual && !currentVersionIsBlocked && rolloutBucket(installationId, manifest.rollout.seed) >= threshold) {
+    return { kind: "deferred", percentage: manifest.rollout.percentage };
+  }
+  return { kind: "available", target };
+}
+
+export function parseUpdateManifest(value: unknown): UpdateManifest {
+  const root = object(value, "Update manifest");
+  exactKeys(root, [
+    "schema_version",
+    "version",
+    "tag",
+    "channel",
+    "published_at",
+    "release_url",
+    "notes",
+    "rollout",
+    "blocked_versions",
+    "targets"
+  ], "Update manifest");
+  if (root.schema_version !== UPDATE_MANIFEST_SCHEMA_VERSION) {
+    throw new Error(`Unsupported update manifest schema ${String(root.schema_version)}.`);
+  }
+  const version = versionString(root.version, "version");
+  const tag = string(root.tag, "tag");
+  if (!TAG_PATTERN.test(tag) || tag !== `v${version}`) {
+    throw new Error("Update manifest tag does not match its version.");
+  }
+  const channel = string(root.channel, "channel");
+  if (!UPDATE_CHANNELS.includes(channel as UpdateChannel)) {
+    throw new Error(`Unsupported update channel ${channel}.`);
+  }
+  if (channelForVersion(version) !== channel) {
+    throw new Error("Update manifest channel does not match its version.");
+  }
+  const publishedAt = string(root.published_at, "published_at");
+  if (!Number.isFinite(Date.parse(publishedAt))) {
+    throw new Error("Update manifest published_at is not an ISO timestamp.");
+  }
+  const releaseUrl = httpsUrl(root.release_url, "release_url");
+  const notes = string(root.notes, "notes", true);
+
+  const rollout = object(root.rollout, "rollout");
+  exactKeys(rollout, ["percentage", "seed"], "rollout");
+  if (
+    typeof rollout.percentage !== "number" ||
+    !Number.isFinite(rollout.percentage) ||
+    rollout.percentage < 0 ||
+    rollout.percentage > 100
+  ) {
+    throw new Error("Update rollout percentage must be between 0 and 100.");
+  }
+  const seed = string(rollout.seed, "rollout.seed");
+
+  if (!Array.isArray(root.blocked_versions)) {
+    throw new Error("Update manifest blocked_versions must be an array.");
+  }
+  const blockedVersions = root.blocked_versions.map((entry, index) =>
+    versionString(entry, `blocked_versions[${index}]`)
+  );
+  if (new Set(blockedVersions).size !== blockedVersions.length) {
+    throw new Error("Update manifest blocked_versions contains duplicates.");
+  }
+
+  const rawTargets = object(root.targets, "targets");
+  const targets: Record<string, UpdateTarget> = {};
+  for (const [key, rawTarget] of Object.entries(rawTargets)) {
+    if (!/^(darwin|win32|linux)-(arm64|x64)$/.test(key)) {
+      throw new Error(`Unsupported update target ${key}.`);
+    }
+    targets[key] = parseTarget(rawTarget, key);
+  }
+  if (Object.keys(targets).length === 0) throw new Error("Update manifest has no targets.");
+
+  return {
+    schema_version: 1,
+    version,
+    tag,
+    channel: channel as UpdateChannel,
+    published_at: new Date(publishedAt).toISOString(),
+    release_url: releaseUrl,
+    notes,
+    rollout: { percentage: rollout.percentage, seed },
+    blocked_versions: blockedVersions,
+    targets
+  };
+}
+
+function parseTarget(value: unknown, key: string): UpdateTarget {
+  const target = object(value, `target ${key}`);
+  exactKeys(target, ["mode", "action_url", "artifacts"], `target ${key}`);
+  const mode = string(target.mode, `${key}.mode`);
+  if (!["automatic", "store", "manual"].includes(mode)) {
+    throw new Error(`Unsupported update mode ${mode}.`);
+  }
+  const actionUrl = httpsUrl(target.action_url, `${key}.action_url`);
+  if (!Array.isArray(target.artifacts)) throw new Error(`${key}.artifacts must be an array.`);
+  const artifacts = target.artifacts.map((entry, index) => parseArtifact(entry, `${key}.artifacts[${index}]`));
+  if (new Set(artifacts.map((artifact) => artifact.name)).size !== artifacts.length) {
+    throw new Error(`${key}.artifacts contains duplicate names.`);
+  }
+  if (mode === "automatic" && !artifacts.some((artifact) => artifact.kind === "zip")) {
+    throw new Error(`${key} automatic updates require a ZIP artifact.`);
+  }
+  if (artifacts.length === 0 && mode !== "store") {
+    throw new Error(`${key} must publish at least one artifact.`);
+  }
+  return { mode: mode as UpdateMode, action_url: actionUrl, artifacts };
+}
+
+function parseArtifact(value: unknown, label: string): UpdateArtifact {
+  const artifact = object(value, label);
+  exactKeys(artifact, ["name", "url", "sigstore_url", "sha256", "size", "kind"], label);
+  const name = string(artifact.name, `${label}.name`);
+  if (
+    name.includes("/") ||
+    name.includes("\\") ||
+    name === "." ||
+    name === ".." ||
+    Buffer.byteLength(name, "utf8") > 240
+  ) {
+    throw new Error(`${label}.name is unsafe.`);
+  }
+  const sha256 = string(artifact.sha256, `${label}.sha256`);
+  if (!SHA256_PATTERN.test(sha256)) throw new Error(`${label}.sha256 is invalid.`);
+  if (
+    typeof artifact.size !== "number" ||
+    !Number.isSafeInteger(artifact.size) ||
+    artifact.size <= 0 ||
+    artifact.size > MAX_ARTIFACT_SIZE
+  ) {
+    throw new Error(`${label}.size is invalid.`);
+  }
+  const kind = string(artifact.kind, `${label}.kind`);
+  if (!["zip", "dmg", "exe", "deb", "rpm"].includes(kind)) {
+    throw new Error(`${label}.kind is invalid.`);
+  }
+  if (!name.toLowerCase().endsWith(`.${kind}`)) {
+    throw new Error(`${label}.kind does not match its filename.`);
+  }
+  return {
+    name,
+    url: httpsUrl(artifact.url, `${label}.url`),
+    sigstore_url: httpsUrl(artifact.sigstore_url, `${label}.sigstore_url`),
+    sha256,
+    size: artifact.size,
+    kind: kind as UpdateArtifact["kind"]
+  };
+}
+
+function parseVersion(value: string): ParsedVersion {
+  const match = VERSION_PATTERN.exec(value);
+  if (!match) throw new Error(`Invalid semantic version ${value}.`);
+  const prerelease = match[4]
+    ? match[4].split(".").map((part) => {
+        if (/^\d+$/.test(part) && !/^(0|[1-9]\d*)$/.test(part)) {
+          throw new Error(`Invalid semantic version ${value}.`);
+        }
+        return /^(0|[1-9]\d*)$/.test(part) ? BigInt(part) : part;
+      })
+    : [];
+  return {
+    main: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
+    prerelease
+  };
+}
+
+function versionString(value: unknown, label: string): string {
+  const result = string(value, label);
+  parseVersion(result);
+  return result;
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function string(value: unknown, label: string, allowEmpty = false): string {
+  if (typeof value !== "string" || (!allowEmpty && !value.trim())) {
+    throw new Error(`${label} must be a string.`);
+  }
+  return value;
+}
+
+function httpsUrl(value: unknown, label: string): string {
+  const result = string(value, label);
+  if (!HTTPS_URL_PATTERN.test(result)) throw new Error(`${label} must use HTTPS.`);
+  const url = new URL(result);
+  if (url.username || url.password || url.hash) throw new Error(`${label} is unsafe.`);
+  return url.href;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: string[], label: string): void {
+  const extras = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (extras.length > 0) throw new Error(`${label} has unknown fields: ${extras.join(", ")}.`);
+  const missing = allowed.filter((key) => !(key in value));
+  if (missing.length > 0) throw new Error(`${label} is missing fields: ${missing.join(", ")}.`);
+}

--- a/apps/desktop/src/main/update-state.ts
+++ b/apps/desktop/src/main/update-state.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { compareVersions } from "./update-policy";
+
+export interface UpdateTransaction {
+  id: string;
+  phase: "prepared" | "installing" | "recovering";
+  target_version: string;
+  previous_version: string;
+  service_installed: boolean;
+  previous_runtime: string | null;
+  started_at: string;
+  error?: string;
+}
+
+export interface PersistedUpdateState {
+  schema_version: 1;
+  installation_id: string;
+  highest_trusted_version?: string;
+  last_checked_at?: string;
+  last_known_good_runtime?: {
+    version: string;
+    path: string;
+  };
+  transaction?: UpdateTransaction;
+}
+
+export class UpdateStateStore {
+  readonly path: string;
+  private state: PersistedUpdateState | null = null;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  async load(): Promise<PersistedUpdateState> {
+    if (this.state) return structuredClone(this.state);
+    try {
+      const parsed = JSON.parse(await readFile(this.path, "utf8")) as unknown;
+      this.state = parsePersistedState(parsed);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        const quarantine = `${this.path}.invalid-${Date.now()}`;
+        await rename(this.path, quarantine).catch(() => undefined);
+      }
+      this.state = freshState();
+      await this.write();
+    }
+    return structuredClone(this.state);
+  }
+
+  async update(
+    change: (current: PersistedUpdateState) => PersistedUpdateState | void
+  ): Promise<PersistedUpdateState> {
+    const current = await this.load();
+    const next = change(current) ?? current;
+    this.state = parsePersistedState(next);
+    await this.write();
+    return structuredClone(this.state);
+  }
+
+  async remove(): Promise<void> {
+    this.state = null;
+    await rm(this.path, { force: true });
+  }
+
+  private async write(): Promise<void> {
+    if (!this.state) throw new Error("Update state has not been initialized.");
+    const parent = dirname(this.path);
+    await mkdir(parent, { recursive: true, mode: 0o700 });
+    await chmod(parent, 0o700).catch(() => undefined);
+    const temporary = `${this.path}.tmp-${process.pid}-${randomUUID()}`;
+    await writeFile(temporary, `${JSON.stringify(this.state, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx"
+    });
+    try {
+      await rename(temporary, this.path);
+      await chmod(this.path, 0o600).catch(() => undefined);
+    } catch (error) {
+      await rm(temporary, { force: true });
+      throw error;
+    }
+  }
+}
+
+export function parsePersistedState(value: unknown): PersistedUpdateState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Update state must be an object.");
+  }
+  const state = value as Record<string, unknown>;
+  if (state.schema_version !== 1 || typeof state.installation_id !== "string" || !state.installation_id) {
+    throw new Error("Update state is invalid.");
+  }
+  const parsed: PersistedUpdateState = {
+    schema_version: 1,
+    installation_id: state.installation_id
+  };
+  if (state.highest_trusted_version !== undefined) {
+    if (typeof state.highest_trusted_version !== "string") throw new Error("Trusted version is invalid.");
+    compareVersions(state.highest_trusted_version, state.highest_trusted_version);
+    parsed.highest_trusted_version = state.highest_trusted_version;
+  }
+  if (state.last_checked_at !== undefined) {
+    if (typeof state.last_checked_at !== "string" || !Number.isFinite(Date.parse(state.last_checked_at))) {
+      throw new Error("Last update check time is invalid.");
+    }
+    parsed.last_checked_at = new Date(state.last_checked_at).toISOString();
+  }
+  if (state.last_known_good_runtime !== undefined) {
+    const runtime = record(state.last_known_good_runtime, "Last-known-good runtime");
+    if (typeof runtime.version !== "string" || typeof runtime.path !== "string" || !runtime.path) {
+      throw new Error("Last-known-good runtime is invalid.");
+    }
+    compareVersions(runtime.version, runtime.version);
+    parsed.last_known_good_runtime = { version: runtime.version, path: runtime.path };
+  }
+  if (state.transaction !== undefined) parsed.transaction = parseTransaction(state.transaction);
+  return parsed;
+}
+
+function parseTransaction(value: unknown): UpdateTransaction {
+  const transaction = record(value, "Update transaction");
+  const phase = transaction.phase;
+  if (!["prepared", "installing", "recovering"].includes(String(phase))) {
+    throw new Error("Update transaction phase is invalid.");
+  }
+  for (const field of ["id", "target_version", "previous_version", "started_at"] as const) {
+    if (typeof transaction[field] !== "string" || !transaction[field]) {
+      throw new Error(`Update transaction ${field} is invalid.`);
+    }
+  }
+  compareVersions(transaction.target_version as string, transaction.target_version as string);
+  compareVersions(transaction.previous_version as string, transaction.previous_version as string);
+  if (!Number.isFinite(Date.parse(transaction.started_at as string))) {
+    throw new Error("Update transaction start time is invalid.");
+  }
+  if (typeof transaction.service_installed !== "boolean") {
+    throw new Error("Update transaction service state is invalid.");
+  }
+  if (transaction.previous_runtime !== null && typeof transaction.previous_runtime !== "string") {
+    throw new Error("Update transaction runtime path is invalid.");
+  }
+  if (transaction.error !== undefined && typeof transaction.error !== "string") {
+    throw new Error("Update transaction error is invalid.");
+  }
+  return {
+    id: transaction.id as string,
+    phase: phase as UpdateTransaction["phase"],
+    target_version: transaction.target_version as string,
+    previous_version: transaction.previous_version as string,
+    service_installed: transaction.service_installed,
+    previous_runtime: transaction.previous_runtime as string | null,
+    started_at: new Date(transaction.started_at as string).toISOString(),
+    ...(transaction.error ? { error: transaction.error as string } : {})
+  };
+}
+
+function freshState(): PersistedUpdateState {
+  return {
+    schema_version: 1,
+    installation_id: randomUUID()
+  };
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -1,5 +1,6 @@
 interface AgentStatus {
   protocol_version: number;
+  binary_version?: string;
   state: "local_only" | "connecting" | "connected" | "offline";
   registered_collections: number;
   paused: boolean;
@@ -64,6 +65,29 @@ interface GrantScope {
 interface StartupSetting {
   enabled: boolean;
   available: boolean;
+}
+
+interface DesktopUpdateStatus {
+  phase:
+    | "unavailable"
+    | "idle"
+    | "checking"
+    | "deferred"
+    | "downloading"
+    | "ready"
+    | "external"
+    | "installing"
+    | "recovery"
+    | "failed";
+  current_version: string;
+  channel: "stable" | "beta";
+  target_version?: string;
+  checked_at?: string;
+  progress?: number;
+  message: string;
+  release_url?: string;
+  can_check: boolean;
+  can_install: boolean;
 }
 
 interface CloudSetting {
@@ -225,6 +249,9 @@ interface ActivityEntry {
 interface Window {
   mdbaseConnect: {
     status(): Promise<AgentStatus>;
+    updateStatus(): Promise<DesktopUpdateStatus>;
+    checkForUpdates(): Promise<DesktopUpdateStatus>;
+    installUpdate(): Promise<DesktopUpdateStatus>;
     listCollections(): Promise<CollectionSummary[]>;
     addCollection(): Promise<
       | { status: "added"; collection: CollectionSummary }
@@ -287,5 +314,6 @@ interface Window {
     disconnectMirror(replicaId: string): Promise<{ ok: true }>;
     openMirror(replicaId: string): Promise<string>;
     onNavigate(listener: (route: string) => void): () => void;
+    onUpdateStatus(listener: (status: DesktopUpdateStatus) => void): () => void;
   };
 }

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -62,6 +62,7 @@ const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }>
 function App() {
   const [route, setRoute] = useState<Route>("overview");
   const [status, setStatus] = useState<AgentStatus | null>(null);
+  const [updateStatus, setUpdateStatus] = useState<DesktopUpdateStatus | null>(null);
   const [collections, setCollections] = useState<CollectionSummary[]>([]);
   const [startup, setStartup] = useState<StartupSetting>({ enabled: false, available: false });
   const [cloud, setCloud] = useState<CloudSetting | null>(null);
@@ -83,6 +84,7 @@ function App() {
     try {
       const results = await Promise.allSettled([
         window.mdbaseConnect.status().then(setStatus),
+        window.mdbaseConnect.updateStatus().then(setUpdateStatus),
         window.mdbaseConnect.listCollections().then(setCollections),
         window.mdbaseConnect.getLaunchAtLogin().then(setStartup),
         window.mdbaseConnect.getCloudConfig().then(setCloud),
@@ -114,9 +116,11 @@ function App() {
         setRoute(next as Route);
       }
     });
+    const removeUpdateStatus = window.mdbaseConnect.onUpdateStatus(setUpdateStatus);
     return () => {
       window.clearInterval(timer);
       removeNavigation();
+      removeUpdateStatus();
     };
   }, [refresh]);
 
@@ -279,6 +283,7 @@ function App() {
             cloud={cloud}
             access={access}
             status={status}
+            updateStatus={updateStatus}
             busy={busy}
             onAct={act}
             onNotice={setNotice}
@@ -1195,11 +1200,12 @@ function Activity({ entries }: { entries: ActivityEntry[] }) {
   );
 }
 
-function Settings({ startup, cloud, access, status, busy, onAct, onNotice }: {
+function Settings({ startup, cloud, access, status, updateStatus, busy, onAct, onNotice }: {
   startup: StartupSetting;
   cloud: CloudSetting;
   access: AccessSnapshot;
   status: AgentStatus | null;
+  updateStatus: DesktopUpdateStatus | null;
   busy: boolean;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
@@ -1246,6 +1252,48 @@ function Settings({ startup, cloud, access, status, busy, onAct, onNotice }: {
               onNotice(checked ? "Application access is available." : "Application access is paused.");
             })}
           />
+        </div>
+      </section>
+      <section>
+        <SectionHeading title="Updates" note="Releases are checked against signed provenance before installation." />
+        <div className="settings-rows">
+          <div className="setting-row">
+            <span>Application</span>
+            <div>
+              <strong>Version {updateStatus?.current_version ?? "checking"}</strong>
+              <small>
+                {updateStatus
+                  ? `${updateStatus.message}${updateStatus.progress !== undefined && updateStatus.phase === "downloading" ? ` ${Math.round(updateStatus.progress)}%` : ""}`
+                  : "Reading update status…"}
+              </small>
+            </div>
+            <button
+              className="quiet-action"
+              disabled={
+                busy ||
+                !updateStatus ||
+                (!updateStatus.can_check && !updateStatus.can_install)
+              }
+              onClick={() =>
+                void onAct(async () => {
+                  if (updateStatus?.can_install) {
+                    await window.mdbaseConnect.installUpdate();
+                  } else {
+                    const next = await window.mdbaseConnect.checkForUpdates();
+                    onNotice(next.message);
+                  }
+                })
+              }
+            >
+              {updateStatus?.can_install
+                ? updateStatus.phase === "ready"
+                  ? "Restart and update"
+                  : "Open update"
+                : updateStatus?.phase === "checking"
+                  ? "Checking…"
+                  : "Check now"}
+            </button>
+          </div>
         </div>
       </section>
       <section>

--- a/apps/desktop/test/forge-config.test.mjs
+++ b/apps/desktop/test/forge-config.test.mjs
@@ -4,6 +4,18 @@ import test from "node:test";
 
 const require = createRequire(import.meta.url);
 
+test("packaged macOS builds allow only local-network ATS exceptions for staging", () => {
+  const config = require("../forge.config.cjs");
+  assert.deepEqual(config.packagerConfig.extendInfo?.NSAppTransportSecurity, {
+    NSAllowsLocalNetworking: true
+  });
+  assert.equal(
+    config.packagerConfig.extendInfo?.NSAppTransportSecurity
+      ?.NSAllowsArbitraryLoads,
+    undefined
+  );
+});
+
 test(
   "Linux makers target the packaged executable",
   { skip: process.platform !== "linux" },

--- a/apps/desktop/test/mac-update-feed.test.mjs
+++ b/apps/desktop/test/mac-update-feed.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  ElectronUpdateBackend,
+  localUpdateServer,
+  parseRange,
+  runtimeNeedsReconciliation
+} = require("../dist/main/electron-update-backend.js");
+
+function manifest() {
+  return {
+    version: "0.1.0-beta.9",
+    notes: "Verified release.",
+    published_at: "2026-07-28T00:00:00.000Z"
+  };
+}
+
+test("loopback update feed serves only the verified archive and supports ranges", async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-feed-"));
+  const archive = join(directory, "update.zip");
+  await writeFile(archive, Buffer.from("0123456789"));
+  const server = await localUpdateServer(archive, manifest());
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  const feed = await fetch(`${origin}/feed`);
+  assert.equal(feed.status, 200);
+  const payload = await feed.json();
+  assert.equal(payload.name, "0.1.0-beta.9");
+  assert.equal(payload.url, `${origin}/artifact`);
+
+  const partial = await fetch(`${origin}/artifact`, {
+    headers: { range: "bytes=2-5" }
+  });
+  assert.equal(partial.status, 206);
+  assert.equal(partial.headers.get("content-range"), "bytes 2-5/10");
+  assert.equal(await partial.text(), "2345");
+
+  const missing = await fetch(`${origin}/anything-else`);
+  assert.equal(missing.status, 404);
+});
+
+test("loopback feed rejects invalid methods and ranges", async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-feed-"));
+  const archive = join(directory, "update.zip");
+  await writeFile(archive, Buffer.from("0123456789"));
+  const server = await localUpdateServer(archive, manifest());
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+  const address = server.address();
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  const post = await fetch(`${origin}/artifact`, { method: "POST" });
+  assert.equal(post.status, 405);
+  const invalid = await fetch(`${origin}/artifact`, {
+    headers: { range: "bytes=9-100" }
+  });
+  assert.equal(invalid.status, 416);
+  assert.equal(invalid.headers.get("content-range"), "bytes */10");
+  assert.throws(() => parseRange("bytes=-2", 10), /Invalid update range/);
+  assert.throws(() => parseRange("bytes=2-1", 10), /Invalid update range/);
+});
+
+test("runtime reconciliation covers stale and stopped services without restarting a match", () => {
+  assert.equal(
+    runtimeNeedsReconciliation(
+      { installed: true, running: true, binaryVersion: "0.1.0-beta.8" },
+      "0.1.0-beta.9"
+    ),
+    true
+  );
+  assert.equal(
+    runtimeNeedsReconciliation(
+      { installed: true, running: false },
+      "0.1.0-beta.9"
+    ),
+    true
+  );
+  assert.equal(
+    runtimeNeedsReconciliation(
+      { installed: true, running: true, binaryVersion: "0.1.0-beta.9" },
+      "0.1.0-beta.9"
+    ),
+    false
+  );
+});
+
+test("recovery refuses a runtime path outside its private version directory", async () => {
+  const backend = new ElectronUpdateBackend({
+    currentVersion: "0.1.0-beta.9",
+    packaged: true,
+    platform: "darwin",
+    arch: "arm64",
+    userDataDirectory: "/private/profile",
+    binaryPath: () => "/Applications/mdbase connect.app/Contents/Resources/mdbase-connect",
+    stateDirectory: () => "/private/profile/state",
+    endpoint: () => "/private/profile/connect.sock"
+  });
+  await assert.rejects(
+    backend.recover({
+      id: "transaction",
+      phase: "recovering",
+      target_version: "0.1.0-beta.9",
+      previous_version: "0.1.0-beta.8",
+      service_installed: true,
+      previous_runtime: "/tmp/attacker-controlled",
+      started_at: "2026-07-28T00:00:00.000Z"
+    }),
+    /outside the private update directory/
+  );
+});

--- a/apps/desktop/test/release-source.test.mjs
+++ b/apps/desktop/test/release-source.test.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { findLatestRelease } = require("../dist/main/release-source.js");
+
+const indexUrl =
+  "https://api.github.com/repos/mdbase-dev/mdbase-connect/releases?per_page=20";
+
+function manifest(version = "0.1.0-beta.9") {
+  const tag = `v${version}`;
+  return {
+    schema_version: 1,
+    version,
+    tag,
+    channel: "beta",
+    published_at: "2026-07-28T00:00:00.000Z",
+    release_url: `https://github.com/mdbase-dev/mdbase-connect/releases/tag/${tag}`,
+    notes: "Verified notes.",
+    rollout: { percentage: 100, seed: tag },
+    blocked_versions: [],
+    targets: {
+      "darwin-arm64": {
+        mode: "automatic",
+        action_url: `https://github.com/mdbase-dev/mdbase-connect/releases/tag/${tag}`,
+        artifacts: [
+          {
+            name: `mdbase-connect-${version}.zip`,
+            url: `https://example.com/mdbase-connect-${version}.zip`,
+            sigstore_url: `https://example.com/mdbase-connect-${version}.zip.sigstore.json`,
+            sha256: "c".repeat(64),
+            size: 42,
+            kind: "zip"
+          }
+        ]
+      }
+    }
+  };
+}
+
+function release(version) {
+  const tag = `v${version}`;
+  return {
+    draft: false,
+    prerelease: true,
+    tag_name: tag,
+    html_url: `https://github.com/mdbase-dev/mdbase-connect/releases/tag/${tag}`,
+    assets: [
+      {
+        name: "mdbase-connect-update.json",
+        browser_download_url: `https://downloads.example/${tag}/manifest`,
+        size: 1000
+      },
+      {
+        name: "mdbase-connect-update.json.sigstore.json",
+        browser_download_url: `https://downloads.example/${tag}/bundle`,
+        size: 1000
+      }
+    ]
+  };
+}
+
+function fetchMap(entries) {
+  return async (url) => {
+    const key = String(url);
+    if (!(key in entries)) throw new Error(`Unexpected URL ${key}`);
+    const value = entries[key];
+    const body = typeof value === "string" ? value : JSON.stringify(value);
+    const response = new Response(body, {
+      status: 200,
+      headers: { "content-length": String(Buffer.byteLength(body)) }
+    });
+    Object.defineProperty(response, "url", { value: key });
+    return response;
+  };
+}
+
+test("release discovery verifies the exact workflow-and-tag identity", async () => {
+  const candidate = release("0.1.0-beta.9");
+  const calls = [];
+  const result = await findLatestRelease({
+    channel: "beta",
+    trustCacheDirectory: "/tmp/not-used",
+    fetchImpl: fetchMap({
+      [indexUrl]: [candidate],
+      [candidate.assets[0].browser_download_url]: manifest(),
+      [candidate.assets[1].browser_download_url]: { mediaType: "application/vnd.dev.sigstore.bundle+json;version=0.3" }
+    }),
+    async verifyBundle(bundle, payload, identity, cache) {
+      calls.push({ bundle, payload: JSON.parse(payload), identity, cache });
+    }
+  });
+  assert.equal(result.manifest.version, "0.1.0-beta.9");
+  assert.equal(
+    calls[0].identity,
+    "https://github.com/mdbase-dev/mdbase-connect/.github/workflows/desktop-release.yml@refs/tags/v0.1.0-beta.9"
+  );
+  assert.equal(calls[0].cache, "/tmp/not-used");
+});
+
+test("the highest verified semantic version wins even when API order is hostile", async () => {
+  const beta9 = release("0.1.0-beta.9");
+  const beta10 = release("0.1.0-beta.10");
+  const result = await findLatestRelease({
+    channel: "beta",
+    trustCacheDirectory: "/tmp/not-used",
+    fetchImpl: fetchMap({
+      [indexUrl]: [beta9, beta10],
+      [beta9.assets[0].browser_download_url]: manifest("0.1.0-beta.9"),
+      [beta9.assets[1].browser_download_url]: {},
+      [beta10.assets[0].browser_download_url]: manifest("0.1.0-beta.10"),
+      [beta10.assets[1].browser_download_url]: {}
+    }),
+    async verifyBundle() {}
+  });
+  assert.equal(result.manifest.version, "0.1.0-beta.10");
+});
+
+test("a manifest is not parsed or trusted when signature verification fails", async () => {
+  const candidate = release("0.1.0-beta.9");
+  await assert.rejects(
+    findLatestRelease({
+      channel: "beta",
+      trustCacheDirectory: "/tmp/not-used",
+      fetchImpl: fetchMap({
+        [indexUrl]: [candidate],
+        [candidate.assets[0].browser_download_url]: "{not valid json",
+        [candidate.assets[1].browser_download_url]: {}
+      }),
+      async verifyBundle() {
+        throw new Error("untrusted signer");
+      }
+    }),
+    /untrusted signer/
+  );
+});
+
+test("signed metadata cannot claim a different GitHub release", async () => {
+  const candidate = release("0.1.0-beta.9");
+  const wrong = manifest();
+  wrong.release_url =
+    "https://github.com/mdbase-dev/mdbase-connect/releases/tag/v0.1.0-beta.10";
+  await assert.rejects(
+    findLatestRelease({
+      channel: "beta",
+      trustCacheDirectory: "/tmp/not-used",
+      fetchImpl: fetchMap({
+        [indexUrl]: [candidate],
+        [candidate.assets[0].browser_download_url]: wrong,
+        [candidate.assets[1].browser_download_url]: {}
+      }),
+      async verifyBundle() {}
+    }),
+    /does not match its release page/
+  );
+});
+
+test("oversized release metadata is rejected before parsing", async () => {
+  const response = new Response("[]", {
+    status: 200,
+    headers: { "content-length": String(3 * 1024 * 1024) }
+  });
+  Object.defineProperty(response, "url", { value: indexUrl });
+  await assert.rejects(
+    findLatestRelease({
+      channel: "beta",
+      trustCacheDirectory: "/tmp/not-used",
+      fetchImpl: async () => response,
+      async verifyBundle() {}
+    }),
+    /size limit/
+  );
+});

--- a/apps/desktop/test/update-coordinator.test.mjs
+++ b/apps/desktop/test/update-coordinator.test.mjs
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { UpdateCoordinator } = require("../dist/main/update-coordinator.js");
+const { parseUpdateManifest } = require("../dist/main/update-policy.js");
+const { UpdateStateStore } = require("../dist/main/update-state.js");
+
+function signedManifest(target = automaticTarget()) {
+  return parseUpdateManifest({
+    schema_version: 1,
+    version: "0.1.0-beta.9",
+    tag: "v0.1.0-beta.9",
+    channel: "beta",
+    published_at: "2026-07-28T00:00:00.000Z",
+    release_url: "https://github.com/mdbase-dev/mdbase-connect/releases/tag/v0.1.0-beta.9",
+    notes: "Update notes.",
+    rollout: { percentage: 100, seed: "v0.1.0-beta.9" },
+    blocked_versions: [],
+    targets: { "darwin-arm64": target }
+  });
+}
+
+function automaticTarget() {
+  return {
+    mode: "automatic",
+    action_url: "https://example.com/release",
+    artifacts: [
+      {
+        name: "update.zip",
+        url: "https://example.com/update.zip",
+        sigstore_url: "https://example.com/update.zip.sigstore.json",
+        sha256: "b".repeat(64),
+        size: 100,
+        kind: "zip"
+      }
+    ]
+  };
+}
+
+function backend(overrides = {}) {
+  const events = [];
+  return {
+    events,
+    currentVersion: "0.1.0-beta.8",
+    channel: "beta",
+    platformKey: "darwin-arm64",
+    packaged: true,
+    async reconcileInstalledRuntime() {
+      events.push("reconcile");
+      return null;
+    },
+    async findLatest() {
+      events.push("find");
+      return { manifest: signedManifest() };
+    },
+    async stageAutomatic(_manifest, _target, progress) {
+      events.push("stage");
+      progress(35);
+      progress(90);
+    },
+    async prepareDaemonHandoff() {
+      events.push("prepare");
+      return { serviceInstalled: true, previousRuntime: "/runtime/beta.8" };
+    },
+    async stopDaemon() {
+      events.push("stop");
+    },
+    installAutomatic() {
+      events.push("install");
+    },
+    async openExternal(url) {
+      events.push(`open:${url}`);
+    },
+    async recover() {
+      events.push("recover");
+      return { healthy: true, rolledBack: false, message: "Recovered." };
+    },
+    ...overrides
+  };
+}
+
+async function fixture() {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-coordinator-"));
+  return {
+    path: join(directory, "state.json"),
+    store: new UpdateStateStore(join(directory, "state.json"))
+  };
+}
+
+test("a verified automatic release moves through download to ready", async () => {
+  const { store } = await fixture();
+  const runtime = backend();
+  const coordinator = new UpdateCoordinator(store, runtime);
+  await coordinator.initialize();
+  const phases = [];
+  coordinator.subscribe((status) => phases.push(status.phase));
+  const status = await coordinator.check();
+  assert.equal(status.phase, "ready");
+  assert.equal(status.target_version, "0.1.0-beta.9");
+  assert.equal(status.progress, 100);
+  assert.equal(status.can_install, true);
+  assert.deepEqual(runtime.events, ["reconcile", "find", "prepare", "stage"]);
+  assert.ok(phases.includes("checking"));
+  assert.ok(phases.includes("downloading"));
+  assert.equal(phases.at(-1), "ready");
+  await coordinator.check();
+  assert.deepEqual(runtime.events, ["reconcile", "find", "prepare", "stage"]);
+});
+
+test("startup surfaces runtime reconciliation and fails closed when it cannot complete", async () => {
+  const first = await fixture();
+  const reconciled = new UpdateCoordinator(
+    first.store,
+    backend({
+      async reconcileInstalledRuntime() {
+        return "Stable runtime refreshed.";
+      }
+    })
+  );
+  assert.match((await reconciled.initialize()).message, /refreshed/);
+
+  const second = await fixture();
+  const failed = new UpdateCoordinator(
+    second.store,
+    backend({
+      async reconcileInstalledRuntime() {
+        throw new Error("service registration denied");
+      }
+    })
+  );
+  const status = await failed.initialize();
+  assert.equal(status.phase, "failed");
+  assert.equal(status.can_check, false);
+  assert.match(status.message, /service registration denied/);
+  await failed.check();
+  assert.deepEqual(failed.status(), status);
+});
+
+test("only one network check runs while a check is in flight", async () => {
+  const { store } = await fixture();
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  let calls = 0;
+  const runtime = backend({
+    async findLatest() {
+      calls += 1;
+      await gate;
+      return { manifest: signedManifest() };
+    }
+  });
+  const coordinator = new UpdateCoordinator(store, runtime);
+  await coordinator.initialize();
+  const first = coordinator.check();
+  const second = coordinator.check();
+  assert.equal(first, second);
+  release();
+  await first;
+  assert.equal(calls, 1);
+});
+
+test("daemon handoff is persisted before stop and survives process exit", async () => {
+  const { path, store } = await fixture();
+  const runtime = backend();
+  const coordinator = new UpdateCoordinator(store, runtime);
+  await coordinator.initialize();
+  await coordinator.check();
+  await coordinator.install();
+  assert.deepEqual(runtime.events, ["reconcile", "find", "prepare", "stage", "stop", "install"]);
+  const persisted = JSON.parse(await readFile(path, "utf8"));
+  assert.equal(persisted.transaction.phase, "installing");
+  assert.equal(persisted.transaction.previous_runtime, "/runtime/beta.8");
+  assert.equal(persisted.transaction.target_version, "0.1.0-beta.9");
+});
+
+test("the next application version rebinds and health-checks the daemon transaction", async () => {
+  const { path, store } = await fixture();
+  const oldRuntime = backend();
+  const oldCoordinator = new UpdateCoordinator(store, oldRuntime);
+  await oldCoordinator.initialize();
+  await oldCoordinator.check();
+  await oldCoordinator.install();
+
+  let recoveredTransaction;
+  const newRuntime = backend({
+    currentVersion: "0.1.0-beta.9",
+    async recover(transaction) {
+      recoveredTransaction = transaction;
+      return { healthy: true, rolledBack: false, message: "Upgrade healthy." };
+    }
+  });
+  const newCoordinator = new UpdateCoordinator(new UpdateStateStore(path), newRuntime);
+  const status = await newCoordinator.initialize();
+  assert.equal(status.phase, "idle");
+  assert.equal(recoveredTransaction.previous_version, "0.1.0-beta.8");
+  const persisted = JSON.parse(await readFile(path, "utf8"));
+  assert.equal(persisted.transaction, undefined);
+  assert.equal(persisted.highest_trusted_version, "0.1.0-beta.9");
+  assert.equal(persisted.last_known_good_runtime.path, "/runtime/beta.8");
+});
+
+test("rolled-back recovery remains visible and allows another check", async () => {
+  const { path, store } = await fixture();
+  const initial = backend();
+  const coordinator = new UpdateCoordinator(store, initial);
+  await coordinator.initialize();
+  await coordinator.check();
+  await coordinator.install();
+
+  const recovering = new UpdateCoordinator(
+    new UpdateStateStore(path),
+    backend({
+      currentVersion: "0.1.0-beta.9",
+      async recover() {
+        return {
+          healthy: true,
+          rolledBack: true,
+          message: "The prior connector was restored."
+        };
+      }
+    })
+  );
+  const status = await recovering.initialize();
+  assert.equal(status.phase, "recovery");
+  assert.equal(status.can_check, true);
+  assert.match(status.message, /restored/);
+  assert.equal((await recovering.check()).phase, "idle");
+});
+
+test("Store and package-manager updates open the signed action target", async () => {
+  const { store } = await fixture();
+  const external = {
+    mode: "store",
+    action_url: "https://apps.microsoft.com/detail/example",
+    artifacts: []
+  };
+  const runtime = backend({
+    async findLatest() {
+      return { manifest: signedManifest(external) };
+    }
+  });
+  const coordinator = new UpdateCoordinator(store, runtime);
+  await coordinator.initialize();
+  const status = await coordinator.check(true);
+  assert.equal(status.phase, "external");
+  await coordinator.install();
+  assert.ok(runtime.events.includes("open:https://apps.microsoft.com/detail/example"));
+  assert.ok(!runtime.events.includes("stop"));
+});
+
+test("download and verification failures never enable installation", async () => {
+  const { path, store } = await fixture();
+  const runtime = backend({
+    async stageAutomatic() {
+      throw new Error("signature mismatch");
+    }
+  });
+  const coordinator = new UpdateCoordinator(store, runtime);
+  await coordinator.initialize();
+  const status = await coordinator.check();
+  assert.equal(status.phase, "failed");
+  assert.equal(status.can_install, false);
+  assert.match(status.message, /signature mismatch/);
+  assert.equal(JSON.parse(await readFile(path, "utf8")).transaction, undefined);
+});
+
+test("a stop failure invokes recovery and clears the transaction", async () => {
+  const { path, store } = await fixture();
+  const runtime = backend({
+    async stopDaemon() {
+      runtime.events.push("stop");
+      throw new Error("daemon refused shutdown");
+    }
+  });
+  const coordinator = new UpdateCoordinator(store, runtime);
+  await coordinator.initialize();
+  await coordinator.check();
+  await assert.rejects(coordinator.install(), /daemon refused shutdown/);
+  assert.ok(runtime.events.includes("recover"));
+  const persisted = JSON.parse(await readFile(path, "utf8"));
+  assert.equal(persisted.transaction, undefined);
+  assert.equal(coordinator.status().phase, "failed");
+  assert.equal(coordinator.status().can_install, false);
+  await assert.rejects(coordinator.install(), /No update is ready/);
+});

--- a/apps/desktop/test/update-download.test.mjs
+++ b/apps/desktop/test/update-download.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  artifactMatches,
+  downloadArtifact,
+  downloadBytes
+} = require("../dist/main/update-download.js");
+
+function response(body, url = "https://downloads.example/artifact", headers = {}) {
+  const value = new Response(body, { status: 200, headers });
+  Object.defineProperty(value, "url", { value: url });
+  return value;
+}
+
+function artifact(bytes, overrides = {}) {
+  return {
+    name: "update.zip",
+    url: "https://downloads.example/update.zip",
+    sigstore_url: "https://downloads.example/update.zip.sigstore.json",
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    size: bytes.length,
+    kind: "zip",
+    ...overrides
+  };
+}
+
+test("artifact download streams, reports progress, and atomically verifies digest", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-download-"));
+  const destination = join(directory, "update.zip");
+  const bytes = Buffer.alloc(128 * 1024, 17);
+  const progress = [];
+  await writeFile(destination, "corrupt cache entry");
+  await downloadArtifact(
+    artifact(bytes),
+    destination,
+    (value) => progress.push(value),
+    async () =>
+      response(bytes, "https://cdn.example/update.zip", {
+        "content-length": String(bytes.length)
+      })
+  );
+  assert.deepEqual(await readFile(destination), bytes);
+  assert.equal(progress.at(-1), 100);
+  assert.equal(await artifactMatches(destination, artifact(bytes)), true);
+});
+
+test("digest mismatch removes partial output and cannot become a staged artifact", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-download-"));
+  const destination = join(directory, "update.zip");
+  const bytes = Buffer.from("tampered update");
+  await assert.rejects(
+    downloadArtifact(
+      artifact(bytes, { sha256: "0".repeat(64) }),
+      destination,
+      () => undefined,
+      async () =>
+        response(bytes, "https://cdn.example/update.zip", {
+          "content-length": String(bytes.length)
+        })
+    ),
+    /signed digest/
+  );
+  await assert.rejects(access(destination));
+  await assert.rejects(access(`${destination}.part-${process.pid}`));
+});
+
+test("declared and streamed size mismatches fail closed", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-download-"));
+  const bytes = Buffer.from("update");
+  await assert.rejects(
+    downloadArtifact(
+      artifact(bytes),
+      join(directory, "declared.zip"),
+      () => undefined,
+      async () =>
+        response(bytes, "https://cdn.example/update.zip", {
+          "content-length": String(bytes.length + 1)
+        })
+    ),
+    /size does not match/
+  );
+  await assert.rejects(
+    downloadArtifact(
+      artifact(bytes),
+      join(directory, "streamed.zip"),
+      () => undefined,
+      async () => response(Buffer.concat([bytes, Buffer.from("extra")]))
+    ),
+    /exceeds its signed size/
+  );
+});
+
+test("signature downloads enforce size, TLS after redirects, and timeout", async () => {
+  await assert.rejects(
+    downloadBytes(
+      "https://downloads.example/bundle",
+      4,
+      async () =>
+        response("12345", "https://cdn.example/bundle", { "content-length": "5" })
+    ),
+    /too large/
+  );
+  await assert.rejects(
+    downloadBytes(
+      "https://downloads.example/bundle",
+      10,
+      async () => response("{}", "http://attacker.example/bundle")
+    ),
+    /insecure URL/
+  );
+  await assert.rejects(
+    downloadBytes(
+      "https://downloads.example/bundle",
+      10,
+      async (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener("abort", () =>
+            reject(new DOMException("timed out", "AbortError"))
+          );
+        }),
+      5
+    ),
+    /timed out/
+  );
+});
+
+test("cached artifacts are rehashed rather than trusted by filename or length", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-download-"));
+  const destination = join(directory, "update.zip");
+  const expected = Buffer.from("expected");
+  await writeFile(destination, Buffer.from("tampered"));
+  assert.equal(
+    await artifactMatches(
+      destination,
+      artifact(expected, { size: Buffer.byteLength("tampered") })
+    ),
+    false
+  );
+});

--- a/apps/desktop/test/update-policy.test.mjs
+++ b/apps/desktop/test/update-policy.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  channelForVersion,
+  compareVersions,
+  decideUpdate,
+  parseUpdateManifest,
+  rolloutBucket
+} = require("../dist/main/update-policy.js");
+
+function manifest(overrides = {}) {
+  return {
+    schema_version: 1,
+    version: "0.1.0-beta.9",
+    tag: "v0.1.0-beta.9",
+    channel: "beta",
+    published_at: "2026-07-28T00:00:00.000Z",
+    release_url: "https://github.com/mdbase-dev/mdbase-connect/releases/tag/v0.1.0-beta.9",
+    notes: "A safer update.",
+    rollout: { percentage: 100, seed: "v0.1.0-beta.9" },
+    blocked_versions: [],
+    targets: {
+      "darwin-arm64": {
+        mode: "automatic",
+        action_url:
+          "https://github.com/mdbase-dev/mdbase-connect/releases/tag/v0.1.0-beta.9",
+        artifacts: [
+          {
+            name: "mdbase-connect-0.1.0-beta.9-macos-arm64.zip",
+            url: "https://example.com/mdbase-connect-0.1.0-beta.9-macos-arm64.zip",
+            sigstore_url:
+              "https://example.com/mdbase-connect-0.1.0-beta.9-macos-arm64.zip.sigstore.json",
+            sha256: "a".repeat(64),
+            size: 1234,
+            kind: "zip"
+          }
+        ]
+      }
+    },
+    ...overrides
+  };
+}
+
+test("semantic versions order prereleases without lexical mistakes", () => {
+  assert.equal(compareVersions("0.1.0-beta.9", "0.1.0-beta.10"), -1);
+  assert.equal(compareVersions("0.1.0-beta.10", "0.1.0"), -1);
+  assert.equal(compareVersions("1.2.3", "1.2.3+build.4"), 0);
+  assert.equal(compareVersions("1.2.3-alpha.1", "1.2.3-alpha.x"), -1);
+  assert.equal(compareVersions("1.2.3-A", "1.2.3-a"), -1);
+  assert.equal(
+    compareVersions(
+      "999999999999999999999999999999.2.3",
+      "999999999999999999999999999998.999999999999999999999999.999"
+    ),
+    1
+  );
+  assert.equal(
+    compareVersions("1.2.3-beta.999999999999999999999999999999", "1.2.3-beta.10"),
+    1
+  );
+  assert.equal(channelForVersion("0.1.0-beta.9"), "beta");
+  assert.equal(channelForVersion("0.1.0"), "stable");
+  assert.throws(() => compareVersions("01.2.3", "1.2.3"), /Invalid semantic version/);
+  assert.throws(() => compareVersions("1.2.3-beta.01", "1.2.3"), /Invalid semantic version/);
+});
+
+test("manifest parsing is strict at the trust boundary", () => {
+  const parsed = parseUpdateManifest(manifest());
+  assert.equal(parsed.version, "0.1.0-beta.9");
+  assert.equal(parsed.targets["darwin-arm64"].mode, "automatic");
+
+  assert.throws(
+    () => parseUpdateManifest(manifest({ unexpected: true })),
+    /unknown fields/
+  );
+  assert.throws(
+    () => parseUpdateManifest(manifest({ tag: "v0.1.0-beta.8" })),
+    /does not match/
+  );
+  assert.throws(
+    () => parseUpdateManifest(manifest({ channel: "stable" })),
+    /channel does not match/
+  );
+  assert.throws(
+    () =>
+      parseUpdateManifest(
+        manifest({
+          targets: {
+            "darwin-arm64": {
+              mode: "automatic",
+              action_url: "http://example.com/update",
+              artifacts: []
+            }
+          }
+        })
+      ),
+    /HTTPS/
+  );
+  const unsafe = manifest();
+  unsafe.targets["darwin-arm64"].artifacts[0].name = "../update.zip";
+  assert.throws(() => parseUpdateManifest(unsafe), /unsafe/);
+
+  const mismatchedKind = manifest();
+  mismatchedKind.targets["darwin-arm64"].artifacts[0].kind = "dmg";
+  assert.throws(() => parseUpdateManifest(mismatchedKind), /does not match its filename/);
+
+  const duplicate = manifest();
+  duplicate.targets["darwin-arm64"].artifacts.push({
+    ...duplicate.targets["darwin-arm64"].artifacts[0]
+  });
+  assert.throws(() => parseUpdateManifest(duplicate), /duplicate names/);
+});
+
+test("rollout cohorts are stable and manual checks can opt in", () => {
+  const parsed = parseUpdateManifest(
+    manifest({ rollout: { percentage: 0, seed: "private-beta" } })
+  );
+  const automatic = decideUpdate({
+    manifest: parsed,
+    currentVersion: "0.1.0-beta.8",
+    channel: "beta",
+    platformKey: "darwin-arm64",
+    installationId: "installation-a"
+  });
+  assert.deepEqual(automatic, { kind: "deferred", percentage: 0 });
+  assert.equal(
+    decideUpdate({
+      manifest: parsed,
+      currentVersion: "0.1.0-beta.8",
+      channel: "beta",
+      platformKey: "darwin-arm64",
+      installationId: "installation-a",
+      manual: true
+    }).kind,
+    "available"
+  );
+  assert.equal(
+    rolloutBucket("installation-a", "release-1"),
+    rolloutBucket("installation-a", "release-1")
+  );
+  assert.notEqual(
+    rolloutBucket("installation-a", "release-1"),
+    rolloutBucket("installation-b", "release-1")
+  );
+});
+
+test("blocked installed versions bypass rollout while withdrawn targets fail closed", () => {
+  const emergency = parseUpdateManifest(
+    manifest({
+      rollout: { percentage: 0, seed: "emergency" },
+      blocked_versions: ["0.1.0-beta.8"]
+    })
+  );
+  assert.equal(
+    decideUpdate({
+      manifest: emergency,
+      currentVersion: "0.1.0-beta.8",
+      channel: "beta",
+      platformKey: "darwin-arm64",
+      installationId: "outside-cohort"
+    }).kind,
+    "available"
+  );
+  const withdrawn = parseUpdateManifest(
+    manifest({ blocked_versions: ["0.1.0-beta.9"] })
+  );
+  assert.equal(
+    decideUpdate({
+      manifest: withdrawn,
+      currentVersion: "0.1.0-beta.8",
+      channel: "beta",
+      platformKey: "darwin-arm64",
+      installationId: "installation-a"
+    }).kind,
+    "blocked"
+  );
+});
+
+test("replayed manifests and cross-channel releases fail closed", () => {
+  const parsed = parseUpdateManifest(manifest());
+  assert.equal(
+    decideUpdate({
+      manifest: parsed,
+      currentVersion: "0.1.0-beta.8",
+      channel: "beta",
+      platformKey: "darwin-arm64",
+      installationId: "installation-a",
+      highestTrustedVersion: "0.1.0-beta.10"
+    }).kind,
+    "blocked"
+  );
+  assert.equal(
+    decideUpdate({
+      manifest: parsed,
+      currentVersion: "0.1.0-beta.8",
+      channel: "stable",
+      platformKey: "darwin-arm64",
+      installationId: "installation-a"
+    }).kind,
+    "current"
+  );
+});

--- a/apps/desktop/test/update-release-scripts.test.mjs
+++ b/apps/desktop/test/update-release-scripts.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { execFile as execFileCallback } from "node:child_process";
+import test from "node:test";
+
+const execFile = promisify(execFileCallback);
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+test("release scripts emit a deterministic, digest-bound platform manifest", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-release-"));
+  const artifact = "mdbase-connect-0.1.0-beta.9-macos-arm64.zip";
+  const bytes = Buffer.from("signed application archive");
+  await writeFile(join(directory, artifact), bytes);
+  await writeFile(join(directory, `${artifact}.sigstore.json`), "{}");
+  await execFile(
+    process.execPath,
+    [
+      "scripts/write-update-input.mjs",
+      "--directory",
+      directory,
+      "--platform",
+      "macos",
+      "--arch",
+      "arm64",
+      "--mode",
+      "automatic",
+      "--action-url",
+      "$RELEASE_URL",
+      "--artifact",
+      artifact
+    ],
+    { cwd: repositoryRoot }
+  );
+  const output = join(directory, "manifest.json");
+  await execFile(
+    process.execPath,
+    [
+      "scripts/generate-update-manifest.mjs",
+      "--directory",
+      directory,
+      "--output",
+      output,
+      "--version",
+      "0.1.0-beta.9",
+      "--repository",
+      "mdbase-dev/mdbase-connect",
+      "--rollout",
+      "25",
+      "--blocked-versions",
+      "0.1.0-beta.7,0.1.0-beta.8",
+      "--published-at",
+      "2026-07-28T00:00:00.000Z"
+    ],
+    { cwd: repositoryRoot }
+  );
+  const manifest = JSON.parse(await readFile(output, "utf8"));
+  const target = manifest.targets["darwin-arm64"];
+  assert.equal(manifest.rollout.percentage, 25);
+  assert.deepEqual(manifest.blocked_versions, ["0.1.0-beta.7", "0.1.0-beta.8"]);
+  assert.equal(target.mode, "automatic");
+  assert.equal(target.artifacts[0].size, bytes.length);
+  assert.equal(
+    target.artifacts[0].sha256,
+    createHash("sha256").update(bytes).digest("hex")
+  );
+  assert.match(target.artifacts[0].sigstore_url, /\.zip\.sigstore\.json$/);
+});
+
+test("release input creation rejects missing provenance bundles", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-release-"));
+  await writeFile(join(directory, "update.zip"), "archive");
+  await assert.rejects(
+    execFile(
+      process.execPath,
+      [
+        "scripts/write-update-input.mjs",
+        "--directory",
+        directory,
+        "--platform",
+        "macos",
+        "--arch",
+        "arm64",
+        "--mode",
+        "automatic",
+        "--action-url",
+        "$RELEASE_URL",
+        "--artifact",
+        "update.zip"
+      ],
+      { cwd: repositoryRoot }
+    )
+  );
+});
+
+test("release manifest generation rejects duplicate targets and invalid rollout", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-release-"));
+  await writeFile(
+    join(directory, "update-input-macos-arm64.json"),
+    JSON.stringify({
+      schema_version: 1,
+      platform: "macos",
+      arch: "arm64",
+      mode: "store",
+      action_url: "https://example.com/store",
+      artifacts: []
+    })
+  );
+  await assert.rejects(
+    execFile(
+      process.execPath,
+      [
+        "scripts/generate-update-manifest.mjs",
+        "--directory",
+        directory,
+        "--output",
+        join(directory, "manifest.json"),
+        "--version",
+        "0.1.0-beta.9",
+        "--repository",
+        "mdbase-dev/mdbase-connect",
+        "--rollout",
+        "101"
+      ],
+      { cwd: repositoryRoot }
+    ),
+    /Rollout percentage/
+  );
+});
+
+test("release manifest generation rejects duplicate artifact names", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-release-"));
+  await writeFile(join(directory, "update.zip"), "archive");
+  await writeFile(join(directory, "update.zip.sigstore.json"), "{}");
+  await writeFile(
+    join(directory, "update-input-macos-arm64.json"),
+    JSON.stringify({
+      schema_version: 1,
+      platform: "macos",
+      arch: "arm64",
+      mode: "automatic",
+      action_url: "https://example.com/release",
+      artifacts: ["update.zip", "update.zip"]
+    })
+  );
+  await assert.rejects(
+    execFile(
+      process.execPath,
+      [
+        "scripts/generate-update-manifest.mjs",
+        "--directory",
+        directory,
+        "--output",
+        join(directory, "manifest.json"),
+        "--version",
+        "0.1.0-beta.9",
+        "--repository",
+        "mdbase-dev/mdbase-connect",
+        "--rollout",
+        "100"
+      ],
+      { cwd: repositoryRoot }
+    ),
+    /duplicate artifact names/
+  );
+});
+
+test("release manifest generation cannot withdraw its own target version", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-release-"));
+  await writeFile(
+    join(directory, "update-input-windows-x64.json"),
+    JSON.stringify({
+      schema_version: 1,
+      platform: "windows",
+      arch: "x64",
+      mode: "store",
+      action_url: "https://apps.microsoft.com/detail/example",
+      artifacts: []
+    })
+  );
+  await assert.rejects(
+    execFile(
+      process.execPath,
+      [
+        "scripts/generate-update-manifest.mjs",
+        "--directory",
+        directory,
+        "--output",
+        join(directory, "manifest.json"),
+        "--version",
+        "0.1.0-beta.9",
+        "--repository",
+        "mdbase-dev/mdbase-connect",
+        "--rollout",
+        "100",
+        "--blocked-versions",
+        "0.1.0-beta.9"
+      ],
+      { cwd: repositoryRoot }
+    ),
+    /cannot block its own/
+  );
+});

--- a/apps/desktop/test/update-state.test.mjs
+++ b/apps/desktop/test/update-state.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { UpdateStateStore, parsePersistedState } = require("../dist/main/update-state.js");
+
+test("state creation is durable and installation identity is stable", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-state-"));
+  const path = join(directory, "nested", "state.json");
+  const store = new UpdateStateStore(path);
+  const first = await store.load();
+  const second = await new UpdateStateStore(path).load();
+  assert.match(first.installation_id, /^[0-9a-f-]{36}$/);
+  assert.equal(second.installation_id, first.installation_id);
+  const mode = (await import("node:fs/promises")).stat(path).then((value) => value.mode & 0o777);
+  assert.equal(await mode, 0o600);
+});
+
+test("state writes are atomic and preserve valid transactions", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-state-"));
+  const path = join(directory, "state.json");
+  const store = new UpdateStateStore(path);
+  await store.load();
+  await store.update((state) => {
+    state.highest_trusted_version = "0.1.0-beta.9";
+    state.transaction = {
+      id: "transaction-1",
+      phase: "prepared",
+      target_version: "0.1.0-beta.9",
+      previous_version: "0.1.0-beta.8",
+      service_installed: true,
+      previous_runtime: "/safe/runtime",
+      started_at: "2026-07-28T00:00:00.000Z"
+    };
+  });
+  const parsed = JSON.parse(await readFile(path, "utf8"));
+  assert.equal(parsed.transaction.phase, "prepared");
+  assert.deepEqual(
+    (await readdir(directory)).filter((name) => name.includes(".tmp-")),
+    []
+  );
+});
+
+test("corrupt state is quarantined instead of silently trusted", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-state-"));
+  const path = join(directory, "state.json");
+  await writeFile(path, '{"schema_version":1,"installation_id":42}');
+  const state = await new UpdateStateStore(path).load();
+  assert.equal(typeof state.installation_id, "string");
+  assert.ok((await readdir(directory)).some((name) => name.startsWith("state.json.invalid-")));
+});
+
+test("invalid transaction versions and paths are rejected", () => {
+  assert.throws(
+    () =>
+      parsePersistedState({
+        schema_version: 1,
+        installation_id: "installation",
+        transaction: {
+          id: "transaction",
+          phase: "installing",
+          target_version: "../bad",
+          previous_version: "0.1.0-beta.8",
+          service_installed: true,
+          previous_runtime: "/runtime",
+          started_at: "2026-07-28T00:00:00Z"
+        }
+      }),
+    /Invalid semantic version/
+  );
+});

--- a/apps/desktop/test/update-workflow.test.mjs
+++ b/apps/desktop/test/update-workflow.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+test("release workflow signs and verifies the update manifest before publication", async () => {
+  const workflow = await readFile(
+    resolve(repositoryRoot, ".github/workflows/desktop-release.yml"),
+    "utf8"
+  );
+  const generate = workflow.indexOf("scripts/generate-update-manifest.mjs");
+  const sign = workflow.indexOf(
+    "cosign sign-blob",
+    workflow.indexOf("Create and verify signed update manifest")
+  );
+  const verify = workflow.indexOf("cosign verify-blob", sign);
+  const publish = workflow.indexOf('gh release create "$GITHUB_REF_NAME"');
+  assert.ok(generate >= 0);
+  assert.ok(sign > generate);
+  assert.ok(verify > sign);
+  assert.ok(publish > verify);
+  assert.match(
+    workflow,
+    /certificate-identity "https:\/\/github\.com\/\$\{GITHUB_REPOSITORY\}\/\.github\/workflows\/desktop-release\.yml@\$\{GITHUB_REF\}"/
+  );
+});
+
+test("unsigned previews cannot be described as automatic targets", async () => {
+  const workflow = await readFile(
+    resolve(repositoryRoot, ".github/workflows/desktop-release.yml"),
+    "utf8"
+  );
+  const description = workflow.slice(
+    workflow.indexOf("- name: Describe platform update"),
+    workflow.indexOf("- name: Sign and verify Microsoft Store", workflow.indexOf("- name: Describe platform update"))
+  );
+  assert.match(description, /MACOS_RELEASE_MODE.*signed[\s\S]*--mode automatic/);
+  assert.match(description, /--mode manual[\s\S]*-UNSIGNED\.dmg/);
+  assert.match(description, /WINDOWS_STORE_MODE.*store[\s\S]*--mode store/);
+  assert.match(description, /WINDOWS_STORE_PRODUCT_ID/);
+});
+
+test("update installation bypasses the tray window's hide-on-close behavior", async () => {
+  const main = await readFile(
+    resolve(repositoryRoot, "apps/desktop/src/main/main.ts"),
+    "utf8"
+  );
+  const updateQuit = main.indexOf('autoUpdater.on("before-quit-for-update"');
+  const hideOnClose = main.indexOf('mainWindow.on("close"');
+  assert.ok(updateQuit >= 0);
+  assert.ok(updateQuit < hideOnClose);
+  assert.match(
+    main.slice(updateQuit, hideOnClose),
+    /before-quit-for-update"[\s\S]*quitting = true/
+  );
+});

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -693,6 +693,7 @@ impl AgentState {
             ControlCommand::Status => self.registry.count().map(|registered_collections| {
                 serde_json::to_value(AgentStatus {
                     protocol_version: LOCAL_CONTROL_PROTOCOL_VERSION,
+                    binary_version: env!("CARGO_PKG_VERSION").to_string(),
                     state: self
                         .connection_state
                         .read()
@@ -1682,6 +1683,28 @@ mod tests {
         assert_eq!(
             response.error.expect("protocol error").code,
             "unsupported_local_protocol"
+        );
+        fs::remove_dir_all(test_root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn status_reports_the_running_binary_version_for_upgrade_health_checks() {
+        let test_root = std::env::temp_dir().join(format!(
+            "mdbase-connect-version-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let registry = CollectionRegistry::open(&test_root).unwrap();
+        let watcher = CollectionWatchService::start(registry.clone());
+        let state = AgentState::new(registry, watcher, None);
+
+        let response = state
+            .execute(ControlRequest::new(ControlCommand::Status))
+            .await;
+
+        assert!(response.ok);
+        assert_eq!(
+            response.result.expect("status result")["binary_version"],
+            env!("CARGO_PKG_VERSION")
         );
         fs::remove_dir_all(test_root).unwrap();
     }

--- a/crates/connect-cli/src/main.rs
+++ b/crates/connect-cli/src/main.rs
@@ -731,9 +731,38 @@ async fn execute_daemon_command(
         CliError::internal(format!("Could not locate this executable: {error}"))
     })?;
     match command {
-        DaemonCommand::Install => service::install(&executable, state_dir)
-            .map_err(CliError::internal)
-            .map(|_| serde_json::json!({"installed": true})),
+        DaemonCommand::Install => {
+            let installed = service::installed();
+            let running = send(endpoint, ControlRequest::new(ControlCommand::Ping))
+                .await
+                .is_ok_and(|response| response.ok);
+            if installed {
+                match service::stop() {
+                    Ok(()) if running => wait_until_stopped(endpoint).await?,
+                    Ok(()) => {}
+                    Err(error) if running => return Err(CliError::internal(error)),
+                    Err(_) => {}
+                }
+            } else if running {
+                let response = send(
+                    endpoint,
+                    ControlRequest::new(ControlCommand::DaemonShutdown),
+                )
+                .await?;
+                if !response.ok {
+                    return Err(CliError::internal(
+                        response
+                            .error
+                            .map(|error| error.message)
+                            .unwrap_or_else(|| "The daemon refused to stop.".to_string()),
+                    ));
+                }
+                wait_until_stopped(endpoint).await?;
+            }
+            service::install(&executable, state_dir)
+                .map_err(CliError::internal)
+                .map(|_| serde_json::json!({"installed": true}))
+        }
         DaemonCommand::Uninstall => service::uninstall()
             .map_err(CliError::internal)
             .map(|_| serde_json::json!({"installed": false})),

--- a/crates/connect-cli/src/service.rs
+++ b/crates/connect-cli/src/service.rs
@@ -9,7 +9,8 @@ pub fn installed() -> bool {
 }
 
 pub fn install(executable: &Path, state_dir: &Path) -> Result<(), String> {
-    platform::install(executable, state_dir)
+    let runtime = install_runtime(executable, state_dir)?;
+    platform::install(&runtime, state_dir)
 }
 
 pub fn uninstall() -> Result<(), String> {
@@ -137,6 +138,77 @@ fn service_file() -> Option<PathBuf> {
     platform::service_file()
 }
 
+fn install_runtime(executable: &Path, state_dir: &Path) -> Result<PathBuf, String> {
+    let directory = state_dir.join("runtime");
+    std::fs::create_dir_all(&directory)
+        .map_err(|error| format!("Could not create {}: {error}", directory.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("Could not protect {}: {error}", directory.display()))?;
+    }
+    let extension = if cfg!(windows) { ".exe" } else { "" };
+    let destination = directory.join(format!("mdbase-connect{extension}"));
+    if executable == destination {
+        return Ok(destination);
+    }
+    let temporary = directory.join(format!("mdbase-connect.tmp-{}", std::process::id()));
+    let _ = std::fs::remove_file(&temporary);
+    if let Err(error) = std::fs::copy(executable, &temporary) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(format!(
+            "Could not stage the Connect runtime from {} to {}: {error}",
+            executable.display(),
+            temporary.display()
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(error) =
+            std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(0o700))
+        {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(format!(
+                "Could not protect {}: {error}",
+                temporary.display()
+            ));
+        }
+    }
+    if let Err(error) = activate_runtime_file(&temporary, &destination) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(format!(
+            "Could not activate the Connect runtime at {}: {error}",
+            destination.display()
+        ));
+    }
+    Ok(destination)
+}
+
+#[cfg(not(windows))]
+fn activate_runtime_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
+    std::fs::rename(temporary, destination)
+}
+
+#[cfg(windows)]
+fn activate_runtime_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
+    let previous = destination.with_extension("previous.exe");
+    let _ = std::fs::remove_file(&previous);
+    let had_previous = destination.exists();
+    if had_previous {
+        std::fs::rename(destination, &previous)?;
+    }
+    if let Err(error) = std::fs::rename(temporary, destination) {
+        if had_previous {
+            let _ = std::fs::rename(&previous, destination);
+        }
+        return Err(error);
+    }
+    let _ = std::fs::remove_file(previous);
+    Ok(())
+}
+
 fn run_checked(command: &mut Command, action: &str) -> Result<(), String> {
     let status = command
         .status()
@@ -148,6 +220,57 @@ fn run_checked(command: &mut Command, action: &str) -> Result<(), String> {
             "Could not {action}: command exited with {}.",
             status.code().unwrap_or(-1)
         ))
+    }
+}
+
+#[cfg(test)]
+mod runtime_tests {
+    use super::*;
+
+    #[test]
+    fn installed_service_runtime_uses_a_stable_private_path_and_is_replaceable() {
+        let root = std::env::temp_dir().join(format!(
+            "mdbase-connect-runtime-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let source = root.join("source");
+        let state = root.join("state");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&source, b"version one").unwrap();
+
+        let installed = install_runtime(&source, &state).unwrap();
+
+        assert_eq!(
+            installed,
+            state.join(if cfg!(windows) {
+                "runtime/mdbase-connect.exe"
+            } else {
+                "runtime/mdbase-connect"
+            })
+        );
+        assert_eq!(std::fs::read(&installed).unwrap(), b"version one");
+        std::fs::write(&source, b"version two").unwrap();
+        assert_eq!(install_runtime(&source, &state).unwrap(), installed);
+        assert_eq!(std::fs::read(&installed).unwrap(), b"version two");
+        assert_eq!(install_runtime(&installed, &state).unwrap(), installed);
+        assert_eq!(std::fs::read(&installed).unwrap(), b"version two");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(state.join("runtime"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                std::fs::metadata(&installed).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
 }
 

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -325,6 +325,8 @@ pub struct ControlError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentStatus {
     pub protocol_version: u32,
+    #[serde(default)]
+    pub binary_version: String,
     pub state: AgentConnectionState,
     pub registered_collections: usize,
     pub paused: bool,

--- a/docs/cli-daemon.md
+++ b/docs/cli-daemon.md
@@ -71,12 +71,17 @@ its stable ID.
 `daemon run` is the foreground primitive used by service managers, containers,
 tests, and debugging. `daemon install` registers a per-user launch agent,
 systemd user unit, or Windows per-user background task. It must not require an
-administrator or run as a different operating-system user.
+administrator or run as a different operating-system user. Installation first
+copies the invoking binary atomically into the private
+`<state>/runtime/mdbase-connect` path and registers that stable path. A service
+never points into a versioned Electron bundle, package extraction directory, or
+developer checkout.
 
 ## State and secrets
 
 The daemon state directory contains:
 
+- the stable installed service runtime;
 - the local collection registry;
 - the hosted mirror registry and durable mirror journals;
 - the relay identity;
@@ -134,10 +139,12 @@ mirror registry, cloud credential, retry loop, or agent child process.
 
 At startup the desktop:
 
-1. connects to the standard daemon endpoint;
-2. asks the installed per-user service to start if the endpoint is absent;
-3. presents a repair action if the service cannot start;
-4. subscribes or polls for versioned status.
+1. compares a reachable daemon's binary version with the bundled CLI;
+2. replaces and re-registers a stale or stopped installed runtime;
+3. connects to the standard daemon endpoint;
+4. asks a matching installed per-user service to start if the endpoint is absent;
+5. presents a repair action if the service cannot start;
+6. subscribes or polls for versioned status.
 
 Desktop exit closes only its control connection.
 

--- a/docs/desktop-updates.md
+++ b/docs/desktop-updates.md
@@ -1,0 +1,125 @@
+# Desktop update architecture
+
+The desktop application and its bundled `mdbase-connect` CLI/daemon are one
+release unit. The updater never replaces the daemon independently and never
+mixes binaries downloaded from different releases.
+
+## Trust and discovery
+
+The desktop checks the GitHub Releases API for its channel:
+
+- prerelease application versions use the `beta` channel;
+- versions without a prerelease suffix use the `stable` channel.
+
+Every release contains `mdbase-connect-update.json` and
+`mdbase-connect-update.json.sigstore.json`. Before parsing or acting on the
+manifest, the desktop verifies its Sigstore bundle against the public Sigstore
+roots, the GitHub Actions OIDC issuer, the exact release workflow, and the
+exact release tag.
+
+The strict, versioned manifest binds each downloadable artifact to its name,
+byte length, SHA-256 digest, Sigstore bundle, platform, architecture, release
+tag, and installation mode. Unknown fields, insecure URLs, mismatched tags,
+unsupported targets, unsafe filenames, and malformed versions fail closed.
+Automatic artifacts are streamed to a private size-limited cache, checked
+against the signed digest, then independently verified against their own
+Sigstore bundle.
+
+The installation records the highest signed release it has observed. A replayed
+older manifest cannot cause a downgrade. A release can name bad installed
+versions in `blocked_versions`; those installations bypass staged rollout so a
+signed recovery release reaches them immediately. A target must never block
+itself.
+
+## Rollout
+
+`UPDATE_ROLLOUT_PERCENTAGE` on the `desktop-release` GitHub environment controls
+the percentage from 0 through 100. Membership is a deterministic SHA-256 cohort
+of a random per-installation identifier and the release tag. It is stable
+without putting user or account identifiers in release traffic. **Check now**
+deliberately opts the local user into an otherwise deferred release.
+
+`UPDATE_BLOCKED_VERSIONS` is a comma-separated list of exact semantic versions.
+Changing either value requires a new release tag and newly signed manifest;
+published manifests are not edited in place.
+
+## Platform installation
+
+The same settings and tray experience reports updates on every platform, while
+the platform trust channel owns replacement:
+
+- A Developer ID-signed and notarized macOS release uses Electron's native
+  updater. The app verifies the ZIP first, then serves it to the platform
+  updater over an ephemeral loopback-only feed. The packaged app declares the
+  narrow macOS local-network ATS exception needed by that feed; it does not
+  allow arbitrary insecure loads. macOS performs its own application-signature
+  check before staging.
+- Microsoft Store builds open the product's Store page. Store certification,
+  signing, rollout, replacement, and platform rollback remain authoritative.
+  Unsigned Squirrel and portable artifacts are never automatic targets.
+- Linux builds open the signed release/package channel. The package manager
+  owns dependencies, replacement, and rollback; Electron never mutates `/usr`
+  or invokes privilege elevation.
+- Unsigned macOS or Windows previews can be announced as manual downloads, but
+  are never automatic targets.
+
+## App and daemon transaction
+
+When an eligible automatic macOS release is selected, the desktop:
+
+1. copies the running CLI/daemon to a private last-known-good runtime;
+2. atomically records previous and target versions, service-registration state,
+   and the recovery runtime;
+3. downloads, verifies, and asks the native updater to stage the application
+   while the existing daemon remains available.
+
+Only after the user chooses **Restart and update**, the desktop:
+
+1. stops the daemon through its normal versioned control path;
+2. marks the transaction `installing`;
+3. handles Electron's update-specific quit path so the tray's normal
+   hide-on-close behavior cannot block replacement;
+4. asks the platform updater to quit and install.
+
+On first launch of the target app, before ordinary daemon startup, it:
+
+1. marks the recorded transaction `recovering`;
+2. atomically copies the new bundled CLI into the private stable service
+   runtime and refreshes service registration, or starts a new transient daemon;
+3. waits for the daemon to open its state and report the exact target version;
+4. commits only after that health check.
+
+If replacement was interrupted, the old app restarts its daemon and clears the
+transaction. If the target daemon cannot start or migrate state, the new app
+re-registers and health-checks the preserved previous daemon. Recovery remains
+visible so the user can install a higher signed recovery release.
+
+The platform installer rolls back a failed application-bundle replacement.
+After a new signed app has launched, mdbase uses publish-forward app recovery
+instead of overwriting a running signed bundle. The preserved daemon keeps
+collection access available. This avoids a second privileged installer and
+keeps signing authority with macOS, Microsoft Store, or the Linux package
+manager.
+
+Update state uses user-only permissions and atomic rename. Invalid state is
+quarantined. A crash at every boundary is safe to retry: before stop there is
+no service impact; after stop the previous runtime is recorded; after
+replacement recovery is idempotent.
+
+## Release and recovery drills
+
+Before enabling a non-zero automatic rollout:
+
+1. publish a signed test beta at 0%;
+2. use **Check now** on both macOS architectures;
+3. interrupt before daemon stop, after stop, and after platform replacement;
+4. verify an installed service is rebound away from the old app bundle;
+5. inject daemon startup failure and verify the last-known-good daemon returns;
+6. publish a higher signed release that blocks the bad version and verify it
+   bypasses a 0% rollout;
+7. test Store and Linux actions without package-manager privilege in Electron;
+8. raise rollout gradually while watching privacy-minimal startup and recovery
+   telemetry.
+
+Never repair a published manifest, reuse a tag, lower the trusted-version
+floor, or point an automatic target at an unsigned preview.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -75,6 +75,8 @@ to additionally build a Store-submission package:
 - `WINDOWS_STORE_IDENTITY_NAME`: the exact package Identity/Name;
 - `WINDOWS_STORE_PUBLISHER`: the exact package Identity/Publisher;
 - `WINDOWS_STORE_PUBLISHER_DISPLAY_NAME`: the exact publisher display name.
+- `WINDOWS_STORE_PRODUCT_ID`: the Store product ID used by the desktop's update
+  action.
 
 When those values are present, the Windows job creates a Store-submission AppX
 whose manifest is checked against them. The workflow uses
@@ -118,12 +120,23 @@ notarization, signature verification, or Store package identity checks fail.
 The workflow also verifies that GitHub preview executables are unsigned before
 labeling and publishing them. Every downloadable artifact receives a keyless
 Sigstore bundle tied to the workflow's GitHub OIDC identity plus a checksum.
+The publish job creates a strict manifest from those exact artifacts, signs it
+with the same tag-bound workflow identity, verifies it, and only then creates
+the GitHub release.
+
+Set `UPDATE_ROLLOUT_PERCENTAGE` on the `desktop-release` environment to a number
+from 0 through 100; it defaults to 100. Set `UPDATE_BLOCKED_VERSIONS` to a
+comma-separated list of exact versions only when a higher recovery release
+must bypass rollout for affected installations. Both values are captured in
+the signed manifest and require a new immutable tag to change.
 
 Before publishing a version, record the exact `mdbase-rs` revision, run the
 local protocol-1, relay, sync, and production-provider end-to-end suites,
 retain checksums for every artifact, verify upgrade and clean-install paths,
-and publish the supported protocol and schema versions. After deployment,
+and publish the supported protocol and schema versions. Exercise the
+interruption and recovery matrix in
+[`desktop-updates.md`](desktop-updates.md) before raising rollout above zero.
+After deployment,
 verify the deployed revision and protocol-1 browser authorization path against
 the actual release environment. Do not use a differently versioned oracle as a
-release gate. Automatic updates should be enabled only after signed rollback
-and staged-rollout behavior has been exercised against a private channel.
+release gate.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@hono/node-server': 2.0.11
   '@electron/rebuild': 4.2.0
   find-my-way: 9.7.0
+  brace-expansion@5.0.7: 5.0.8
   tar@<7.5.19: 7.5.19
   tmp@<0.2.6: 0.2.7
 
@@ -85,6 +86,9 @@ importers:
       playwright-core:
         specifier: ^1.61.1
         version: 1.61.1
+      sigstore:
+        specifier: 4.1.1
+        version: 4.1.1(supports-color@8.1.1)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -308,8 +312,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       '@fastify/static':
-        specifier: ^10.1.0
-        version: 10.1.0
+        specifier: ^10.1.2
+        version: 10.1.2
       '@fastify/websocket':
         specifier: ^11.3.0
         version: 11.3.0
@@ -697,8 +701,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@10.1.0':
-    resolution: {integrity: sha512-iK/8TvRM/EgNOyQL+EpWu+x3aR6o4GWt+UI+27zmE7w6t/6d80mXqOtWLdEKQ13vL/g1Jry0ae2icj6GP7tGzA==}
+  '@fastify/static@10.1.2':
+    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
   '@fastify/websocket@11.3.0':
     resolution: {integrity: sha512-g89ag4BCcD9YP5wBZXixzoLnuf5j89p/sXFcfpCiv2pdEkYYukBEoK3heVzqsp0EAtszVDc2BBZG0KZqeAShIA==}
@@ -708,6 +712,10 @@ packages:
 
   '@fontsource/azeret-mono@5.3.0':
     resolution: {integrity: sha512-Ag/+gN67fUry7i1yLlTnk16Rr1nnTQI2YefA/G7tYcCSr/+TC/ayMrE8Km7O0OKRgI/B5Mfel46Gq9IGY50Uaw==}
+
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@hono/node-server@2.0.11':
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
@@ -860,6 +868,18 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@npmcli/agent@4.0.2':
+    resolution: {integrity: sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
@@ -969,6 +989,30 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sigstore/bundle@4.0.0':
+    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/core@3.2.1':
+    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/protobuf-specs@0.5.1':
+    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@4.1.1':
+    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/tuf@4.0.2':
+    resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/verify@3.1.1':
+    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -979,6 +1023,14 @@ packages:
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@4.1.0':
+    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1430,9 +1482,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1455,6 +1507,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cacache@20.0.4:
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -2008,6 +2064,10 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   fs-temp@1.2.1:
     resolution: {integrity: sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==}
 
@@ -2164,6 +2224,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -2489,6 +2553,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-fetch-happen@15.0.6:
+    resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   map-age-cleaner@0.1.3:
     resolution: {integrity: sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==}
     engines: {node: '>=6'}
@@ -2612,6 +2680,30 @@ packages:
         optional: true
       uglify-js:
         optional: true
+
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -2794,6 +2886,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map@7.0.6:
+    resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
+    engines: {node: '>=18'}
 
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -3283,9 +3379,25 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sigstore@4.1.1:
+    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -3319,6 +3431,10 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3489,6 +3605,10 @@ packages:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tuf-js@4.1.0:
+    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
@@ -4312,7 +4432,7 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@10.1.0':
+  '@fastify/static@10.1.2':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/error': 4.2.0
@@ -4334,6 +4454,8 @@ snapshots:
   '@fontsource/atkinson-hyperlegible@5.3.0': {}
 
   '@fontsource/azeret-mono@5.3.0': {}
+
+  '@gar/promise-retry@1.0.3': {}
 
   '@hono/node-server@2.0.11(hono@4.12.31)':
     dependencies:
@@ -4538,6 +4660,22 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@npmcli/agent@4.0.2(supports-color@8.1.1)':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      lru-cache: 11.5.2
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.8.5
+
+  '@npmcli/redact@4.0.0': {}
+
   '@oxc-project/types@0.139.0': {}
 
   '@pinojs/redact@0.4.0': {}
@@ -4597,6 +4735,38 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sigstore/bundle@4.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+
+  '@sigstore/core@3.2.1': {}
+
+  '@sigstore/protobuf-specs@0.5.1': {}
+
+  '@sigstore/sign@4.1.1(supports-color@8.1.1)':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.1
+      make-fetch-happen: 15.0.6(supports-color@8.1.1)
+      proc-log: 6.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/tuf@4.0.2(supports-color@8.1.1)':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+      tuf-js: 4.1.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@3.1.1':
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.1
+
   '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -4604,6 +4774,13 @@ snapshots:
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@4.1.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 10.2.5
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -5036,7 +5213,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5059,6 +5236,19 @@ snapshots:
   buffer-from@1.1.2: {}
 
   bytes@3.1.2: {}
+
+  cacache@20.0.4:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.6
+      ssri: 13.0.1
 
   cacheable-lookup@5.0.4: {}
 
@@ -5732,6 +5922,10 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
   fs-temp@1.2.1:
     dependencies:
       random-path: 0.1.2
@@ -5933,6 +6127,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   http2-wrapper@1.0.3:
     dependencies:
@@ -6237,6 +6438,23 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-fetch-happen@15.0.6(supports-color@8.1.1):
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.2(supports-color@8.1.1)
+      '@npmcli/redact': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   map-age-cleaner@0.1.3:
     dependencies:
       p-defer: 1.0.0
@@ -6288,7 +6506,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -6311,6 +6529,34 @@ snapshots:
       esbuild: 0.28.1
       lightningcss: 1.33.0
       postcss: 8.5.20
+
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.3
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
 
   minipass@7.1.3: {}
 
@@ -6470,6 +6716,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@7.0.6: {}
 
   p-try@1.0.0: {}
 
@@ -6950,10 +7198,36 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sigstore@4.1.1(supports-color@8.1.1):
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.1
+      '@sigstore/sign': 4.1.1(supports-color@8.1.1)
+      '@sigstore/tuf': 4.0.2(supports-color@8.1.1)
+      '@sigstore/verify': 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
     dependencies:
@@ -6986,6 +7260,10 @@ snapshots:
 
   sprintf-js@1.1.3:
     optional: true
+
+  ssri@13.0.1:
+    dependencies:
+      minipass: 7.1.3
 
   stackback@0.0.2: {}
 
@@ -7154,6 +7432,14 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tuf-js@4.1.0(supports-color@8.1.1):
+    dependencies:
+      '@tufjs/models': 4.1.0
+      debug: 4.4.3(supports-color@8.1.1)
+      make-fetch-happen: 15.0.6(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   tweetnacl@1.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,5 +26,6 @@ overrides:
   "@hono/node-server": "2.0.11"
   "@electron/rebuild": "4.2.0"
   "find-my-way": "9.7.0"
+  "brace-expansion@5.0.7": "5.0.8"
   "tar@<7.5.19": "7.5.19"
   "tmp@<0.2.6": "0.2.7"

--- a/scripts/generate-update-manifest.mjs
+++ b/scripts/generate-update-manifest.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+const options = argumentsFrom(process.argv.slice(2));
+const directory = required(options, "directory");
+const output = required(options, "output");
+const version = semanticVersion(required(options, "version"));
+const repository = required(options, "repository");
+if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) fail("Invalid GitHub repository.");
+const percentage = Number(required(options, "rollout"));
+if (!Number.isFinite(percentage) || percentage < 0 || percentage > 100) {
+  fail("Rollout percentage must be between 0 and 100.");
+}
+const tag = `v${version}`;
+const releaseUrl = `https://github.com/${repository}/releases/tag/${tag}`;
+const downloadRoot = `https://github.com/${repository}/releases/download/${tag}`;
+const publishedAt = options.get("published-at")?.[0] ?? new Date().toISOString();
+if (!Number.isFinite(Date.parse(publishedAt))) fail("Invalid publication timestamp.");
+const blockedVersions = (options.get("blocked-versions")?.[0] ?? "")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean)
+  .map(semanticVersion);
+if (new Set(blockedVersions).size !== blockedVersions.length) fail("Blocked versions contain duplicates.");
+if (blockedVersions.includes(version)) fail("A release cannot block its own target version.");
+
+const names = (await readdir(directory))
+  .filter((name) => /^update-input-(macos|windows|linux)-(arm64|x64)\.json$/.test(name))
+  .sort();
+if (names.length === 0) fail("No update inputs were found.");
+
+const targets = {};
+for (const name of names) {
+  const input = parseInput(JSON.parse(await readFile(join(directory, name), "utf8")));
+  const key = `${platformKey(input.platform)}-${input.arch}`;
+  if (targets[key]) fail(`Duplicate update target ${key}.`);
+  const artifacts = [];
+  if (new Set(input.artifacts).size !== input.artifacts.length) {
+    fail(`Update target ${key} contains duplicate artifact names.`);
+  }
+  for (const artifactName of input.artifacts.sort()) {
+    const path = join(directory, artifactName);
+    const bundle = `${artifactName}.sigstore.json`;
+    await stat(join(directory, bundle));
+    const details = await stat(path);
+    const digest = await sha256(path);
+    artifacts.push({
+      name: artifactName,
+      url: `${downloadRoot}/${encodeURIComponent(artifactName)}`,
+      sigstore_url: `${downloadRoot}/${encodeURIComponent(bundle)}`,
+      sha256: digest,
+      size: details.size,
+      kind: artifactKind(artifactName)
+    });
+  }
+  targets[key] = {
+    mode: input.mode,
+    action_url: input.action_url === "$RELEASE_URL" ? releaseUrl : httpsUrl(input.action_url),
+    artifacts
+  };
+}
+
+const manifest = {
+  schema_version: 1,
+  version,
+  tag,
+  channel: version.includes("-") ? "beta" : "stable",
+  published_at: new Date(publishedAt).toISOString(),
+  release_url: releaseUrl,
+  notes: "See the release page for changes, platform trust information, and recovery guidance.",
+  rollout: {
+    percentage,
+    seed: tag
+  },
+  blocked_versions: blockedVersions,
+  targets
+};
+await writeFile(output, `${JSON.stringify(manifest, null, 2)}\n`, {
+  encoding: "utf8",
+  flag: "wx"
+});
+console.log(output);
+
+function parseInput(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail("Invalid update input.");
+  const allowed = ["schema_version", "platform", "arch", "mode", "action_url", "artifacts"];
+  const keys = Object.keys(value);
+  if (keys.some((key) => !allowed.includes(key)) || allowed.some((key) => !keys.includes(key))) {
+    fail("Update input has missing or unknown fields.");
+  }
+  if (
+    value.schema_version !== 1 ||
+    !["macos", "windows", "linux"].includes(value.platform) ||
+    !["arm64", "x64"].includes(value.arch) ||
+    !["automatic", "store", "manual"].includes(value.mode) ||
+    typeof value.action_url !== "string" ||
+    !Array.isArray(value.artifacts) ||
+    value.artifacts.some((name) => typeof name !== "string" || name !== basename(name))
+  ) {
+    fail("Invalid update input.");
+  }
+  if (value.mode !== "store" && value.artifacts.length === 0) fail("Update input requires artifacts.");
+  return value;
+}
+
+function artifactKind(name) {
+  const match = /\.(zip|dmg|exe|deb|rpm)$/i.exec(name);
+  if (!match) fail(`Unsupported update artifact ${name}.`);
+  return match[1].toLowerCase();
+}
+
+function platformKey(value) {
+  return value === "macos" ? "darwin" : value === "windows" ? "win32" : "linux";
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function semanticVersion(value) {
+  const match =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.exec(
+      value
+    );
+  if (
+    !match ||
+    match[4]?.split(".").some((part) => /^\d+$/.test(part) && !/^(0|[1-9]\d*)$/.test(part))
+  ) {
+    fail(`Invalid semantic version ${value}.`);
+  }
+  return value;
+}
+
+function httpsUrl(value) {
+  if (!value.startsWith("https://")) fail("Update action URL must use HTTPS.");
+  const parsed = new URL(value);
+  if (parsed.username || parsed.password || parsed.hash) fail("Unsafe update action URL.");
+  return parsed.href;
+}
+
+function argumentsFrom(values) {
+  const result = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const name = values[index];
+    const value = values[index + 1];
+    if (!name?.startsWith("--") || value === undefined) fail("Arguments must be --name value pairs.");
+    const key = name.slice(2);
+    const entries = result.get(key) ?? [];
+    entries.push(value);
+    result.set(key, entries);
+  }
+  return result;
+}
+
+function required(values, name) {
+  const entries = values.get(name);
+  if (!entries || entries.length !== 1 || !entries[0]) fail(`--${name} is required once.`);
+  return entries[0];
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/write-update-input.mjs
+++ b/scripts/write-update-input.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { access, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+const options = argumentsFrom(process.argv.slice(2));
+const directory = required(options, "directory");
+const platform = required(options, "platform");
+const arch = required(options, "arch");
+const mode = required(options, "mode");
+const actionUrl = required(options, "action-url");
+const artifacts = list(options, "artifact");
+
+if (!["macos", "windows", "linux"].includes(platform)) fail(`Unsupported platform ${platform}.`);
+if (!["arm64", "x64"].includes(arch)) fail(`Unsupported architecture ${arch}.`);
+if (!["automatic", "store", "manual"].includes(mode)) fail(`Unsupported update mode ${mode}.`);
+if (mode !== "store" && artifacts.length === 0) fail("Non-Store targets require an artifact.");
+
+for (const artifact of artifacts) {
+  if (artifact !== basename(artifact)) fail(`Unsafe artifact name ${artifact}.`);
+  await access(join(directory, artifact));
+  await access(join(directory, `${artifact}.sigstore.json`));
+}
+
+const output = join(directory, `update-input-${platform}-${arch}.json`);
+await writeFile(
+  output,
+  `${JSON.stringify(
+    {
+      schema_version: 1,
+      platform,
+      arch,
+      mode,
+      action_url: actionUrl,
+      artifacts
+    },
+    null,
+    2
+  )}\n`,
+  { encoding: "utf8", flag: "wx" }
+);
+console.log(output);
+
+function argumentsFrom(values) {
+  const result = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const name = values[index];
+    const value = values[index + 1];
+    if (!name?.startsWith("--") || value === undefined) fail("Arguments must be --name value pairs.");
+    const key = name.slice(2);
+    const entries = result.get(key) ?? [];
+    entries.push(value);
+    result.set(key, entries);
+  }
+  return result;
+}
+
+function required(values, name) {
+  const entries = values.get(name);
+  if (!entries || entries.length !== 1 || !entries[0]) fail(`--${name} is required once.`);
+  return entries[0];
+}
+
+function list(values, name) {
+  return values.get(name) ?? [];
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -17,7 +17,7 @@
     "@fastify/formbody": "^8.0.2",
     "@fastify/helmet": "^13.1.0",
     "@fastify/rate-limit": "^11.1.0",
-    "@fastify/static": "^10.1.0",
+    "@fastify/static": "^10.1.2",
     "@fastify/websocket": "^11.3.0",
     "@mdbase/connect-protocol": "workspace:*",
     "@mdbase/connect-sync": "workspace:*",


### PR DESCRIPTION
## Summary

- add strict, Sigstore-verified release discovery, rollout policy, bounded downloads, native macOS staging, and Store/Linux handoff
- make app and daemon upgrades transactional with a private stable service runtime, exact-version health checks, interruption recovery, and last-known-good rollback
- expose update status and actions in Electron settings/tray and publish tag-bound manifests from deterministic release artifacts
- document the trust, rollout, recovery, and pre-release operations contract

## Verification

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm test (44 desktop tests plus every workspace suite)
- pnpm typecheck
- pnpm build and pnpm package:audit
- pnpm install --frozen-lockfile
- pnpm audit --prod --audit-level high
- pnpm e2e, e2e:relay, e2e:sync, and e2e:provider
- Docker-backed native Electron end-to-end path
- production Electron package build and isolated packaged-daemon smoke test
- live tag-bound Sigstore acceptance/rejection check against a published beta artifact

## Release gates intentionally left open

Apple signing/notarization setup, Partner Center configuration, real cross-version platform recovery drills, and immutable mdbase-rs dependency pinning remain explicit pre-release tasks. Automatic rollout should begin at zero percent until those drills pass.

## Dependency audit note

The production graph has no known vulnerabilities. The complete development-tool audit still reports legacy brace-expansion versions under the current Electron Forge 7.11.2 packaging chain; the bundled Sigstore/runtime path is pinned to the patched v5.0.8 line.