### PR TITLE
Disambiguate collection choices and isolate test stacks

### DIFF
--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -1308,6 +1308,12 @@ function ApprovalForm({
     () => choices.filter((choice) => choice.compatibility.compatible),
     [choices]
   );
+  const collectionLocations = useMemo(
+    () => disambiguatedCollectionLocations(
+      compatible.map((choice) => choice.collection)
+    ),
+    [compatible]
+  );
   const unavailable = useMemo(
     () => choices.filter((choice) => !choice.compatibility.compatible),
     [choices]
@@ -1431,7 +1437,10 @@ function ApprovalForm({
                     disabled={submitting !== null}
                     onChange={() => setCollectionId(collection.id)}
                   />
-                  <span><strong>{collection.display_name}</strong><small>{collection.connector_name}</small></span>
+                  <span>
+                    <strong>{collection.display_name}</strong>
+                    <small>{collectionLocations.get(collection.id)}</small>
+                  </span>
                   {provisions.length > 0 && <b>Setup needed</b>}
                 </label>;
               })}
@@ -1526,6 +1535,51 @@ function ApprovalForm({
       </footer>
     </div>
   );
+}
+
+function disambiguatedCollectionLocations(
+  collections: AvailableCollection[]
+): Map<string, string> {
+  const groups = new Map<string, AvailableCollection[]>();
+  for (const collection of collections) {
+    const key = [
+      collection.display_name.normalize("NFKC").toLocaleLowerCase(),
+      collection.connector_name.normalize("NFKC").toLocaleLowerCase()
+    ].join("\u0000");
+    const group = groups.get(key) ?? [];
+    group.push(collection);
+    groups.set(key, group);
+  }
+
+  const labels = new Map<string, string>();
+  for (const group of groups.values()) {
+    for (const collection of group) {
+      labels.set(
+        collection.id,
+        group.length === 1
+          ? collection.connector_name
+          : `${collection.connector_name} · ID …${uniqueIdSuffix(
+              collection.id,
+              group.map((candidate) => candidate.id)
+            )}`
+      );
+    }
+  }
+  return labels;
+}
+
+function uniqueIdSuffix(id: string, candidates: string[]): string {
+  let length = Math.min(8, id.length);
+  while (
+    length < id.length &&
+    candidates.some(
+      (candidate) =>
+        candidate !== id && candidate.slice(-length) === id.slice(-length)
+    )
+  ) {
+    length += 1;
+  }
+  return id.slice(-length);
 }
 
 function PermissionChoices({

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "profile:connect": "cargo run --release -p mdbase-connect-core --bin connect-profile --",
     "profile:rs": "cargo run --release --manifest-path ../mdbase-rs/Cargo.toml --bin mdb-profile -- --scenario queries",
     "profile:views:rs": "cargo run --release --manifest-path ../mdbase-rs/Cargo.toml --bin mdb-profile -- --scenario views",
-    "test": "pnpm --filter @mdbase/connect-desktop test && pnpm --filter '!@mdbase/connect-desktop' -r test",
+    "test": "node --test scripts/lib/*.test.mjs && pnpm --filter @mdbase/connect-desktop test && pnpm --filter '!@mdbase/connect-desktop' -r test",
     "typecheck": "pnpm -r typecheck",
     "version:check": "node scripts/check-release-version.mjs"
   },

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -33,6 +33,7 @@ const { app } = await buildApp({
   db: database,
   devAuth: true,
   allowInsecureManifests: true,
+  portalDist: join(repoRoot, "apps", "portal", "dist"),
   publicUrl: "http://127.0.0.1"
 });
 await app.listen({ host: "127.0.0.1", port: 0 });
@@ -215,6 +216,26 @@ secret: connector scope test
     throw new Error(`Authorization did not establish encrypted relay protocol 1: ${JSON.stringify(token.body)}`);
   }
 
+  const duplicateCollectionPath = join(scratch, "workouts-duplicate");
+  await run(cliBinary, [
+    "--state-dir", stateDir,
+    "collection", "create", duplicateCollectionPath,
+    "--name", "Workouts"
+  ]);
+  await mkdir(join(duplicateCollectionPath, "_types"), { recursive: true });
+  await writeFile(
+    join(duplicateCollectionPath, "_types", "workout.md"),
+    await readFile(join(collectionPath, "_types", "workout.md"))
+  );
+  await stopAgent(agent);
+  agent = startAgent(["--server-url", serverUrl], connector.body.token);
+  await poll(async () => {
+    const current = await request("/v1/me", { cookie });
+    return current.body.collections.filter(
+      (candidate) => candidate.display_name === "Workouts"
+    ).length === 2 ? current.body : null;
+  }, "same-name collection metadata did not reach the portal");
+
   const portalVerifier = "portal-live-offer-pkce-verifier-with-forty-three-characters";
   const portalChallenge = createHash("sha256").update(portalVerifier).digest("base64url");
   const portalAuthorize = await fetch(
@@ -237,6 +258,46 @@ secret: connector scope test
     throw new Error(
       `The live connector did not offer its local collection to the portal: ${JSON.stringify(portalRequest.body)}`
     );
+  }
+  const portalBrowser = await chromium.launch({ headless: true });
+  try {
+    const portalContext = await portalBrowser.newContext();
+    const cookieSeparator = cookie.indexOf("=");
+    await portalContext.addCookies([{
+      name: cookie.slice(0, cookieSeparator),
+      value: cookie.slice(cookieSeparator + 1),
+      url: serverUrl
+    }]);
+    const portalPage = await portalContext.newPage();
+    await portalPage.goto(`${serverUrl}/authorize/${portalAuthorizationId}`);
+    const duplicateRows = portalPage
+      .locator(".collection-choice-list label")
+      .filter({ hasText: "Workouts" });
+    await duplicateRows.first().waitFor({ state: "visible" });
+    const duplicateRowCount = await duplicateRows.count();
+    if (duplicateRowCount !== 2) {
+      throw new Error(
+        `Expected two same-name collection rows, found ${duplicateRowCount}: `
+        + JSON.stringify(portalRequest.body.collections)
+      );
+    }
+    const radioLabels = await duplicateRows.locator("input[type=radio]").evaluateAll(
+      (inputs) => inputs.map((input) =>
+        input.labels?.[0]?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+      )
+    );
+    if (radioLabels.length !== 2
+        || radioLabels.some((label) => !label.includes("ID …"))
+        || new Set(radioLabels).size !== 2) {
+      throw new Error(`Same-name radio labels remained ambiguous: ${JSON.stringify(radioLabels)}`);
+    }
+    const details = await duplicateRows.locator("small").allTextContents();
+    if (details.length !== 2 || new Set(details).size !== 2) {
+      throw new Error(`Same-name collection details remained ambiguous: ${JSON.stringify(details)}`);
+    }
+    await portalContext.close();
+  } finally {
+    await portalBrowser.close();
   }
   await request(`/v1/authorization-requests/${portalAuthorizationId}/approve`, {
     method: "POST",

--- a/scripts/lib/connect-test-environment.mjs
+++ b/scripts/lib/connect-test-environment.mjs
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 import { createServer } from "node:net";
 import { dirname, resolve } from "node:path";
@@ -140,12 +140,21 @@ export function availablePort() {
   });
 }
 
-function sanitizeProjectName(value) {
+export function sanitizeProjectName(value) {
   const sanitized = value.toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
   if (!sanitized || !/^[a-z0-9]/.test(sanitized)) {
     throw new Error("The Docker Compose project name is invalid");
   }
-  return sanitized.slice(0, 63);
+  if (sanitized === value && sanitized.length <= 63) return sanitized;
+
+  // Docker resource names need a bounded, normalized project name. Retain a
+  // digest whenever normalization would otherwise discard information so two
+  // explicitly different test environments cannot silently become one.
+  const digest = createHash("sha256").update(value).digest("hex").slice(0, 12);
+  const prefix = sanitized
+    .slice(0, 50)
+    .replace(/[-_]+$/g, "");
+  return `${prefix}-${digest}`;
 }
 
 function run(command, arguments_, options) {

--- a/scripts/lib/connect-test-environment.test.mjs
+++ b/scripts/lib/connect-test-environment.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sanitizeProjectName } from "./connect-test-environment.mjs";
+
+test("keeps already-valid Compose project names stable", () => {
+  assert.equal(
+    sanitizeProjectName("mdbase-connect-e2e-1234-abcd"),
+    "mdbase-connect-e2e-1234-abcd"
+  );
+});
+
+test("preserves uniqueness when long project names share a prefix", () => {
+  const shared = `bughunt-${"x".repeat(55)}`;
+  const first = sanitizeProjectName(`${shared}-first`);
+  const second = sanitizeProjectName(`${shared}-second`);
+
+  assert.notEqual(first, second);
+  assert.ok(first.length <= 63);
+  assert.ok(second.length <= 63);
+  assert.match(first, /^[a-z0-9][a-z0-9_-]*$/);
+  assert.match(second, /^[a-z0-9][a-z0-9_-]*$/);
+});
+
+test("preserves uniqueness when normalization changes project names", () => {
+  assert.notEqual(
+    sanitizeProjectName("desktop suite"),
+    sanitizeProjectName("desktop-suite")
+  );
+});


### PR DESCRIPTION
## Summary
- keep unique collection choices concise while adding a collision-safe short ID when display name and connector are otherwise identical
- verify the visible details and native radio labels in the live portal authorization flow
- give normalized or truncated Docker Compose project names a stable digest so concurrent harnesses cannot silently share resources
- add unit coverage for safe names, long shared prefixes, and normalization collisions

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e` (live portal picker, relay, direct connector, and SDK path)
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- real Docker regression: two formerly colliding long project names ran healthy simultaneously with distinct networks/volumes and were torn down cleanly