### PR TITLE
Add invite-only password authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,16 @@ MDBASE_CONNECT_REGISTRATION=closed
 # MDBASE_CONNECT_GOOGLE_CLIENT_ID=
 # MDBASE_CONNECT_ALLOWED_GOOGLE_SUBJECTS=
 
+# Password authentication can coexist with external providers or operate on its
+# own. This stable HMAC secret protects privacy-safe shared rate-limit keys.
+# Configure both legal document URLs before enabling invited signup.
+# MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET=replace-with-at-least-32-random-characters
+# MDBASE_CONNECT_TERMS_URL=https://example.com/terms/
+# MDBASE_CONNECT_PRIVACY_URL=https://example.com/privacy/
+# One-shot auth-admin invitation delivery only:
+# MDBASE_CONNECT_RESEND_API_KEY=
+# MDBASE_CONNECT_EMAIL_FROM="mdbase connect <hello@example.com>"
+
 # Leave hosted collection routes unavailable during the relay-only preview.
 MDBASE_CONNECT_HOSTED_COLLECTIONS=0
 

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -23,8 +23,8 @@ export interface DashboardData {
   user: { id: string; name: string; email: string | null; login: string | null };
   hosted_collections_available?: boolean;
   authentication: {
-    provider: "google" | "github" | "tailscale" | "session";
-    registration: "closed" | "open";
+    provider: "google" | "github" | "password" | "tailscale" | "session";
+    registration: "closed" | "invite" | "open";
   };
   connectors: Array<{ id: string; name: string; last_seen_at: string | null; created_at: string }>;
   collections: Array<{

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -42,6 +42,7 @@ function Portal() {
   const authorityTransferId = location.pathname.match(/^\/transfer\/([0-9a-f-]+)$/i)?.[1];
   const authorizationId = location.pathname.match(/^\/authorize\/([0-9a-f-]+)$/i)?.[1];
   if (location.pathname === "/login") return <Login />;
+  if (location.pathname === "/signup") return <Signup />;
   if (location.pathname === "/device") return <DeviceAuthorization />;
   if (pairingId) return <Pairing pairingId={pairingId} />;
   if (mirrorPairingId) return <MirrorPairing pairingId={mirrorPairingId} />;
@@ -105,7 +106,7 @@ function Login() {
     : config.provider === "github"
       ? [{ id: "github" as const, label: "Continue with GitHub", login_url: "/auth/github" }]
       : [];
-  if (providers.length > 0) return (
+  if (providers.length > 0 || config.password_login) return (
     <main className="center-page">
       <PageBrand label="connect" />
       <section className="auth-panel">
@@ -114,10 +115,19 @@ function Login() {
         <p>{continuingAuthorization
           ? `After you choose a collection and approve access, you’ll return to the app.${config.registration === "open" ? "" : " Sign-in is currently limited to invited accounts."}`
           : config.registration === "open"
-            ? "Choose an identity provider to create or open your account."
-            : "Access is currently limited to invited accounts."}</p>
+            ? "Open your account with email or a connected identity provider."
+            : "Access is currently limited to invited accounts. Sign in with the method attached to yours."}</p>
         {error && <div className="message error" role="alert">{error}</div>}
-        <div className="auth-providers">
+        {config.password_login && (
+          <PasswordLoginForm
+            onError={setError}
+            onSignedIn={() => { location.href = returnTarget(); }}
+          />
+        )}
+        {providers.length > 0 && <div className="auth-providers">
+          {config.password_login && providers.length > 0 && (
+            <div className="provider-divider"><span>or</span></div>
+          )}
           {providers.map((provider, index) => <React.Fragment key={provider.id}>
             {index > 0 && <div className="provider-divider"><span>or</span></div>}
             {provider.id === "google"
@@ -126,7 +136,12 @@ function Login() {
                   {provider.label}
                 </a>}
           </React.Fragment>)}
-        </div>
+        </div>}
+        {config.password_registration && (
+          <p className="auth-footnote">
+            New here? Your invitation email contains the one-time account setup link.
+          </p>
+        )}
       </section>
     </main>
   );
@@ -147,6 +162,233 @@ function Login() {
   );
 }
 
+function PasswordLoginForm({
+  onError,
+  onSignedIn
+}: {
+  onError(value: string): void;
+  onSignedIn(): void;
+}) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function signIn(event: React.FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    onError("");
+    try {
+      await api("/v1/auth/password/login", {
+        method: "POST",
+        body: JSON.stringify({ email, password })
+      });
+      onSignedIn();
+    } catch (reason) {
+      onError(message(reason));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="password-auth-form" onSubmit={(event) => void signIn(event)}>
+      <label>
+        <span>Email</span>
+        <input
+          type="email"
+          autoComplete="username"
+          maxLength={320}
+          required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+      </label>
+      <label>
+        <span>Password</span>
+        <input
+          type="password"
+          autoComplete="current-password"
+          maxLength={1024}
+          required
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+        />
+      </label>
+      <button className="button primary" disabled={busy} type="submit">
+        {busy ? "Signing in…" : "Sign in with email"}
+      </button>
+    </form>
+  );
+}
+
+function Signup() {
+  const [invitationToken] = useState(invitationTokenFromFragment);
+  const [config, setConfig] = useState<AuthConfig | null>(null);
+  const [invitation, setInvitation] = useState<InvitationPreview | null>(null);
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [agreementsAccepted, setAgreementsAccepted] = useState(false);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const prepared = useRef(false);
+
+  useEffect(() => {
+    if (prepared.current) return;
+    prepared.current = true;
+    async function prepare() {
+      try {
+        const authentication = await api<AuthConfig>("/v1/auth/config");
+        setConfig(authentication);
+        if (
+          !invitationToken
+          || !authentication.password_registration
+          || !authentication.agreements
+        ) return;
+        const result = await api<{ invitation: InvitationPreview }>(
+          "/v1/auth/password/invitation",
+          {
+            method: "POST",
+            body: JSON.stringify({ invitation_token: invitationToken })
+          }
+        );
+        setInvitation(result.invitation);
+      } catch (reason) {
+        setError(message(reason));
+      } finally {
+        setLoading(false);
+      }
+    }
+    void prepare();
+  }, [invitationToken]);
+
+  async function createAccount(event: React.FormEvent) {
+    event.preventDefault();
+    if (!config?.agreements || !invitation) return;
+    if (password !== passwordConfirmation) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      await api("/v1/auth/password/signup", {
+        method: "POST",
+        body: JSON.stringify({
+          invitation_token: invitationToken,
+          name,
+          password,
+          terms_version: config.agreements.terms.version,
+          privacy_version: config.agreements.privacy.version
+        })
+      });
+      location.href = returnTarget();
+    } catch (reason) {
+      setError(message(reason));
+      setBusy(false);
+    }
+  }
+
+  if (loading || !config) return <Loading error={error} />;
+  const ready = Boolean(
+    invitation
+    && config.password_registration
+    && config.agreements
+  );
+  return (
+    <main className="center-page">
+      <PageBrand label="connect" />
+      <section className="auth-panel">
+        <p className="eyebrow">Private preview / invitation</p>
+        <h1>{ready ? "Create your account" : "This invitation can’t be opened"}</h1>
+        <p>{ready
+          ? "Your email is already verified by this one-time invitation. Choose the name and password you’ll use for mdbase connect."
+          : invitationToken
+            ? "The link is invalid, expired, already used, or account setup is temporarily unavailable."
+            : "Open the complete account setup link from your invitation email."}</p>
+        {error && <div className="message error" role="alert">{error}</div>}
+        {ready && invitation && config.agreements && (
+          <form className="password-auth-form signup-form" onSubmit={(event) => void createAccount(event)}>
+            <label>
+              <span>Email</span>
+              <input
+                type="email"
+                autoComplete="username"
+                readOnly
+                value={invitation.email}
+              />
+            </label>
+            <label>
+              <span>Name</span>
+              <input
+                autoComplete="name"
+                maxLength={100}
+                required
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+            <label>
+              <span>Password</span>
+              <input
+                type="password"
+                autoComplete="new-password"
+                minLength={15}
+                maxLength={1024}
+                aria-describedby="password-guidance"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </label>
+            <p className="field-note" id="password-guidance">
+              Use at least 15 characters. Spaces are welcome.
+            </p>
+            <label>
+              <span>Confirm password</span>
+              <input
+                type="password"
+                autoComplete="new-password"
+                minLength={15}
+                maxLength={1024}
+                required
+                value={passwordConfirmation}
+                onChange={(event) => setPasswordConfirmation(event.target.value)}
+              />
+            </label>
+            <label className="auth-agreement">
+              <input
+                type="checkbox"
+                required
+                checked={agreementsAccepted}
+                onChange={(event) => setAgreementsAccepted(event.target.checked)}
+              />
+              <span>
+                I agree to the{" "}
+                <a href={config.agreements.terms.url} target="_blank" rel="noreferrer">
+                  Terms of Service
+                </a>{" "}
+                and have read the{" "}
+                <a href={config.agreements.privacy.url} target="_blank" rel="noreferrer">
+                  Privacy Policy
+                </a>.
+              </span>
+            </label>
+            <button
+              className="button primary"
+              disabled={busy || !agreementsAccepted}
+              type="submit"
+            >
+              {busy ? "Creating account…" : "Create account"}
+            </button>
+          </form>
+        )}
+        <a className="quiet-auth-link" href="/login">Return to sign in</a>
+      </section>
+    </main>
+  );
+}
+
 interface AuthProviderOption {
   id: "google" | "github";
   label: string;
@@ -156,8 +398,21 @@ interface AuthProviderOption {
 interface AuthConfig {
   provider: "google" | "github" | "tailscale" | "development" | "session";
   providers: AuthProviderOption[];
-  registration: "closed" | "open";
+  registration: "closed" | "invite" | "open";
   development_login: boolean;
+  password_login?: true;
+  password_registration?: true;
+  agreements?: {
+    terms: { version: string; url: string };
+    privacy: { version: string; url: string };
+  };
+}
+
+interface InvitationPreview {
+  email: string;
+  expires_at: string;
+  terms_version: string;
+  privacy_version: string;
 }
 
 interface GoogleAccountsApi {
@@ -369,7 +624,7 @@ function Dashboard() {
         </section>
         <section id="account">
           <SectionHeading title="Account" note="Authentication and service details." />
-          <div className="account-rows"><AccountRow label="Authentication" value={authenticationLabel(data.authentication.provider)} detail={data.authentication.provider === "tailscale" ? "Controlled by your tailnet" : undefined} /><AccountRow label="Registration" value={data.authentication.registration === "open" ? "Open" : "Invitation only"} detail={data.authentication.registration === "open" ? "New identities may create an account" : "New accounts require service access"} /></div>
+          <div className="account-rows"><AccountRow label="Authentication" value={authenticationLabel(data.authentication.provider)} detail={data.authentication.provider === "tailscale" ? "Controlled by your tailnet" : undefined} /><AccountRow label="Registration" value={registrationLabel(data.authentication.registration)} detail={data.authentication.registration === "open" ? "New identities may create an account" : data.authentication.registration === "invite" ? "New accounts require an invitation" : "New account creation is paused"} /></div>
           {data.authentication.provider !== "tailscale" && <button className="button secondary" onClick={() => void api("/v1/logout", { method: "POST" }).then(() => { location.href = "/login"; })}>Sign out</button>}
         </section>
       </main>
@@ -1648,6 +1903,15 @@ function returnTarget() {
   const target = new URL(requested, location.origin);
   return target.origin === location.origin ? target.href : "/";
 }
+function invitationTokenFromFragment() {
+  const token = new URLSearchParams(location.hash.slice(1))
+    .get("invitation")
+    ?.trim() ?? "";
+  if (location.hash) {
+    history.replaceState(history.state, "", `${location.pathname}${location.search}`);
+  }
+  return token;
+}
 function isAuthorizationReturnTarget() {
   try {
     return new URL(returnTarget(), location.origin).pathname.startsWith("/authorize/");
@@ -1662,7 +1926,13 @@ function authenticationLabel(provider: DashboardData["authentication"]["provider
   if (provider === "google") return "Google";
   if (provider === "github") return "GitHub";
   if (provider === "tailscale") return "Tailscale identity";
+  if (provider === "password") return "Email and password";
   return "Development session";
+}
+function registrationLabel(registration: DashboardData["authentication"]["registration"]) {
+  if (registration === "open") return "Open";
+  if (registration === "invite") return "Invitation only";
+  return "Closed";
 }
 function relativeTime(value: string) {
   const seconds = Math.round((new Date(value).getTime() - Date.now()) / 1_000);

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -1238,6 +1238,68 @@ select {
   margin-top: 1.5rem;
 }
 
+.password-auth-form {
+  display: grid;
+  width: min(25rem, 100%);
+  margin-top: 1.6rem;
+}
+
+.password-auth-form label:first-child {
+  margin-top: 0;
+}
+
+.password-auth-form input[readonly] {
+  color: var(--ink-soft);
+  background: var(--paper-hover);
+}
+
+.password-auth-form .field-note {
+  margin-top: 0.45rem;
+}
+
+.auth-panel .auth-agreement {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  margin-top: 1.25rem;
+  cursor: pointer;
+}
+
+.auth-agreement input {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 auto;
+  margin: 0.16rem 0 0;
+  accent-color: var(--accent-dark);
+}
+
+.auth-panel .auth-agreement > span {
+  color: var(--ink-soft);
+  font-size: 0.74rem;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.auth-agreement a,
+.quiet-auth-link {
+  color: var(--accent-dark);
+  text-underline-offset: 0.16em;
+}
+
+.auth-panel > .auth-footnote {
+  max-width: 25rem;
+  margin-top: 1.4rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--line);
+  font-size: 0.72rem;
+}
+
+.quiet-auth-link {
+  display: inline-block;
+  margin-top: 1.4rem;
+  font-size: 0.72rem;
+}
+
 .auth-providers {
   display: grid;
   width: min(25rem, 100%);

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -5,12 +5,25 @@ MDBASE_CONNECT_VERSION=0.1.0-beta.8
 CONNECT_PUBLIC_URL=https://connect.example.com
 CONNECT_BIND_PORT=8787
 
-# Production authentication. Create a GitHub OAuth app whose callback is
+# Production authentication. GitHub is optional when password authentication
+# infrastructure is configured. If used, its OAuth callback is
 # https://connect.example.com/auth/github/callback.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 ALLOWED_GITHUB_USER_IDS=
 REGISTRATION_MODE=closed
+
+# Required before password authentication can be enabled in the database.
+# Generate AUTH_RATE_LIMIT_SECRET independently. Legal URLs must identify the
+# documents whose versions are configured through the authentication admin CLI.
+AUTH_RATE_LIMIT_SECRET=
+TERMS_URL=https://example.com/terms/
+PRIVACY_URL=https://example.com/privacy/
+
+# Optional invitation delivery from the one-shot auth-admin service. EMAIL_FROM
+# must use a sender identity authorized by the configured Resend account.
+RESEND_API_KEY=
+EMAIL_FROM="mdbase connect <hello@example.com>"
 
 # Generate independent random values. Never commit the populated file.
 CONTROL_DATABASE_PASSWORD=

--- a/deploy/self-host/compose.yml
+++ b/deploy/self-host/compose.yml
@@ -74,6 +74,9 @@ services:
       MDBASE_CONNECT_GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
       MDBASE_CONNECT_ALLOWED_GITHUB_USER_IDS: ${ALLOWED_GITHUB_USER_IDS}
       MDBASE_CONNECT_REGISTRATION: ${REGISTRATION_MODE:-closed}
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: ${AUTH_RATE_LIMIT_SECRET:-}
+      MDBASE_CONNECT_TERMS_URL: ${TERMS_URL:-}
+      MDBASE_CONNECT_PRIVACY_URL: ${PRIVACY_URL:-}
       MDBASE_CONNECT_HOSTED_COLLECTIONS: ${HOSTED_COLLECTIONS:-0}
       MDBASE_CONNECT_HOSTED_PROVIDER_URL: ${HOSTED_PROVIDER_PUBLIC_URL:-}
       MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: ${HOSTED_PROVIDER_INTERNAL_TOKEN:-}
@@ -102,6 +105,29 @@ services:
       timeout: 3s
       retries: 12
     restart: unless-stopped
+
+  auth-admin:
+    <<: *connect-image
+    profiles: ["admin"]
+    entrypoint: ["node", "services/server/dist/auth-admin-cli.js"]
+    command: ["policy", "show"]
+    environment:
+      DATABASE_URL: postgres://mdbase_connect:${CONTROL_DATABASE_PASSWORD}@control-db:5432/mdbase_connect
+      PUBLIC_URL: ${CONNECT_PUBLIC_URL}
+      MDBASE_CONNECT_REGISTRATION: ${REGISTRATION_MODE:-closed}
+      MDBASE_CONNECT_RESEND_API_KEY: ${RESEND_API_KEY:-}
+      MDBASE_CONNECT_EMAIL_FROM: ${EMAIL_FROM:-}
+    depends_on:
+      control-migrate:
+        condition: service_completed_successfully
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,noexec,nosuid
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: "no"
 
   hosted-db:
     profiles: ["hosted"]

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -1,0 +1,197 @@
+# Account authentication
+
+mdbase connect separates an account from the identities and credentials that
+can authenticate it. This keeps account ownership stable when an email address
+changes, a password is added to an existing Google or GitHub account, or a
+future passkey is enrolled.
+
+## Identity model
+
+`users` is the durable account boundary. Authentication data belongs to one of
+the following tables:
+
+- `external_identities` binds an immutable provider subject to an account;
+- `email_identities` binds a normalized, optionally verified email address;
+- `password_credentials` stores one versioned password hash for an account;
+- future passkey and TOTP credentials should use separate credential tables.
+
+Matching email text never links accounts. Linking requires an authenticated
+session for the existing account plus fresh proof of the identity being added.
+An OAuth callback may update presentation data for its existing provider
+subject, but it cannot claim an email identity owned by another account.
+
+Email normalization is deliberately conservative and versioned. Version 1
+trims outer whitespace, applies Unicode NFC, lower-cases the local and domain
+parts, and converts international domain names to ASCII. It does not remove
+plus-tags, remove dots, or apply provider-specific alias rules. Active
+normalized addresses are unique; retired identities remain available for
+audit while no longer reserving the address.
+
+## Password credentials
+
+New passwords are hashed with Argon2id using a unique library-generated salt
+and an encoded PHC string. The current minimum work factors are:
+
+- 19 MiB memory;
+- two iterations;
+- one lane;
+- a 32-byte output.
+
+The hashing API is isolated in `services/server/src/password.ts`. Route code
+must not call the Argon2 package directly. The encoded hash records its
+algorithm and parameters, and `passwordHashNeedsUpgrade` identifies a
+credential that should be rehashed after a successful login.
+
+Passwords permit spaces and Unicode without composition rules. New passwords
+must contain 15 to 256 Unicode code points and no more than 1,024 UTF-8 bytes.
+They are never truncated or normalized.
+
+Password login is available at `POST /v1/auth/password/login`. Invitation
+inspection and redemption use `POST /v1/auth/password/invitation` and
+`POST /v1/auth/password/signup`. All three require an exact same-origin
+`Origin` header. Successful login and signup issue the same HTTP-only,
+same-site session cookie used by external providers.
+
+## Invitations and challenges
+
+Invitations are bound to one normalized email address. At most one unrevoked,
+unaccepted invitation may exist for an address. Reissuing an invitation must
+revoke the previous row before inserting its replacement.
+
+Authentication challenges contain only a SHA-256 digest of a random
+256-bit token. The plaintext token is returned once to the delivery boundary
+and is never persisted or logged. Challenge redemption must use one
+transactional statement that marks an unexpired, unconsumed challenge as
+consumed and returns it. A read followed by a separate update is not safe.
+
+One active challenge per purpose and normalized email prevents unbounded
+parallel reset or verification links. Creating a replacement must invalidate
+the previous challenge first. Expired, consumed, and invalidated rows can be
+retained briefly for security metrics and then deleted by maintenance.
+
+Invitation links put the token in the URL fragment:
+`/signup#invitation=<token>`. Fragments are not sent in HTTP request targets or
+referrers. The portal removes the fragment from browser history immediately,
+then submits the token in a same-origin JSON request. Neither application logs
+nor database rows may contain the plaintext token.
+
+## Registration and kill switches
+
+`MDBASE_CONNECT_REGISTRATION` supplies the fail-safe deployment default:
+`closed`, `invite`, or `open`. If `authentication_settings` has no row, the
+server uses that value with password authentication and email delivery
+disabled.
+
+An audited database setting can override the default without a deployment.
+Updates use an expected revision, so concurrent operators cannot silently
+overwrite one another. Every successful revision is copied to
+`authentication_settings_history` with its actor and reason.
+
+The policy is read on authentication-sensitive requests. This is intentionally
+uncached for the private beta so a kill switch reaches every server instance
+as soon as PostgreSQL commits it. If authentication volume later warrants a
+cache, invalidation must use PostgreSQL notifications or a similarly shared
+mechanism; an instance-local TTL alone must not weaken emergency shutdown.
+
+Password registration currently supports `invite` mode only. `open` continues
+to govern configured external providers, but it does not advertise password
+signup: public password registration needs a separate email-verification flow.
+This prevents an operator setting from silently creating unverified
+email/password accounts.
+
+## Abuse controls
+
+Authentication limits use PostgreSQL-backed buckets because production runs
+multiple server instances. Bucket keys must be keyed digests, never raw email
+addresses or IP addresses and never unkeyed hashes of low-entropy identifiers.
+Separate scopes cover normalized email, source network, account, and global
+send volume.
+
+The application will own limit duration, escalation, and cleanup policy. The
+database table owns only the shared counter state. This lets the beta use
+PostgreSQL without permanently coupling the policy to it; a later distributed
+rate-limit service can implement the same interface.
+
+Set `MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET` to a stable random value of at least
+32 bytes on every server instance. Rotating it resets effective buckets and
+must therefore be treated as an intentional security operation. Raw email
+addresses, source IPs, and invitation tokens never appear in the bucket table.
+
+## Sessions and suspension
+
+Each account and session has an account session epoch. Sign-out-everywhere and
+credential recovery increment the account epoch; sessions from older epochs
+then fail without a bulk delete. Individual sessions have a revocation time,
+and accounts have a suspension time. Authentication checks must require:
+
+- no account suspension;
+- no session revocation;
+- an unexpired session;
+- matching account and session epochs.
+
+`last_seen_at` is for user-facing session inspection. It should be updated at a
+coarse interval rather than on every request to avoid a write hotspot.
+
+## Deployment
+
+Authentication schema changes are additive. Render applies them through the
+existing Connect pre-deploy migration before new application instances start.
+Old application builds ignore the added tables and columns, which preserves the
+release rollback window. Feature settings remain disabled until staging has
+completed invitation, password, replay, expiry, concurrency, and provider
+outage tests.
+
+Password signup also requires
+`MDBASE_CONNECT_TERMS_URL` and `MDBASE_CONNECT_PRIVACY_URL`. These URLs identify
+the exact documents represented by the database policy versions. Both must use
+HTTPS outside loopback development.
+
+## Operator CLI
+
+The server image contains a generic database-backed operator command. It is
+not an HTTP administration API and should run only in an authenticated
+operator shell or one-shot job with `DATABASE_URL`.
+
+Inspect the effective policy:
+
+```bash
+node services/server/dist/auth-admin-cli.js policy show
+```
+
+Create the first audited policy revision:
+
+```bash
+node services/server/dist/auth-admin-cli.js policy update \
+  --expected-revision 0 \
+  --registration invite \
+  --password-auth enabled \
+  --terms-version 2026-07-25 \
+  --privacy-version 2026-07-25 \
+  --actor operator:example \
+  --reason "Enable private beta invitations"
+```
+
+Create an invitation:
+
+```bash
+node services/server/dist/auth-admin-cli.js invite create \
+  --email person@example.com \
+  --actor operator:example \
+  --reason "Approved private beta participant"
+```
+
+To deliver the generated link through Resend in the same operation, configure
+`MDBASE_CONNECT_RESEND_API_KEY` and `MDBASE_CONNECT_EMAIL_FROM`, enable
+`email-delivery` in the audited policy, and add `--send-email enabled`. The
+transport sends both plain-text and HTML versions and uses
+`invitation/<invitation-id>` as Resend's idempotency key. If delivery fails,
+the command exits with status 2 and still writes structured sensitive output
+containing the active invitation URL, a provider error code, and whether the
+failure is retryable.
+
+Commands emit structured JSON. Policy changes use an expected revision so a
+stale operator cannot overwrite a concurrent change. Invitation output is
+sensitive: its token and URL appear once on standard output, while the database
+stores only the digest. Deployment-specific wrappers, recipient lists, and
+email-provider credentials belong in the operator's private infrastructure
+repository.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,16 +198,20 @@ remain generic; domain planning stays in the application.
 
 ## Application identity and authorization
 
-Account sign-in is separate from application authorization. External identity
-providers normalize verified identities into a shared account and session
-boundary. GitHub OAuth binds its callback to a one-time browser state and PKCE
-verifier. Google Identity Services binds its signed ID token to a one-time
-browser nonce. Provider subjects, rather than email addresses or mutable
-usernames, identify accounts. GitHub access tokens are used only to fetch the
-identity and are not retained; Google access tokens are not requested. Closed
-registration admits only configured provider subjects. Local development can
-use an explicitly enabled unverified email session; public origins refuse that
-mode.
+Account sign-in is separate from application authorization. An account may
+have external, email, password, and eventually passkey or TOTP credentials.
+Identity linking always requires fresh proof of both sides; matching email text
+never merges accounts. GitHub OAuth binds its callback to a one-time browser
+state and PKCE verifier. Google Identity Services binds its signed ID token to
+a one-time browser nonce. Provider subjects, rather than email addresses or
+mutable usernames, identify external accounts. GitHub access tokens are used
+only to fetch the identity and are not retained; Google access tokens are not
+requested. Registration supports closed, invitation-only, and open policy.
+The deployment setting is the fail-safe default, while an audited,
+revision-controlled database policy supports an immediate kill switch across
+all instances. Local development can use an explicitly enabled unverified
+email session; public origins refuse that mode. See
+[Account authentication](./account-authentication.md).
 
 Applications bundle a v1 manifest and send it inline during registration.
 Connect canonicalizes the manifest and identifies that exact content by its

--- a/docs/google-auth.md
+++ b/docs/google-auth.md
@@ -57,6 +57,19 @@ Open registration applies to every configured external provider. Do not enable
 it on the public service until the homepage, privacy policy, support contact,
 account lifecycle, monitoring, and abuse response are ready.
 
+Invitation-only registration is also available:
+
+```text
+MDBASE_CONNECT_REGISTRATION=invite
+```
+
+Invite mode does not admit an external provider merely because its verified
+email matches an invitation. Existing provider subject allowlists continue to
+work, and linking an invited email identity to Google or GitHub requires fresh
+proof of both identities. The deployment value is the fail-safe default; an
+audited database policy may change the effective mode without restarting the
+service.
+
 To bootstrap the first preview user, configure the client ID while leaving the
 Google allowlist empty. Closed registration rejects every Google account in
 that state. Attempt a sign-in, find the verified `google_subject` field in the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -33,8 +33,10 @@ ignored by Git and must not be copied into images or backups.
 
 ## DNS, TLS, and authentication
 
-Choose a public HTTPS origin such as `https://connect.example.com`. Create a
-GitHub OAuth application with:
+Choose a public HTTPS origin such as `https://connect.example.com`.
+Authentication may use GitHub, invited email/password accounts, or both.
+
+For GitHub, create an OAuth application with:
 
 - homepage: the exact Connect origin;
 - callback: `<Connect origin>/auth/github/callback`;
@@ -42,7 +44,28 @@ GitHub OAuth application with:
 
 Fill `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and
 `ALLOWED_GITHUB_USER_IDS`. The allowlist contains immutable numeric GitHub user
-IDs. Leave registration `closed` until account creation is deliberately opened.
+IDs.
+
+For password authentication, generate `AUTH_RATE_LIMIT_SECRET` and configure
+the HTTPS `TERMS_URL` and `PRIVACY_URL` published by the operator. The secret
+must be stable and identical across every Connect instance. Leave registration
+`closed` and password authentication disabled in the database until deployment
+and migration checks pass. Then use the audited operator CLI described in
+[`account-authentication.md`](./account-authentication.md) to configure document
+versions, enable invite mode, and create invitations.
+
+The optional `auth-admin` Compose profile runs the same CLI as a hardened
+one-shot container without exposing an administration endpoint. For example:
+
+```bash
+docker compose --env-file deploy/self-host/.env \
+  -f deploy/self-host/compose.yml \
+  --profile admin run --rm auth-admin policy show
+```
+
+Populate `RESEND_API_KEY` and `EMAIL_FROM` only if the operator wants
+`invite create --send-email enabled`; otherwise the CLI returns the sensitive
+invitation URL for delivery through another trusted process.
 
 The Compose stack binds application ports to host loopback. Terminate TLS in a
 reverse proxy on the same host and forward to `127.0.0.1:8787`. An example
@@ -184,7 +207,10 @@ environment and verify it first.
 - Public origins use HTTPS and resolve only to the TLS proxy.
 - Application, database, NATS, and monitoring ports are not publicly exposed.
 - Development and Tailscale authentication are disabled.
-- Registration is closed or intentionally open with abuse controls.
+- Registration is closed, invitation-only, or intentionally open with abuse
+  controls.
+- Password authentication has a stable shared rate-limit secret and current
+  legal-document URLs before it is enabled.
 - Every secret is unique, stable where required, and stored outside Git.
 - Databases have encrypted off-host backups and a tested restore procedure.
 - `/ready`, resource exhaustion, certificate expiry, and backup failures alert

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       '@nats-io/transport-node':
         specifier: ^3.4.0
         version: 3.4.0
+      '@node-rs/argon2':
+        specifier: ^2.0.2
+        version: 2.0.2
       fastify:
         specifier: ^5.10.0
         version: 5.10.0
@@ -831,6 +834,9 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -855,6 +861,97 @@ packages:
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    resolution: {integrity: sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    resolution: {integrity: sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    resolution: {integrity: sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    resolution: {integrity: sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@2.0.2':
+    resolution: {integrity: sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4622,6 +4719,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -4647,6 +4751,67 @@ snapshots:
       '@nats-io/nuid': 3.0.0
 
   '@noble/hashes@2.2.0': {}
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2@2.0.2':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 2.0.2
+      '@node-rs/argon2-android-arm64': 2.0.2
+      '@node-rs/argon2-darwin-arm64': 2.0.2
+      '@node-rs/argon2-darwin-x64': 2.0.2
+      '@node-rs/argon2-freebsd-x64': 2.0.2
+      '@node-rs/argon2-linux-arm-gnueabihf': 2.0.2
+      '@node-rs/argon2-linux-arm64-gnu': 2.0.2
+      '@node-rs/argon2-linux-arm64-musl': 2.0.2
+      '@node-rs/argon2-linux-x64-gnu': 2.0.2
+      '@node-rs/argon2-linux-x64-musl': 2.0.2
+      '@node-rs/argon2-wasm32-wasi': 2.0.2
+      '@node-rs/argon2-win32-arm64-msvc': 2.0.2
+      '@node-rs/argon2-win32-ia32-msvc': 2.0.2
+      '@node-rs/argon2-win32-x64-msvc': 2.0.2
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "auth:admin": "node dist/auth-admin-cli.js",
     "dev": "tsx watch src/index.ts",
     "migrate": "node dist/migrate.js",
     "start": "node dist/index.js",
@@ -22,6 +23,7 @@
     "@mdbase/connect-protocol": "workspace:*",
     "@mdbase/connect-sync": "workspace:*",
     "@nats-io/transport-node": "^3.4.0",
+    "@node-rs/argon2": "^2.0.2",
     "fastify": "^5.10.0",
     "google-auth-library": "^10.9.0",
     "pg": "^8.22.0",

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -31,6 +31,10 @@ import { z, ZodError } from "zod";
 import { SyncError } from "@mdbase/connect-sync";
 import type { DatabasePool, DatabaseQueryable } from "./db.js";
 import {
+  AuthRateLimiter,
+  type AuthRateLimitRule
+} from "./auth-rate-limit.js";
+import {
   ApplicationManifestError,
   registerApplicationManifest,
   type RegisteredApplicationManifest
@@ -68,13 +72,36 @@ import {
   GitHubIdentityError,
   type GitHubAuthConfig
 } from "./github-auth.js";
-import { createExternalSession } from "./external-auth.js";
+import {
+  AccountUnavailableError,
+  createExternalSession
+} from "./external-auth.js";
+import { AuthenticationPolicyStore } from "./authentication-policy.js";
+import {
+  InvalidInvitationError,
+  InvitationTargetConflictError,
+  PasswordAccountService,
+  PasswordAuthenticationUnavailableError,
+  PasswordLoginRejectedError,
+  AuthenticationPolicyIncompleteError
+} from "./password-auth.js";
+import {
+  PASSWORD_MAX_UTF8_BYTES,
+  PasswordPolicyError
+} from "./password.js";
+import {
+  InvalidEmailAddressError,
+  normalizeEmailAddress
+} from "./email-identity.js";
 import {
   GoogleIdentityError,
   verifyGoogleCredential,
   type GoogleAuthConfig
 } from "./google-auth.js";
-import type { RegistrationMode } from "./runtime-config.js";
+import type {
+  AuthenticationLegalDocuments,
+  RegistrationMode
+} from "./runtime-config.js";
 import {
   activeGrantForToken,
   NotificationService,
@@ -108,6 +135,36 @@ const OPERATIONS = [
 ] as const;
 const operationSchema = z.enum(OPERATIONS);
 const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+const PASSWORD_LOGIN_EMAIL_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 5,
+  windowSeconds: 15 * 60,
+  baseBlockSeconds: 5 * 60,
+  maxBlockSeconds: 60 * 60
+};
+const PASSWORD_LOGIN_IP_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 30,
+  windowSeconds: 15 * 60,
+  baseBlockSeconds: 5 * 60,
+  maxBlockSeconds: 60 * 60
+};
+const PASSWORD_SIGNUP_TOKEN_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 5,
+  windowSeconds: 60 * 60,
+  baseBlockSeconds: 15 * 60,
+  maxBlockSeconds: 6 * 60 * 60
+};
+const PASSWORD_SIGNUP_IP_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 10,
+  windowSeconds: 60 * 60,
+  baseBlockSeconds: 15 * 60,
+  maxBlockSeconds: 6 * 60 * 60
+};
+const PASSWORD_AUTH_GLOBAL_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 300,
+  windowSeconds: 60,
+  baseBlockSeconds: 60,
+  maxBlockSeconds: 15 * 60
+};
 const DEVICE_AUTHORIZATION_SECONDS = 600;
 const DEVICE_POLL_INTERVAL_SECONDS = 5;
 const contractRequirementSchema = z.object({
@@ -149,6 +206,8 @@ interface BuildOptions {
   githubAuth?: GitHubAuthConfig;
   googleAuth?: GoogleAuthConfig;
   registration?: RegistrationMode;
+  authRateLimitSecret?: string;
+  authenticationLegalDocuments?: AuthenticationLegalDocuments;
   hostedCollections?: boolean;
   hostedProvider?: HostedProviderClient;
   hostedReferenceAuthority?: boolean;
@@ -169,7 +228,7 @@ interface User {
   email: string | null;
   name: string;
   login: string | null;
-  authentication_provider?: "github" | "google" | "session" | "tailscale";
+  authentication_provider?: "github" | "google" | "password" | "session" | "tailscale";
 }
 
 interface ConnectorIdentity {
@@ -252,7 +311,17 @@ export async function buildApp(options: BuildOptions) {
   });
   const publicUrl = options.publicUrl ?? "http://127.0.0.1:8787";
   const revision = options.revision?.trim() || undefined;
-  const registration = options.registration ?? "closed";
+  const authenticationPolicy = new AuthenticationPolicyStore(
+    options.db,
+    options.registration ?? "closed"
+  );
+  const passwordAccounts = new PasswordAccountService(
+    options.db,
+    authenticationPolicy
+  );
+  const authenticationRateLimiter = options.authRateLimitSecret
+    ? new AuthRateLimiter(options.db, options.authRateLimitSecret)
+    : null;
   const relay = new RelayHub(options.db, options.relayBroker);
   const notifications = options.notifications
     ? new NotificationService(
@@ -358,6 +427,12 @@ export async function buildApp(options: BuildOptions) {
     if (error instanceof RequestValidationError) {
       return reply.code(400).send(apiError("invalid_request", error.message));
     }
+    if (error instanceof OriginDeniedError) {
+      return reply.code(403).send(apiError(
+        "origin_denied",
+        "The request origin is not allowed."
+      ));
+    }
     if (error instanceof RelayUnavailableError) {
       return reply.code(409).send(apiError("connector_offline", error.message));
     }
@@ -396,6 +471,49 @@ export async function buildApp(options: BuildOptions) {
         "Google sign-in could not be completed. Please try again."
       ));
     }
+    if (error instanceof AccountUnavailableError) {
+      return reply.code(403).send(apiError(
+        "account_not_allowed",
+        "This account does not have access."
+      ));
+    }
+    if (error instanceof PasswordLoginRejectedError) {
+      return reply.code(401).send(apiError(
+        "invalid_credentials",
+        "Email or password is incorrect."
+      ));
+    }
+    if (
+      error instanceof InvalidInvitationError
+      || error instanceof InvitationTargetConflictError
+    ) {
+      return reply.code(400).send(apiError(
+        "invalid_invitation",
+        "This invitation is invalid, expired, or can no longer be used."
+      ));
+    }
+    if (error instanceof PasswordPolicyError) {
+      return reply.code(400).send(apiError("invalid_password", error.message));
+    }
+    if (error instanceof InvalidEmailAddressError) {
+      return reply.code(400).send(apiError(
+        "invalid_request",
+        "Email address is invalid."
+      ));
+    }
+    if (error instanceof PasswordAuthenticationUnavailableError) {
+      return reply.code(503).send(apiError(
+        "authentication_unavailable",
+        "Password authentication is temporarily unavailable."
+      ));
+    }
+    if (error instanceof AuthenticationPolicyIncompleteError) {
+      request.log.error("Password authentication policy is incomplete");
+      return reply.code(503).send(apiError(
+        "authentication_unavailable",
+        "Password authentication is temporarily unavailable."
+      ));
+    }
     const statusCode = httpErrorStatus(error);
     if (statusCode === 413) {
       return reply.code(413).send(apiError(
@@ -432,7 +550,18 @@ export async function buildApp(options: BuildOptions) {
     }
   });
 
-  app.get("/v1/auth/config", async () => {
+  app.get("/v1/auth/config", async (_request, reply) => {
+    reply.header("cache-control", "no-store");
+    const authenticationSettings = await authenticationPolicy.current();
+    const passwordLogin =
+      authenticationSettings.passwordAuthEnabled
+      && authenticationRateLimiter !== null;
+    const passwordRegistration =
+      passwordLogin
+      && authenticationSettings.registrationMode === "invite"
+      && Boolean(authenticationSettings.termsVersion)
+      && Boolean(authenticationSettings.privacyVersion)
+      && options.authenticationLegalDocuments !== undefined;
     const providers = [
       ...(options.googleAuth
         ? [{ id: "google" as const, label: "Continue with Google", login_url: "/auth/google" }]
@@ -453,10 +582,167 @@ export async function buildApp(options: BuildOptions) {
     return {
       provider,
       providers,
-      registration,
+      registration: authenticationSettings.registrationMode,
       development_login: options.devAuth === true,
+      ...(passwordLogin
+        ? {
+            password_login: true,
+            ...(passwordRegistration
+              ? {
+                  password_registration: true,
+                  agreements: {
+                    terms: {
+                      version: authenticationSettings.termsVersion!,
+                      url: options.authenticationLegalDocuments!.termsUrl
+                    },
+                    privacy: {
+                      version: authenticationSettings.privacyVersion!,
+                      url: options.authenticationLegalDocuments!.privacyUrl
+                    }
+                  }
+                }
+              : {})
+          }
+        : {}),
       ...(providers.length === 1 ? { login_url: providers[0].login_url } : {})
     };
+  });
+
+  app.post("/v1/auth/password/signup", async (request, reply) => {
+    reply.header("cache-control", "no-store");
+    requireSameOrigin(request, publicUrl);
+    if (!authenticationRateLimiter) {
+      throw new PasswordAuthenticationUnavailableError();
+    }
+    if (!options.authenticationLegalDocuments) {
+      throw new AuthenticationPolicyIncompleteError();
+    }
+    const input = z.object({
+      invitation_token: z.string().min(1).max(200),
+      name: z.string().trim().min(1).max(100),
+      password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES),
+      terms_version: z.string().min(1).max(100),
+      privacy_version: z.string().min(1).max(100)
+    }).strict().parse(request.body);
+    const allowed = await consumeAuthenticationLimits(
+      authenticationRateLimiter,
+      [
+        {
+          scope: "password.signup.token",
+          key: input.invitation_token,
+          rule: PASSWORD_SIGNUP_TOKEN_LIMIT
+        },
+        {
+          scope: "password.signup.ip",
+          key: request.ip,
+          rule: PASSWORD_SIGNUP_IP_LIMIT
+        },
+        {
+          scope: "password.signup.global",
+          key: "global",
+          rule: PASSWORD_AUTH_GLOBAL_LIMIT
+        }
+      ],
+      reply
+    );
+    if (!allowed) return;
+    const session = await passwordAccounts.acceptInvitation({
+      invitationToken: input.invitation_token,
+      name: input.name,
+      password: input.password,
+      termsVersion: input.terms_version,
+      privacyVersion: input.privacy_version
+    });
+    setSessionCookie(reply, session.token, publicUrl);
+    return reply.code(201).send({ user: session.user });
+  });
+
+  app.post("/v1/auth/password/invitation", async (request, reply) => {
+    reply.header("cache-control", "no-store");
+    requireSameOrigin(request, publicUrl);
+    if (!authenticationRateLimiter) {
+      throw new PasswordAuthenticationUnavailableError();
+    }
+    if (!options.authenticationLegalDocuments) {
+      throw new AuthenticationPolicyIncompleteError();
+    }
+    const input = z.object({
+      invitation_token: z.string().min(1).max(200)
+    }).strict().parse(request.body);
+    const allowed = await consumeAuthenticationLimits(
+      authenticationRateLimiter,
+      [
+        {
+          scope: "password.signup.token",
+          key: input.invitation_token,
+          rule: PASSWORD_SIGNUP_TOKEN_LIMIT
+        },
+        {
+          scope: "password.signup.ip",
+          key: request.ip,
+          rule: PASSWORD_SIGNUP_IP_LIMIT
+        },
+        {
+          scope: "password.signup.global",
+          key: "global",
+          rule: PASSWORD_AUTH_GLOBAL_LIMIT
+        }
+      ],
+      reply
+    );
+    if (!allowed) return;
+    const invitation = await passwordAccounts.invitationDetails(
+      input.invitation_token
+    );
+    return {
+      invitation: {
+        email: invitation.email,
+        expires_at: invitation.expiresAt.toISOString(),
+        terms_version: invitation.termsVersion,
+        privacy_version: invitation.privacyVersion
+      }
+    };
+  });
+
+  app.post("/v1/auth/password/login", async (request, reply) => {
+    reply.header("cache-control", "no-store");
+    requireSameOrigin(request, publicUrl);
+    if (!authenticationRateLimiter) {
+      throw new PasswordAuthenticationUnavailableError();
+    }
+    const input = z.object({
+      email: z.email().max(320),
+      password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES)
+    }).strict().parse(request.body);
+    const normalizedEmail = normalizeEmailAddress(input.email);
+    const allowed = await consumeAuthenticationLimits(
+      authenticationRateLimiter,
+      [
+        {
+          scope: "password.login.email",
+          key: normalizedEmail,
+          rule: PASSWORD_LOGIN_EMAIL_LIMIT
+        },
+        {
+          scope: "password.login.ip",
+          key: request.ip,
+          rule: PASSWORD_LOGIN_IP_LIMIT
+        },
+        {
+          scope: "password.login.global",
+          key: "global",
+          rule: PASSWORD_AUTH_GLOBAL_LIMIT
+        }
+      ],
+      reply
+    );
+    if (!allowed) return;
+    const session = await passwordAccounts.authenticate({
+      email: normalizedEmail,
+      password: input.password
+    });
+    setSessionCookie(reply, session.token, publicUrl);
+    return { user: session.user };
   });
 
   app.get("/auth/github", {
@@ -466,6 +752,7 @@ export async function buildApp(options: BuildOptions) {
     const query = z.object({ return_to: z.string().max(2_048).optional() }).parse(request.query);
     const state = randomToken("oauth");
     const codeVerifier = randomToken("pkce");
+    const authenticationSettings = await authenticationPolicy.current();
     await options.db.query(
       "DELETE FROM oauth_login_states WHERE expires_at <= now() OR consumed_at IS NOT NULL"
     );
@@ -488,7 +775,10 @@ export async function buildApp(options: BuildOptions) {
     authorize.searchParams.set("state", state);
     authorize.searchParams.set("code_challenge", pkceChallenge(codeVerifier));
     authorize.searchParams.set("code_challenge_method", "S256");
-    authorize.searchParams.set("allow_signup", registration === "open" ? "true" : "false");
+    authorize.searchParams.set(
+      "allow_signup",
+      authenticationSettings.registrationMode === "open" ? "true" : "false"
+    );
     return reply.redirect(authorize.href);
   });
 
@@ -524,7 +814,12 @@ export async function buildApp(options: BuildOptions) {
     if (!/^[1-9][0-9]*$/.test(identity.id) || !identity.login || identity.login.length > 100) {
       throw new GitHubIdentityError("GitHub returned an invalid user identity.");
     }
-    if (!identityAllowed(registration, options.githubAuth.allowedUserIds, identity.id)) {
+    const authenticationSettings = await authenticationPolicy.current();
+    if (!identityAllowed(
+      authenticationSettings.registrationMode,
+      options.githubAuth.allowedUserIds,
+      identity.id
+    )) {
       request.log.warn({ github_user_id: identity.id }, "GitHub user is not on the login allowlist");
       return reply.code(403).send(apiError("account_not_allowed", "This account does not have access."));
     }
@@ -603,7 +898,12 @@ export async function buildApp(options: BuildOptions) {
     if (!/^[A-Za-z0-9_-]{1,255}$/.test(identity.id)) {
       throw new GoogleIdentityError("Google returned an invalid account subject.");
     }
-    if (!identityAllowed(registration, options.googleAuth.allowedSubjects, identity.id)) {
+    const authenticationSettings = await authenticationPolicy.current();
+    if (!identityAllowed(
+      authenticationSettings.registrationMode,
+      options.googleAuth.allowedSubjects,
+      identity.id
+    )) {
       request.log.warn({ google_subject: identity.id }, "Google user is not on the login allowlist");
       return reply.code(403).send(apiError("account_not_allowed", "This account does not have access."));
     }
@@ -1966,8 +2266,10 @@ export async function buildApp(options: BuildOptions) {
     );
     const token = randomToken("ses");
     await options.db.query(
-      `INSERT INTO sessions (id, user_id, token_hash, expires_at)
-       VALUES ($1, $2, $3, now() + interval '30 days')`,
+      `INSERT INTO sessions
+         (id, user_id, token_hash, account_session_epoch, expires_at)
+       SELECT $1, id, $3, session_epoch, now() + interval '30 days'
+       FROM users WHERE id = $2 AND suspended_at IS NULL`,
       [randomUUID(), user.rows[0].id, tokenHash(token)]
     );
     setSessionCookie(reply, token, publicUrl);
@@ -2091,12 +2393,13 @@ export async function buildApp(options: BuildOptions) {
        ORDER BY ar.expires_at`,
       [user.id]
     );
+    const authenticationSettings = await authenticationPolicy.current();
     return {
       user,
       hosted_collections_available: options.hostedCollections === true,
       authentication: {
         provider: authenticationProvider ?? (options.tailscaleAuth ? "tailscale" : "session"),
-        registration
+        registration: authenticationSettings.registrationMode
       },
       connectors: connectors.rows,
       collections: collections.rows,
@@ -6446,18 +6749,25 @@ function requiredTypeProvisions(
 }
 
 class RequestValidationError extends Error {}
+class OriginDeniedError extends Error {}
 
 async function sessionUser(request: FastifyRequest, db: DatabasePool): Promise<User | null> {
   const token = sessionToken(request);
   if (!token) return null;
   const user = await db.query<User>(
     `SELECT u.id,
-            CASE WHEN i.provider IS NULL THEN u.email ELSE i.email END AS email,
+            COALESCE(i.email, e.email, u.email) AS email,
             u.name, i.login, s.provider AS authentication_provider
      FROM sessions s
      JOIN users u ON u.id = s.user_id
      LEFT JOIN external_identities i ON i.user_id = u.id AND i.provider = s.provider
-     WHERE s.token_hash = $1 AND s.expires_at > now()`,
+     LEFT JOIN email_identities e ON e.user_id = u.id
+       AND e.is_primary = true AND e.retired_at IS NULL
+     WHERE s.token_hash = $1
+       AND s.expires_at > now()
+       AND s.revoked_at IS NULL
+       AND u.suspended_at IS NULL
+       AND s.account_session_epoch = u.session_epoch`,
     [tokenHash(token)]
   );
   return user.rows[0] ?? null;
@@ -6471,13 +6781,15 @@ async function tailscaleUser(request: FastifyRequest, db: DatabasePool): Promise
   const suppliedName = (Array.isArray(nameHeader) ? nameHeader[0] : nameHeader)?.trim();
   const fallbackName = login.split("@")[0] || login;
   const name = suppliedName && suppliedName.length <= 100 ? suppliedName : fallbackName.slice(0, 100);
-  const user = await db.query<User>(
+  const user = await db.query<User & { suspended_at: string | null }>(
     `INSERT INTO users (id, email, name) VALUES ($1, $2, $3)
      ON CONFLICT(email) DO UPDATE SET name = excluded.name
-     RETURNING id, email, name`,
+     RETURNING id, email, name, suspended_at`,
     [randomUUID(), login, name]
   );
-  return { ...user.rows[0], login: null, authentication_provider: "tailscale" };
+  if (!user.rows[0] || user.rows[0].suspended_at) return null;
+  const { suspended_at: _suspendedAt, ...activeUser } = user.rows[0];
+  return { ...activeUser, login: null, authentication_provider: "tailscale" };
 }
 
 async function authenticatedUser(
@@ -7416,6 +7728,46 @@ function identityAllowed(
   subject: string
 ): boolean {
   return registration === "open" || allowedSubjects.has(subject);
+}
+
+function requireSameOrigin(request: FastifyRequest, publicUrl: string): void {
+  if (request.headers.origin !== new URL(publicUrl).origin) {
+    throw new OriginDeniedError();
+  }
+}
+
+interface AuthenticationLimitAttempt {
+  scope: string;
+  key: string;
+  rule: AuthRateLimitRule;
+}
+
+async function consumeAuthenticationLimits(
+  limiter: AuthRateLimiter,
+  attempts: AuthenticationLimitAttempt[],
+  reply: FastifyReply
+): Promise<boolean> {
+  let retryAfterSeconds = 0;
+  for (const attempt of attempts) {
+    const decision = await limiter.consume(
+      attempt.scope,
+      attempt.key,
+      attempt.rule
+    );
+    if (!decision.allowed) {
+      retryAfterSeconds = Math.max(
+        retryAfterSeconds,
+        decision.retryAfterSeconds
+      );
+    }
+  }
+  if (retryAfterSeconds === 0) return true;
+  reply.header("retry-after", String(retryAfterSeconds));
+  await reply.code(429).send(apiError(
+    "authentication_throttled",
+    "Too many authentication attempts. Please try again later."
+  ));
+  return false;
 }
 
 function safeReturnTarget(requested: string | undefined, publicUrl: string): string {

--- a/services/server/src/auth-admin-cli.ts
+++ b/services/server/src/auth-admin-cli.ts
@@ -1,0 +1,62 @@
+import {
+  InvitationDeliveryError,
+  runAuthAdminCommand
+} from "./auth-admin.js";
+import { createDatabase } from "./db.js";
+import { ResendEmailTransport } from "./email.js";
+import type { RegistrationMode } from "./runtime-config.js";
+
+const db = await createDatabase();
+try {
+  const emailTransport = resendTransport(process.env);
+  const result = await runAuthAdminCommand(process.argv.slice(2), {
+    db,
+    defaultRegistrationMode: registrationMode(
+      process.env.MDBASE_CONNECT_REGISTRATION
+    ),
+    ...(process.env.PUBLIC_URL ? { publicUrl: process.env.PUBLIC_URL } : {}),
+    ...(emailTransport ? { emailTransport } : {})
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} catch (error) {
+  if (error instanceof InvitationDeliveryError) {
+    process.stdout.write(`${JSON.stringify(error.output, null, 2)}\n`);
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  } else {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+} finally {
+  await db.end();
+}
+
+function resendTransport(
+  env: NodeJS.ProcessEnv
+): ResendEmailTransport | null {
+  const apiKey = env.MDBASE_CONNECT_RESEND_API_KEY?.trim() ?? "";
+  const from = env.MDBASE_CONNECT_EMAIL_FROM?.trim() ?? "";
+  if (Boolean(apiKey) !== Boolean(from)) {
+    throw new Error(
+      "MDBASE_CONNECT_RESEND_API_KEY and MDBASE_CONNECT_EMAIL_FROM must be configured together."
+    );
+  }
+  return apiKey && from
+    ? new ResendEmailTransport({ apiKey, from })
+    : null;
+}
+
+function registrationMode(value: string | undefined): RegistrationMode {
+  const normalized = value?.trim() || "closed";
+  if (
+    normalized !== "closed"
+    && normalized !== "invite"
+    && normalized !== "open"
+  ) {
+    throw new Error(
+      "MDBASE_CONNECT_REGISTRATION must be closed, invite, or open."
+    );
+  }
+  return normalized;
+}

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AuthAdminUsageError,
+  InvitationDeliveryError,
+  runAuthAdminCommand
+} from "./auth-admin.js";
+import { createDatabase } from "./db.js";
+import {
+  EmailDeliveryError,
+  type EmailTransport
+} from "./email.js";
+import { tokenHash } from "./security.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("authentication operator command", () => {
+  it("updates policy with optimistic concurrency and preserves omitted settings", async () => {
+    const context = await fixture();
+    const updated = await runAuthAdminCommand([
+      "policy",
+      "update",
+      "--expected-revision",
+      "0",
+      "--registration",
+      "invite",
+      "--password-auth",
+      "enabled",
+      "--terms-version",
+      "terms-2026-07-25",
+      "--privacy-version",
+      "privacy-2026-07-25",
+      "--actor",
+      "operator:test",
+      "--reason",
+      "Enable private beta invitations"
+    ], context);
+    expect(updated).toEqual({
+      policy: expect.objectContaining({
+        revision: 1,
+        registrationMode: "invite",
+        passwordAuthEnabled: true,
+        emailDeliveryEnabled: false,
+        termsVersion: "terms-2026-07-25",
+        privacyVersion: "privacy-2026-07-25"
+      })
+    });
+    await expect(runAuthAdminCommand([
+      "policy",
+      "update",
+      "--expected-revision",
+      "0",
+      "--email-delivery",
+      "enabled",
+      "--actor",
+      "operator:stale",
+      "--reason",
+      "A stale concurrent change"
+    ], context)).rejects.toThrow(/changed before/);
+  });
+
+  it("creates a one-time invitation URL without storing the raw token", async () => {
+    const context = await fixture();
+    await configurePolicy(context);
+    const result = await runAuthAdminCommand([
+      "invite",
+      "create",
+      "--email",
+      "Person@Example.com",
+      "--actor",
+      "operator:test",
+      "--reason",
+      "Invite the first private beta account"
+    ], context) as {
+      invitation: {
+        token: string;
+        invitation_url: string;
+        email: string;
+      };
+      sensitive: boolean;
+    };
+    expect(result.sensitive).toBe(true);
+    expect(result.invitation.email).toBe("Person@Example.com");
+    expect(result.invitation.invitation_url).toBe(
+      `https://connect.example/signup#invitation=${encodeURIComponent(result.invitation.token)}`
+    );
+    const stored = await context.db.query<{ token_hash: string }>(
+      "SELECT token_hash FROM invitations"
+    );
+    expect(stored.rows[0]?.token_hash).toBe(tokenHash(result.invitation.token));
+    expect(JSON.stringify(stored.rows)).not.toContain(result.invitation.token);
+  });
+
+  it("rejects ambiguous or unsafe command input", async () => {
+    const context = await fixture();
+    await expect(runAuthAdminCommand([
+      "policy",
+      "update",
+      "--expected-revision",
+      "0",
+      "--actor",
+      "operator:test",
+      "--reason",
+      "No actual change"
+    ], context)).rejects.toThrow(/setting change/);
+    await expect(runAuthAdminCommand([
+      "invite",
+      "create",
+      "--email"
+    ], context)).rejects.toBeInstanceOf(AuthAdminUsageError);
+  });
+
+  it("delivers an invitation explicitly and reports provider failure with the recoverable token", async () => {
+    const base = await fixture();
+    await configurePolicy(base);
+    let delivered: Parameters<EmailTransport["send"]> | null = null;
+    const context = {
+      ...base,
+      emailTransport: {
+        async send(...input: Parameters<EmailTransport["send"]>) {
+          delivered = input;
+          return { provider: "test", messageId: "message-123" };
+        }
+      }
+    };
+    const result = await runAuthAdminCommand([
+      "invite",
+      "create",
+      "--email",
+      "person@example.com",
+      "--actor",
+      "operator:test",
+      "--reason",
+      "Deliver the private beta invitation",
+      "--send-email",
+      "enabled"
+    ], context) as {
+      delivery: { status: string; provider: string; message_id: string };
+    };
+    expect(result.delivery).toEqual({
+      status: "sent",
+      provider: "test",
+      message_id: "message-123"
+    });
+    expect(delivered?.[0]).toMatchObject({
+      to: "person@example.com",
+      subject: "Your mdbase connect invitation"
+    });
+    expect(delivered?.[1]).toMatch(/^invitation\//);
+    const recorded = await base.db.query<{
+      send_count: number;
+      last_sent_at: Date;
+    }>(
+      `SELECT send_count, last_sent_at FROM invitations
+       WHERE normalized_email = 'person@example.com'`
+    );
+    expect(recorded.rows[0]?.send_count).toBe(1);
+    expect(recorded.rows[0]?.last_sent_at).toBeInstanceOf(Date);
+
+    const failing = {
+      ...base,
+      emailTransport: {
+        async send() {
+          throw new EmailDeliveryError("rate_limit_exceeded", true, 429);
+        }
+      }
+    };
+    const error = await runAuthAdminCommand([
+      "invite",
+      "create",
+      "--email",
+      "second@example.com",
+      "--actor",
+      "operator:test",
+      "--reason",
+      "Exercise safe delivery failure",
+      "--send-email",
+      "enabled"
+    ], failing).catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(InvitationDeliveryError);
+    if (!(error instanceof InvitationDeliveryError)) throw error;
+    expect(error.output).toEqual(expect.objectContaining({
+      invitation: expect.objectContaining({
+        email: "second@example.com",
+        token: expect.stringMatching(/^inv_/)
+      }),
+      delivery: {
+        status: "failed",
+        code: "rate_limit_exceeded",
+        retryable: true
+      }
+    }));
+    const audit = await base.db.query<{ event_type: string }>(
+      `SELECT event_type FROM audit_events
+       WHERE event_type LIKE 'invitation.%'
+       ORDER BY created_at`
+    );
+    expect(audit.rows.map(({ event_type }) => event_type)).toEqual(
+      expect.arrayContaining([
+        "invitation.created",
+        "invitation.sent",
+        "invitation.delivery_failed"
+      ])
+    );
+  });
+});
+
+async function fixture() {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  return {
+    db,
+    defaultRegistrationMode: "closed" as const,
+    publicUrl: "https://connect.example"
+  };
+}
+
+async function configurePolicy(
+  context: Awaited<ReturnType<typeof fixture>>
+): Promise<void> {
+  await runAuthAdminCommand([
+    "policy",
+    "update",
+    "--expected-revision",
+    "0",
+    "--registration",
+    "invite",
+    "--password-auth",
+    "enabled",
+    "--email-delivery",
+    "enabled",
+    "--terms-version",
+    "terms-2026-07-25",
+    "--privacy-version",
+    "privacy-2026-07-25",
+    "--actor",
+    "operator:test",
+    "--reason",
+    "Configure invitation test"
+  ], context);
+}

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -1,0 +1,366 @@
+import type { DatabasePool } from "./db.js";
+import {
+  AuthenticationPolicyStore,
+  type AuthenticationSettings
+} from "./authentication-policy.js";
+import { PasswordAccountService } from "./password-auth.js";
+import type { RegistrationMode } from "./runtime-config.js";
+import {
+  EmailDeliveryError,
+  type EmailTransport
+} from "./email.js";
+import { sendInvitationEmail } from "./invitation-email.js";
+
+export interface AuthAdminContext {
+  db: DatabasePool;
+  defaultRegistrationMode: RegistrationMode;
+  publicUrl?: string;
+  emailTransport?: EmailTransport;
+}
+
+export async function runAuthAdminCommand(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<unknown> {
+  const [area, action, ...rest] = argv;
+  if (area === "policy" && action === "show") {
+    requireNoArguments(rest);
+    return {
+      policy: await new AuthenticationPolicyStore(
+        context.db,
+        context.defaultRegistrationMode
+      ).current()
+    };
+  }
+  if (area === "policy" && action === "update") {
+    return updatePolicy(rest, context);
+  }
+  if (area === "invite" && action === "create") {
+    return createInvitation(rest, context);
+  }
+  throw new AuthAdminUsageError(usage());
+}
+
+export class AuthAdminUsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthAdminUsageError";
+  }
+}
+
+export class InvitationDeliveryError extends Error {
+  constructor(public readonly output: unknown) {
+    super("The invitation was created, but delivery did not complete cleanly.");
+    this.name = "InvitationDeliveryError";
+  }
+}
+
+async function updatePolicy(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<{ policy: AuthenticationSettings }> {
+  const flags = parseFlags(argv, new Set([
+    "expected-revision",
+    "registration",
+    "password-auth",
+    "email-delivery",
+    "terms-version",
+    "privacy-version",
+    "actor",
+    "reason"
+  ]));
+  if (![...flags.keys()].some((name) => [
+    "registration",
+    "password-auth",
+    "email-delivery",
+    "terms-version",
+    "privacy-version"
+  ].includes(name))) {
+    throw new AuthAdminUsageError(
+      "Policy update requires at least one setting change."
+    );
+  }
+  const policy = new AuthenticationPolicyStore(
+    context.db,
+    context.defaultRegistrationMode
+  );
+  const current = await policy.current();
+  const updated = await policy.update({
+    registrationMode: flags.has("registration")
+      ? registrationMode(requiredFlag(flags, "registration"))
+      : current.registrationMode,
+    passwordAuthEnabled: flags.has("password-auth")
+      ? enabledFlag(requiredFlag(flags, "password-auth"), "password-auth")
+      : current.passwordAuthEnabled,
+    emailDeliveryEnabled: flags.has("email-delivery")
+      ? enabledFlag(requiredFlag(flags, "email-delivery"), "email-delivery")
+      : current.emailDeliveryEnabled,
+    termsVersion: flags.has("terms-version")
+      ? nullableVersion(requiredFlag(flags, "terms-version"))
+      : current.termsVersion,
+    privacyVersion: flags.has("privacy-version")
+      ? nullableVersion(requiredFlag(flags, "privacy-version"))
+      : current.privacyVersion,
+    expectedRevision: nonNegativeInteger(
+      requiredFlag(flags, "expected-revision"),
+      "expected-revision"
+    ),
+    updatedBy: requiredFlag(flags, "actor"),
+    reason: requiredFlag(flags, "reason")
+  });
+  return { policy: updated };
+}
+
+async function createInvitation(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<unknown> {
+  const flags = parseFlags(argv, new Set([
+    "email",
+    "actor",
+    "reason",
+    "expires-in",
+    "send-email"
+  ]));
+  const policy = new AuthenticationPolicyStore(
+    context.db,
+    context.defaultRegistrationMode
+  );
+  const sendEmail = flags.has("send-email")
+    && enabledFlag(requiredFlag(flags, "send-email"), "send-email");
+  if (sendEmail && !context.emailTransport) {
+    throw new AuthAdminUsageError(
+      "Email delivery requires MDBASE_CONNECT_RESEND_API_KEY and MDBASE_CONNECT_EMAIL_FROM."
+    );
+  }
+  if (sendEmail && !(await policy.current()).emailDeliveryEnabled) {
+    throw new AuthAdminUsageError(
+      "Email delivery is disabled by the current authentication policy."
+    );
+  }
+  const invitationOrigin = context.publicUrl
+    ? publicOrigin(context.publicUrl)
+    : null;
+  if (sendEmail && !invitationOrigin) {
+    throw new AuthAdminUsageError(
+      "Email delivery requires PUBLIC_URL to generate the invitation link."
+    );
+  }
+  const passwordAccounts = new PasswordAccountService(
+    context.db,
+    policy
+  );
+  const invitation = await passwordAccounts.createInvitation({
+    email: requiredFlag(flags, "email"),
+    actor: requiredFlag(flags, "actor"),
+    reason: requiredFlag(flags, "reason"),
+    ...(flags.has("expires-in")
+      ? {
+          expiresInSeconds: positiveInteger(
+            requiredFlag(flags, "expires-in"),
+            "expires-in"
+          )
+        }
+      : {})
+  });
+  const invitationPath =
+    `/signup#invitation=${encodeURIComponent(invitation.token)}`;
+  const invitationOutput = {
+    id: invitation.id,
+    email: invitation.email,
+    expires_at: invitation.expiresAt.toISOString(),
+    terms_version: invitation.termsVersion,
+    privacy_version: invitation.privacyVersion,
+    token: invitation.token,
+    invitation_path: invitationPath,
+    ...(invitationOrigin
+      ? { invitation_url: `${invitationOrigin}${invitationPath}` }
+      : {})
+  };
+  const output = {
+    invitation: {
+      ...invitationOutput
+    },
+    delivery: { status: "not_requested" as const },
+    sensitive: true,
+    notice: "The invitation token is shown once. Send it only to the intended recipient."
+  };
+  if (!sendEmail) return output;
+  const invitationUrl = "invitation_url" in invitationOutput
+    ? invitationOutput.invitation_url
+    : null;
+  if (!invitationUrl) throw new Error("Invitation URL invariant failed.");
+  let delivery: Awaited<ReturnType<typeof sendInvitationEmail>>;
+  try {
+    delivery = await sendInvitationEmail(context.emailTransport!, {
+      invitationId: invitation.id,
+      to: invitation.email,
+      invitationUrl,
+      expiresAt: invitation.expiresAt
+    });
+  } catch (error) {
+    const failure = {
+      status: "failed" as const,
+      code: error instanceof EmailDeliveryError
+        ? error.code
+        : "email_delivery_failed",
+      retryable: error instanceof EmailDeliveryError
+        ? error.retryable
+        : false
+    };
+    await passwordAccounts.recordInvitationDelivery(invitation.id, {
+      ...failure,
+      provider: "transactional_email"
+    }).catch(() => {});
+    throw new InvitationDeliveryError({
+      ...output,
+      delivery: failure
+    });
+  }
+  try {
+    await passwordAccounts.recordInvitationDelivery(invitation.id, {
+      status: "sent",
+      provider: delivery.provider,
+      messageId: delivery.messageId
+    });
+  } catch {
+    throw new InvitationDeliveryError({
+      ...output,
+      delivery: {
+        status: "sent_unrecorded",
+        provider: delivery.provider,
+        message_id: delivery.messageId,
+        retryable: false
+      }
+    });
+  }
+  return {
+    ...output,
+    delivery: {
+      status: "sent",
+      provider: delivery.provider,
+      message_id: delivery.messageId
+    }
+  };
+}
+
+function parseFlags(
+  argv: string[],
+  allowed: ReadonlySet<string>
+): Map<string, string> {
+  const flags = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const option = argv[index] ?? "";
+    const value = argv[index + 1];
+    if (!option.startsWith("--") || !value || value.startsWith("--")) {
+      throw new AuthAdminUsageError(`Expected a value after ${option || "option"}.`);
+    }
+    const name = option.slice(2);
+    if (!allowed.has(name)) {
+      throw new AuthAdminUsageError(`Unknown option: --${name}.`);
+    }
+    if (flags.has(name)) {
+      throw new AuthAdminUsageError(`Option --${name} may be supplied only once.`);
+    }
+    flags.set(name, value);
+  }
+  return flags;
+}
+
+function requiredFlag(flags: Map<string, string>, name: string): string {
+  const value = flags.get(name)?.trim();
+  if (!value) throw new AuthAdminUsageError(`Missing required option: --${name}.`);
+  return value;
+}
+
+function registrationMode(value: string): RegistrationMode {
+  if (value !== "closed" && value !== "invite" && value !== "open") {
+    throw new AuthAdminUsageError(
+      "--registration must be closed, invite, or open."
+    );
+  }
+  return value;
+}
+
+function enabledFlag(value: string, name: string): boolean {
+  if (value === "enabled") return true;
+  if (value === "disabled") return false;
+  throw new AuthAdminUsageError(`--${name} must be enabled or disabled.`);
+}
+
+function nullableVersion(value: string): string | null {
+  return value === "none" ? null : value;
+}
+
+function nonNegativeInteger(value: string, name: string): number {
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new AuthAdminUsageError(`--${name} must be a non-negative integer.`);
+  }
+  const number = Number(value);
+  if (!Number.isSafeInteger(number)) {
+    throw new AuthAdminUsageError(`--${name} is too large.`);
+  }
+  return number;
+}
+
+function positiveInteger(value: string, name: string): number {
+  const number = nonNegativeInteger(value, name);
+  if (number === 0) {
+    throw new AuthAdminUsageError(`--${name} must be greater than zero.`);
+  }
+  return number;
+}
+
+function publicOrigin(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new AuthAdminUsageError(
+      "PUBLIC_URL must be an absolute origin before an invitation URL can be generated."
+    );
+  }
+  if (
+    url.username
+    || url.password
+    || url.pathname !== "/"
+    || url.search
+    || url.hash
+  ) {
+    throw new AuthAdminUsageError(
+      "PUBLIC_URL must be an origin before an invitation URL can be generated."
+    );
+  }
+  if (
+    url.protocol !== "https:"
+    && !(
+      url.protocol === "http:"
+      && ["localhost", "127.0.0.1", "[::1]", "::1"].includes(url.hostname)
+    )
+  ) {
+    throw new AuthAdminUsageError(
+      "PUBLIC_URL must use HTTPS outside loopback development."
+    );
+  }
+  return url.origin;
+}
+
+function requireNoArguments(argv: string[]): void {
+  if (argv.length > 0) throw new AuthAdminUsageError(usage());
+}
+
+export function usage(): string {
+  return [
+    "Usage:",
+    "  auth-admin policy show",
+    "  auth-admin policy update --expected-revision <n> --actor <id> --reason <text> [changes]",
+    "  auth-admin invite create --email <address> --actor <id> --reason <text> [--expires-in <seconds>] [--send-email enabled]",
+    "",
+    "Policy changes:",
+    "  --registration closed|invite|open",
+    "  --password-auth enabled|disabled",
+    "  --email-delivery enabled|disabled",
+    "  --terms-version <version|none>",
+    "  --privacy-version <version|none>"
+  ].join("\n");
+}

--- a/services/server/src/auth-rate-limit.test.ts
+++ b/services/server/src/auth-rate-limit.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthRateLimiter } from "./auth-rate-limit.js";
+import { createDatabase } from "./db.js";
+
+const resources: Array<() => Promise<void>> = [];
+const rule = {
+  maxAttempts: 2,
+  windowSeconds: 60,
+  baseBlockSeconds: 30,
+  maxBlockSeconds: 300
+};
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("distributed authentication rate limits", () => {
+  it("shares limits through the database without storing the source key", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const firstInstance = new AuthRateLimiter(db, "a".repeat(32));
+    const secondInstance = new AuthRateLimiter(db, "a".repeat(32));
+
+    await expect(firstInstance.consume(
+      "password.email",
+      "person@example.com",
+      rule
+    )).resolves.toEqual({ allowed: true, retryAfterSeconds: 0 });
+    await expect(secondInstance.consume(
+      "password.email",
+      "person@example.com",
+      rule
+    )).resolves.toEqual({ allowed: true, retryAfterSeconds: 0 });
+    const denied = await secondInstance.consume(
+      "password.email",
+      "person@example.com",
+      rule
+    );
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThanOrEqual(29);
+
+    const stored = await db.query<{
+      key_digest: string;
+      attempt_count: number;
+      blocked_until: Date;
+    }>("SELECT key_digest, attempt_count, blocked_until FROM auth_rate_limit_buckets");
+    expect(stored.rows[0]).toMatchObject({
+      key_digest: firstInstance.keyDigest("password.email", "person@example.com"),
+      attempt_count: 3
+    });
+    expect(stored.rows[0]?.key_digest).not.toContain("person@example.com");
+    expect(stored.rows[0]?.blocked_until).toBeInstanceOf(Date);
+  });
+
+  it("does not let blocked probes extend another user's cooldown", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const limiter = new AuthRateLimiter(db, "b".repeat(32));
+    await limiter.consume("password.email", "person@example.com", rule);
+    await limiter.consume("password.email", "person@example.com", rule);
+    const denied = await limiter.consume("password.email", "person@example.com", rule);
+    const repeated = await limiter.consume("password.email", "person@example.com", rule);
+    expect(repeated).toEqual(denied);
+    const stored = await db.query<{ attempt_count: number }>(
+      "SELECT attempt_count FROM auth_rate_limit_buckets"
+    );
+    expect(stored.rows[0]?.attempt_count).toBe(3);
+  });
+
+  it("resets an elapsed window and isolates scopes", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const limiter = new AuthRateLimiter(db, "c".repeat(32));
+    await limiter.consume("password.email", "person@example.com", rule);
+    await db.query(
+      `UPDATE auth_rate_limit_buckets
+       SET window_started_at = now() - interval '2 minutes',
+           blocked_until = NULL`
+    );
+    await expect(limiter.consume(
+      "password.email",
+      "person@example.com",
+      rule
+    )).resolves.toEqual({ allowed: true, retryAfterSeconds: 0 });
+    await expect(limiter.consume(
+      "password.ip",
+      "192.0.2.0/24",
+      rule
+    )).resolves.toEqual({ allowed: true, retryAfterSeconds: 0 });
+    const buckets = await db.query<{ attempt_count: number }>(
+      "SELECT attempt_count FROM auth_rate_limit_buckets"
+    );
+    expect(buckets.rows.map(({ attempt_count }) => attempt_count).sort())
+      .toEqual([1, 1]);
+  });
+
+  it("validates secrets, scopes, and policies", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    expect(() => new AuthRateLimiter(db, "short")).toThrow(/too short/);
+    const limiter = new AuthRateLimiter(db, "d".repeat(32));
+    await expect(limiter.consume("Raw Email", "person@example.com", rule))
+      .rejects.toThrow(/scope is invalid/);
+    await expect(limiter.consume("password.email", "person@example.com", {
+      ...rule,
+      maxAttempts: 0
+    })).rejects.toThrow(/positive integer/);
+  });
+});

--- a/services/server/src/auth-rate-limit.ts
+++ b/services/server/src/auth-rate-limit.ts
@@ -1,0 +1,162 @@
+import { createHmac } from "node:crypto";
+import type { DatabasePool } from "./db.js";
+
+export interface AuthRateLimitRule {
+  maxAttempts: number;
+  windowSeconds: number;
+  baseBlockSeconds: number;
+  maxBlockSeconds: number;
+}
+
+export interface AuthRateLimitDecision {
+  allowed: boolean;
+  retryAfterSeconds: number;
+}
+
+interface RateLimitRow {
+  attempt_count: number;
+  window_started_at: Date | string;
+  blocked_until: Date | string | null;
+}
+
+export class AuthRateLimiter {
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly digestSecret: string
+  ) {
+    if (Buffer.byteLength(digestSecret, "utf8") < 32) {
+      throw new TypeError("Authentication rate-limit digest secret is too short.");
+    }
+  }
+
+  async consume(
+    scope: string,
+    key: string,
+    rule: AuthRateLimitRule
+  ): Promise<AuthRateLimitDecision> {
+    validateScope(scope);
+    validateRule(rule);
+    const keyDigest = this.keyDigest(scope, key);
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const clock = await connection.query<{ clock_now: Date }>(
+        "SELECT now() AS clock_now"
+      );
+      const now = new Date(clock.rows[0]!.clock_now);
+      // Establish the row before locking it. Concurrent first attempts then
+      // serialize on the unique key instead of both calculating attempt one
+      // from an absent row and losing an increment in the upsert.
+      await connection.query(
+        `INSERT INTO auth_rate_limit_buckets
+           (scope, key_digest, window_started_at, attempt_count, updated_at)
+         VALUES ($1, $2, $3, 0, $3)
+         ON CONFLICT(scope, key_digest) DO NOTHING`,
+        [scope, keyDigest, now]
+      );
+      const existing = await connection.query<RateLimitRow>(
+        `SELECT attempt_count, window_started_at, blocked_until
+         FROM auth_rate_limit_buckets
+         WHERE scope = $1 AND key_digest = $2
+         FOR UPDATE`,
+        [scope, keyDigest]
+      );
+      const row = existing.rows[0]!;
+      const blockedUntil = row?.blocked_until
+        ? new Date(row.blocked_until)
+        : null;
+      if (blockedUntil && blockedUntil.getTime() > now.getTime()) {
+        await connection.query("COMMIT");
+        return {
+          allowed: false,
+          retryAfterSeconds: secondsUntil(now, blockedUntil)
+        };
+      }
+
+      const windowStartedAt = new Date(row.window_started_at);
+      const windowExpired =
+        now.getTime() - windowStartedAt.getTime() >= rule.windowSeconds * 1_000;
+      const attemptCount = windowExpired ? 1 : row.attempt_count + 1;
+      const nextWindowStartedAt = windowExpired ? now : windowStartedAt;
+      const allowed = attemptCount <= rule.maxAttempts;
+      const nextBlockedUntil = allowed
+        ? null
+        : new Date(
+            now.getTime()
+            + escalatingBlockSeconds(attemptCount, rule) * 1_000
+          );
+      await connection.query(
+        `UPDATE auth_rate_limit_buckets SET
+           window_started_at = $3,
+           attempt_count = $4,
+           blocked_until = $5,
+           updated_at = $6
+         WHERE scope = $1 AND key_digest = $2`,
+        [
+          scope,
+          keyDigest,
+          nextWindowStartedAt,
+          attemptCount,
+          nextBlockedUntil,
+          now
+        ]
+      );
+      await connection.query("COMMIT");
+      return {
+        allowed,
+        retryAfterSeconds: nextBlockedUntil
+          ? secondsUntil(now, nextBlockedUntil)
+          : 0
+      };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  keyDigest(scope: string, key: string): string {
+    validateScope(scope);
+    return createHmac("sha256", this.digestSecret)
+      .update(scope)
+      .update("\0")
+      .update(key)
+      .digest("hex");
+  }
+}
+
+function escalatingBlockSeconds(
+  attemptCount: number,
+  rule: AuthRateLimitRule
+): number {
+  const excess = attemptCount - rule.maxAttempts - 1;
+  const escalation = Math.max(0, Math.floor(excess / rule.maxAttempts));
+  return Math.min(
+    rule.maxBlockSeconds,
+    rule.baseBlockSeconds * (2 ** Math.min(escalation, 20))
+  );
+}
+
+function secondsUntil(now: Date, future: Date): number {
+  return Math.max(1, Math.ceil((future.getTime() - now.getTime()) / 1_000));
+}
+
+function validateScope(scope: string): void {
+  if (!/^[a-z][a-z0-9_.:-]{0,99}$/.test(scope)) {
+    throw new TypeError("Authentication rate-limit scope is invalid.");
+  }
+}
+
+function validateRule(rule: AuthRateLimitRule): void {
+  for (const [name, value] of Object.entries(rule)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new TypeError(`Authentication rate-limit ${name} must be a positive integer.`);
+    }
+  }
+  if (rule.maxBlockSeconds < rule.baseBlockSeconds) {
+    throw new TypeError(
+      "Authentication maximum block duration cannot be shorter than its base duration."
+    );
+  }
+}

--- a/services/server/src/authentication-policy.test.ts
+++ b/services/server/src/authentication-policy.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AuthenticationPolicyStore,
+  AuthenticationSettingsConflictError
+} from "./authentication-policy.js";
+import { createDatabase } from "./db.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("authentication policy", () => {
+  it("uses deployment configuration until an audited database override exists", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const policy = new AuthenticationPolicyStore(db, "invite");
+
+    await expect(policy.current()).resolves.toEqual({
+      registrationMode: "invite",
+      passwordAuthEnabled: false,
+      emailDeliveryEnabled: false,
+      termsVersion: null,
+      privacyVersion: null,
+      revision: 0,
+      source: "runtime"
+    });
+
+    const updated = await policy.update({
+      registrationMode: "invite",
+      passwordAuthEnabled: true,
+      emailDeliveryEnabled: false,
+      termsVersion: "2026-07-28",
+      privacyVersion: "2026-07-28",
+      expectedRevision: 0,
+      updatedBy: "operator:test",
+      reason: "Enable the staging password flow"
+    });
+    expect(updated).toMatchObject({
+      registrationMode: "invite",
+      passwordAuthEnabled: true,
+      emailDeliveryEnabled: false,
+      revision: 1,
+      source: "database"
+    });
+    await expect(policy.current()).resolves.toEqual(updated);
+
+    const history = await db.query<{
+      revision: number;
+      updated_by: string;
+      update_reason: string;
+    }>("SELECT revision, updated_by, update_reason FROM authentication_settings_history");
+    expect(history.rows).toEqual([{
+      revision: 1,
+      updated_by: "operator:test",
+      update_reason: "Enable the staging password flow"
+    }]);
+  });
+
+  it("uses optimistic concurrency and preserves every successful revision", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const policy = new AuthenticationPolicyStore(db, "closed");
+    const first = await policy.update({
+      registrationMode: "closed",
+      passwordAuthEnabled: false,
+      emailDeliveryEnabled: false,
+      termsVersion: null,
+      privacyVersion: null,
+      expectedRevision: 0,
+      updatedBy: "operator:first",
+      reason: "Create the policy"
+    });
+    expect(first.revision).toBe(1);
+
+    await expect(policy.update({
+      registrationMode: "open",
+      passwordAuthEnabled: true,
+      emailDeliveryEnabled: true,
+      termsVersion: null,
+      privacyVersion: null,
+      expectedRevision: 0,
+      updatedBy: "operator:stale",
+      reason: "Stale update"
+    })).rejects.toBeInstanceOf(AuthenticationSettingsConflictError);
+
+    const second = await policy.update({
+      registrationMode: "invite",
+      passwordAuthEnabled: true,
+      emailDeliveryEnabled: true,
+      termsVersion: null,
+      privacyVersion: null,
+      expectedRevision: 1,
+      updatedBy: "operator:second",
+      reason: "Enable invited signup"
+    });
+    expect(second.revision).toBe(2);
+    const history = await db.query<{ revision: number }>(
+      "SELECT revision FROM authentication_settings_history ORDER BY revision"
+    );
+    expect(history.rows.map(({ revision }) => Number(revision))).toEqual([1, 2]);
+  });
+
+  it("requires attributable, reasoned updates", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const policy = new AuthenticationPolicyStore(db, "closed");
+    const base = {
+      registrationMode: "closed" as const,
+      passwordAuthEnabled: false,
+      emailDeliveryEnabled: false,
+      termsVersion: null,
+      privacyVersion: null,
+      expectedRevision: 0
+    };
+    await expect(policy.update({
+      ...base,
+      updatedBy: "",
+      reason: "A reason"
+    })).rejects.toThrow(/valid actor/);
+    await expect(policy.update({
+      ...base,
+      updatedBy: "operator:test",
+      reason: ""
+    })).rejects.toThrow(/concise reason/);
+    await expect(policy.update({
+      ...base,
+      registrationMode: "invalid" as never,
+      updatedBy: "operator:test",
+      reason: "Invalid mode"
+    })).rejects.toThrow(/mode is invalid/);
+  });
+});

--- a/services/server/src/authentication-policy.ts
+++ b/services/server/src/authentication-policy.ts
@@ -1,0 +1,205 @@
+import type {
+  DatabasePool,
+  DatabaseQueryable
+} from "./db.js";
+import type { RegistrationMode } from "./runtime-config.js";
+
+export interface AuthenticationSettings {
+  registrationMode: RegistrationMode;
+  passwordAuthEnabled: boolean;
+  emailDeliveryEnabled: boolean;
+  termsVersion: string | null;
+  privacyVersion: string | null;
+  revision: number;
+  source: "runtime" | "database";
+}
+
+export interface AuthenticationSettingsUpdate {
+  registrationMode: RegistrationMode;
+  passwordAuthEnabled: boolean;
+  emailDeliveryEnabled: boolean;
+  termsVersion: string | null;
+  privacyVersion: string | null;
+  expectedRevision: number;
+  updatedBy: string;
+  reason: string;
+}
+
+interface AuthenticationSettingsRow {
+  registration_mode: RegistrationMode;
+  password_auth_enabled: boolean;
+  email_delivery_enabled: boolean;
+  terms_version: string | null;
+  privacy_version: string | null;
+  revision: string | number;
+}
+
+export class AuthenticationSettingsConflictError extends Error {
+  constructor() {
+    super("Authentication settings changed before this update was applied.");
+    this.name = "AuthenticationSettingsConflictError";
+  }
+}
+
+export class AuthenticationPolicyStore {
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly defaultRegistrationMode: RegistrationMode
+  ) {}
+
+  async current(): Promise<AuthenticationSettings> {
+    return readAuthenticationSettings(this.db, this.defaultRegistrationMode);
+  }
+
+  async currentForAccountChange(
+    db: DatabaseQueryable
+  ): Promise<AuthenticationSettings> {
+    return readAuthenticationSettings(db, this.defaultRegistrationMode, true);
+  }
+
+  async update(input: AuthenticationSettingsUpdate): Promise<AuthenticationSettings> {
+    validateSettingsUpdate(input);
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const values = [
+        input.registrationMode,
+        input.passwordAuthEnabled,
+        input.emailDeliveryEnabled,
+        input.termsVersion?.trim() ?? null,
+        input.privacyVersion?.trim() ?? null,
+        input.updatedBy.trim(),
+        input.reason.trim(),
+        input.expectedRevision
+      ];
+      let result = await connection.query<AuthenticationSettingsRow>(
+        `UPDATE authentication_settings SET
+           registration_mode = $1,
+           password_auth_enabled = $2,
+           email_delivery_enabled = $3,
+           terms_version = $4,
+           privacy_version = $5,
+           revision = revision + 1,
+           updated_by = $6,
+           update_reason = $7,
+           updated_at = now()
+         WHERE singleton = true AND revision = $8
+         RETURNING registration_mode, password_auth_enabled,
+                   email_delivery_enabled, terms_version, privacy_version,
+                   revision`,
+        values
+      );
+      if (!result.rows[0] && input.expectedRevision === 0) {
+        result = await connection.query<AuthenticationSettingsRow>(
+          `INSERT INTO authentication_settings
+             (singleton, registration_mode, password_auth_enabled,
+              email_delivery_enabled, terms_version, privacy_version, revision,
+              updated_by, update_reason, updated_at)
+           VALUES (true, $1, $2, $3, $4, $5, 1, $6, $7, now())
+           ON CONFLICT(singleton) DO NOTHING
+           RETURNING registration_mode, password_auth_enabled,
+                     email_delivery_enabled, terms_version, privacy_version,
+                     revision`,
+          values.slice(0, 7)
+        );
+      }
+      const row = result.rows[0];
+      const revision = row ? Number(row.revision) : Number.NaN;
+      if (!row || revision !== input.expectedRevision + 1) {
+        await connection.query("ROLLBACK");
+        throw new AuthenticationSettingsConflictError();
+      }
+      const existingHistory = await connection.query(
+        "SELECT revision FROM authentication_settings_history WHERE revision = $1",
+        [revision]
+      );
+      if (existingHistory.rows[0]) {
+        await connection.query("ROLLBACK");
+        throw new AuthenticationSettingsConflictError();
+      }
+      await connection.query(
+        `INSERT INTO authentication_settings_history
+           (revision, registration_mode, password_auth_enabled,
+            email_delivery_enabled, terms_version, privacy_version,
+            updated_by, update_reason, updated_at)
+         SELECT revision, registration_mode, password_auth_enabled,
+                email_delivery_enabled, terms_version, privacy_version,
+                updated_by, update_reason, updated_at
+         FROM authentication_settings WHERE singleton = true`,
+      );
+      await connection.query("COMMIT");
+      return settingsFromRow(row);
+    } catch (error) {
+      if (!(error instanceof AuthenticationSettingsConflictError)) {
+        await connection.query("ROLLBACK");
+      }
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+}
+
+export async function readAuthenticationSettings(
+  db: DatabaseQueryable,
+  defaultRegistrationMode: RegistrationMode,
+  lock = false
+): Promise<AuthenticationSettings> {
+  const result = await db.query<AuthenticationSettingsRow>(
+    `SELECT registration_mode, password_auth_enabled, email_delivery_enabled,
+            terms_version, privacy_version, revision
+     FROM authentication_settings WHERE singleton = true${lock ? " FOR SHARE" : ""}`
+  );
+  return result.rows[0]
+    ? settingsFromRow(result.rows[0])
+    : {
+        registrationMode: defaultRegistrationMode,
+        passwordAuthEnabled: false,
+        emailDeliveryEnabled: false,
+        termsVersion: null,
+        privacyVersion: null,
+        revision: 0,
+        source: "runtime"
+      };
+}
+
+function settingsFromRow(row: AuthenticationSettingsRow): AuthenticationSettings {
+  return {
+    registrationMode: row.registration_mode,
+    passwordAuthEnabled: row.password_auth_enabled,
+    emailDeliveryEnabled: row.email_delivery_enabled,
+    termsVersion: row.terms_version,
+    privacyVersion: row.privacy_version,
+    revision: Number(row.revision),
+    source: "database"
+  };
+}
+
+function validateSettingsUpdate(input: AuthenticationSettingsUpdate): void {
+  if (!["closed", "invite", "open"].includes(input.registrationMode)) {
+    throw new TypeError("Authentication registration mode is invalid.");
+  }
+  if (
+    typeof input.passwordAuthEnabled !== "boolean"
+    || typeof input.emailDeliveryEnabled !== "boolean"
+  ) {
+    throw new TypeError("Authentication feature controls must be boolean.");
+  }
+  if (!Number.isSafeInteger(input.expectedRevision) || input.expectedRevision < 0) {
+    throw new TypeError("Expected authentication settings revision must be a non-negative integer.");
+  }
+  if (!input.updatedBy.trim() || input.updatedBy.trim().length > 200) {
+    throw new TypeError("Authentication settings updates require a valid actor.");
+  }
+  if (!input.reason.trim() || input.reason.trim().length > 500) {
+    throw new TypeError("Authentication settings updates require a concise reason.");
+  }
+  for (const [name, value] of [
+    ["terms", input.termsVersion],
+    ["privacy", input.privacyVersion]
+  ] as const) {
+    if (value !== null && (!value.trim() || value.trim().length > 100)) {
+      throw new TypeError(`${name} version must be null or a non-empty version identifier.`);
+    }
+  }
+}

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  backfillExternalIdentityEmails,
   backfillSessionProviders,
   createDatabase,
   revokeLegacyHostedBearerGrants
@@ -13,6 +14,234 @@ afterEach(async () => {
 });
 
 describe("database migrations", () => {
+  it("creates the authentication foundation without changing existing account data", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const userId = randomUUID();
+    const sessionId = randomUUID();
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, 'existing@example.com', 'Existing')",
+      [userId]
+    );
+    await db.query(
+      `INSERT INTO sessions (id, user_id, token_hash, expires_at)
+       VALUES ($1, $2, 'legacy-session', now() + interval '30 days')`,
+      [sessionId, userId]
+    );
+
+    const user = await db.query<{
+      email: string;
+      suspended_at: Date | null;
+      session_epoch: number;
+    }>(
+      "SELECT email, suspended_at, session_epoch FROM users WHERE id = $1",
+      [userId]
+    );
+    const session = await db.query<{
+      account_session_epoch: number;
+      revoked_at: Date | null;
+      last_seen_at: Date;
+    }>(
+      `SELECT account_session_epoch, revoked_at, last_seen_at
+       FROM sessions WHERE id = $1`,
+      [sessionId]
+    );
+    expect(user.rows[0]).toMatchObject({
+      email: "existing@example.com",
+      suspended_at: null,
+      session_epoch: 1
+    });
+    expect(session.rows[0]).toMatchObject({
+      account_session_epoch: 1,
+      revoked_at: null
+    });
+    expect(session.rows[0]?.last_seen_at).toBeInstanceOf(Date);
+
+    const authTables = await db.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_name IN (
+         'email_identities',
+         'password_credentials',
+         'invitations',
+         'authentication_challenges',
+         'auth_rate_limit_buckets',
+         'authentication_settings',
+         'authentication_settings_history',
+         'account_agreements'
+       )`
+    );
+    expect(new Set(authTables.rows.map(({ table_name }) => table_name))).toEqual(
+      new Set([
+        "email_identities",
+        "password_credentials",
+        "invitations",
+        "authentication_challenges",
+        "auth_rate_limit_buckets",
+        "authentication_settings",
+        "authentication_settings_history",
+        "account_agreements"
+      ])
+    );
+  });
+
+  it("enforces active email identity and primary identity uniqueness", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const firstUserId = randomUUID();
+    const secondUserId = randomUUID();
+    await db.query(
+      `INSERT INTO users (id, email, name)
+       VALUES ($1, NULL, 'First'), ($2, NULL, 'Second')`,
+      [firstUserId, secondUserId]
+    );
+    const firstIdentityId = randomUUID();
+    await db.query(
+      `INSERT INTO email_identities
+         (id, user_id, email, normalized_email, is_primary, verified_at)
+       VALUES ($1, $2, 'Person@example.com', 'person@example.com', true, now())`,
+      [firstIdentityId, firstUserId]
+    );
+
+    await expect(db.query(
+      `INSERT INTO email_identities
+         (id, user_id, email, normalized_email, is_primary)
+       VALUES ($1, $2, 'person@example.com', 'person@example.com', true)`,
+      [randomUUID(), secondUserId]
+    )).rejects.toThrow();
+    await expect(db.query(
+      `INSERT INTO email_identities
+         (id, user_id, email, normalized_email, is_primary)
+       VALUES ($1, $2, 'other@example.com', 'other@example.com', true)`,
+      [randomUUID(), firstUserId]
+    )).rejects.toThrow();
+
+    await db.query(
+      "UPDATE email_identities SET retired_at = now() WHERE id = $1",
+      [firstIdentityId]
+    );
+    await expect(db.query(
+      `INSERT INTO email_identities
+         (id, user_id, email, normalized_email, is_primary, verified_at)
+       VALUES ($1, $2, 'person@example.com', 'person@example.com', true, now())`,
+      [randomUUID(), secondUserId]
+    )).resolves.toBeDefined();
+  });
+
+  it("keeps one active invitation and challenge per normalized email", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const invitationId = randomUUID();
+    await db.query(
+      `INSERT INTO invitations
+         (id, email, normalized_email, token_hash, created_by, expires_at)
+       VALUES ($1, 'Person@example.com', 'person@example.com', 'invite-one',
+               'operator:test', now() + interval '7 days')`,
+      [invitationId]
+    );
+    await expect(db.query(
+      `INSERT INTO invitations
+         (id, email, normalized_email, token_hash, created_by, expires_at)
+       VALUES ($1, 'person@example.com', 'person@example.com', 'invite-two',
+               'operator:test', now() + interval '7 days')`,
+      [randomUUID()]
+    )).rejects.toThrow();
+
+    await db.query(
+      "UPDATE invitations SET revoked_at = now() WHERE id = $1",
+      [invitationId]
+    );
+    const replacementInvitationId = randomUUID();
+    await db.query(
+      `INSERT INTO invitations
+         (id, email, normalized_email, token_hash, created_by, expires_at)
+       VALUES ($1, 'person@example.com', 'person@example.com', 'invite-two',
+               'operator:test', now() + interval '7 days')`,
+      [replacementInvitationId]
+    );
+    const challengeId = randomUUID();
+    await db.query(
+      `INSERT INTO authentication_challenges
+         (id, purpose, token_hash, normalized_email, invitation_id, expires_at)
+       VALUES ($1, 'invitation_acceptance', 'challenge-one',
+               'person@example.com', $2, now() + interval '30 minutes')`,
+      [challengeId, replacementInvitationId]
+    );
+    await expect(db.query(
+      `INSERT INTO authentication_challenges
+         (id, purpose, token_hash, normalized_email, invitation_id, expires_at)
+       VALUES ($1, 'invitation_acceptance', 'challenge-two',
+               'person@example.com', $2, now() + interval '30 minutes')`,
+      [randomUUID(), replacementInvitationId]
+    )).rejects.toThrow();
+
+    await db.query(
+      "UPDATE authentication_challenges SET consumed_at = now() WHERE id = $1",
+      [challengeId]
+    );
+    await expect(db.query(
+      `INSERT INTO authentication_challenges
+         (id, purpose, token_hash, normalized_email, invitation_id, expires_at)
+       VALUES ($1, 'invitation_acceptance', 'challenge-two',
+               'person@example.com', $2, now() + interval '30 minutes')`,
+      [randomUUID(), replacementInvitationId]
+    )).resolves.toBeDefined();
+  });
+
+  it("stores versioned credentials, agreements, settings, and privacy-safe rate keys", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const userId = randomUUID();
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, NULL, 'Beta User')",
+      [userId]
+    );
+    await db.query(
+      `INSERT INTO password_credentials (user_id, password_hash)
+       VALUES ($1, '$argon2id$example')`,
+      [userId]
+    );
+    await db.query(
+      `INSERT INTO account_agreements
+         (user_id, document, version, acceptance_method)
+       VALUES ($1, 'terms', '2026-07-28', 'invitation')`,
+      [userId]
+    );
+    await db.query(
+      `INSERT INTO authentication_settings
+         (registration_mode, password_auth_enabled, email_delivery_enabled,
+          updated_by, update_reason)
+       VALUES ('invite', true, true, 'operator:test', 'staging acceptance')`
+    );
+    await db.query(
+      `INSERT INTO auth_rate_limit_buckets
+         (scope, key_digest, window_started_at, attempt_count)
+       VALUES ('signup:email', 'hmac-digest', now(), 1)`
+    );
+
+    const credential = await db.query<{ credential_version: number }>(
+      "SELECT credential_version FROM password_credentials WHERE user_id = $1",
+      [userId]
+    );
+    const settings = await db.query<{
+      registration_mode: string;
+      password_auth_enabled: boolean;
+      email_delivery_enabled: boolean;
+      revision: number;
+    }>("SELECT * FROM authentication_settings");
+    expect(credential.rows[0]?.credential_version).toBe(1);
+    expect(settings.rows[0]).toMatchObject({
+      registration_mode: "invite",
+      password_auth_enabled: true,
+      email_delivery_enabled: true,
+      revision: 1
+    });
+    await expect(db.query(
+      `INSERT INTO authentication_settings
+         (registration_mode, updated_by, update_reason)
+       VALUES ('closed', 'operator:test', 'duplicate')`
+    )).rejects.toThrow();
+  });
+
   it("backfills existing GitHub sessions with their authentication provider", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());
@@ -41,6 +270,49 @@ describe("database migrations", () => {
       [userId]
     );
     expect(session.rows[0]?.provider).toBe("github");
+  });
+
+  it("backfills only valid verified external email linking keys", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const validUserId = randomUUID();
+    const invalidUserId = randomUUID();
+    await db.query(
+      `INSERT INTO users (id, email, name)
+       VALUES ($1, NULL, 'Valid'), ($2, NULL, 'Invalid')`,
+      [validUserId, invalidUserId]
+    );
+    await db.query(
+      `INSERT INTO external_identities
+         (provider, subject, user_id, email, email_verified)
+       VALUES
+         ('google', 'valid', $1, 'Person@Example.com', true),
+         ('google', 'invalid', $2, 'not-an-email', true)`,
+      [validUserId, invalidUserId]
+    );
+
+    await backfillExternalIdentityEmails(db);
+
+    const identities = await db.query<{
+      subject: string;
+      normalized_email: string | null;
+      email_normalization_version: number | null;
+    }>(
+      `SELECT subject, normalized_email, email_normalization_version
+       FROM external_identities ORDER BY subject`
+    );
+    expect(identities.rows).toEqual([
+      {
+        subject: "invalid",
+        normalized_email: null,
+        email_normalization_version: null
+      },
+      {
+        subject: "valid",
+        normalized_email: "person@example.com",
+        email_normalization_version: 1
+      }
+    ]);
   });
 
   it("revokes legacy opaque-origin hosted grants that have no proof key", async () => {

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -1,4 +1,8 @@
 import pg, { type Pool, type QueryResult, type QueryResultRow } from "pg";
+import {
+  EMAIL_NORMALIZATION_VERSION,
+  normalizeEmailAddress
+} from "./email-identity.js";
 
 export interface DatabaseQueryable {
   query<R extends QueryResultRow = any>(text: string, values?: unknown[]): Promise<QueryResult<R>>;
@@ -41,6 +45,8 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       id uuid PRIMARY KEY,
       email text UNIQUE,
       name text NOT NULL,
+      suspended_at timestamptz,
+      session_epoch bigint NOT NULL DEFAULT 1,
       created_at timestamptz NOT NULL DEFAULT now()
     );
     CREATE TABLE IF NOT EXISTS external_identities (
@@ -50,12 +56,129 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       login text,
       email text,
       email_verified boolean NOT NULL DEFAULT false,
+      normalized_email text,
+      email_normalization_version integer,
       avatar_url text,
       last_login_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now(),
       PRIMARY KEY(provider, subject),
       UNIQUE(provider, user_id)
+    );
+    CREATE TABLE IF NOT EXISTS email_identities (
+      id uuid PRIMARY KEY,
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      email text NOT NULL,
+      normalized_email text NOT NULL,
+      normalization_version integer NOT NULL DEFAULT 1,
+      verified_at timestamptz,
+      is_primary boolean NOT NULL DEFAULT false,
+      retired_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS email_identities_active_email_idx
+      ON email_identities(normalized_email) WHERE retired_at IS NULL;
+    CREATE UNIQUE INDEX IF NOT EXISTS email_identities_primary_user_idx
+      ON email_identities(user_id) WHERE is_primary = true AND retired_at IS NULL;
+    CREATE INDEX IF NOT EXISTS email_identities_user_idx
+      ON email_identities(user_id);
+    CREATE TABLE IF NOT EXISTS password_credentials (
+      user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      password_hash text NOT NULL,
+      credential_version bigint NOT NULL DEFAULT 1,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS account_agreements (
+      user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      document text NOT NULL,
+      version text NOT NULL,
+      acceptance_method text NOT NULL,
+      accepted_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY(user_id, document, version)
+    );
+    CREATE TABLE IF NOT EXISTS invitations (
+      id uuid PRIMARY KEY,
+      email text NOT NULL,
+      normalized_email text NOT NULL,
+      token_hash text NOT NULL UNIQUE,
+      created_by text NOT NULL,
+      terms_version text,
+      privacy_version text,
+      expires_at timestamptz NOT NULL,
+      accepted_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+      accepted_at timestamptz,
+      revoked_at timestamptz,
+      revoked_by text,
+      revocation_reason text,
+      send_count integer NOT NULL DEFAULT 0,
+      last_sent_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS invitations_active_email_idx
+      ON invitations(normalized_email)
+      WHERE accepted_at IS NULL AND revoked_at IS NULL;
+    CREATE INDEX IF NOT EXISTS invitations_expiry_idx
+      ON invitations(expires_at) WHERE accepted_at IS NULL AND revoked_at IS NULL;
+    CREATE TABLE IF NOT EXISTS authentication_challenges (
+      id uuid PRIMARY KEY,
+      purpose text NOT NULL,
+      token_hash text NOT NULL UNIQUE,
+      normalized_email text NOT NULL,
+      user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+      invitation_id uuid REFERENCES invitations(id) ON DELETE CASCADE,
+      expires_at timestamptz NOT NULL,
+      consumed_at timestamptz,
+      invalidated_at timestamptz,
+      attempt_count integer NOT NULL DEFAULT 0,
+      max_attempts integer NOT NULL DEFAULT 1,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      CHECK (attempt_count >= 0),
+      CHECK (max_attempts > 0)
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS authentication_challenges_active_email_idx
+      ON authentication_challenges(purpose, normalized_email)
+      WHERE consumed_at IS NULL AND invalidated_at IS NULL;
+    CREATE INDEX IF NOT EXISTS authentication_challenges_expiry_idx
+      ON authentication_challenges(expires_at)
+      WHERE consumed_at IS NULL AND invalidated_at IS NULL;
+    CREATE TABLE IF NOT EXISTS auth_rate_limit_buckets (
+      scope text NOT NULL,
+      key_digest text NOT NULL,
+      window_started_at timestamptz NOT NULL,
+      attempt_count integer NOT NULL DEFAULT 0,
+      blocked_until timestamptz,
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY(scope, key_digest),
+      CHECK (attempt_count >= 0)
+    );
+    CREATE INDEX IF NOT EXISTS auth_rate_limit_buckets_updated_idx
+      ON auth_rate_limit_buckets(updated_at);
+    CREATE TABLE IF NOT EXISTS authentication_settings (
+      singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton = true),
+      registration_mode text NOT NULL
+        CHECK (registration_mode IN ('closed', 'invite', 'open')),
+      password_auth_enabled boolean NOT NULL DEFAULT false,
+      email_delivery_enabled boolean NOT NULL DEFAULT false,
+      terms_version text,
+      privacy_version text,
+      revision bigint NOT NULL DEFAULT 1,
+      updated_by text NOT NULL,
+      update_reason text NOT NULL,
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE TABLE IF NOT EXISTS authentication_settings_history (
+      revision bigint PRIMARY KEY,
+      registration_mode text NOT NULL
+        CHECK (registration_mode IN ('closed', 'invite', 'open')),
+      password_auth_enabled boolean NOT NULL,
+      email_delivery_enabled boolean NOT NULL,
+      terms_version text,
+      privacy_version text,
+      updated_by text NOT NULL,
+      update_reason text NOT NULL,
+      updated_at timestamptz NOT NULL
     );
     CREATE TABLE IF NOT EXISTS oauth_login_states (
       id uuid PRIMARY KEY,
@@ -72,7 +195,10 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       token_hash text NOT NULL UNIQUE,
       provider text NOT NULL DEFAULT 'session',
+      account_session_epoch bigint NOT NULL DEFAULT 1,
       expires_at timestamptz NOT NULL,
+      revoked_at timestamptz,
+      last_seen_at timestamptz NOT NULL DEFAULT now(),
       created_at timestamptz NOT NULL DEFAULT now()
     );
     CREATE TABLE IF NOT EXISTS connectors (
@@ -384,6 +510,70 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     CREATE INDEX IF NOT EXISTS notification_webhook_deliveries_ready_idx
       ON notification_webhook_deliveries(status, available_at);
   `);
+  await ensureColumn(
+    db,
+    "users",
+    "suspended_at",
+    "ALTER TABLE users ADD COLUMN suspended_at timestamptz"
+  );
+  await ensureColumn(
+    db,
+    "users",
+    "session_epoch",
+    "ALTER TABLE users ADD COLUMN session_epoch bigint NOT NULL DEFAULT 1"
+  );
+  await db.query("UPDATE users SET session_epoch = 1 WHERE session_epoch IS NULL");
+  await ensureNotNullable(db, "users", "session_epoch");
+  await ensureColumn(
+    db,
+    "sessions",
+    "account_session_epoch",
+    "ALTER TABLE sessions ADD COLUMN account_session_epoch bigint NOT NULL DEFAULT 1"
+  );
+  await db.query(
+    "UPDATE sessions SET account_session_epoch = 1 WHERE account_session_epoch IS NULL"
+  );
+  await ensureNotNullable(db, "sessions", "account_session_epoch");
+  await ensureColumn(
+    db,
+    "sessions",
+    "revoked_at",
+    "ALTER TABLE sessions ADD COLUMN revoked_at timestamptz"
+  );
+  await ensureColumn(
+    db,
+    "sessions",
+    "last_seen_at",
+    "ALTER TABLE sessions ADD COLUMN last_seen_at timestamptz NOT NULL DEFAULT now()"
+  );
+  await db.query(
+    "UPDATE sessions SET last_seen_at = created_at WHERE last_seen_at IS NULL"
+  );
+  await ensureNotNullable(db, "sessions", "last_seen_at");
+  await ensureColumn(
+    db,
+    "external_identities",
+    "email_verified",
+    "ALTER TABLE external_identities ADD COLUMN email_verified boolean NOT NULL DEFAULT false"
+  );
+  await ensureColumn(
+    db,
+    "external_identities",
+    "normalized_email",
+    "ALTER TABLE external_identities ADD COLUMN normalized_email text"
+  );
+  await ensureColumn(
+    db,
+    "external_identities",
+    "email_normalization_version",
+    "ALTER TABLE external_identities ADD COLUMN email_normalization_version integer"
+  );
+  await db.query(
+    `CREATE INDEX IF NOT EXISTS external_identities_verified_email_idx
+     ON external_identities(normalized_email)
+     WHERE email_verified = true AND normalized_email IS NOT NULL`
+  );
+  await backfillExternalIdentityEmails(db);
   const authorizationColumns = await db.query<{ column_name: string }>(
     `SELECT column_name FROM information_schema.columns
      WHERE table_name = 'authorization_requests'`
@@ -670,12 +860,6 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
     "transferred_collection_id",
     "ALTER TABLE hosted_collections ADD COLUMN transferred_collection_id uuid"
   );
-  await ensureColumn(
-    db,
-    "external_identities",
-    "email_verified",
-    "ALTER TABLE external_identities ADD COLUMN email_verified boolean NOT NULL DEFAULT false"
-  );
   await ensureColumn(db, "external_identities", "avatar_url", "ALTER TABLE external_identities ADD COLUMN avatar_url text");
   await ensureColumn(db, "external_identities", "last_login_at", "ALTER TABLE external_identities ADD COLUMN last_login_at timestamptz");
   await ensureColumn(
@@ -833,6 +1017,42 @@ export async function backfillSessionProviders(db: DatabaseQueryable): Promise<v
        AND external_identities.user_id = sessions.user_id
        AND external_identities.provider = 'github'`
   );
+}
+
+export async function backfillExternalIdentityEmails(
+  db: DatabaseQueryable
+): Promise<void> {
+  const identities = await db.query<{
+    provider: string;
+    subject: string;
+    email: string;
+  }>(
+    `SELECT provider, subject, email FROM external_identities
+     WHERE email_verified = true
+       AND email IS NOT NULL
+       AND COALESCE(normalized_email, '') = ''`
+  );
+  for (const identity of identities.rows) {
+    let normalizedEmail: string;
+    try {
+      normalizedEmail = normalizeEmailAddress(identity.email);
+    } catch {
+      // Invalid provider presentation data is not an account-linking key.
+      continue;
+    }
+    await db.query(
+      `UPDATE external_identities
+       SET normalized_email = $3, email_normalization_version = $4
+       WHERE provider = $1 AND subject = $2
+         AND COALESCE(normalized_email, '') = ''`,
+      [
+        identity.provider,
+        identity.subject,
+        normalizedEmail,
+        EMAIL_NORMALIZATION_VERSION
+      ]
+    );
+  }
 }
 
 export async function revokeLegacyHostedBearerGrants(db: DatabaseQueryable): Promise<void> {

--- a/services/server/src/email-identity.test.ts
+++ b/services/server/src/email-identity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMAIL_NORMALIZATION_VERSION,
+  InvalidEmailAddressError,
+  normalizeEmailAddress
+} from "./email-identity.js";
+
+describe("email identity normalization", () => {
+  it("uses a versioned, stable lower-case key", () => {
+    expect(EMAIL_NORMALIZATION_VERSION).toBe(1);
+    expect(normalizeEmailAddress("  Callum@MDBASE.dev ")).toBe("callum@mdbase.dev");
+  });
+
+  it("canonicalizes international domain names without provider-specific aliases", () => {
+    expect(normalizeEmailAddress("Person@BÜCHER.example")).toBe(
+      "person@xn--bcher-kva.example"
+    );
+    expect(normalizeEmailAddress("person+beta@example.com")).toBe(
+      "person+beta@example.com"
+    );
+    expect(normalizeEmailAddress("first.last@gmail.com")).not.toBe(
+      normalizeEmailAddress("firstlast@gmail.com")
+    );
+  });
+
+  it("rejects malformed or unbounded identity keys", () => {
+    for (const value of [
+      "missing-at.example",
+      "@example.com",
+      "person@",
+      "two@signs@example.com",
+      "person @example.com",
+      `${"a".repeat(310)}@example.com`
+    ]) {
+      expect(() => normalizeEmailAddress(value)).toThrow(InvalidEmailAddressError);
+    }
+  });
+});

--- a/services/server/src/email-identity.ts
+++ b/services/server/src/email-identity.ts
@@ -1,0 +1,42 @@
+import { domainToASCII } from "node:url";
+
+export const EMAIL_NORMALIZATION_VERSION = 1;
+
+/**
+ * Produces the stable account-identity key used for uniqueness and rate limits.
+ *
+ * This intentionally does not apply provider-specific rules such as removing
+ * dots or plus-tags. Those rules can make distinct mailboxes collide. Callers
+ * must still validate that the input is a syntactically valid email address.
+ */
+export function normalizeEmailAddress(value: string): string {
+  const trimmed = value.trim().normalize("NFC");
+  const separator = trimmed.lastIndexOf("@");
+  if (
+    separator <= 0
+    || separator === trimmed.length - 1
+    || trimmed.slice(0, separator).includes("@")
+  ) {
+    throw new InvalidEmailAddressError();
+  }
+
+  const localPart = trimmed.slice(0, separator).toLowerCase();
+  const domain = domainToASCII(trimmed.slice(separator + 1)).toLowerCase();
+  const normalized = `${localPart}@${domain}`;
+  if (
+    !domain
+    || /\s/u.test(normalized)
+    || normalized.length > 320
+    || Buffer.byteLength(normalized, "utf8") > 320
+  ) {
+    throw new InvalidEmailAddressError();
+  }
+  return normalized;
+}
+
+export class InvalidEmailAddressError extends Error {
+  constructor() {
+    super("Email address cannot be normalized.");
+    this.name = "InvalidEmailAddressError";
+  }
+}

--- a/services/server/src/email.test.ts
+++ b/services/server/src/email.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  EmailDeliveryError,
+  ResendEmailTransport
+} from "./email.js";
+
+const message = {
+  to: "person@example.com",
+  subject: "Your invitation",
+  text: "Use the invitation link.",
+  html: "<p>Use the invitation link.</p>"
+};
+
+describe("Resend transactional email transport", () => {
+  it("sends text and HTML with authentication, user agent, and idempotency", async () => {
+    const request = vi.fn(async () => new Response(
+      JSON.stringify({ id: "email_123" }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      }
+    ));
+    const transport = new ResendEmailTransport({
+      apiKey: "re_test_secret",
+      from: "mdbase connect <hello@mdbase.dev>",
+      fetch: request
+    });
+    await expect(transport.send(message, "invitation/example"))
+      .resolves.toEqual({
+        provider: "resend",
+        messageId: "email_123"
+      });
+    expect(request).toHaveBeenCalledOnce();
+    const [url, init] = request.mock.calls[0]!;
+    expect(url).toBe("https://api.resend.com/emails");
+    expect(init?.headers).toMatchObject({
+      authorization: "Bearer re_test_secret",
+      "content-type": "application/json",
+      "idempotency-key": "invitation/example",
+      "user-agent": "mdbase-connect/transactional-email"
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      from: "mdbase connect <hello@mdbase.dev>",
+      to: ["person@example.com"],
+      subject: message.subject,
+      text: message.text,
+      html: message.html
+    });
+  });
+
+  it("classifies retryable provider and network failures without exposing response text", async () => {
+    const provider = new ResendEmailTransport({
+      apiKey: "re_test_secret",
+      from: "hello@mdbase.dev",
+      fetch: async () => new Response(
+        JSON.stringify({
+          name: "rate_limit_exceeded",
+          message: "sensitive provider detail"
+        }),
+        {
+          status: 429,
+          headers: { "content-type": "application/json" }
+        }
+      )
+    });
+    const providerError = await provider.send(
+      message,
+      "invitation/provider-error"
+    ).catch((error: unknown) => error);
+    expect(providerError).toBeInstanceOf(EmailDeliveryError);
+    expect(providerError).toMatchObject({
+      code: "rate_limit_exceeded",
+      retryable: true,
+      status: 429
+    });
+    expect(String(providerError)).not.toContain("sensitive provider detail");
+
+    const network = new ResendEmailTransport({
+      apiKey: "re_test_secret",
+      from: "hello@mdbase.dev",
+      fetch: async () => { throw new Error("socket details"); }
+    });
+    await expect(network.send(message, "invitation/network-error"))
+      .rejects.toMatchObject({
+        code: "network_error",
+        retryable: true,
+        status: null
+      });
+  });
+
+  it("validates configuration and request metadata before network access", async () => {
+    expect(() => new ResendEmailTransport({
+      apiKey: "",
+      from: "hello@mdbase.dev"
+    })).toThrow(/API key/);
+    expect(() => new ResendEmailTransport({
+      apiKey: "re_test",
+      from: "hello@mdbase.dev\r\nBcc: other@example.com"
+    })).toThrow(/sender/);
+    const transport = new ResendEmailTransport({
+      apiKey: "re_test",
+      from: "hello@mdbase.dev",
+      fetch: async () => { throw new Error("must not be called"); }
+    });
+    await expect(transport.send(message, "")).rejects.toThrow(/idempotency/);
+  });
+});

--- a/services/server/src/email.ts
+++ b/services/server/src/email.ts
@@ -1,0 +1,145 @@
+export interface TransactionalEmail {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export interface EmailDelivery {
+  provider: string;
+  messageId: string;
+}
+
+export interface EmailTransport {
+  send(
+    message: TransactionalEmail,
+    idempotencyKey: string
+  ): Promise<EmailDelivery>;
+}
+
+export interface ResendEmailTransportOptions {
+  apiKey: string;
+  from: string;
+  fetch?: typeof fetch;
+  endpoint?: string;
+}
+
+interface ResendSuccess {
+  id?: unknown;
+}
+
+interface ResendErrorBody {
+  name?: unknown;
+}
+
+export class EmailDeliveryError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly retryable: boolean,
+    public readonly status: number | null = null
+  ) {
+    super("Transactional email delivery failed.");
+    this.name = "EmailDeliveryError";
+  }
+}
+
+export class ResendEmailTransport implements EmailTransport {
+  private readonly apiKey: string;
+  private readonly from: string;
+  private readonly fetch: typeof fetch;
+  private readonly endpoint: string;
+
+  constructor(options: ResendEmailTransportOptions) {
+    this.apiKey = options.apiKey.trim();
+    this.from = options.from.trim();
+    this.fetch = options.fetch ?? fetch;
+    this.endpoint = options.endpoint ?? "https://api.resend.com/emails";
+    if (!this.apiKey) throw new TypeError("Resend API key is required.");
+    if (!this.from || /[\r\n]/u.test(this.from)) {
+      throw new TypeError("Transactional email sender is invalid.");
+    }
+    const endpoint = new URL(this.endpoint);
+    if (
+      endpoint.username
+      || endpoint.password
+      || endpoint.search
+      || endpoint.hash
+      || (endpoint.protocol !== "https:" && !isLoopback(endpoint.hostname))
+    ) {
+      throw new TypeError("Resend email endpoint must use HTTPS.");
+    }
+  }
+
+  async send(
+    message: TransactionalEmail,
+    idempotencyKey: string
+  ): Promise<EmailDelivery> {
+    validateMessage(message);
+    validateIdempotencyKey(idempotencyKey);
+    let response: Response;
+    try {
+      response = await this.fetch(this.endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.apiKey}`,
+          "content-type": "application/json",
+          "idempotency-key": idempotencyKey,
+          "user-agent": "mdbase-connect/transactional-email"
+        },
+        body: JSON.stringify({
+          from: this.from,
+          to: [message.to],
+          subject: message.subject,
+          text: message.text,
+          html: message.html
+        }),
+        signal: AbortSignal.timeout(15_000)
+      });
+    } catch {
+      throw new EmailDeliveryError("network_error", true);
+    }
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({})) as ResendErrorBody;
+      const providerCode = typeof body.name === "string"
+        && /^[a-z0-9_]{1,100}$/u.test(body.name)
+        ? body.name
+        : `http_${response.status}`;
+      throw new EmailDeliveryError(
+        providerCode,
+        response.status === 408
+          || response.status === 409
+          || response.status === 429
+          || response.status >= 500,
+        response.status
+      );
+    }
+    const body = await response.json().catch(() => ({})) as ResendSuccess;
+    if (typeof body.id !== "string" || !body.id) {
+      throw new EmailDeliveryError("invalid_provider_response", true, response.status);
+    }
+    return { provider: "resend", messageId: body.id };
+  }
+}
+
+function validateMessage(message: TransactionalEmail): void {
+  if (
+    !message.to.trim()
+    || /[\r\n]/u.test(message.to)
+    || !message.subject.trim()
+    || /[\r\n]/u.test(message.subject)
+    || !message.text
+    || !message.html
+  ) {
+    throw new TypeError("Transactional email message is invalid.");
+  }
+}
+
+function validateIdempotencyKey(value: string): void {
+  if (!value || value.length > 256 || /[^\x21-\x7e]/u.test(value)) {
+    throw new TypeError("Email idempotency key is invalid.");
+  }
+}
+
+function isLoopback(hostname: string): boolean {
+  return ["localhost", "127.0.0.1", "[::1]", "::1"].includes(hostname);
+}

--- a/services/server/src/external-auth.test.ts
+++ b/services/server/src/external-auth.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AccountUnavailableError,
+  createExternalSession
+} from "./external-auth.js";
+import { createDatabase } from "./db.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("external account sessions", () => {
+  it("captures the account epoch and refuses sessions for suspended accounts", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const identity = {
+      provider: "google" as const,
+      subject: "subject-1",
+      name: "Beta User",
+      login: null,
+      email: "beta@example.com",
+      emailVerified: true,
+      avatarUrl: null
+    };
+    const first = await createExternalSession(db, identity);
+    const firstSession = await db.query<{
+      account_session_epoch: number;
+      revoked_at: Date | null;
+    }>(
+      `SELECT account_session_epoch, revoked_at
+       FROM sessions WHERE user_id = $1`,
+      [first.userId]
+    );
+    expect(firstSession.rows[0]).toMatchObject({
+      account_session_epoch: 1,
+      revoked_at: null
+    });
+
+    await db.query(
+      "UPDATE users SET session_epoch = session_epoch + 1 WHERE id = $1",
+      [first.userId]
+    );
+    await createExternalSession(db, identity);
+    const epochs = await db.query<{ account_session_epoch: number }>(
+      `SELECT account_session_epoch FROM sessions
+       WHERE user_id = $1 ORDER BY created_at, id`,
+      [first.userId]
+    );
+    expect(epochs.rows.map(({ account_session_epoch }) => account_session_epoch))
+      .toEqual([1, 2]);
+
+    await db.query(
+      "UPDATE users SET suspended_at = now() WHERE id = $1",
+      [first.userId]
+    );
+    await expect(createExternalSession(db, identity))
+      .rejects.toBeInstanceOf(AccountUnavailableError);
+    const count = await db.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM sessions WHERE user_id = $1",
+      [first.userId]
+    );
+    expect(count.rows[0]?.count).toBe("2");
+  });
+});

--- a/services/server/src/external-auth.ts
+++ b/services/server/src/external-auth.ts
@@ -1,5 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { DatabasePool } from "./db.js";
+import {
+  EMAIL_NORMALIZATION_VERSION,
+  normalizeEmailAddress
+} from "./email-identity.js";
 import { randomToken, tokenHash } from "./security.js";
 
 export type ExternalProvider = "github" | "google";
@@ -19,11 +23,19 @@ export interface ExternalSession {
   userId: string;
 }
 
+export class AccountUnavailableError extends Error {
+  constructor() {
+    super("Account is unavailable.");
+    this.name = "AccountUnavailableError";
+  }
+}
+
 export async function createExternalSession(
   db: DatabasePool,
   identity: VerifiedExternalIdentity
 ): Promise<ExternalSession> {
   const token = randomToken("ses");
+  const normalizedEmail = normalizedVerifiedEmail(identity);
   const connection = await db.connect();
   try {
     await connection.query("BEGIN");
@@ -42,12 +54,15 @@ export async function createExternalSession(
     }
     await connection.query(
       `INSERT INTO external_identities
-         (provider, subject, user_id, login, email, email_verified, avatar_url, last_login_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+         (provider, subject, user_id, login, email, email_verified,
+          normalized_email, email_normalization_version, avatar_url, last_login_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
        ON CONFLICT(provider, subject) DO UPDATE SET
          login = excluded.login,
          email = excluded.email,
          email_verified = excluded.email_verified,
+         normalized_email = excluded.normalized_email,
+         email_normalization_version = excluded.email_normalization_version,
          avatar_url = excluded.avatar_url,
          last_login_at = now(),
          updated_at = now()`,
@@ -58,15 +73,21 @@ export async function createExternalSession(
         identity.login,
         identity.email,
         identity.emailVerified,
+        normalizedEmail,
+        normalizedEmail ? EMAIL_NORMALIZATION_VERSION : null,
         identity.avatarUrl
       ]
     );
     await connection.query("DELETE FROM sessions WHERE expires_at <= now()");
-    await connection.query(
-      `INSERT INTO sessions (id, user_id, token_hash, provider, expires_at)
-       VALUES ($1, $2, $3, $4, now() + interval '30 days')`,
+    const createdSession = await connection.query(
+      `INSERT INTO sessions
+         (id, user_id, token_hash, provider, account_session_epoch, expires_at)
+       SELECT $1, id, $3, $4, session_epoch, now() + interval '30 days'
+       FROM users WHERE id = $2 AND suspended_at IS NULL
+       RETURNING id`,
       [randomUUID(), userId, tokenHash(token), identity.provider]
     );
+    if (!createdSession.rows[0]) throw new AccountUnavailableError();
     await connection.query(
       `INSERT INTO audit_events (id, user_id, event_type, subject_id, metadata)
        VALUES ($1, $2, 'session.created', NULL, $3::jsonb)`,
@@ -79,6 +100,15 @@ export async function createExternalSession(
     throw error;
   } finally {
     connection.release();
+  }
+}
+
+function normalizedVerifiedEmail(identity: VerifiedExternalIdentity): string | null {
+  if (!identity.emailVerified || !identity.email) return null;
+  try {
+    return normalizeEmailAddress(identity.email);
+  } catch {
+    return null;
   }
 }
 

--- a/services/server/src/google-auth.test.ts
+++ b/services/server/src/google-auth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OAuth2Client } from "google-auth-library";
 import { buildApp } from "./app.js";
+import { AuthenticationPolicyStore } from "./authentication-policy.js";
 import { createDatabase } from "./db.js";
 import {
   GoogleIdentityError,
@@ -140,7 +141,7 @@ describe("Google authentication", () => {
     expect(verifyCredential).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps closed registration allowlisted and permits explicit open registration", async () => {
+  it("keeps closed registration allowlisted and applies an audited policy change without restart", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());
     const identity = {
@@ -165,19 +166,22 @@ describe("Google authentication", () => {
     expect(denied.statusCode).toBe(403);
     expect((await db.query("SELECT id FROM users")).rows).toHaveLength(0);
 
-    const { app: open } = await buildApp({
-      db,
-      publicUrl: "https://connect.example",
-      registration: "open",
-      googleAuth: {
-        clientId: "google-client.apps.googleusercontent.com",
-        allowedSubjects: new Set(),
-        verifyCredential: async () => identity
-      }
+    const policy = new AuthenticationPolicyStore(db, "closed");
+    await policy.update({
+      registrationMode: "open",
+      passwordAuthEnabled: false,
+      emailDeliveryEnabled: false,
+      termsVersion: null,
+      privacyVersion: null,
+      expectedRevision: 0,
+      updatedBy: "operator:test",
+      reason: "Exercise dynamic registration"
     });
-    resources.push(() => open.close());
-    const openStart = await open.inject({ method: "GET", url: "/auth/google" });
-    const admitted = await googleCallback(open, openStart);
+    const config = await closed.inject({ method: "GET", url: "/v1/auth/config" });
+    expect(config.json().registration).toBe("open");
+
+    const openStart = await closed.inject({ method: "GET", url: "/auth/google" });
+    const admitted = await googleCallback(closed, openStart);
     expect(admitted.statusCode).toBe(200);
     expect((await db.query("SELECT id FROM users")).rows).toHaveLength(1);
   });

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -23,6 +23,9 @@ const { app } = await buildApp({
   githubAuth: runtime.githubAuth ?? undefined,
   googleAuth: runtime.googleAuth ?? undefined,
   registration: runtime.registration,
+  authRateLimitSecret: runtime.authRateLimitSecret ?? undefined,
+  authenticationLegalDocuments:
+    runtime.authenticationLegalDocuments ?? undefined,
   hostedCollections: runtime.hostedCollections,
   hostedProvider: runtime.hostedProvider
     ? new HostedProviderClient(runtime.hostedProvider)

--- a/services/server/src/invitation-email.test.ts
+++ b/services/server/src/invitation-email.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EmailTransport } from "./email.js";
+import {
+  renderInvitationEmail,
+  sendInvitationEmail
+} from "./invitation-email.js";
+
+const invitation = {
+  invitationId: "3e74e919-fc87-4e90-ad93-05d40464ecac",
+  to: "person@example.com",
+  invitationUrl:
+    "https://connect.mdbase.dev/signup#invitation=inv_abcdefghijklmnopqrstuvwxyz0123456789ABCDE",
+  expiresAt: new Date("2026-08-04T02:30:00.000Z")
+};
+
+describe("invitation email", () => {
+  it("renders restrained text and HTML versions with the same account action", () => {
+    const rendered = renderInvitationEmail(invitation);
+    expect(rendered.subject).toBe("Your mdbase connect invitation");
+    expect(rendered.text).toContain(invitation.to);
+    expect(rendered.text).toContain(invitation.invitationUrl);
+    expect(rendered.text).toContain("one-time invitation");
+    expect(rendered.html).toContain("Create your account");
+    expect(rendered.html).toContain(invitation.invitationUrl);
+    expect(rendered.html).not.toContain("<script");
+  });
+
+  it("escapes recipient presentation and rejects unsafe invitation links", () => {
+    const rendered = renderInvitationEmail({
+      ...invitation,
+      to: `person@example.com"><img src=x onerror=alert(1)>`
+    });
+    expect(rendered.html).not.toContain("<img");
+    expect(rendered.html).toContain("&quot;&gt;&lt;img");
+    expect(() => renderInvitationEmail({
+      ...invitation,
+      invitationUrl:
+        "http://connect.example/signup#invitation=inv_abcdefghijklmnopqrstuvwxyz"
+    })).toThrow(/URL is invalid/);
+  });
+
+  it("uses the invitation identity as the provider idempotency key", async () => {
+    const send = vi.fn(async () => ({
+      provider: "test",
+      messageId: "message-1"
+    }));
+    const transport: EmailTransport = { send };
+    await expect(sendInvitationEmail(transport, invitation)).resolves.toEqual({
+      provider: "test",
+      messageId: "message-1"
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: invitation.to,
+        subject: "Your mdbase connect invitation"
+      }),
+      `invitation/${invitation.invitationId}`
+    );
+  });
+});

--- a/services/server/src/invitation-email.ts
+++ b/services/server/src/invitation-email.ts
@@ -1,0 +1,125 @@
+import type {
+  EmailDelivery,
+  EmailTransport,
+  TransactionalEmail
+} from "./email.js";
+
+export interface InvitationEmailInput {
+  invitationId: string;
+  to: string;
+  invitationUrl: string;
+  expiresAt: Date;
+}
+
+export function renderInvitationEmail(
+  input: Omit<InvitationEmailInput, "invitationId">
+): TransactionalEmail {
+  const invitationUrl = safeInvitationUrl(input.invitationUrl);
+  const expiry = new Intl.DateTimeFormat("en-AU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short"
+  }).format(input.expiresAt);
+  const escapedUrl = escapeHtml(invitationUrl);
+  const escapedEmail = escapeHtml(input.to);
+  const escapedExpiry = escapeHtml(expiry);
+  return {
+    to: input.to,
+    subject: "Your mdbase connect invitation",
+    text: [
+      "mdbase connect",
+      "",
+      "You’re invited to the private preview.",
+      "",
+      `Create the account for ${input.to}:`,
+      invitationUrl,
+      "",
+      `This one-time invitation expires ${expiry}.`,
+      "",
+      "If you weren’t expecting this invitation, you can ignore this email.",
+      "",
+      "mdbase connect gives applications access to the Markdown collections you choose."
+    ].join("\n"),
+    html: `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Your mdbase connect invitation</title>
+</head>
+<body style="margin:0;background:#f8f9fa;color:#222831;font-family:Arial,sans-serif">
+  <div style="display:none;max-height:0;overflow:hidden">Create your invited mdbase connect account.</div>
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f8f9fa">
+    <tr>
+      <td align="center" style="padding:40px 20px">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #dfe3e8">
+          <tr>
+            <td style="padding:30px 34px 12px;color:#59636f;font-family:monospace;font-size:13px">mdbase&nbsp;&nbsp;connect</td>
+          </tr>
+          <tr>
+            <td style="padding:12px 34px 34px">
+              <h1 style="margin:0 0 16px;font-size:27px;line-height:1.2;color:#222831">You’re invited.</h1>
+              <p style="margin:0 0 20px;font-size:16px;line-height:1.55;color:#46515d">Create the private-preview account for <strong>${escapedEmail}</strong>. Your email is verified by this one-time link.</p>
+              <p style="margin:0 0 24px">
+                <a href="${escapedUrl}" style="display:inline-block;padding:11px 16px;border:1px solid #8f99a5;border-radius:4px;color:#1d5f87;font-family:monospace;font-size:13px;font-weight:bold;text-decoration:none">Create your account</a>
+              </p>
+              <p style="margin:0 0 9px;font-size:13px;line-height:1.5;color:#66717c">This invitation expires ${escapedExpiry}.</p>
+              <p style="margin:0;font-size:13px;line-height:1.5;color:#66717c">If you weren’t expecting it, you can ignore this email.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:22px 34px;border-top:1px solid #e5e8ec;font-size:12px;line-height:1.5;color:#7a838d">mdbase connect gives applications access to the Markdown collections you choose.</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+  };
+}
+
+export async function sendInvitationEmail(
+  transport: EmailTransport,
+  input: InvitationEmailInput
+): Promise<EmailDelivery> {
+  return transport.send(
+    renderInvitationEmail(input),
+    `invitation/${input.invitationId}`
+  );
+}
+
+function safeInvitationUrl(value: string): string {
+  const url = new URL(value);
+  const fragment = new URLSearchParams(url.hash.slice(1));
+  const token = fragment.get("invitation") ?? "";
+  if (
+    url.username
+    || url.password
+    || url.pathname !== "/signup"
+    || url.search
+    || [...fragment.keys()].some((key) => key !== "invitation")
+    || !/^inv_[A-Za-z0-9_-]{32,196}$/u.test(token)
+    || (url.protocol !== "https:" && !isLoopback(url.hostname))
+  ) {
+    throw new TypeError("Invitation email URL is invalid.");
+  }
+  return url.href;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function isLoopback(hostname: string): boolean {
+  return ["localhost", "127.0.0.1", "[::1]", "::1"].includes(hostname);
+}

--- a/services/server/src/password-auth-routes.test.ts
+++ b/services/server/src/password-auth-routes.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "./app.js";
+import { AuthenticationPolicyStore } from "./authentication-policy.js";
+import { createDatabase } from "./db.js";
+import { PasswordAccountService } from "./password-auth.js";
+
+const resources: Array<() => Promise<void>> = [];
+const origin = "https://connect.example";
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("password authentication HTTP boundary", () => {
+  it("requires same-origin invitation acceptance and creates a usable secure session", async () => {
+    const { app, db, invitation } = await fixture();
+    const config = await app.inject({ method: "GET", url: "/v1/auth/config" });
+    expect(config.headers["cache-control"]).toBe("no-store");
+    expect(config.json()).toMatchObject({
+      registration: "invite",
+      password_login: true,
+      password_registration: true,
+      agreements: {
+        terms: {
+          version: invitation.termsVersion,
+          url: "https://mdbase.dev/terms/"
+        },
+        privacy: {
+          version: invitation.privacyVersion,
+          url: "https://mdbase.dev/privacy/"
+        }
+      }
+    });
+    const payload = {
+      invitation_token: invitation.token,
+      name: "Person Example",
+      password: "a durable private beta password",
+      terms_version: invitation.termsVersion,
+      privacy_version: invitation.privacyVersion
+    };
+    const preview = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/invitation",
+      headers: { origin },
+      payload: { invitation_token: invitation.token }
+    });
+    expect(preview.statusCode).toBe(200);
+    expect(preview.headers["cache-control"]).toBe("no-store");
+    expect(preview.json().invitation).toMatchObject({
+      email: "person@example.com",
+      terms_version: invitation.termsVersion,
+      privacy_version: invitation.privacyVersion
+    });
+    expect(preview.json().invitation.expires_at).toMatch(/Z$/);
+    const crossOrigin = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/signup",
+      headers: { origin: "https://evil.example" },
+      payload
+    });
+    expect(crossOrigin.statusCode).toBe(403);
+    expect(crossOrigin.json().error.code).toBe("origin_denied");
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/signup",
+      headers: { origin },
+      payload
+    });
+    expect(accepted.statusCode).toBe(201);
+    expect(accepted.json().user).toMatchObject({
+      email: "person@example.com",
+      name: "Person Example"
+    });
+    const sessionCookie = accepted.cookies.find(
+      ({ name }) => name === "__Host-mdbase_session"
+    );
+    expect(sessionCookie).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax"
+    });
+
+    const me = await app.inject({
+      method: "GET",
+      url: "/v1/me",
+      headers: {
+        cookie: `${sessionCookie!.name}=${sessionCookie!.value}`
+      }
+    });
+    expect(me.statusCode).toBe(200);
+    expect(me.json()).toEqual(expect.objectContaining({
+      user: expect.objectContaining({
+        email: "person@example.com",
+        name: "Person Example"
+      }),
+      authentication: {
+        provider: "password",
+        registration: "invite"
+      }
+    }));
+    const rawLimits = JSON.stringify(
+      (await db.query("SELECT * FROM auth_rate_limit_buckets")).rows
+    );
+    expect(rawLimits).not.toContain(invitation.token);
+  });
+
+  it("returns the same login failure for unknown, incorrect, and suspended accounts", async () => {
+    const { app, db, invitation } = await fixture();
+    const signup = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/signup",
+      headers: { origin },
+      payload: {
+        invitation_token: invitation.token,
+        name: "Person Example",
+        password: "a durable private beta password",
+        terms_version: invitation.termsVersion,
+        privacy_version: invitation.privacyVersion
+      }
+    });
+    expect(signup.statusCode).toBe(201);
+
+    const wrong = await login(app, "person@example.com", "the wrong beta password");
+    const unknown = await login(app, "unknown@example.com", "the wrong beta password");
+    expect(wrong.statusCode).toBe(401);
+    expect(unknown.statusCode).toBe(401);
+    expect(wrong.json()).toEqual(unknown.json());
+
+    await db.query(
+      `UPDATE users SET suspended_at = now()
+       WHERE id = (SELECT user_id FROM email_identities
+                   WHERE normalized_email = 'person@example.com')`
+    );
+    const suspended = await login(
+      app,
+      "person@example.com",
+      "a durable private beta password"
+    );
+    expect(suspended.statusCode).toBe(401);
+    expect(suspended.json()).toEqual(unknown.json());
+  });
+
+  it("does not reveal why an invitation cannot be used", async () => {
+    const { app, passwordAccounts, invitation } = await fixture();
+    const unknown = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/invitation",
+      headers: { origin },
+      payload: { invitation_token: "inv_unknown" }
+    });
+    expect(unknown.statusCode).toBe(400);
+    await passwordAccounts.createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Reissue the HTTP test invitation"
+    });
+    const revoked = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/invitation",
+      headers: { origin },
+      payload: { invitation_token: invitation.token }
+    });
+    expect(revoked.statusCode).toBe(400);
+    expect(revoked.json()).toEqual(unknown.json());
+  });
+
+  it("enforces shared email limits and stores only keyed digests", async () => {
+    const { app, db } = await fixture();
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const response = await login(
+        app,
+        "unknown@example.com",
+        "the wrong beta password"
+      );
+      expect(response.statusCode).toBe(401);
+    }
+    const throttled = await login(
+      app,
+      "UNKNOWN@example.com",
+      "the wrong beta password"
+    );
+    expect(throttled.statusCode).toBe(429);
+    expect(throttled.headers["retry-after"]).toMatch(/^[1-9][0-9]*$/);
+    expect(throttled.json().error.code).toBe("authentication_throttled");
+
+    const buckets = await db.query<{ key_digest: string }>(
+      "SELECT key_digest FROM auth_rate_limit_buckets"
+    );
+    expect(buckets.rows.length).toBeGreaterThan(0);
+    expect(JSON.stringify(buckets.rows)).not.toContain("unknown@example.com");
+  });
+
+  it("does not advertise or execute password auth without the shared limit secret", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const policy = await configurePolicy(db);
+    const passwordAccounts = new PasswordAccountService(db, policy);
+    const invitation = await passwordAccounts.createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Missing limiter configuration"
+    });
+    const { app } = await buildApp({ db, publicUrl: origin });
+    resources.push(() => app.close());
+    const config = await app.inject({ method: "GET", url: "/v1/auth/config" });
+    expect(config.json().password_login).toBeUndefined();
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/auth/password/signup",
+      headers: { origin },
+      payload: {
+        invitation_token: invitation.token,
+        name: "Person Example",
+        password: "a durable private beta password",
+        terms_version: invitation.termsVersion,
+        privacy_version: invitation.privacyVersion
+      }
+    });
+    expect(response.statusCode).toBe(503);
+    expect(response.json().error.code).toBe("authentication_unavailable");
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(0);
+  });
+
+  it("keeps registration unavailable when legal documents are missing or mode is open", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const policy = await configurePolicy(db);
+    const invitation = await new PasswordAccountService(
+      db,
+      policy
+    ).createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Incomplete registration configuration"
+    });
+    const withoutDocuments = await buildApp({
+      db,
+      publicUrl: origin,
+      authRateLimitSecret: "test-auth-rate-limit-secret-value"
+    });
+    resources.push(() => withoutDocuments.app.close());
+    const incompleteConfig = await withoutDocuments.app.inject({
+      method: "GET",
+      url: "/v1/auth/config"
+    });
+    expect(incompleteConfig.json().password_login).toBe(true);
+    expect(incompleteConfig.json().password_registration).toBeUndefined();
+    const incompleteSignup = await withoutDocuments.app.inject({
+      method: "POST",
+      url: "/v1/auth/password/signup",
+      headers: { origin },
+      payload: {
+        invitation_token: invitation.token,
+        name: "Person Example",
+        password: "a durable private beta password",
+        terms_version: invitation.termsVersion,
+        privacy_version: invitation.privacyVersion
+      }
+    });
+    expect(incompleteSignup.statusCode).toBe(503);
+
+    await policy.update({
+      registrationMode: "open",
+      passwordAuthEnabled: true,
+      emailDeliveryEnabled: false,
+      termsVersion: invitation.termsVersion,
+      privacyVersion: invitation.privacyVersion,
+      expectedRevision: 1,
+      updatedBy: "operator:test",
+      reason: "Verify open mode cannot bypass email verification"
+    });
+    const withDocuments = await buildApp({
+      db,
+      publicUrl: origin,
+      authRateLimitSecret: "test-auth-rate-limit-secret-value",
+      authenticationLegalDocuments: {
+        termsUrl: "https://mdbase.dev/terms/",
+        privacyUrl: "https://mdbase.dev/privacy/"
+      }
+    });
+    resources.push(() => withDocuments.app.close());
+    const openConfig = await withDocuments.app.inject({
+      method: "GET",
+      url: "/v1/auth/config"
+    });
+    expect(openConfig.json().registration).toBe("open");
+    expect(openConfig.json().password_login).toBe(true);
+    expect(openConfig.json().password_registration).toBeUndefined();
+    const openSignup = await withDocuments.app.inject({
+      method: "POST",
+      url: "/v1/auth/password/signup",
+      headers: { origin },
+      payload: {
+        invitation_token: invitation.token,
+        name: "Person Example",
+        password: "a durable private beta password",
+        terms_version: invitation.termsVersion,
+        privacy_version: invitation.privacyVersion
+      }
+    });
+    expect(openSignup.statusCode).toBe(503);
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(0);
+  });
+});
+
+async function fixture() {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  const policy = await configurePolicy(db);
+  const passwordAccounts = new PasswordAccountService(db, policy);
+  const invitation = await passwordAccounts.createInvitation({
+    email: "person@example.com",
+    actor: "operator:test",
+    reason: "HTTP authentication test"
+  });
+  const { app } = await buildApp({
+    db,
+    publicUrl: origin,
+    authRateLimitSecret: "test-auth-rate-limit-secret-value",
+    authenticationLegalDocuments: {
+      termsUrl: "https://mdbase.dev/terms/",
+      privacyUrl: "https://mdbase.dev/privacy/"
+    }
+  });
+  resources.push(() => app.close());
+  return { app, db, policy, passwordAccounts, invitation };
+}
+
+async function configurePolicy(db: Awaited<ReturnType<typeof createDatabase>>) {
+  const policy = new AuthenticationPolicyStore(db, "closed");
+  await policy.update({
+    registrationMode: "invite",
+    passwordAuthEnabled: true,
+    emailDeliveryEnabled: false,
+    termsVersion: "terms-2026-07",
+    privacyVersion: "privacy-2026-07",
+    expectedRevision: 0,
+    updatedBy: "operator:test",
+    reason: "Configure password route tests"
+  });
+  return policy;
+}
+
+async function login(
+  app: Awaited<ReturnType<typeof buildApp>>["app"],
+  email: string,
+  password: string
+) {
+  return app.inject({
+    method: "POST",
+    url: "/v1/auth/password/login",
+    headers: { origin },
+    payload: { email, password }
+  });
+}

--- a/services/server/src/password-auth.test.ts
+++ b/services/server/src/password-auth.test.ts
@@ -1,0 +1,383 @@
+import { randomUUID } from "node:crypto";
+import { hash } from "@node-rs/argon2";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthenticationPolicyStore } from "./authentication-policy.js";
+import { createDatabase, type DatabasePool } from "./db.js";
+import { createExternalSession } from "./external-auth.js";
+import {
+  InvalidInvitationError,
+  InvitationTargetConflictError,
+  PasswordAccountService,
+  PasswordAuthenticationUnavailableError,
+  PasswordLoginRejectedError
+} from "./password-auth.js";
+import { tokenHash } from "./security.js";
+import {
+  PASSWORD_HASH_PARAMETERS,
+  passwordHashNeedsUpgrade
+} from "./password.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("invite-only password accounts", () => {
+  it("issues only one active hashed invitation for a new identity", async () => {
+    const { db, service } = await fixture();
+    const first = await service.createInvitation({
+      email: "  Person@Example.com ",
+      actor: "operator:test",
+      reason: "Private beta"
+    });
+    expect(first).toMatchObject({
+      email: "Person@Example.com",
+      termsVersion: "terms-2026-07",
+      privacyVersion: "privacy-2026-07"
+    });
+    expect(first.token).toMatch(/^inv_/);
+    const stored = await db.query<{
+      normalized_email: string;
+      token_hash: string;
+      revoked_at: Date | null;
+    }>(
+      `SELECT normalized_email, token_hash, revoked_at
+       FROM invitations WHERE id = $1`,
+      [first.id]
+    );
+    expect(stored.rows[0]).toMatchObject({
+      normalized_email: "person@example.com",
+      token_hash: tokenHash(first.token),
+      revoked_at: null
+    });
+    expect(JSON.stringify(stored.rows[0])).not.toContain(first.token);
+
+    const replacement = await service.createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Replace a lost invitation"
+    });
+    expect(replacement.id).not.toBe(first.id);
+    const invitations = await db.query<{
+      id: string;
+      normalized_email: string;
+      revoked_at: Date | null;
+    }>(
+      "SELECT id, normalized_email, revoked_at FROM invitations"
+    );
+    const matchingInvitations = invitations.rows.filter(
+      ({ normalized_email }) => normalized_email === "person@example.com"
+    );
+    expect(matchingInvitations).toHaveLength(2);
+    expect(matchingInvitations.find(({ id }) => id === first.id)?.revoked_at)
+      .not.toBeNull();
+    expect(matchingInvitations.find(({ id }) => id === replacement.id)?.revoked_at)
+      .toBeNull();
+  });
+
+  it("atomically creates a verified account, credential, agreements, and session", async () => {
+    const { db, service } = await fixture();
+    const invitation = await service.createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Private beta"
+    });
+    const accepted = await service.acceptInvitation({
+      invitationToken: invitation.token,
+      name: "Person Example",
+      password: "a durable private beta password",
+      termsVersion: invitation.termsVersion,
+      privacyVersion: invitation.privacyVersion
+    });
+    expect(accepted.user).toMatchObject({
+      email: "person@example.com",
+      name: "Person Example"
+    });
+    expect(accepted.token).toMatch(/^ses_/);
+
+    const account = await db.query<{
+      account_email: string | null;
+      identity_email: string;
+      normalized_email: string;
+      verified_at: Date;
+      is_primary: boolean;
+      password_hash: string;
+      provider: string;
+      token_hash: string;
+    }>(
+      `SELECT u.email AS account_email, e.email AS identity_email,
+              e.normalized_email, e.verified_at, e.is_primary,
+              p.password_hash, s.provider, s.token_hash
+       FROM users u
+       JOIN email_identities e ON e.user_id = u.id
+       JOIN password_credentials p ON p.user_id = u.id
+       JOIN sessions s ON s.user_id = u.id
+       WHERE u.id = $1`,
+      [accepted.user.id]
+    );
+    expect(account.rows[0]).toMatchObject({
+      account_email: null,
+      identity_email: "person@example.com",
+      normalized_email: "person@example.com",
+      is_primary: true,
+      provider: "password",
+      token_hash: tokenHash(accepted.token)
+    });
+    expect(account.rows[0]?.verified_at).toBeInstanceOf(Date);
+    expect(account.rows[0]?.password_hash).toMatch(/^\$argon2id\$/);
+
+    const agreements = await db.query<{ document: string; version: string }>(
+      `SELECT document, version FROM account_agreements
+       WHERE user_id = $1 ORDER BY document`,
+      [accepted.user.id]
+    );
+    expect(agreements.rows).toEqual([
+      { document: "privacy", version: "privacy-2026-07" },
+      { document: "terms", version: "terms-2026-07" }
+    ]);
+    const acceptedInvitation = await db.query<{
+      accepted_by_user_id: string;
+      accepted_at: Date;
+    }>(
+      "SELECT accepted_by_user_id, accepted_at FROM invitations WHERE id = $1",
+      [invitation.id]
+    );
+    expect(acceptedInvitation.rows[0]?.accepted_by_user_id)
+      .toBe(accepted.user.id);
+    expect(acceptedInvitation.rows[0]?.accepted_at).toBeInstanceOf(Date);
+  });
+
+  it("supports password login without exposing unknown, wrong, or suspended accounts", async () => {
+    const { db, service } = await fixture();
+    const invitation = await service.createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Private beta"
+    });
+    const account = await service.acceptInvitation({
+      invitationToken: invitation.token,
+      name: "Person Example",
+      password: "a durable private beta password",
+      termsVersion: invitation.termsVersion,
+      privacyVersion: invitation.privacyVersion
+    });
+
+    const login = await service.authenticate({
+      email: "PERSON@example.com",
+      password: "a durable private beta password"
+    });
+    expect(login.user).toEqual(account.user);
+    expect(login.token).not.toBe(account.token);
+
+    await expect(service.authenticate({
+      email: "person@example.com",
+      password: "an incorrect private beta password"
+    })).rejects.toBeInstanceOf(PasswordLoginRejectedError);
+    await expect(service.authenticate({
+      email: "unknown@example.com",
+      password: "an incorrect private beta password"
+    })).rejects.toBeInstanceOf(PasswordLoginRejectedError);
+
+    await db.query(
+      "UPDATE users SET suspended_at = now() WHERE id = $1",
+      [account.user.id]
+    );
+    await expect(service.authenticate({
+      email: "person@example.com",
+      password: "a durable private beta password"
+    })).rejects.toBeInstanceOf(PasswordLoginRejectedError);
+  });
+
+  it("upgrades an older Argon2 work factor after successful authentication", async () => {
+    const { db, service } = await fixture();
+    const invitation = await service.createInvitation({
+      email: "upgrade@example.com",
+      actor: "operator:test",
+      reason: "Credential upgrade test"
+    });
+    const password = "a durable credential upgrade password";
+    const account = await service.acceptInvitation({
+      invitationToken: invitation.token,
+      name: "Upgrade Person",
+      password,
+      termsVersion: invitation.termsVersion,
+      privacyVersion: invitation.privacyVersion
+    });
+    const weakerHash = await hash(password, {
+      ...PASSWORD_HASH_PARAMETERS,
+      memoryCost: 12_288
+    });
+    await db.query(
+      `UPDATE password_credentials
+       SET password_hash = $2, credential_version = 1
+       WHERE user_id = $1`,
+      [account.user.id, weakerHash]
+    );
+
+    await service.authenticate({
+      email: invitation.email,
+      password
+    });
+
+    const credential = await db.query<{
+      password_hash: string;
+      credential_version: number;
+    }>(
+      `SELECT password_hash, credential_version
+       FROM password_credentials WHERE user_id = $1`,
+      [account.user.id]
+    );
+    expect(passwordHashNeedsUpgrade(credential.rows[0]!.password_hash)).toBe(false);
+    expect(credential.rows[0]?.credential_version).toBe(2);
+  });
+
+  it("rejects replay, stale agreements, and disabled registration without partial accounts", async () => {
+    const { db, policy, service } = await fixture();
+    const invitation = await service.createInvitation({
+      email: "person@example.com",
+      actor: "operator:test",
+      reason: "Private beta"
+    });
+    const input = {
+      invitationToken: invitation.token,
+      name: "Person Example",
+      password: "a durable private beta password",
+      termsVersion: invitation.termsVersion,
+      privacyVersion: invitation.privacyVersion
+    };
+    await expect(service.acceptInvitation({
+      ...input,
+      termsVersion: "terms-not-accepted"
+    })).rejects.toBeInstanceOf(InvalidInvitationError);
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(0);
+
+    await service.acceptInvitation(input);
+    await expect(service.acceptInvitation(input))
+      .rejects.toBeInstanceOf(InvalidInvitationError);
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(1);
+
+    await policy.update({
+      registrationMode: "closed",
+      passwordAuthEnabled: true,
+      emailDeliveryEnabled: false,
+      termsVersion: "terms-2026-07",
+      privacyVersion: "privacy-2026-07",
+      expectedRevision: 1,
+      updatedBy: "operator:test",
+      reason: "Close registration"
+    });
+    const closedInvitation = await service.createInvitation({
+      email: "second@example.com",
+      actor: "operator:test",
+      reason: "Prepare without admitting"
+    });
+    await expect(service.acceptInvitation({
+      invitationToken: closedInvitation.token,
+      name: "Second Person",
+      password: "another durable beta password",
+      termsVersion: closedInvitation.termsVersion,
+      privacyVersion: closedInvitation.privacyVersion
+    })).rejects.toBeInstanceOf(PasswordAuthenticationUnavailableError);
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(1);
+  });
+
+  it("allows only one concurrent redemption of an invitation", async () => {
+    const { db, service } = await fixture();
+    const invitation = await service.createInvitation({
+      email: "concurrent@example.com",
+      actor: "operator:test",
+      reason: "Concurrent redemption test"
+    });
+    const input = {
+      invitationToken: invitation.token,
+      name: "Concurrent Person",
+      password: "a durable concurrent beta password",
+      termsVersion: invitation.termsVersion,
+      privacyVersion: invitation.privacyVersion
+    };
+    const outcomes = await Promise.allSettled([
+      service.acceptInvitation(input),
+      service.acceptInvitation(input)
+    ]);
+    expect(outcomes.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter(({ status }) => status === "rejected")).toHaveLength(1);
+    const accepted = await db.query(
+      `SELECT id FROM invitations
+       WHERE id = $1 AND accepted_at IS NOT NULL`,
+      [invitation.id]
+    );
+    expect(accepted.rows).toHaveLength(1);
+  });
+
+  it("refuses email and verified external identity collisions without merging accounts", async () => {
+    const { db, service } = await fixture();
+    const existingInvitation = await service.createInvitation({
+      email: "existing@example.com",
+      actor: "operator:test",
+      reason: "Create the first account"
+    });
+    await service.acceptInvitation({
+      invitationToken: existingInvitation.token,
+      name: "Existing",
+      password: "the existing account password",
+      termsVersion: existingInvitation.termsVersion,
+      privacyVersion: existingInvitation.privacyVersion
+    });
+    await expect(service.createInvitation({
+      email: "EXISTING@example.com",
+      actor: "operator:test",
+      reason: "Must not merge"
+    })).rejects.toBeInstanceOf(InvitationTargetConflictError);
+
+    await createExternalSession(db, {
+      provider: "google",
+      subject: "google-subject",
+      name: "Google User",
+      login: null,
+      email: "google@example.com",
+      emailVerified: true,
+      avatarUrl: null
+    });
+    await expect(service.createInvitation({
+      email: "google@example.com",
+      actor: "operator:test",
+      reason: "Must require explicit linking"
+    })).rejects.toBeInstanceOf(InvitationTargetConflictError);
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, 'Legacy@Example.com', 'Legacy')",
+      [randomUUID()]
+    );
+    await expect(service.createInvitation({
+      email: "legacy@example.com",
+      actor: "operator:test",
+      reason: "Must not duplicate a legacy account email"
+    })).rejects.toBeInstanceOf(InvitationTargetConflictError);
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(3);
+  });
+});
+
+async function fixture(): Promise<{
+  db: DatabasePool;
+  policy: AuthenticationPolicyStore;
+  service: PasswordAccountService;
+}> {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  const policy = new AuthenticationPolicyStore(db, "closed");
+  await policy.update({
+    registrationMode: "invite",
+    passwordAuthEnabled: true,
+    emailDeliveryEnabled: false,
+    termsVersion: "terms-2026-07",
+    privacyVersion: "privacy-2026-07",
+    expectedRevision: 0,
+    updatedBy: "operator:test",
+    reason: "Configure the test fixture"
+  });
+  return {
+    db,
+    policy,
+    service: new PasswordAccountService(db, policy)
+  };
+}

--- a/services/server/src/password-auth.ts
+++ b/services/server/src/password-auth.ts
@@ -1,0 +1,562 @@
+import { randomUUID } from "node:crypto";
+import type {
+  DatabasePool,
+  DatabaseQueryable
+} from "./db.js";
+import {
+  EMAIL_NORMALIZATION_VERSION,
+  normalizeEmailAddress
+} from "./email-identity.js";
+import {
+  AuthenticationPolicyStore,
+  type AuthenticationSettings
+} from "./authentication-policy.js";
+import {
+  hashPassword,
+  passwordHashNeedsUpgrade,
+  verifyPassword
+} from "./password.js";
+import { randomToken, tokenHash } from "./security.js";
+
+const DEFAULT_INVITATION_LIFETIME_SECONDS = 7 * 24 * 60 * 60;
+const MIN_INVITATION_LIFETIME_SECONDS = 5 * 60;
+const MAX_INVITATION_LIFETIME_SECONDS = 30 * 24 * 60 * 60;
+const DUMMY_PASSWORD_HASH = hashPassword(
+  "mdbase timing-only password credential"
+);
+
+export interface CreateInvitationInput {
+  email: string;
+  actor: string;
+  reason: string;
+  expiresInSeconds?: number;
+}
+
+export interface CreatedInvitation {
+  id: string;
+  email: string;
+  token: string;
+  expiresAt: Date;
+  termsVersion: string;
+  privacyVersion: string;
+}
+
+export interface AcceptInvitationInput {
+  invitationToken: string;
+  name: string;
+  password: string;
+  termsVersion: string;
+  privacyVersion: string;
+}
+
+export interface PasswordLoginInput {
+  email: string;
+  password: string;
+}
+
+export type InvitationDeliveryOutcome =
+  | {
+      status: "sent";
+      provider: string;
+      messageId: string;
+    }
+  | {
+      status: "failed";
+      provider: string;
+      code: string;
+      retryable: boolean;
+    };
+
+export interface PasswordSession {
+  token: string;
+  user: {
+    id: string;
+    email: string;
+    name: string;
+  };
+}
+
+export interface InvitationDetails {
+  email: string;
+  termsVersion: string;
+  privacyVersion: string;
+  expiresAt: Date;
+}
+
+interface InvitationRow {
+  id: string;
+  email: string;
+  normalized_email: string;
+  terms_version: string | null;
+  privacy_version: string | null;
+  expires_at: Date | string;
+}
+
+interface PasswordCredentialRow {
+  user_id: string;
+  name: string;
+  email: string;
+  password_hash: string;
+  suspended_at: Date | string | null;
+  session_epoch: string | number;
+}
+
+export class PasswordAuthenticationUnavailableError extends Error {
+  constructor() {
+    super("Password authentication is unavailable.");
+    this.name = "PasswordAuthenticationUnavailableError";
+  }
+}
+
+export class AuthenticationPolicyIncompleteError extends Error {
+  constructor() {
+    super("Current terms and privacy versions must be configured first.");
+    this.name = "AuthenticationPolicyIncompleteError";
+  }
+}
+
+export class InvitationTargetConflictError extends Error {
+  constructor() {
+    super("The invitation address already belongs to an account identity.");
+    this.name = "InvitationTargetConflictError";
+  }
+}
+
+export class InvalidInvitationError extends Error {
+  constructor() {
+    super("Invitation is invalid or expired.");
+    this.name = "InvalidInvitationError";
+  }
+}
+
+export class PasswordLoginRejectedError extends Error {
+  constructor() {
+    super("Email or password is incorrect.");
+    this.name = "PasswordLoginRejectedError";
+  }
+}
+
+export class PasswordAccountService {
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly policy: AuthenticationPolicyStore
+  ) {}
+
+  async createInvitation(input: CreateInvitationInput): Promise<CreatedInvitation> {
+    const actor = requiredText(input.actor, 200, "Invitation actor");
+    const reason = requiredText(input.reason, 500, "Invitation reason");
+    const normalizedEmail = normalizeEmailAddress(input.email);
+    const email = input.email.trim().normalize("NFC");
+    const lifetime = input.expiresInSeconds ?? DEFAULT_INVITATION_LIFETIME_SECONDS;
+    if (
+      !Number.isSafeInteger(lifetime)
+      || lifetime < MIN_INVITATION_LIFETIME_SECONDS
+      || lifetime > MAX_INVITATION_LIFETIME_SECONDS
+    ) {
+      throw new TypeError("Invitation lifetime is outside the supported range.");
+    }
+    const settings = await this.policy.current();
+    const agreements = requiredAgreements(settings);
+    const token = randomToken("inv");
+    const id = randomUUID();
+    const expiresAt = new Date(Date.now() + lifetime * 1_000);
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      if (await identityExists(connection, normalizedEmail)) {
+        throw new InvitationTargetConflictError();
+      }
+      await connection.query(
+        `UPDATE invitations SET
+           revoked_at = now(),
+           revoked_by = $2,
+           revocation_reason = 'Superseded by a new invitation'
+         WHERE normalized_email = $1
+           AND accepted_at IS NULL
+           AND revoked_at IS NULL`,
+        [normalizedEmail, actor]
+      );
+      await connection.query(
+        `INSERT INTO invitations
+           (id, email, normalized_email, token_hash, created_by,
+            terms_version, privacy_version, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [
+          id,
+          email,
+          normalizedEmail,
+          tokenHash(token),
+          actor,
+          agreements.termsVersion,
+          agreements.privacyVersion,
+          expiresAt
+        ]
+      );
+      await audit(connection, null, "invitation.created", id, {
+        actor,
+        reason
+      });
+      await connection.query("COMMIT");
+      return {
+        id,
+        email,
+        token,
+        expiresAt,
+        ...agreements
+      };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async acceptInvitation(input: AcceptInvitationInput): Promise<PasswordSession> {
+    const name = requiredText(input.name, 100, "Account name");
+    if (input.invitationToken.length > 200) throw new InvalidInvitationError();
+    requireSignupEnabled(await this.policy.current());
+    const invitationHash = tokenHash(input.invitationToken);
+    const preliminary = await this.db.query<InvitationRow>(
+      `SELECT id, email, normalized_email, terms_version, privacy_version
+       FROM invitations
+       WHERE token_hash = $1
+         AND accepted_at IS NULL
+         AND revoked_at IS NULL
+         AND expires_at > now()`,
+      [invitationHash]
+    );
+    if (!preliminary.rows[0]) throw new InvalidInvitationError();
+    agreementsMatch(preliminary.rows[0], input);
+    const passwordHash = await hashPassword(input.password);
+    const userId = randomUUID();
+    const sessionId = randomUUID();
+    const sessionToken = randomToken("ses");
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const settings = await this.policy.currentForAccountChange(connection);
+      requireSignupEnabled(settings);
+      const invitation = await connection.query<InvitationRow>(
+        `SELECT id, email, normalized_email, terms_version, privacy_version
+         FROM invitations
+         WHERE token_hash = $1
+           AND accepted_at IS NULL
+           AND revoked_at IS NULL
+           AND expires_at > now()
+         FOR UPDATE`,
+        [invitationHash]
+      );
+      const row = invitation.rows[0];
+      if (!row) throw new InvalidInvitationError();
+      agreementsMatch(row, input);
+      const currentAgreements = requiredAgreements(settings);
+      if (
+        currentAgreements.termsVersion !== row.terms_version
+        || currentAgreements.privacyVersion !== row.privacy_version
+      ) {
+        throw new InvalidInvitationError();
+      }
+      if (await identityExists(connection, row.normalized_email)) {
+        throw new InvitationTargetConflictError();
+      }
+      await connection.query(
+        "INSERT INTO users (id, email, name) VALUES ($1, NULL, $2)",
+        [userId, name]
+      );
+      await connection.query(
+        `INSERT INTO email_identities
+           (id, user_id, email, normalized_email, normalization_version,
+            verified_at, is_primary)
+         VALUES ($1, $2, $3, $4, $5, now(), true)`,
+        [
+          randomUUID(),
+          userId,
+          row.email,
+          row.normalized_email,
+          EMAIL_NORMALIZATION_VERSION
+        ]
+      );
+      await connection.query(
+        `INSERT INTO password_credentials (user_id, password_hash)
+         VALUES ($1, $2)`,
+        [userId, passwordHash]
+      );
+      await connection.query(
+        `INSERT INTO account_agreements
+           (user_id, document, version, acceptance_method)
+         VALUES
+           ($1, 'terms', $2, 'invitation'),
+           ($1, 'privacy', $3, 'invitation')`,
+        [userId, currentAgreements.termsVersion, currentAgreements.privacyVersion]
+      );
+      await connection.query(
+        `UPDATE invitations SET accepted_by_user_id = $2, accepted_at = now()
+         WHERE id = $1`,
+        [row.id, userId]
+      );
+      await connection.query(
+        `INSERT INTO sessions
+           (id, user_id, token_hash, provider, account_session_epoch, expires_at)
+         VALUES ($1, $2, $3, 'password', 1, now() + interval '30 days')`,
+        [sessionId, userId, tokenHash(sessionToken)]
+      );
+      await audit(connection, userId, "account.created", userId, {
+        provider: "password",
+        invitation_id: row.id
+      });
+      await audit(connection, userId, "session.created", sessionId, {
+        provider: "password"
+      });
+      await connection.query("COMMIT");
+      return {
+        token: sessionToken,
+        user: { id: userId, email: row.email, name }
+      };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async invitationDetails(invitationToken: string): Promise<InvitationDetails> {
+    if (invitationToken.length > 200) throw new InvalidInvitationError();
+    const settings = await this.policy.current();
+    requireSignupEnabled(settings);
+    const invitation = await this.db.query<InvitationRow>(
+      `SELECT id, email, normalized_email, terms_version, privacy_version,
+              expires_at
+       FROM invitations
+       WHERE token_hash = $1
+         AND accepted_at IS NULL
+         AND revoked_at IS NULL
+         AND expires_at > now()`,
+      [tokenHash(invitationToken)]
+    );
+    const row = invitation.rows[0];
+    if (!row) throw new InvalidInvitationError();
+    const agreements = requiredAgreements(settings);
+    if (
+      agreements.termsVersion !== row.terms_version
+      || agreements.privacyVersion !== row.privacy_version
+    ) {
+      throw new InvalidInvitationError();
+    }
+    return {
+      email: row.email,
+      ...agreements,
+      expiresAt: new Date(row.expires_at)
+    };
+  }
+
+  async recordInvitationDelivery(
+    invitationId: string,
+    outcome: InvitationDeliveryOutcome
+  ): Promise<void> {
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      if (outcome.status === "sent") {
+        const updated = await connection.query(
+          `UPDATE invitations SET
+             send_count = send_count + 1,
+             last_sent_at = now()
+           WHERE id = $1
+           RETURNING id`,
+          [invitationId]
+        );
+        if (!updated.rows[0]) {
+          throw new TypeError("Invitation delivery target does not exist.");
+        }
+        await audit(connection, null, "invitation.sent", invitationId, {
+          provider: outcome.provider,
+          message_id: outcome.messageId
+        });
+      } else {
+        await audit(connection, null, "invitation.delivery_failed", invitationId, {
+          provider: outcome.provider,
+          code: outcome.code,
+          retryable: outcome.retryable
+        });
+      }
+      await connection.query("COMMIT");
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async authenticate(input: PasswordLoginInput): Promise<PasswordSession> {
+    const settings = await this.policy.current();
+    if (!settings.passwordAuthEnabled) {
+      throw new PasswordAuthenticationUnavailableError();
+    }
+    const normalizedEmail = normalizeEmailAddress(input.email);
+    const credential = await this.db.query<PasswordCredentialRow>(
+      `SELECT u.id AS user_id, u.name, e.email, p.password_hash,
+              u.suspended_at, u.session_epoch
+       FROM email_identities e
+       JOIN users u ON u.id = e.user_id
+       JOIN password_credentials p ON p.user_id = u.id
+       WHERE e.normalized_email = $1
+         AND e.retired_at IS NULL
+         AND e.verified_at IS NOT NULL`,
+      [normalizedEmail]
+    );
+    const row = credential.rows[0];
+    const passwordMatches = await verifyPassword(
+      row?.password_hash ?? await DUMMY_PASSWORD_HASH,
+      input.password
+    );
+    if (!row || !passwordMatches || row.suspended_at) {
+      throw new PasswordLoginRejectedError();
+    }
+    const upgradedHash = passwordHashNeedsUpgrade(row.password_hash)
+      ? await hashPassword(input.password)
+      : null;
+    const sessionId = randomUUID();
+    const sessionToken = randomToken("ses");
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const current = await connection.query<PasswordCredentialRow>(
+        `SELECT u.id AS user_id, u.name, e.email, p.password_hash,
+                u.suspended_at, u.session_epoch
+         FROM email_identities e
+         JOIN users u ON u.id = e.user_id
+         JOIN password_credentials p ON p.user_id = u.id
+         WHERE e.normalized_email = $1
+           AND e.retired_at IS NULL
+           AND e.verified_at IS NOT NULL
+         FOR UPDATE`,
+        [normalizedEmail]
+      );
+      const active = current.rows[0];
+      if (
+        !active
+        || active.suspended_at
+        || active.password_hash !== row.password_hash
+      ) {
+        throw new PasswordLoginRejectedError();
+      }
+      if (upgradedHash) {
+        await connection.query(
+          `UPDATE password_credentials SET
+             password_hash = $2,
+             credential_version = credential_version + 1,
+             updated_at = now()
+           WHERE user_id = $1`,
+          [active.user_id, upgradedHash]
+        );
+      }
+      await connection.query(
+        `INSERT INTO sessions
+           (id, user_id, token_hash, provider, account_session_epoch, expires_at)
+         VALUES ($1, $2, $3, 'password', $4, now() + interval '30 days')`,
+        [
+          sessionId,
+          active.user_id,
+          tokenHash(sessionToken),
+          active.session_epoch
+        ]
+      );
+      await audit(connection, active.user_id, "session.created", sessionId, {
+        provider: "password"
+      });
+      await connection.query("COMMIT");
+      return {
+        token: sessionToken,
+        user: {
+          id: active.user_id,
+          email: active.email,
+          name: active.name
+        }
+      };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+}
+
+function requiredAgreements(settings: AuthenticationSettings): {
+  termsVersion: string;
+  privacyVersion: string;
+} {
+  if (!settings.termsVersion || !settings.privacyVersion) {
+    throw new AuthenticationPolicyIncompleteError();
+  }
+  return {
+    termsVersion: settings.termsVersion,
+    privacyVersion: settings.privacyVersion
+  };
+}
+
+function requireSignupEnabled(settings: AuthenticationSettings): void {
+  if (
+    !settings.passwordAuthEnabled
+    || settings.registrationMode !== "invite"
+  ) {
+    throw new PasswordAuthenticationUnavailableError();
+  }
+}
+
+function agreementsMatch(
+  invitation: InvitationRow,
+  input: Pick<AcceptInvitationInput, "termsVersion" | "privacyVersion">
+): void {
+  if (
+    invitation.terms_version !== input.termsVersion
+    || invitation.privacy_version !== input.privacyVersion
+  ) {
+    throw new InvalidInvitationError();
+  }
+}
+
+async function identityExists(
+  db: DatabaseQueryable,
+  normalizedEmail: string
+): Promise<boolean> {
+  const result = await db.query(
+    `SELECT user_id FROM email_identities
+     WHERE normalized_email = $1 AND retired_at IS NULL
+     UNION ALL
+     SELECT user_id FROM external_identities
+     WHERE normalized_email = $1 AND email_verified = true
+     UNION ALL
+     SELECT id AS user_id FROM users
+     WHERE email IS NOT NULL AND lower(email) = lower($1)
+     LIMIT 1`,
+    [normalizedEmail]
+  );
+  return Boolean(result.rows[0]);
+}
+
+function requiredText(value: string, maxLength: number, name: string): string {
+  const normalized = value.trim().normalize("NFC");
+  if (!normalized || normalized.length > maxLength) {
+    throw new TypeError(`${name} must contain between 1 and ${maxLength} characters.`);
+  }
+  return normalized;
+}
+
+async function audit(
+  db: DatabaseQueryable,
+  userId: string | null,
+  eventType: string,
+  subjectId: string | null,
+  metadata: unknown
+): Promise<void> {
+  await db.query(
+    `INSERT INTO audit_events
+       (id, user_id, event_type, subject_id, metadata)
+     VALUES ($1, $2, $3, $4, $5::jsonb)`,
+    [randomUUID(), userId, eventType, subjectId, JSON.stringify(metadata)]
+  );
+}

--- a/services/server/src/password.test.ts
+++ b/services/server/src/password.test.ts
@@ -1,0 +1,49 @@
+import { hash } from "@node-rs/argon2";
+import { describe, expect, it } from "vitest";
+import {
+  PASSWORD_HASH_PARAMETERS,
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PasswordPolicyError,
+  hashPassword,
+  passwordHashNeedsUpgrade,
+  validateNewPassword,
+  verifyPassword
+} from "./password.js";
+
+describe("password credentials", () => {
+  it("stores salted Argon2id hashes with the configured work factors", async () => {
+    const password = "a durable beta passphrase";
+    const first = await hashPassword(password);
+    const second = await hashPassword(password);
+
+    expect(first).toMatch(/^\$argon2id\$v=19\$m=19456,t=2,p=1\$/);
+    expect(first).not.toBe(second);
+    expect(await verifyPassword(first, password)).toBe(true);
+    expect(await verifyPassword(first, "not the password")).toBe(false);
+    expect(passwordHashNeedsUpgrade(first)).toBe(false);
+  });
+
+  it("recognizes hashes that need a work-factor or algorithm upgrade", async () => {
+    const weaker = await hash("a durable beta passphrase", {
+      ...PASSWORD_HASH_PARAMETERS,
+      memoryCost: 12_288
+    });
+    expect(passwordHashNeedsUpgrade(weaker)).toBe(true);
+    expect(passwordHashNeedsUpgrade("$scrypt$not-an-argon-hash")).toBe(true);
+  });
+
+  it("allows spaces and Unicode without composition rules", () => {
+    expect(() => validateNewPassword("correct horse battery 🔋")).not.toThrow();
+  });
+
+  it("rejects short and unbounded passwords without truncating", async () => {
+    expect(() => validateNewPassword("x".repeat(PASSWORD_MIN_LENGTH - 1)))
+      .toThrow(PasswordPolicyError);
+    expect(() => validateNewPassword("x".repeat(PASSWORD_MAX_LENGTH + 1)))
+      .toThrow(PasswordPolicyError);
+    await expect(
+      verifyPassword("not-a-valid-hash", "x".repeat(PASSWORD_MAX_LENGTH + 1))
+    ).resolves.toBe(false);
+  });
+});

--- a/services/server/src/password.ts
+++ b/services/server/src/password.ts
@@ -1,0 +1,72 @@
+import { Algorithm, Version, hash, verify } from "@node-rs/argon2";
+
+export const PASSWORD_MIN_LENGTH = 15;
+export const PASSWORD_MAX_LENGTH = 256;
+export const PASSWORD_MAX_UTF8_BYTES = 1_024;
+
+export const PASSWORD_HASH_PARAMETERS = Object.freeze({
+  algorithm: Algorithm.Argon2id,
+  version: Version.V0x13,
+  memoryCost: 19_456,
+  timeCost: 2,
+  parallelism: 1,
+  outputLen: 32
+});
+
+export class PasswordPolicyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PasswordPolicyError";
+  }
+}
+
+export function validateNewPassword(password: string): void {
+  const characters = [...password].length;
+  if (characters < PASSWORD_MIN_LENGTH) {
+    throw new PasswordPolicyError(
+      `Password must contain at least ${PASSWORD_MIN_LENGTH} characters.`
+    );
+  }
+  if (
+    characters > PASSWORD_MAX_LENGTH
+    || Buffer.byteLength(password, "utf8") > PASSWORD_MAX_UTF8_BYTES
+  ) {
+    throw new PasswordPolicyError(
+      `Password must contain no more than ${PASSWORD_MAX_LENGTH} characters.`
+    );
+  }
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  validateNewPassword(password);
+  return hash(password, PASSWORD_HASH_PARAMETERS);
+}
+
+export async function verifyPassword(
+  passwordHash: string,
+  candidate: string
+): Promise<boolean> {
+  if (
+    [...candidate].length > PASSWORD_MAX_LENGTH
+    || Buffer.byteLength(candidate, "utf8") > PASSWORD_MAX_UTF8_BYTES
+  ) {
+    return false;
+  }
+  try {
+    return await verify(passwordHash, candidate);
+  } catch {
+    return false;
+  }
+}
+
+export function passwordHashNeedsUpgrade(passwordHash: string): boolean {
+  const match = passwordHash.match(
+    /^\$argon2id\$v=(\d+)\$m=(\d+),t=(\d+),p=(\d+)\$/
+  );
+  if (!match) return true;
+  const [, version, memoryCost, timeCost, parallelism] = match.map(Number);
+  return version !== 19
+    || memoryCost < PASSWORD_HASH_PARAMETERS.memoryCost
+    || timeCost < PASSWORD_HASH_PARAMETERS.timeCost
+    || parallelism < PASSWORD_HASH_PARAMETERS.parallelism;
+}

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -11,6 +11,8 @@ function config(overrides: Partial<Parameters<typeof validateRuntimeConfig>[0]> 
     githubAuth: null,
     googleAuth: null,
     registration: "closed" as const,
+    authRateLimitSecret: null,
+    authenticationLegalDocuments: null,
     hostedCollections: false,
     hostedProvider: null,
     allowInsecureHostedProvider: false,
@@ -44,7 +46,7 @@ describe("public runtime configuration", () => {
   });
 
   it("refuses to start without a real authentication mode", () => {
-    expect(() => validateRuntimeConfig(config())).toThrow(/Exactly one authentication mode/);
+    expect(() => validateRuntimeConfig(config())).toThrow(/authentication path/);
   });
 
   it("accepts one allowlisted GitHub provider on a canonical HTTPS origin", () => {
@@ -77,7 +79,7 @@ describe("public runtime configuration", () => {
       PUBLIC_URL: "http://localhost:8787",
       MDBASE_CONNECT_DEV_AUTH: "1",
       MDBASE_CONNECT_TAILSCALE_AUTH: "1"
-    })).toThrow(/Exactly one authentication mode/);
+    })).toThrow(/mutually exclusive/);
   });
 
   it("supports Google and GitHub together while keeping registration policy explicit", () => {
@@ -115,6 +117,64 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_GOOGLE_CLIENT_ID: "google-client.apps.googleusercontent.com",
       MDBASE_CONNECT_ALLOWED_GOOGLE_SUBJECTS: "not a subject"
     })).toThrow(/subject identifiers/);
+  });
+
+  it("accepts invite-only registration without opening external providers", () => {
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_GOOGLE_CLIENT_ID: "google-client.apps.googleusercontent.com",
+      MDBASE_CONNECT_ALLOWED_GOOGLE_SUBJECTS: "109876543210",
+      MDBASE_CONNECT_REGISTRATION: "invite"
+    });
+    expect(value.registration).toBe("invite");
+    expect(value.googleAuth?.allowedSubjects).toEqual(new Set(["109876543210"]));
+
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_GOOGLE_CLIENT_ID: "google-client.apps.googleusercontent.com",
+      MDBASE_CONNECT_REGISTRATION: "waitlist"
+    })).toThrow(/closed, invite, or open/);
+  });
+
+  it("validates the shared authentication rate-limit digest secret", () => {
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "x".repeat(32)
+    });
+    expect(value.authRateLimitSecret).toBe("x".repeat(32));
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "too-short"
+    })).toThrow(/at least 32 bytes/);
+  });
+
+  it("supports password-only authentication infrastructure and validates legal document URLs", () => {
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "x".repeat(32),
+      MDBASE_CONNECT_TERMS_URL: "https://mdbase.dev/terms/",
+      MDBASE_CONNECT_PRIVACY_URL: "https://mdbase.dev/privacy/"
+    });
+    expect(value.authenticationLegalDocuments).toEqual({
+      termsUrl: "https://mdbase.dev/terms/",
+      privacyUrl: "https://mdbase.dev/privacy/"
+    });
+    expect(value.githubAuth).toBeNull();
+    expect(value.googleAuth).toBeNull();
+
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "x".repeat(32),
+      MDBASE_CONNECT_TERMS_URL: "https://mdbase.dev/terms/"
+    })).toThrow(/configured together/);
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "x".repeat(32),
+      MDBASE_CONNECT_TERMS_URL: "http://mdbase.dev/terms/",
+      MDBASE_CONNECT_PRIVACY_URL: "https://mdbase.dev/privacy/"
+    })).toThrow(/must use HTTPS/);
   });
 
   it("rejects public URLs containing path or credential components", () => {

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -5,7 +5,12 @@ import type { RelayBrokerConfig } from "./relay-broker.js";
 import type { VapidConfig } from "./web-push.js";
 import type { WebhookSigningConfig } from "./webhook.js";
 
-export type RegistrationMode = "closed" | "open";
+export type RegistrationMode = "closed" | "invite" | "open";
+
+export interface AuthenticationLegalDocuments {
+  termsUrl: string;
+  privacyUrl: string;
+}
 
 export interface RuntimeConfig {
   host: string;
@@ -15,6 +20,8 @@ export interface RuntimeConfig {
   githubAuth: GitHubAuthConfig | null;
   googleAuth: GoogleAuthConfig | null;
   registration: RegistrationMode;
+  authRateLimitSecret: string | null;
+  authenticationLegalDocuments: AuthenticationLegalDocuments | null;
   hostedCollections: boolean;
   hostedProvider: HostedProviderConfig | null;
   allowInsecureHostedProvider: boolean;
@@ -40,8 +47,15 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
   const externalAuth = Boolean(config.githubAuth || config.googleAuth);
   const authenticationModes = [config.devAuth, config.tailscaleAuth, externalAuth]
     .filter(Boolean).length;
-  if (authenticationModes !== 1) {
-    throw new Error("Exactly one authentication mode must be configured before the server starts.");
+  if (authenticationModes > 1) {
+    throw new Error(
+      "Development, Tailscale, and external-provider authentication modes are mutually exclusive."
+    );
+  }
+  if (authenticationModes === 0 && config.authRateLimitSecret === null) {
+    throw new Error(
+      "At least one authentication path must be configured before the server starts."
+    );
   }
   if (config.githubAuth) {
     if (!config.githubAuth.clientId.trim() || !config.githubAuth.clientSecret.trim()) {
@@ -65,6 +79,24 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
         throw new Error("Google allowed subjects must be valid account subject identifiers.");
       }
     }
+  }
+  if (
+    config.authRateLimitSecret !== null
+    && Buffer.byteLength(config.authRateLimitSecret, "utf8") < 32
+  ) {
+    throw new Error(
+      "Authentication rate-limit digest secret must contain at least 32 bytes."
+    );
+  }
+  if (config.authenticationLegalDocuments) {
+    validatePublicDocumentUrl(
+      config.authenticationLegalDocuments.termsUrl,
+      "MDBASE_CONNECT_TERMS_URL"
+    );
+    validatePublicDocumentUrl(
+      config.authenticationLegalDocuments.privacyUrl,
+      "MDBASE_CONNECT_PRIVACY_URL"
+    );
   }
   let hostedProvider = config.hostedProvider;
   if (config.hostedCollections && !hostedProvider) {
@@ -185,6 +217,18 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   const allowedGoogleSubjects = commaSeparatedSet(env.MDBASE_CONNECT_ALLOWED_GOOGLE_SUBJECTS);
   const googleConfigured = Boolean(googleClientId || allowedGoogleSubjects.size);
   const registration = registrationMode(env.MDBASE_CONNECT_REGISTRATION);
+  const authRateLimitSecret =
+    env.MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET?.trim() || null;
+  const termsUrl = env.MDBASE_CONNECT_TERMS_URL?.trim() ?? "";
+  const privacyUrl = env.MDBASE_CONNECT_PRIVACY_URL?.trim() ?? "";
+  if (Boolean(termsUrl) !== Boolean(privacyUrl)) {
+    throw new Error(
+      "MDBASE_CONNECT_TERMS_URL and MDBASE_CONNECT_PRIVACY_URL must be configured together."
+    );
+  }
+  const authenticationLegalDocuments = termsUrl && privacyUrl
+    ? { termsUrl, privacyUrl }
+    : null;
   const port = Number(env.PORT ?? 8787);
   const host = env.HOST ?? "127.0.0.1";
   const hostedProviderUrl = env.MDBASE_CONNECT_HOSTED_PROVIDER_URL?.trim() ?? "";
@@ -245,6 +289,8 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
       ? { clientId: googleClientId, allowedSubjects: allowedGoogleSubjects }
       : null,
     registration,
+    authRateLimitSecret,
+    authenticationLegalDocuments,
     hostedCollections: env.MDBASE_CONNECT_HOSTED_COLLECTIONS === "1",
     hostedProvider: hostedProviderConfigured
       ? {
@@ -311,14 +357,32 @@ function commaSeparatedSet(value: string | undefined): Set<string> {
 
 function registrationMode(value: string | undefined): RegistrationMode {
   const normalized = value?.trim() || "closed";
-  if (normalized !== "closed" && normalized !== "open") {
-    throw new Error("MDBASE_CONNECT_REGISTRATION must be either closed or open.");
+  if (normalized !== "closed" && normalized !== "invite" && normalized !== "open") {
+    throw new Error(
+      "MDBASE_CONNECT_REGISTRATION must be closed, invite, or open."
+    );
   }
   return normalized;
 }
 
 function isLoopback(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]" || hostname === "::1";
+}
+
+function validatePublicDocumentUrl(value: string, name: string): void {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an absolute URL.`);
+  }
+  if (
+    url.username
+    || url.password
+    || (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback(url.hostname)))
+  ) {
+    throw new Error(`${name} must use HTTPS outside loopback development.`);
+  }
 }
 
 function validateRelayBrokerServer(server: string): void {

--- a/services/server/src/session-auth.test.ts
+++ b/services/server/src/session-auth.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("account session enforcement", () => {
+  it("rejects revoked, stale-epoch, and suspended sessions", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://127.0.0.1:8787"
+    });
+    resources.push(() => app.close());
+    const login = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Beta User", email: "beta@example.com" }
+    });
+    const userId = login.json().user.id as string;
+    const cookie = login.cookies[0]?.name && login.cookies[0]?.value
+      ? `${login.cookies[0].name}=${login.cookies[0].value}`
+      : "";
+    expect(cookie).not.toBe("");
+    await expectMe(app, cookie, 200);
+
+    await db.query(
+      "UPDATE sessions SET revoked_at = now() WHERE user_id = $1",
+      [userId]
+    );
+    await expectMe(app, cookie, 401);
+
+    const secondLogin = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Beta User", email: "beta@example.com" }
+    });
+    const secondCookie = `${secondLogin.cookies[0]?.name}=${secondLogin.cookies[0]?.value}`;
+    await expectMe(app, secondCookie, 200);
+    await db.query(
+      "UPDATE users SET session_epoch = session_epoch + 1 WHERE id = $1",
+      [userId]
+    );
+    await expectMe(app, secondCookie, 401);
+
+    const thirdLogin = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Beta User", email: "beta@example.com" }
+    });
+    const thirdCookie = `${thirdLogin.cookies[0]?.name}=${thirdLogin.cookies[0]?.value}`;
+    await expectMe(app, thirdCookie, 200);
+    await db.query(
+      "UPDATE users SET suspended_at = now() WHERE id = $1",
+      [userId]
+    );
+    await expectMe(app, thirdCookie, 401);
+  });
+
+  it("applies account suspension to Tailscale-authenticated requests", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      tailscaleAuth: true,
+      publicUrl: "https://connect.example"
+    });
+    resources.push(() => app.close());
+    const headers = {
+      "tailscale-user-login": "beta@example.com",
+      "tailscale-user-name": "Beta User"
+    };
+    const active = await app.inject({ method: "GET", url: "/v1/me", headers });
+    expect(active.statusCode).toBe(200);
+    await db.query(
+      "UPDATE users SET suspended_at = now() WHERE email = 'beta@example.com'"
+    );
+    const suspended = await app.inject({ method: "GET", url: "/v1/me", headers });
+    expect(suspended.statusCode).toBe(401);
+  });
+});
+
+async function expectMe(
+  app: Awaited<ReturnType<typeof buildApp>>["app"],
+  cookie: string,
+  statusCode: number
+): Promise<void> {
+  const response = await app.inject({
+    method: "GET",
+    url: "/v1/me",
+    headers: { cookie }
+  });
+  expect(response.statusCode).toBe(statusCode);
+}


### PR DESCRIPTION
## What changed

- add invite-only email/password signup and login alongside existing external authentication
- introduce normalized email identities, Argon2id credentials, invitations, authentication challenges, session revocation epochs, and privacy-safe rate limiting
- add database-backed authentication policy with audited, compare-and-swap operator updates
- add a Resend-backed email abstraction, invitation templates, delivery auditing, and an operator CLI
- add portal login and invited-signup experiences, self-host deployment configuration, and account-authentication documentation

## Why

Hosted mdbase users need a non-Google/GitHub signup path without weakening the invite-only beta boundary. The implementation keeps portable server capabilities in the open-source repository while leaving hosted secrets and operational policy outside source control.

## Impact

Operators can enable password authentication, issue single-use expiring invitations, and optionally send them through Resend. Existing OAuth users continue to work, and self-hosters can configure the same primitives without depending on mdbase-hosted infrastructure.

## Validation

- `pnpm test` (128 server tests across 30 files plus workspace tests)
- `pnpm typecheck`
- `pnpm e2e`
- `pnpm audit --prod --audit-level high` (no known vulnerabilities)
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- PostgreSQL 17 migration compatibility and idempotency tests
- concurrent invitation redemption and exact database rate-limit tests
- production Docker image build and native Argon2 hash/verify smoke test
- Docker Compose admin profile validation
