### PR TITLE
Release mdbase connect 0.1.0-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "clap",
  "directories",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "clap",
  "directories",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "clap",
  "directories",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "clap",
  "directories",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 dependencies = [
  "chrono",
  "mdbase",

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -1,6 +1,6 @@
 # Deploy an immutable mdbase connect release checkout. This value labels the
 # locally built images and must match the checked-out tag without the leading v.
-MDBASE_CONNECT_VERSION=0.1.0-beta.8
+MDBASE_CONNECT_VERSION=0.1.0-beta.9
 
 CONNECT_PUBLIC_URL=https://connect.example.com
 CONNECT_BIND_PORT=8787

--- a/docs/portable-apps.md
+++ b/docs/portable-apps.md
@@ -112,7 +112,7 @@ Use an exact package version, copy the SHA-384 value from that version's
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/npm/@mdbase/connect@0.1.0-beta.8/dist/browser/mdbase-connect.min.js"
+  src="https://cdn.jsdelivr.net/npm/@mdbase/connect@0.1.0-beta.9/dist/browser/mdbase-connect.min.js"
   integrity="sha384-JgzBsv1HgBayXOV/4RiWNNRkv1wRLyTFqOUlPL7q99aTaFIaoCIfws6zpZLExIsi"
   crossorigin="anonymous"></script>
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -106,10 +106,10 @@ services require a branch reference; deploy tooling separately verifies and
 deploys the exact tag commit:
 
 ```bash
-pnpm version:check v0.1.0-beta.8
-git branch releases/v0.1.0-beta.8
-git tag -a v0.1.0-beta.8 -m "mdbase connect 0.1.0-beta.8"
-git push origin releases/v0.1.0-beta.8 v0.1.0-beta.8
+pnpm version:check v0.1.0-beta.9
+git branch releases/v0.1.0-beta.9
+git tag -a v0.1.0-beta.9 -m "mdbase connect 0.1.0-beta.9"
+git push origin releases/v0.1.0-beta.9 v0.1.0-beta.9
 ```
 
 When platform publisher configuration is wholly absent, the workflow publishes

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -17,8 +17,8 @@ Production deployments must use a signed or annotated release tag, never
 ```bash
 git clone https://github.com/mdbase-dev/mdbase-connect.git
 cd mdbase-connect
-git checkout v0.1.0-beta.8
-test "$(git describe --tags --exact-match)" = "v0.1.0-beta.8"
+git checkout v0.1.0-beta.9
+test "$(git describe --tags --exact-match)" = "v0.1.0-beta.9"
 ```
 
 Copy the production environment template:
@@ -186,7 +186,7 @@ and update `MDBASE_CONNECT_VERSION` to match it:
 
 ```bash
 git fetch --tags
-git checkout v0.1.0-beta.8
+git checkout v0.1.0-beta.9
 docker compose --env-file deploy/self-host/.env \
   -f deploy/self-host/compose.yml \
   --profile hosted --profile mcp \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.8" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.9" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.8",
+  "version": "0.1.0-beta.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- advance all JavaScript package and Rust workspace versions to `0.1.0-beta.9`
- update the hosted-provider lockfile, MCP advertised version, self-host example, and release documentation

## Why

The merged invite-only password authentication foundation needs a new immutable beta identity before it can be promoted to permanent staging. Staging deliberately refuses arbitrary `main` commits.

## Impact

This is a version-only release commit. After CI and the documented cross-platform release preflight pass, it will be tagged as `v0.1.0-beta.9` with a matching immutable `releases/v0.1.0-beta.9` branch.

## Validation

- `pnpm version:check v0.1.0-beta.9`
- release-version diff compared with the preceding beta promotion
- full auth/workspace validation and all PR #94 checks passed on the immediately preceding product commit
