### PR TITLE
Make update state test portable on Windows

### DIFF
--- a/apps/desktop/test/update-state.test.mjs
+++ b/apps/desktop/test/update-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRequire } from "node:module";
@@ -16,8 +16,10 @@ test("state creation is durable and installation identity is stable", async () =
   const second = await new UpdateStateStore(path).load();
   assert.match(first.installation_id, /^[0-9a-f-]{36}$/);
   assert.equal(second.installation_id, first.installation_id);
-  const mode = (await import("node:fs/promises")).stat(path).then((value) => value.mode & 0o777);
-  assert.equal(await mode, 0o600);
+  // Windows inherits profile-directory ACLs and reports a synthetic POSIX mode.
+  if (process.platform !== "win32") {
+    assert.equal((await stat(path)).mode & 0o777, 0o600);
+  }
 });
 
 test("state writes are atomic and preserve valid transactions", async () => {


### PR DESCRIPTION
## What changed

- keep the update-state durability and stable-identity assertions on every platform
- assert owner-only POSIX file mode only where POSIX modes are meaningful
- document that Windows inherits profile-directory ACLs and reports a synthetic POSIX mode

## Why

The mandatory beta.9 release preflight failed on the full Windows desktop job because Node reports `0666` for this file on Windows even after `chmod(0600)`. The test was asserting Unix permission bits on NTFS; the application behavior was not failing.

## Impact

Unix CI continues to enforce the `0600` state-file mode. Windows CI now tests the portable durability behavior without treating its synthetic mode bits as an ACL result.

## Validation

- `pnpm --filter @mdbase/connect-desktop test`
- `pnpm --filter @mdbase/connect-desktop typecheck`
- failure isolated from release preflight run `30317900609`
