### PR TITLE
Prepare collection access for collaboration

### DIFF
--- a/crates/connect-hosted-provider/migrations/0013_change_attribution.sql
+++ b/crates/connect-hosted-provider/migrations/0013_change_attribution.sql
@@ -1,0 +1,6 @@
+ALTER TABLE hosted_provider_changes
+  ADD COLUMN IF NOT EXISTS source_replica_id uuid;
+
+CREATE INDEX IF NOT EXISTS hosted_provider_changes_source_replica_idx
+  ON hosted_provider_changes(source_replica_id)
+  WHERE source_replica_id IS NOT NULL;

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -2749,8 +2749,9 @@ impl HostedProvider {
             sqlx::query(
                 r#"INSERT INTO hosted_provider_changes
                      (collection_id, sequence, record_id, before_types, after_types,
-                      before_ciphertext, after_ciphertext, revision)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"#,
+                      before_ciphertext, after_ciphertext, revision,
+                      source_replica_id)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"#,
             )
             .bind(collection_id)
             .bind(to_i64(head, "change sequence")?)
@@ -2770,6 +2771,7 @@ impl HostedProvider {
             .bind(before_ciphertext)
             .bind(after_ciphertext)
             .bind(revision)
+            .bind(replica.id)
             .execute(&mut *transaction)
             .await?;
             if let Some((event_type, payload)) = notification_event {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,35 @@ that ID as a preselection hint, but the approval UI still requires an explicit
 compatible user choice. Collection IDs are non-secret locators and can appear
 in browser history and logs; grants remain the authorization boundary.
 
+## Collaboration boundary
+
+Collection visibility and authority are deliberately separate. A
+`CollectionLocator` identifies one logical collection, its current local or
+hosted authority row, owner, authority epoch, and state. Local locators use the
+portable `local_id`; hosted locators use the hosted collection ID. Routes do
+not infer identity from a mutable name or filesystem location.
+
+All user-to-collection decisions pass through the collection catalog and
+access-policy modules. The current resolver emits only owner access. Its
+context already carries relationship, policy revision, product actions,
+operation ceiling, and contract/full-collection scope ceiling, so adding
+membership later is confined to those repository and policy boundaries.
+Collection responses include an access summary and explicit authority
+metadata rather than asking clients to infer permissions from ownership.
+
+Application capabilities are computed by a pure grant planner. It intersects
+the operations selected by the user, the application's request and manifest,
+and the user's current operation and scope ceilings. Provisioning is a
+separate `schema.manage` action. Token renewal re-resolves access, which makes
+membership removal fail closed without rewriting OAuth.
+
+Every hosted replica records the user whose access authorized it, while the
+provider records the source replica on each record change. Revocation first
+atomically disables the grant, tokens, and replica in the control plane, then
+delivers provider cleanup from a durable retry queue. These attribution and
+lifecycle boundaries allow later member removal and role changes to target
+derived capabilities without taking the service offline.
+
 ## Components
 
 - `mdbase-rs` owns collection loading, validation, querying, mutation,
@@ -88,7 +117,9 @@ in browser history and logs; grants remain the authorization boundary.
 - `connect-cli` and the Electron controller use the agent's versioned local
   control socket.
 - `connect-server` owns accounts, pairing, app discovery, grants, token
-  issuance, audit metadata, and transient request routing.
+  issuance, collection access policy, audit metadata, and transient request
+  routing. Its schema changes use the versioned, pre-deploy process in
+  [Control-plane migrations](./control-plane-migrations.md).
 - `connect-mcp` owns MCP host OAuth sessions and encrypted upstream Connect
   credentials. It uses one exact Connect grant per approved collection and
   never shares a collection grant across MCP connection sets.

--- a/docs/control-plane-migrations.md
+++ b/docs/control-plane-migrations.md
@@ -1,0 +1,30 @@
+# Control-plane migrations
+
+The Connect server applies database changes only through
+`pnpm --filter @mdbase/connect-server migrate`. The production process opens
+the database without changing its schema, so every instance sees a fully
+migrated control plane before it can become ready.
+
+Migrations live in `services/server/migrations` and run in filename order. The
+`schema_migrations` ledger records each filename and SHA-256 checksum. Applied
+files are immutable: the migration command fails if an existing filename has
+different contents. The runner takes a PostgreSQL advisory lock, so concurrent
+pre-deploy jobs serialize safely.
+
+The pre-versioned schema is recorded once as `0000_legacy_baseline`; new schema
+work must use a new numbered SQL file. Migrations are transactional unless the
+file starts with `-- mdbase:no-transaction`.
+
+Production changes follow expand-and-contract:
+
+1. Add nullable columns, new tables, or compatible indexes.
+2. Deploy code that can read both old and new states.
+3. Backfill through an idempotent migration or a separately monitored job.
+4. Move reads and writes to the new representation.
+5. Remove the old representation only in a later release, after the rollback
+   window closes.
+
+Application rollback does not roll back database migrations. Consequently,
+every migration in a deploy must remain compatible with the previously live
+application release. `mdbase-cloud-ops/bin/check-release-safety` enforces that
+versioned migration files are additive and are never edited or removed.

--- a/services/server/migrations/0001_collaboration_foundations.sql
+++ b/services/server/migrations/0001_collaboration_foundations.sql
@@ -1,0 +1,48 @@
+ALTER TABLE hosted_replicas
+  ADD COLUMN IF NOT EXISTS authorized_user_id uuid REFERENCES users(id);
+
+UPDATE hosted_replicas
+SET authorized_user_id = grant_record.user_id
+FROM grants grant_record
+WHERE grant_record.hosted_replica_id = hosted_replicas.id
+  AND hosted_replicas.authorized_user_id IS NULL;
+
+UPDATE hosted_replicas
+SET authorized_user_id = pairing.user_id
+FROM mirror_pairing_requests pairing
+WHERE pairing.replica_id = hosted_replicas.id
+  AND pairing.user_id IS NOT NULL
+  AND hosted_replicas.authorized_user_id IS NULL;
+
+UPDATE hosted_replicas
+SET authorized_user_id = collection.user_id
+FROM hosted_collections collection
+WHERE collection.id = hosted_replicas.collection_id
+  AND hosted_replicas.authorized_user_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS hosted_replicas_user_collection_idx
+  ON hosted_replicas(collection_id, authorized_user_id)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS provider_revocation_jobs (
+  id uuid PRIMARY KEY,
+  replica_id uuid NOT NULL,
+  grant_id uuid,
+  collection_id uuid NOT NULL,
+  reason text NOT NULL,
+  state text NOT NULL DEFAULT 'pending'
+    CHECK (state IN ('pending', 'sending', 'completed')),
+  attempts integer NOT NULL DEFAULT 0,
+  available_at timestamptz NOT NULL DEFAULT now(),
+  last_error text,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS provider_revocation_jobs_active_replica_idx
+  ON provider_revocation_jobs(replica_id)
+  WHERE completed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS provider_revocation_jobs_ready_idx
+  ON provider_revocation_jobs(state, available_at)
+  WHERE completed_at IS NULL;

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -15,6 +15,7 @@ import type {
   ApplicationRequirements,
   ApplicationNotifications,
   CollectionContractDescriptor,
+  CollectionOperation,
   ContractRequirement,
   EncryptedRelayOperationRequest,
   GrantEncryption,
@@ -121,33 +122,31 @@ import {
   type EmailTransport
 } from "./email.js";
 import { sendPasswordResetEmail } from "./password-reset-email.js";
+import {
+  accessView,
+  CollectionAccessDeniedError,
+  COLLECTION_OPERATIONS,
+  requireCollectionAction,
+  resolveHostedCollectionAccess,
+  resolveLocalCollectionAccess,
+  type CollectionAction,
+  type CollectionAccessContext
+} from "./collection-access.js";
+import {
+  listLocalCollectionsVisibleToUser,
+  listHostedCollectionsVisibleToUser,
+  resolveHostedCollection
+} from "./collection-catalog.js";
+import {
+  GrantPlanningError,
+  planCollectionGrant
+} from "./grant-planner.js";
+import {
+  ProviderRevocationWorker,
+  queueHostedGrantRevocation
+} from "./hosted-capability-lifecycle.js";
 
-const OPERATIONS = [
-  "describe",
-  "changes",
-  "read",
-  "query",
-  "validate",
-  "list_views",
-  "execute_view",
-  "read_view_source",
-  "create_view_source",
-  "update_view_source",
-  "delete_view_source",
-  "create",
-  "update",
-  "delete",
-  "rename",
-  "read_type",
-  "create_type",
-  "update_type",
-  "list_timers",
-  "put_timer",
-  "cancel_timer",
-  "reconcile_timers",
-  "sync"
-] as const;
-const operationSchema = z.enum(OPERATIONS);
+const operationSchema = z.enum(COLLECTION_OPERATIONS);
 const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 const PASSWORD_LOGIN_EMAIL_LIMIT: AuthRateLimitRule = {
   maxAttempts: 5,
@@ -402,6 +401,16 @@ export async function buildApp(options: BuildOptions) {
   const hostedReference = options.hostedReferenceAuthority
     ? new HostedAuthorityRegistry(options.db)
     : undefined;
+  const providerRevocations = options.hostedProvider
+    ? new ProviderRevocationWorker(
+        options.db,
+        options.hostedProvider,
+        (error) => app.log.error(
+          { err: error },
+          "hosted provider revocation worker failed"
+        )
+      )
+    : undefined;
 
   await app.register(cookie);
   await app.register(helmet, {
@@ -436,10 +445,12 @@ export async function buildApp(options: BuildOptions) {
   await app.register(websocket);
 
   app.addHook("onClose", async () => {
+    await providerRevocations?.close();
     await notifications?.close();
     await relay.close();
   });
   notifications?.start();
+  providerRevocations?.start();
 
   app.addHook("onRequest", async (request, reply) => {
     if (
@@ -488,6 +499,12 @@ export async function buildApp(options: BuildOptions) {
     }
     if (error instanceof RequestValidationError) {
       return reply.code(400).send(apiError("invalid_request", error.message));
+    }
+    if (error instanceof GrantPlanningError) {
+      return reply.code(400).send(apiError("invalid_grant", error.message));
+    }
+    if (error instanceof CollectionAccessDeniedError) {
+      return reply.code(403).send(apiError("collection_access_denied", error.message));
     }
     if (error instanceof OriginDeniedError) {
       return reply.code(403).send(apiError(
@@ -1529,11 +1546,13 @@ export async function buildApp(options: BuildOptions) {
       registered = true;
       await connection.query(
         `INSERT INTO hosted_replicas
-           (id, collection_id, name, mode, allowed_types, token_hash)
-         VALUES ($1, $2, $3, $4, '[]'::jsonb, $5)`,
+           (id, collection_id, authorized_user_id, name, mode, allowed_types,
+            token_hash)
+         VALUES ($1, $2, $3, $4, $5, '[]'::jsonb, $6)`,
         [
           replicaId,
           current.collection_id,
+          current.user_id,
           current.mirror_name,
           current.mode,
           options.hostedProvider ? null : tokenHash(token)
@@ -2203,6 +2222,24 @@ export async function buildApp(options: BuildOptions) {
     const { transferId } = z.object({ transferId: z.uuid() }).parse(request.params);
     z.object({}).strict().parse(request.body ?? {});
     await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
+    const candidate = await options.db.query<{ hosted_collection_id: string }>(
+      `SELECT hosted_collection_id FROM authority_transfers
+       WHERE id = $1 AND user_id = $2`,
+      [transferId, user.id]
+    );
+    const transferAccess = candidate.rows[0]
+      ? await resolveHostedCollectionAccess(
+          options.db,
+          user.id,
+          candidate.rows[0].hosted_collection_id
+        )
+      : null;
+    if (!transferAccess?.actions.has("authority.transfer")) {
+      return reply.code(404).send(apiError(
+        "authority_transfer_not_found",
+        "Authority transfer was not found."
+      ));
+    }
     const approved = await options.db.query<AuthorityTransferRow>(
       `UPDATE authority_transfers
        SET state = 'approved', approved_at = now()
@@ -2672,54 +2709,63 @@ export async function buildApp(options: BuildOptions) {
        ORDER BY c.created_at`,
       [user.id]
     );
-    const collections = await options.db.query(
-      `SELECT col.id, col.connector_id, col.local_id, col.display_name, col.spec_version, col.enabled,
-              col.authority_state, col.authority_epoch, col.contracts, col.last_seen_at,
-              c.name AS connector_name
-       FROM collections col JOIN connectors c ON c.id = col.connector_id
-       WHERE c.user_id = $1 AND c.revoked_at IS NULL
-         AND col.authority_state = 'active'
-         AND col.present = true
-       ORDER BY col.display_name`,
-      [user.id]
+    const localCatalog = await listLocalCollectionsVisibleToUser(
+      options.db,
+      user.id
     );
-    const hostedCollections = options.hostedCollections
-      ? await options.db.query<{
-          id: string;
-          display_name: string;
-          template: string;
-          contracts: CollectionContractDescriptor[];
-          provider_url: string | null;
-          authority_state: "active" | "transferring" | "transferred";
-          authority_epoch: string | number;
-          transferred_collection_id: string | null;
-          created_at: string;
-        }>(
-          `SELECT id, display_name, template, provider_url, contracts, authority_state,
-                  authority_epoch, transferred_collection_id, created_at
-           FROM hosted_collections
-           WHERE user_id = $1 AND authority_state <> 'importing'
-           ORDER BY display_name`,
-          [user.id]
+    const localAuthorityIds = localCatalog.map(
+      (collection) => collection.authorityRowId
+    );
+    const collections = localAuthorityIds.length
+      ? await options.db.query(
+          `SELECT col.id, col.connector_id, col.local_id, col.display_name,
+                  col.spec_version, col.enabled, col.authority_state,
+                  col.authority_epoch, col.contracts, col.last_seen_at,
+                  connector.name AS connector_name
+           FROM collections col
+           JOIN connectors connector ON connector.id = col.connector_id
+           WHERE col.id IN (${sqlPlaceholders(localAuthorityIds.length)})
+             AND connector.revoked_at IS NULL
+             AND col.authority_state = 'active'
+             AND col.present = true
+           ORDER BY col.display_name`,
+          localAuthorityIds
         )
       : { rows: [] };
-    const hostedReplicas = hostedCollections.rows.length
-      ? await options.db.query<{
-          id: string;
-          collection_id: string;
-          name: string;
-          mode: "read_only" | "read_write";
-          allowed_types: string[];
-          revoked_at: string | null;
-          created_at: string;
-        }>(
-          `SELECT r.id, r.collection_id, r.name, r.mode, r.allowed_types,
-                  r.revoked_at, r.created_at
-           FROM hosted_replicas r JOIN hosted_collections c ON c.id = r.collection_id
-           WHERE c.user_id = $1 AND r.purpose = 'mirror' ORDER BY r.created_at`,
-          [user.id]
-        )
-      : { rows: [] };
+    const hostedCatalog = options.hostedCollections
+      ? (await listHostedCollectionsVisibleToUser(options.db, user.id))
+          .filter((collection) =>
+            collection.locator.authorityState !== "importing"
+          )
+      : [];
+    const hostedCollections = {
+      rows: await Promise.all(hostedCatalog.map(async (collection) => ({
+        id: collection.locator.collectionId,
+        display_name: collection.locator.displayName,
+        template: collection.template,
+        contracts: collection.contracts,
+        provider_url: collection.locator.providerUrl ?? null,
+        authority_state:
+          collection.locator.authorityState as "active" | "transferring" | "transferred",
+        authority_epoch: collection.locator.authorityEpoch,
+        transferred_collection_id: collection.transferredCollectionId,
+        created_at: collection.createdAt,
+        access: accessView(requireCollectionAction(
+          await resolveHostedCollectionAccess(
+            options.db,
+            user.id,
+            collection.locator.collectionId
+          ),
+          "collection.discover"
+        ))
+      })))
+    };
+    const hostedReplicas = {
+      rows: await hostedMirrorReplicas(
+        options.db,
+        hostedCollections.rows.map((collection) => collection.id)
+      )
+    };
     const hostedReplicaStatuses = new Map<string, {
       head: number;
       acknowledged_sequence: number;
@@ -2779,12 +2825,37 @@ export async function buildApp(options: BuildOptions) {
         registration: authenticationSettings.registrationMode
       },
       connectors: connectors.rows,
-      collections: collections.rows,
+      collections: await Promise.all(collections.rows.map(async (collection) => {
+        const access = await resolveLocalCollectionAccess(
+          options.db,
+          user.id,
+          collection.id
+        );
+        return {
+          ...collection,
+          ...(access ? {
+            access: accessView(access),
+            authority: {
+              kind: "local",
+              collection_id: access.collection.collectionId,
+              row_id: access.collection.authorityRowId,
+              epoch: access.collection.authorityEpoch,
+              state: access.collection.authorityState
+            }
+          } : {})
+        };
+      })),
       hosted_collections: hostedCollections.rows.map((collection) => ({
         ...collection,
         provider_url: collection.provider_url ?? publicUrl,
         spec_version: "0.3.0",
         authority_epoch: Number(collection.authority_epoch),
+        authority: {
+          kind: "hosted",
+          collection_id: collection.id,
+          epoch: Number(collection.authority_epoch),
+          state: collection.authority_state
+        },
         contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template)),
         replicas: hostedReplicas.rows
           .filter((replica) => replica.collection_id === collection.id)
@@ -2941,12 +3012,17 @@ export async function buildApp(options: BuildOptions) {
           transferred_collection_id: string | null;
         }>(
           `SELECT authority_state, authority_epoch, transferred_collection_id
-           FROM hosted_collections WHERE id = $1 AND user_id = $2`,
-          [collection.id, connector.user_id]
+           FROM hosted_collections WHERE id = $1`,
+          [collection.id]
+        );
+        const hostedAccess = await resolveHostedCollectionAccess(
+          connection,
+          connector.user_id,
+          collection.id
         );
         const existingCollection = existing.rows[0];
         const currentAuthority = activeAuthority.rows[0];
-        const hostedCollection = hosted.rows[0];
+        const hostedCollection = hostedAccess ? hosted.rows[0] : undefined;
         const isActivatedTransfer = Boolean(
           hostedCollection?.authority_state === "transferred"
           && hostedCollection.transferred_collection_id
@@ -4076,31 +4152,36 @@ export async function buildApp(options: BuildOptions) {
           "Hosted application access is temporarily unavailable."
         ));
       }
-      const hosted = await options.db.query<{
-        id: string;
-        template: HostedTemplate;
-        display_name: string;
-        contracts: CollectionContractDescriptor[];
-      }>(
-        `SELECT id, template, display_name, contracts FROM hosted_collections
-         WHERE id = $1 AND user_id = $2 AND authority_state = 'active'`,
-        [input.collection_id, connector.user_id]
+      const access = await resolveHostedCollectionAccess(
+        options.db,
+        connector.user_id,
+        input.collection_id
       );
-      const collection = hosted.rows[0];
-      if (!collection) {
+      const collection = await resolveHostedCollection(
+        options.db,
+        input.collection_id
+      );
+      if (
+        !access
+        || !collection
+        || collection.locator.authorityState !== "active"
+      ) {
         return reply.code(404).send(apiError(
           "hosted_collection_not_found",
           "Hosted collection not found."
         ));
       }
+      requireCollectionAction(access, "application.authorize");
       const approved = await approveHostedAuthorization(options.db, options.hostedProvider, {
         requestId,
         userId: connector.user_id,
-        collectionId: collection.id,
+        collectionId: collection.locator.collectionId,
         operations: input.operations,
-        template: collection.template,
-        displayName: collection.display_name,
-        contracts: collection.contracts
+        contracts: effectiveHostedContractDescriptors(
+          collection.contracts,
+          collection.template
+        ),
+        access
       });
       if (!approved) {
         return reply.code(404).send(apiError(
@@ -4202,7 +4283,13 @@ export async function buildApp(options: BuildOptions) {
       mode: z.enum(["read_only", "read_write"]),
       allowed_types: z.array(z.string().min(1).max(100)).max(100).default([])
     }).strict().parse(request.body);
-    if (!await ownsActiveHostedCollection(options.db, user.id, collectionId)) {
+    if (!await permitsHostedCollectionAction(
+      options.db,
+      user.id,
+      collectionId,
+      "mirror.enroll",
+      true
+    )) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
     }
     const replicaId = randomUUID();
@@ -4225,11 +4312,14 @@ export async function buildApp(options: BuildOptions) {
     }
     try {
       await options.db.query(
-        `INSERT INTO hosted_replicas (id, collection_id, name, mode, allowed_types, token_hash)
-         VALUES ($1, $2, $3, $4, $5::jsonb, $6)`,
+        `INSERT INTO hosted_replicas
+           (id, collection_id, authorized_user_id, name, mode, allowed_types,
+            token_hash)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)`,
         [
           replicaId,
           collectionId,
+          user.id,
           input.name,
           input.mode,
           JSON.stringify(input.allowed_types),
@@ -4267,7 +4357,12 @@ export async function buildApp(options: BuildOptions) {
     if (!user) return;
     const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
     const input = z.object({ display_name: z.string().trim().min(1).max(200) }).strict().parse(request.body);
-    if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
+    if (!await permitsHostedCollectionAction(
+      options.db,
+      user.id,
+      collectionId,
+      "collection.rename"
+    )) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
     }
     if (options.hostedProvider) {
@@ -4291,7 +4386,12 @@ export async function buildApp(options: BuildOptions) {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
     const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
-    if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
+    if (!await permitsHostedCollectionAction(
+      options.db,
+      user.id,
+      collectionId,
+      "collection.delete"
+    )) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
     }
     if (options.hostedProvider) await options.hostedProvider.deleteCollection(collectionId);
@@ -4322,12 +4422,33 @@ export async function buildApp(options: BuildOptions) {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
     const { replicaId } = z.object({ replicaId: z.uuid() }).parse(request.params);
-    const active = await options.db.query<{ id: string; collection_id: string }>(
-      `SELECT r.id, r.collection_id FROM hosted_replicas r JOIN hosted_collections c ON c.id = r.collection_id
-       WHERE r.id = $1 AND c.user_id = $2 AND r.revoked_at IS NULL`,
-      [replicaId, user.id]
+    const active = await options.db.query<{
+      id: string;
+      collection_id: string;
+      authorized_user_id: string | null;
+    }>(
+      `SELECT id, collection_id, authorized_user_id
+       FROM hosted_replicas
+       WHERE id = $1 AND revoked_at IS NULL`,
+      [replicaId]
     );
-    if (!active.rows[0]) return reply.code(404).send(apiError("replica_not_found", "Active replica not found."));
+    const access = active.rows[0]
+      ? await resolveHostedCollectionAccess(
+          options.db,
+          user.id,
+          active.rows[0].collection_id
+        )
+      : null;
+    if (
+      !active.rows[0]
+      || !access
+      || !canManageHostedReplica(access, active.rows[0].authorized_user_id)
+    ) {
+      return reply.code(404).send(apiError(
+        "replica_not_found",
+        "Active replica not found."
+      ));
+    }
     const token = randomToken("hsr");
     if (options.hostedProvider) {
       await options.hostedProvider.rotateReplicaToken(replicaId, token);
@@ -4348,13 +4469,32 @@ export async function buildApp(options: BuildOptions) {
     const user = await requireUser(request, reply, options.db, options.tailscaleAuth);
     if (!user) return;
     const { replicaId } = z.object({ replicaId: z.uuid() }).parse(request.params);
-    const active = await options.db.query<{ collection_id: string }>(
-      `SELECT r.collection_id FROM hosted_replicas r
-       JOIN hosted_collections c ON c.id = r.collection_id
-       WHERE r.id = $1 AND r.revoked_at IS NULL AND c.user_id = $2`,
-      [replicaId, user.id]
+    const active = await options.db.query<{
+      collection_id: string;
+      authorized_user_id: string | null;
+    }>(
+      `SELECT collection_id, authorized_user_id
+       FROM hosted_replicas
+       WHERE id = $1 AND revoked_at IS NULL`,
+      [replicaId]
     );
-    if (!active.rows[0]) return reply.code(404).send(apiError("replica_not_found", "Active replica not found."));
+    const access = active.rows[0]
+      ? await resolveHostedCollectionAccess(
+          options.db,
+          user.id,
+          active.rows[0].collection_id
+        )
+      : null;
+    if (
+      !active.rows[0]
+      || !access
+      || !canManageHostedReplica(access, active.rows[0].authorized_user_id)
+    ) {
+      return reply.code(404).send(apiError(
+        "replica_not_found",
+        "Active replica not found."
+      ));
+    }
     if (options.hostedProvider) await options.hostedProvider.revokeReplica(replicaId);
     else await hostedReference!.revokeReplica(active.rows[0].collection_id, replicaId);
     await options.db.query(
@@ -4371,7 +4511,12 @@ export async function buildApp(options: BuildOptions) {
     if (!user) return;
     const { collectionId } = z.object({ collectionId: z.uuid() }).parse(request.params);
     const input = z.object({ through: z.number().int().nonnegative() }).strict().parse(request.body);
-    if (!await ownsHostedCollection(options.db, user.id, collectionId)) {
+    if (!await permitsHostedCollectionAction(
+      options.db,
+      user.id,
+      collectionId,
+      "schema.manage"
+    )) {
       return reply.code(404).send(apiError("hosted_collection_not_found", "Hosted collection not found."));
     }
     if (options.hostedProvider) {
@@ -4538,10 +4683,23 @@ export async function buildApp(options: BuildOptions) {
     const ownership = await options.db.query<{ connector_id: string; contracts: CollectionContractDescriptor[]; spec_version: string }>(
       `SELECT col.connector_id, col.contracts, col.spec_version FROM collections col
        JOIN connectors c ON c.id = col.connector_id
-       WHERE col.id = $1 AND c.user_id = $2 AND c.revoked_at IS NULL`,
-      [input.collection_id, user.id]
+       WHERE col.id = $1 AND c.revoked_at IS NULL`,
+      [input.collection_id]
     );
-    if (!ownership.rows[0]) return reply.code(404).send(apiError("collection_not_found", "Collection not found."));
+    const collectionAccess = await resolveLocalCollectionAccess(
+      options.db,
+      user.id,
+      input.collection_id
+    );
+    if (
+      !ownership.rows[0]
+      || !collectionAccess?.actions.has("application.authorize")
+    ) {
+      return reply.code(404).send(apiError(
+        "collection_not_found",
+        "Collection not found."
+      ));
+    }
     const application = await options.db.query<{
       id: string;
       distribution: "web" | "portable";
@@ -4565,12 +4723,7 @@ export async function buildApp(options: BuildOptions) {
         "This application requires an mdbase cloud collection."
       ));
     }
-    assertOperationsAllowedByRequirements(input.operations, application.rows[0].requirements);
     assertCollectionSupportsOperations(ownership.rows[0].spec_version, input.operations);
-    const scope = scopeForRequirements(
-      application.rows[0].requirements,
-      ownership.rows[0].contracts
-    );
     if (!contractsSatisfy(
       ownership.rows[0].contracts,
       requiredContractsForRequirements(application.rows[0].requirements)
@@ -4580,12 +4733,19 @@ export async function buildApp(options: BuildOptions) {
         "This collection does not provide the contracts required by the application."
       ));
     }
+    const plan = planCollectionGrant({
+      requestedOperations: input.operations,
+      applicationOperationCeiling: input.operations,
+      requirements: application.rows[0].requirements,
+      availableContracts: ownership.rows[0].contracts,
+      access: collectionAccess
+    });
     const grant = await createOrUpdateGrant(options.db, {
       userId: user.id,
       applicationId: input.application_id,
       collectionId: input.collection_id,
-      operations: input.operations,
-      scope,
+      operations: plan.operations,
+      scope: plan.scope,
       applicationOrigin: new URL(application.rows[0].homepage).origin,
       notificationCriteria: application.rows[0].notifications.criteria
     });
@@ -4683,21 +4843,33 @@ export async function buildApp(options: BuildOptions) {
       if (!options.hostedProvider) {
         return reply.code(503).send(apiError("hosted_provider_unavailable", "Hosted application access is temporarily unavailable."));
       }
-      await options.hostedProvider.revokeReplica(active.rows[0].hosted_replica_id);
-      if (active.rows[0].hosted_collection_id) {
-        await options.hostedProvider.revokeNotificationGrant(
-          active.rows[0].hosted_collection_id,
-          grantId
-        );
+      const queued = await queueHostedGrantRevocation(
+        options.db,
+        user.id,
+        grantId,
+        "user_request"
+      );
+      if (!queued) {
+        return reply.code(404).send(apiError(
+          "grant_not_found",
+          "Active grant not found."
+        ));
       }
+      await providerRevocations?.drain();
+    } else {
       await options.db.query(
-        "UPDATE hosted_replicas SET revoked_at = now() WHERE id = $1",
-        [active.rows[0].hosted_replica_id]
+        "UPDATE grants SET revoked_at = now() WHERE id = $1",
+        [grantId]
+      );
+      await options.db.query(
+        "UPDATE access_tokens SET revoked_at = now() WHERE grant_id = $1",
+        [grantId]
+      );
+      await options.db.query(
+        "UPDATE refresh_tokens SET revoked_at = now() WHERE grant_id = $1",
+        [grantId]
       );
     }
-    await options.db.query("UPDATE grants SET revoked_at = now() WHERE id = $1", [grantId]);
-    await options.db.query("UPDATE access_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
-    await options.db.query("UPDATE refresh_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
     if (active.rows[0].connector_id) await relay.pushPolicy(active.rows[0].connector_id);
     await audit(options.db, user.id, "grant.revoked", grantId, {});
     return { ok: true };
@@ -4836,27 +5008,37 @@ export async function buildApp(options: BuildOptions) {
       ? { collections: [], unavailable_connectors: [] }
       : await liveAuthorizationCollections(options.db, relay, user.id, requestId);
     const hosted = options.hostedCollections
-      ? await options.db.query<{
-          id: string;
-          display_name: string;
-          spec_version?: string;
-          template: HostedTemplate;
-          contracts: CollectionContractDescriptor[];
-        }>(
-          `SELECT id, display_name, template, contracts FROM hosted_collections
-           WHERE user_id = $1 AND authority_state = 'active' ORDER BY display_name`,
-          [user.id]
-        )
-      : { rows: [] };
-    const availableCollections = [
-      ...local.collections,
-      ...hosted.rows.map((collection) => ({
-        ...collection,
+      ? (await listHostedCollectionsVisibleToUser(options.db, user.id))
+          .filter((collection) =>
+            collection.locator.authorityState === "active"
+          )
+      : [];
+    const hostedCollections = await Promise.all(hosted.map(async (collection) => {
+      const access = requireCollectionAction(
+        await resolveHostedCollectionAccess(
+          options.db,
+          user.id,
+          collection.locator.collectionId
+        ),
+        "application.authorize"
+      );
+      return {
+        id: collection.locator.collectionId,
+        display_name: collection.locator.displayName,
+        template: collection.template,
         kind: "hosted" as const,
         connector_name: "Hosted by mdbase",
         spec_version: "0.3.0",
-        contracts: contractRequirements(effectiveHostedContractDescriptors(collection.contracts, collection.template))
-      }))
+        contracts: contractRequirements(effectiveHostedContractDescriptors(
+          collection.contracts,
+          collection.template
+        )),
+        access: accessView(access)
+      };
+    }));
+    const availableCollections = [
+      ...local.collections,
+      ...hostedCollections
     ];
     return {
       authorization: authorization.rows[0],
@@ -4934,22 +5116,34 @@ export async function buildApp(options: BuildOptions) {
         operations: input.operations
       });
     } else {
-      const hosted = await options.db.query<{ id: string; template: string; display_name: string; contracts: CollectionContractDescriptor[] }>(
-        `SELECT id, template, display_name, contracts FROM hosted_collections
-         WHERE id = $1 AND user_id = $2 AND authority_state = 'active'`,
-        [input.collection_id, user.id]
+      const access = await resolveHostedCollectionAccess(
+        options.db,
+        user.id,
+        input.collection_id
       );
-      if (!hosted.rows[0] || !options.hostedProvider) {
+      const hosted = await resolveHostedCollection(
+        options.db,
+        input.collection_id
+      );
+      if (
+        !access
+        || !hosted
+        || hosted.locator.authorityState !== "active"
+        || !options.hostedProvider
+      ) {
         return reply.code(404).send(apiError("collection_not_found", "Collection not found."));
       }
+      requireCollectionAction(access, "application.authorize");
       approved = await approveHostedAuthorization(options.db, options.hostedProvider, {
         requestId,
         userId: user.id,
         collectionId: input.collection_id,
         operations: input.operations,
-        template: hosted.rows[0].template,
-        displayName: hosted.rows[0].display_name,
-        contracts: effectiveHostedContractDescriptors(hosted.rows[0].contracts, hosted.rows[0].template)
+        contracts: effectiveHostedContractDescriptors(
+          hosted.contracts,
+          hosted.template
+        ),
+        access
       });
     }
     if (!approved) return reply.code(404).send(apiError("authorization_not_found", "Authorization request expired or was not found."));
@@ -5983,6 +6177,13 @@ function sameStrings(left: string[], right: string[]): boolean {
     && [...leftValues].every((value) => rightValues.has(value));
 }
 
+function sqlPlaceholders(count: number, offset = 0): string {
+  return Array.from(
+    { length: count },
+    (_, index) => `$${index + offset + 1}`
+  ).join(", ");
+}
+
 interface LiveAuthorizationCollection {
   id: string;
   offer_id: string;
@@ -5991,6 +6192,7 @@ interface LiveAuthorizationCollection {
   display_name: string;
   spec_version: string;
   contracts: CollectionContractDescriptor[];
+  access: ReturnType<typeof accessView>;
 }
 
 async function liveAuthorizationCollections(
@@ -6011,7 +6213,18 @@ async function liveAuthorizationCollections(
      WHERE authorization_id = $1 AND expires_at <= now()`,
     [authorizationId]
   );
-  const connectors = await db.query<{
+  const visibleCollections = await listLocalCollectionsVisibleToUser(db, userId);
+  const visibleByConnector = new Map<string, Set<string>>();
+  for (const collection of visibleCollections) {
+    if (
+      collection.authorityState !== "active"
+      || !collection.connectorId
+    ) continue;
+    const ids = visibleByConnector.get(collection.connectorId) ?? new Set();
+    ids.add(collection.authorityRowId);
+    visibleByConnector.set(collection.connectorId, ids);
+  }
+  const ownerConnectors = await db.query<{
     id: string;
     name: string;
     inventory_revision: string | number;
@@ -6021,6 +6234,25 @@ async function liveAuthorizationCollections(
      ORDER BY created_at`,
     [userId]
   );
+  const ownerConnectorIds = new Set(ownerConnectors.rows.map(({ id }) => id));
+  const sharedConnectorIds = [...visibleByConnector.keys()]
+    .filter((id) => !ownerConnectorIds.has(id));
+  const sharedConnectors = sharedConnectorIds.length
+    ? await db.query<{
+        id: string;
+        name: string;
+        inventory_revision: string | number;
+      }>(
+        `SELECT id, name, inventory_revision FROM connectors
+         WHERE id IN (${sqlPlaceholders(sharedConnectorIds.length)})
+           AND revoked_at IS NULL
+         ORDER BY created_at`,
+        sharedConnectorIds
+      )
+    : { rows: [] };
+  const connectors = {
+    rows: [...ownerConnectors.rows, ...sharedConnectors.rows]
+  };
   const settled = await Promise.allSettled(connectors.rows.map(async (connector) => ({
     connector,
     response: await relay.authorizationOffers(connector.id, authorizationId)
@@ -6056,14 +6288,14 @@ async function liveAuthorizationCollections(
       authority_epoch: string | number;
     }>(
       `SELECT id, local_id, authority_epoch FROM collections
-       WHERE user_id = $1 AND connector_id = $2
+       WHERE connector_id = $1
          AND present = true AND enabled = true AND authority_state = 'active'`,
-      [userId, connector.id]
+      [connector.id]
     );
-    const byLocalId = new Map(authoritative.rows.map((collection) => [
-      collection.local_id,
-      collection
-    ]));
+    const visibleIds = visibleByConnector.get(connector.id) ?? new Set();
+    const byLocalId = new Map(authoritative.rows
+      .filter((collection) => visibleIds.has(collection.id))
+      .map((collection) => [collection.local_id, collection] as const));
     for (const offered of result.value.response.collections) {
       const collection = byLocalId.get(offered.collection_id);
       if (!collection) continue;
@@ -6091,6 +6323,12 @@ async function liveAuthorizationCollections(
         ]
       );
       if (!offer.rows[0]) continue;
+      const access = await resolveLocalCollectionAccess(
+        db,
+        userId,
+        collection.id
+      );
+      if (!access || !access.actions.has("application.authorize")) continue;
       collections.push({
         id: collection.id,
         offer_id: offer.rows[0].id,
@@ -6098,7 +6336,8 @@ async function liveAuthorizationCollections(
         connector_name: connector.name,
         display_name: offered.display_name,
         spec_version: offered.spec_version,
-        contracts: offered.contracts
+        contracts: offered.contracts,
+        access: accessView(access)
       });
     }
   }
@@ -6121,7 +6360,7 @@ async function approvePortalAuthorization(
     userId: string;
     offerId: string;
     collectionId: string;
-    operations: string[];
+    operations: CollectionOperation[];
   }
 ): Promise<boolean> {
   const connection = await db.connect();
@@ -6131,6 +6370,7 @@ async function approvePortalAuthorization(
   let requirements: ApplicationRequirements;
   let provisions: ApplicationProvisions;
   let grant: GrantPolicy;
+  let grantAccess: CollectionAccessContext;
   try {
     await connection.query("BEGIN");
     const authorization = await connection.query<{
@@ -6209,13 +6449,6 @@ async function approvePortalAuthorization(
     if (requiresHostedCollection(pending.requirements)) {
       throw new RequestValidationError("This application requires an mdbase cloud collection.");
     }
-    const operations = [...new Set(input.operations)];
-    if (operations.some((operation) => !pending.requested_operations.includes(operation))) {
-      throw new RequestValidationError(
-        "Approved operations must be requested by the application."
-      );
-    }
-    assertOperationsAllowedByRequirements(operations, pending.requirements);
     const offer = await connection.query<{
       connector_id: string;
       local_id: string;
@@ -6233,7 +6466,7 @@ async function approvePortalAuthorization(
        WHERE offer.id = $1 AND offer.authorization_id = $2
          AND offer.user_id = $3 AND offer.collection_id = $4
          AND offer.consumed_at IS NULL AND offer.expires_at > now()
-         AND col.user_id = $3 AND col.present = true AND col.enabled = true
+         AND col.present = true AND col.enabled = true
          AND col.authority_state = 'active'
          AND col.authority_epoch = offer.authority_epoch
          AND con.revoked_at IS NULL
@@ -6247,8 +6480,25 @@ async function approvePortalAuthorization(
         "That collection is no longer being offered by a live connector. Refresh and choose again."
       );
     }
+    grantAccess = requireCollectionAction(
+      await resolveLocalCollectionAccess(
+        connection,
+        input.userId,
+        input.collectionId
+      ),
+      "application.authorize"
+    );
+    const plan = planCollectionGrant({
+      requestedOperations: input.operations,
+      applicationOperationCeiling:
+        pending.requested_operations as CollectionOperation[],
+      requirements: pending.requirements,
+      availableContracts: selected.contracts,
+      access: grantAccess
+    });
+    const operations = plan.operations;
     assertCollectionSupportsOperations(selected.spec_version, operations);
-    const scope = scopeForRequirements(pending.requirements, selected.contracts);
+    const scope = plan.scope;
     let encryption: GrantEncryption | undefined;
     if (pending.relay_protocol === ENCRYPTED_RELAY_PROTOCOL_VERSION) {
       if (!pending.application_public_key || !selected.relay_public_key) {
@@ -6360,7 +6610,13 @@ async function approvePortalAuthorization(
         "The authorization request changed before activation completed."
       );
     }
-    const finalScope = scopeForRequirements(requirements, activation.contracts);
+    const finalScope = planCollectionGrant({
+      requestedOperations: grant!.operations,
+      applicationOperationCeiling: grant!.operations,
+      requirements,
+      availableContracts: activation.contracts,
+      access: grantAccess!
+    }).scope;
     await finalize.query(
       `UPDATE grants SET activated_at = now(), scope = $2::jsonb
        WHERE id = $1 AND activated_at IS NULL`,
@@ -6589,10 +6845,9 @@ async function approveHostedAuthorization(
     requestId: string;
     userId: string;
     collectionId: string;
-    operations: string[];
-    template: string;
-    displayName: string;
+    operations: CollectionOperation[];
     contracts: CollectionContractDescriptor[];
+    access: CollectionAccessContext;
   }
 ): Promise<boolean> {
   const connection = await db.connect();
@@ -6648,10 +6903,6 @@ async function approveHostedAuthorization(
         "Device authorization is reserved for downloaded applications."
       );
     }
-    if (input.operations.some((operation) => !pending.requested_operations.includes(operation))) {
-      throw new RequestValidationError("Approved operations must be requested by the application.");
-    }
-    assertOperationsAllowedByRequirements(input.operations, pending.requirements);
     const requiredContracts = requiredContractsForRequirements(pending.requirements);
     let availableDescriptors = input.contracts;
     let availableContracts = contractRequirements(availableDescriptors);
@@ -6666,6 +6917,7 @@ async function approveHostedAuthorization(
       );
     }
     if (provisions.length > 0) {
+      requireCollectionAction(input.access, "schema.manage");
       availableDescriptors = await provider.provisionTypePacks(
         input.collectionId,
         provisions
@@ -6681,17 +6933,20 @@ async function approveHostedAuthorization(
         "This hosted collection does not provide the contracts required by the application."
       );
     }
-    const scope = scopeForRequirements(
-      pending.requirements,
-      availableDescriptors
-    );
+    const plan = planCollectionGrant({
+      requestedOperations: input.operations,
+      applicationOperationCeiling:
+        pending.requested_operations as CollectionOperation[],
+      requirements: pending.requirements,
+      availableContracts: availableDescriptors,
+      access: input.access
+    });
+    const scope = plan.scope;
     const allowedTypes = allowedTypesForRequirements(
       availableDescriptors,
       pending.requirements
     );
-    await provider.renameCollection(input.collectionId, input.displayName);
-    const operations = [...new Set(input.operations)];
-    const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type", "create_view_source", "update_view_source", "delete_view_source", "put_timer", "cancel_timer", "reconcile_timers"].includes(operation));
+    const operations = plan.operations;
     const applicationOrigin = pending.flow === "device_code"
       ? "null"
       : applicationOriginForRedirect(
@@ -6711,10 +6966,10 @@ async function approveHostedAuthorization(
       id: replicaId,
       name: `${pending.application_name} application access`,
       purpose: "application",
-      mode: write ? "read_write" : "read_only",
+      mode: plan.replicaMode,
       allowedTypes,
       contractScope: scope.access === "contract" ? scope.contracts : [],
-      fullCollection: pending.requirements.access === "full_collection",
+      fullCollection: scope.access === "full_collection",
       allowedOperations: operations,
       allowedOrigin,
       proofPublicKey: pending.flow === "device_code"
@@ -6726,13 +6981,15 @@ async function approveHostedAuthorization(
     });
     await connection.query(
       `INSERT INTO hosted_replicas
-         (id, collection_id, name, purpose, mode, allowed_types, token_hash)
-       VALUES ($1, $2, $3, 'application', $4, $5::jsonb, NULL)`,
+         (id, collection_id, authorized_user_id, name, purpose, mode,
+          allowed_types, token_hash)
+       VALUES ($1, $2, $3, $4, 'application', $5, $6::jsonb, NULL)`,
       [
         replicaId,
         input.collectionId,
+        input.userId,
         `${pending.application_name} application access`,
-        write ? "read_write" : "read_only",
+        plan.replicaMode,
         JSON.stringify(allowedTypes)
       ]
     );
@@ -6876,7 +7133,9 @@ async function issueApplicationTokens(
   };
 }> {
   const grant = await db.query<{
+    user_id: string;
     collection_id: string;
+    local_authority_row_id: string | null;
     collection_name: string;
     hosted_collection_id: string | null;
     hosted_replica_id: string | null;
@@ -6887,7 +7146,9 @@ async function issueApplicationTokens(
     proof_public_key: string | null;
     application_origin: string;
   }>(
-    `SELECT COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
+    `SELECT g.user_id,
+            COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
+            g.collection_id AS local_authority_row_id,
             COALESCE(col.display_name, hosted.display_name) AS collection_name,
             g.hosted_collection_id, g.hosted_replica_id, hosted.provider_url,
             g.operations, g.scope, g.encryption, g.proof_public_key,
@@ -6898,12 +7159,33 @@ async function issueApplicationTokens(
      JOIN applications app ON app.id = g.application_id
      LEFT JOIN collections col ON col.id = g.collection_id
      LEFT JOIN hosted_collections hosted ON hosted.id = g.hosted_collection_id
+     LEFT JOIN hosted_replicas replica ON replica.id = g.hosted_replica_id
      WHERE g.id = $1 AND g.revoked_at IS NULL
        AND g.activated_at IS NOT NULL
-       AND u.suspended_at IS NULL`,
+       AND u.suspended_at IS NULL
+       AND (g.hosted_replica_id IS NULL OR replica.revoked_at IS NULL)`,
     [grantId]
   );
   if (!grant.rows[0]) throw new RequestValidationError("The application grant is no longer active.");
+  if (grant.rows[0].hosted_collection_id) {
+    requireCollectionAction(
+      await resolveHostedCollectionAccess(
+        db,
+        grant.rows[0].user_id,
+        grant.rows[0].hosted_collection_id
+      ),
+      "application.authorize"
+    );
+  } else if (grant.rows[0].local_authority_row_id) {
+    requireCollectionAction(
+      await resolveLocalCollectionAccess(
+        db,
+        grant.rows[0].user_id,
+        grant.rows[0].local_authority_row_id
+      ),
+      "application.authorize"
+    );
+  }
   const accessToken = randomToken("mdb");
   const refreshToken = randomToken("ref");
   let authority: {
@@ -7283,6 +7565,12 @@ async function authorityPairing(
   ) {
     return null;
   }
+  const access = await resolveHostedCollectionAccess(
+    db,
+    pairing.user_id,
+    pairing.collection_id
+  );
+  if (!access?.actions.has("authority.transfer")) return null;
   const {
     replica_collection_id: _replicaCollectionId,
     consumed_at: _consumedAt,
@@ -7312,7 +7600,14 @@ async function mirrorAuthorityTransfer(
        AND account.suspended_at IS NULL`,
     [transferId, tokenHash(secret)]
   );
-  return result.rows[0] ?? null;
+  const transfer = result.rows[0];
+  if (!transfer) return null;
+  const access = await resolveHostedCollectionAccess(
+    db,
+    transfer.user_id,
+    transfer.hosted_collection_id
+  );
+  return access?.actions.has("authority.transfer") ? transfer : null;
 }
 
 function authorityAdoptionSelect(): string {
@@ -7620,6 +7915,33 @@ function authorityImportCapability(
   };
 }
 
+interface HostedMirrorReplicaRow {
+  id: string;
+  collection_id: string;
+  name: string;
+  mode: "read_only" | "read_write";
+  allowed_types: string[];
+  revoked_at: string | null;
+  created_at: string;
+}
+
+async function hostedMirrorReplicas(
+  db: DatabaseQueryable,
+  collectionIds: string[]
+): Promise<HostedMirrorReplicaRow[]> {
+  if (collectionIds.length === 0) return [];
+  const result = await db.query<HostedMirrorReplicaRow>(
+    `SELECT id, collection_id, name, mode, allowed_types, revoked_at,
+            created_at
+     FROM hosted_replicas
+     WHERE collection_id IN (${sqlPlaceholders(collectionIds.length)})
+       AND purpose = 'mirror'
+     ORDER BY created_at`,
+    collectionIds
+  );
+  return result.rows;
+}
+
 async function hostedControlSnapshot(
   options: BuildOptions,
   hostedReference: HostedAuthorityRegistry | undefined,
@@ -7636,7 +7958,8 @@ async function hostedControlSnapshot(
     };
   }
   await recoverExpiredAuthorityTransfers(options.db, options.hostedProvider, hostedReference);
-  const collections = await options.db.query<{
+  const catalog = await listHostedCollectionsVisibleToUser(options.db, userId);
+  const collections: { rows: Array<{
     id: string;
     display_name: string;
     template: HostedTemplate;
@@ -7645,32 +7968,36 @@ async function hostedControlSnapshot(
     authority_state: "active" | "transferring" | "transferred";
     authority_epoch: string | number;
     transferred_collection_id: string | null;
-    created_at: string;
-  }>(
-    `SELECT id, display_name, template, provider_url, contracts, authority_state,
-            authority_epoch, transferred_collection_id, created_at
-     FROM hosted_collections WHERE user_id = $1 ORDER BY display_name`,
-    [userId]
-  );
-  const replicas = collections.rows.length
-    ? await options.db.query<{
-        id: string;
-        collection_id: string;
-        name: string;
-        mode: "read_only" | "read_write";
-        allowed_types: string[];
-        revoked_at: string | null;
-        created_at: string;
-      }>(
-        `SELECT replica.id, replica.collection_id, replica.name, replica.mode,
-                replica.allowed_types, replica.revoked_at, replica.created_at
-         FROM hosted_replicas replica
-         JOIN hosted_collections collection ON collection.id = replica.collection_id
-         WHERE collection.user_id = $1 AND replica.purpose = 'mirror'
-         ORDER BY replica.created_at`,
-        [userId]
-      )
-    : { rows: [] };
+    created_at: string | Date;
+    access: ReturnType<typeof accessView>;
+  }> } = {
+    rows: await Promise.all(catalog.map(async (collection) => ({
+      id: collection.locator.collectionId,
+      display_name: collection.locator.displayName,
+      template: collection.template,
+      contracts: collection.contracts,
+      provider_url: collection.locator.providerUrl ?? null,
+      authority_state:
+        collection.locator.authorityState as "active" | "transferring" | "transferred",
+      authority_epoch: collection.locator.authorityEpoch,
+      transferred_collection_id: collection.transferredCollectionId,
+      created_at: collection.createdAt,
+      access: accessView(requireCollectionAction(
+        await resolveHostedCollectionAccess(
+          options.db,
+          userId,
+          collection.locator.collectionId
+        ),
+        "collection.discover"
+      ))
+    })))
+  };
+  const replicas = {
+    rows: await hostedMirrorReplicas(
+      options.db,
+      collections.rows.map((collection) => collection.id)
+    )
+  };
   const statuses = new Map<string, {
     head: number;
     acknowledged_sequence: number;
@@ -7732,6 +8059,12 @@ async function hostedControlSnapshot(
       provider_url: collection.provider_url ?? publicUrl,
       spec_version: "0.3.0",
       authority_epoch: Number(collection.authority_epoch),
+      authority: {
+        kind: "hosted",
+        collection_id: collection.id,
+        epoch: Number(collection.authority_epoch),
+        state: collection.authority_state
+      },
       contracts: contractRequirements(
         effectiveHostedContractDescriptors(collection.contracts, collection.template)
       ),
@@ -7818,7 +8151,12 @@ async function renameHostedCollectionForUser(
   collectionId: string,
   displayName: string
 ): Promise<{ id: string; display_name: string } | null> {
-  if (!await ownsHostedCollection(options.db, userId, collectionId)) return null;
+  if (!await permitsHostedCollectionAction(
+    options.db,
+    userId,
+    collectionId,
+    "collection.rename"
+  )) return null;
   if (options.hostedProvider) {
     await options.hostedProvider.renameCollection(collectionId, displayName);
   }
@@ -7840,7 +8178,12 @@ async function deleteHostedCollectionForUser(
   userId: string,
   collectionId: string
 ): Promise<boolean> {
-  if (!await ownsHostedCollection(options.db, userId, collectionId)) return false;
+  if (!await permitsHostedCollectionAction(
+    options.db,
+    userId,
+    collectionId,
+    "collection.delete"
+  )) return false;
   if (options.hostedProvider) await options.hostedProvider.deleteCollection(collectionId);
   else await hostedReference!.delete(collectionId);
   const connection = await options.db.connect();
@@ -7875,16 +8218,27 @@ async function revokeHostedReplicaForUser(
 ): Promise<boolean> {
   const found = await options.db.query<{
     collection_id: string;
+    authorized_user_id: string | null;
     revoked_at: string | null;
   }>(
-    `SELECT replica.collection_id, replica.revoked_at FROM hosted_replicas replica
-     JOIN hosted_collections collection ON collection.id = replica.collection_id
-     WHERE replica.id = $1 AND replica.purpose = 'mirror'
-       AND collection.user_id = $2`,
-    [replicaId, userId]
+    `SELECT collection_id, authorized_user_id, revoked_at
+     FROM hosted_replicas
+     WHERE id = $1 AND purpose = 'mirror'`,
+    [replicaId]
   );
   const replica = found.rows[0];
-  if (!replica) return false;
+  const access = replica
+    ? await resolveHostedCollectionAccess(
+        options.db,
+        userId,
+        replica.collection_id
+      )
+    : null;
+  if (
+    !replica
+    || !access
+    || !canManageHostedReplica(access, replica.authorized_user_id)
+  ) return false;
   if (replica.revoked_at) return true;
   if (options.hostedProvider) await options.hostedProvider.revokeReplica(replicaId);
   else await hostedReference!.revokeReplica(replica.collection_id, replicaId);
@@ -7978,58 +8332,49 @@ async function revokeHostedGrantForUser(
   userId: string,
   grantId: string
 ): Promise<boolean> {
-  const active = await options.db.query<{
-    hosted_collection_id: string;
-    hosted_replica_id: string;
-  }>(
-    `SELECT g.hosted_collection_id, g.hosted_replica_id
-     FROM grants g
-     JOIN hosted_collections h ON h.id = g.hosted_collection_id
-     WHERE g.id = $1 AND g.user_id = $2 AND g.revoked_at IS NULL
-       AND g.activated_at IS NOT NULL`,
-    [grantId, userId]
-  );
-  const current = active.rows[0];
-  if (!current) return false;
   if (!options.hostedProvider) {
     throw new RequestValidationError("Hosted application access is temporarily unavailable.");
   }
-  await options.hostedProvider.revokeReplica(current.hosted_replica_id);
-  await options.hostedProvider.revokeNotificationGrant(current.hosted_collection_id, grantId);
-  await options.db.query(
-    "UPDATE hosted_replicas SET revoked_at = now() WHERE id = $1",
-    [current.hosted_replica_id]
+  const queued = await queueHostedGrantRevocation(
+    options.db,
+    userId,
+    grantId,
+    "user_request"
   );
-  await options.db.query("UPDATE grants SET revoked_at = now() WHERE id = $1", [grantId]);
-  await options.db.query("UPDATE access_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
-  await options.db.query("UPDATE refresh_tokens SET revoked_at = now() WHERE grant_id = $1", [grantId]);
+  if (!queued) return false;
+  const worker = new ProviderRevocationWorker(
+    options.db,
+    options.hostedProvider
+  );
+  await worker.drain();
   await audit(options.db, userId, "grant.revoked", grantId, { source: "desktop" });
   return true;
 }
 
-async function ownsHostedCollection(
+async function permitsHostedCollectionAction(
   db: DatabasePool,
   userId: string,
-  collectionId: string
+  collectionId: string,
+  action: CollectionAction,
+  activeOnly = false
 ): Promise<boolean> {
-  const result = await db.query(
-    "SELECT id FROM hosted_collections WHERE id = $1 AND user_id = $2",
-    [collectionId, userId]
+  const access = await resolveHostedCollectionAccess(db, userId, collectionId);
+  return Boolean(
+    access
+    && access.actions.has(action)
+    && (!activeOnly || access.collection.authorityState === "active")
   );
-  return Boolean(result.rows[0]);
 }
 
-async function ownsActiveHostedCollection(
-  db: DatabasePool,
-  userId: string,
-  collectionId: string
-): Promise<boolean> {
-  const result = await db.query(
-    `SELECT id FROM hosted_collections
-     WHERE id = $1 AND user_id = $2 AND authority_state = 'active'`,
-    [collectionId, userId]
-  );
-  return Boolean(result.rows[0]);
+function canManageHostedReplica(
+  access: CollectionAccessContext,
+  authorizedUserId: string | null
+): boolean {
+  return access.actions.has("members.manage")
+    || (
+      authorizedUserId === access.userId
+      && access.actions.has("mirror.enroll")
+    );
 }
 
 async function rotateMirrorPairingToken(

--- a/services/server/src/auth-admin-cli.ts
+++ b/services/server/src/auth-admin-cli.ts
@@ -2,7 +2,8 @@ import {
   InvitationDeliveryError,
   runAuthAdminCommand
 } from "./auth-admin.js";
-import { createDatabase } from "./db.js";
+import { openDatabase } from "./db.js";
+import { assertControlPlaneMigrationsCurrent } from "./migrations.js";
 import { ResendEmailTransport } from "./email.js";
 import {
   HostedProviderClient,
@@ -13,9 +14,10 @@ import {
   type RegistrationMode
 } from "./runtime-config.js";
 
-const db = await createDatabase();
+const db = await openDatabase();
 const requestEnvelope = process.argv[2] === "request";
 try {
+  await assertControlPlaneMigrationsCurrent(db);
   const emailTransport = resendTransport(process.env);
   const hostedProviderConfig = hostedProviderConfigFromEnv(process.env);
   const hostedProvider = hostedProviderConfig

--- a/services/server/src/collection-access.test.ts
+++ b/services/server/src/collection-access.test.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatabase, type DatabasePool } from "./db.js";
+import {
+  accessView,
+  requireCollectionAction,
+  resolveHostedCollectionAccess,
+  resolveLocalCollectionAccess
+} from "./collection-access.js";
+
+let database: DatabasePool | undefined;
+afterEach(async () => database?.end());
+
+describe("collection access policy", () => {
+  it("resolves hosted ownership through a stable logical locator", async () => {
+    database = await createDatabase("memory");
+    const ownerId = await insertUser(database, "owner@example.com");
+    const otherId = await insertUser(database, "other@example.com");
+    const collectionId = randomUUID();
+    await database.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, authority_epoch)
+       VALUES ($1, $2, 'Shared later', 'mdbase', 7)`,
+      [collectionId, ownerId]
+    );
+
+    const access = await resolveHostedCollectionAccess(
+      database,
+      ownerId,
+      collectionId
+    );
+    expect(access?.collection).toMatchObject({
+      collectionId,
+      authorityKind: "hosted",
+      authorityRowId: collectionId,
+      ownerUserId: ownerId,
+      authorityEpoch: 7
+    });
+    expect(accessView(access!)).toEqual({
+      relationship: "owner",
+      role: "owner",
+      can_authorize_applications: true,
+      can_manage_collection: true,
+      can_manage_members: true
+    });
+    expect(await resolveHostedCollectionAccess(
+      database,
+      otherId,
+      collectionId
+    )).toBeNull();
+  });
+
+  it("uses local_id as the logical identity of a connector-backed collection", async () => {
+    database = await createDatabase("memory");
+    const ownerId = await insertUser(database, "local@example.com");
+    const connectorId = randomUUID();
+    const authorityRowId = randomUUID();
+    const logicalId = randomUUID();
+    await database.query(
+      `INSERT INTO connectors (id, user_id, name, token_hash)
+       VALUES ($1, $2, 'Desktop', $3)`,
+      [connectorId, ownerId, randomUUID()]
+    );
+    await database.query(
+      `INSERT INTO collections
+         (id, user_id, connector_id, local_id, display_name, spec_version)
+       VALUES ($1, $2, $3, $4, 'Vault', '0.3.0')`,
+      [authorityRowId, ownerId, connectorId, logicalId]
+    );
+
+    const access = await resolveLocalCollectionAccess(
+      database,
+      ownerId,
+      authorityRowId
+    );
+    expect(access?.collection).toMatchObject({
+      collectionId: logicalId,
+      authorityKind: "local",
+      authorityRowId,
+      connectorId
+    });
+    expect(requireCollectionAction(access, "authority.transfer")).toBe(access);
+  });
+
+  it("fails closed when an action is absent", async () => {
+    database = await createDatabase("memory");
+    expect(() => requireCollectionAction(null, "members.manage"))
+      .toThrow("members.manage");
+  });
+});
+
+async function insertUser(db: DatabasePool, email: string): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, $2, 'User')",
+    [id, email]
+  );
+  return id;
+}

--- a/services/server/src/collection-access.ts
+++ b/services/server/src/collection-access.ts
@@ -1,0 +1,155 @@
+import type {
+  CollectionOperation,
+  GrantScope
+} from "@mdbase/connect-protocol";
+import type { DatabaseQueryable } from "./db.js";
+import {
+  resolveHostedCollection,
+  resolveLocalCollection,
+  type CollectionLocator
+} from "./collection-catalog.js";
+
+export const COLLECTION_OPERATIONS = [
+  "describe",
+  "changes",
+  "read",
+  "query",
+  "validate",
+  "list_views",
+  "execute_view",
+  "read_view_source",
+  "create_view_source",
+  "update_view_source",
+  "delete_view_source",
+  "create",
+  "update",
+  "delete",
+  "rename",
+  "read_type",
+  "create_type",
+  "update_type",
+  "list_timers",
+  "put_timer",
+  "cancel_timer",
+  "reconcile_timers",
+  "sync"
+] as const satisfies readonly CollectionOperation[];
+
+export type CollectionAction =
+  | "collection.discover"
+  | "record.read"
+  | "record.write"
+  | "application.authorize"
+  | "mirror.enroll"
+  | "schema.manage"
+  | "collection.rename"
+  | "collection.delete"
+  | "authority.transfer"
+  | "members.manage";
+
+export type CollectionRole = "owner" | "manager" | "editor" | "viewer";
+
+export interface CollectionAccessContext {
+  collection: CollectionLocator;
+  userId: string;
+  relationship: "owner" | "member";
+  role: CollectionRole;
+  policyId: string | null;
+  policyRevision: number;
+  actions: ReadonlySet<CollectionAction>;
+  operationCeiling: ReadonlySet<CollectionOperation>;
+  scopeCeiling: GrantScope;
+}
+
+export interface CollectionAccessView {
+  relationship: "owner" | "member";
+  role: CollectionRole;
+  can_authorize_applications: boolean;
+  can_manage_collection: boolean;
+  can_manage_members: boolean;
+}
+
+const OWNER_ACTIONS: ReadonlySet<CollectionAction> = new Set([
+  "collection.discover",
+  "record.read",
+  "record.write",
+  "application.authorize",
+  "mirror.enroll",
+  "schema.manage",
+  "collection.rename",
+  "collection.delete",
+  "authority.transfer",
+  "members.manage"
+]);
+
+const OWNER_OPERATIONS: ReadonlySet<CollectionOperation> = new Set(
+  COLLECTION_OPERATIONS
+);
+
+export async function resolveHostedCollectionAccess(
+  db: DatabaseQueryable,
+  userId: string,
+  collectionId: string
+): Promise<CollectionAccessContext | null> {
+  const collection = await resolveHostedCollection(db, collectionId);
+  if (!collection || collection.locator.ownerUserId !== userId) return null;
+  return ownerAccess(collection.locator, userId);
+}
+
+export async function resolveLocalCollectionAccess(
+  db: DatabaseQueryable,
+  userId: string,
+  authorityRowId: string
+): Promise<CollectionAccessContext | null> {
+  const collection = await resolveLocalCollection(db, authorityRowId);
+  if (!collection || collection.ownerUserId !== userId) return null;
+  return ownerAccess(collection, userId);
+}
+
+export function requireCollectionAction(
+  access: CollectionAccessContext | null,
+  action: CollectionAction
+): CollectionAccessContext {
+  if (!access || !access.actions.has(action)) {
+    throw new CollectionAccessDeniedError(action);
+  }
+  return access;
+}
+
+export function accessView(
+  access: CollectionAccessContext
+): CollectionAccessView {
+  return {
+    relationship: access.relationship,
+    role: access.role,
+    can_authorize_applications: access.actions.has("application.authorize"),
+    can_manage_collection:
+      access.actions.has("collection.rename")
+      && access.actions.has("collection.delete"),
+    can_manage_members: access.actions.has("members.manage")
+  };
+}
+
+export function ownerAccess(
+  collection: CollectionLocator,
+  userId: string
+): CollectionAccessContext {
+  return {
+    collection,
+    userId,
+    relationship: "owner",
+    role: "owner",
+    policyId: null,
+    policyRevision: collection.authorityEpoch,
+    actions: OWNER_ACTIONS,
+    operationCeiling: OWNER_OPERATIONS,
+    scopeCeiling: { access: "full_collection", contracts: [] }
+  };
+}
+
+export class CollectionAccessDeniedError extends Error {
+  constructor(readonly action: CollectionAction) {
+    super(`Collection access does not permit ${action}.`);
+    this.name = "CollectionAccessDeniedError";
+  }
+}

--- a/services/server/src/collection-catalog.ts
+++ b/services/server/src/collection-catalog.ts
@@ -1,0 +1,180 @@
+import type { CollectionContractDescriptor } from "@mdbase/connect-protocol";
+import type { DatabaseQueryable } from "./db.js";
+import type { HostedTemplate } from "./hosted.js";
+
+export type CollectionAuthorityKind = "local" | "hosted";
+
+export interface CollectionLocator {
+  collectionId: string;
+  authorityKind: CollectionAuthorityKind;
+  authorityRowId: string;
+  ownerUserId: string;
+  authorityEpoch: number;
+  authorityState: string;
+  displayName: string;
+  connectorId?: string;
+  providerUrl?: string;
+}
+
+export interface HostedCollectionCatalogEntry {
+  locator: CollectionLocator & {
+    authorityKind: "hosted";
+  };
+  template: HostedTemplate;
+  contracts: CollectionContractDescriptor[];
+  transferredCollectionId: string | null;
+  createdAt: string | Date;
+}
+
+export async function resolveHostedCollection(
+  db: DatabaseQueryable,
+  collectionId: string
+): Promise<HostedCollectionCatalogEntry | null> {
+  const result = await db.query<{
+    id: string;
+    user_id: string;
+    display_name: string;
+    template: HostedTemplate;
+    provider_url: string | null;
+    contracts: CollectionContractDescriptor[];
+    authority_state: string;
+    authority_epoch: string | number;
+    transferred_collection_id: string | null;
+    created_at: string | Date;
+  }>(
+    `SELECT id, user_id, display_name, template, provider_url, contracts,
+            authority_state, authority_epoch, transferred_collection_id,
+            created_at
+     FROM hosted_collections
+     WHERE id = $1`,
+    [collectionId]
+  );
+  return result.rows[0] ? hostedEntry(result.rows[0]) : null;
+}
+
+export async function listHostedCollectionsVisibleToUser(
+  db: DatabaseQueryable,
+  userId: string
+): Promise<HostedCollectionCatalogEntry[]> {
+  const result = await db.query<{
+    id: string;
+    user_id: string;
+    display_name: string;
+    template: HostedTemplate;
+    provider_url: string | null;
+    contracts: CollectionContractDescriptor[];
+    authority_state: string;
+    authority_epoch: string | number;
+    transferred_collection_id: string | null;
+    created_at: string | Date;
+  }>(
+    `SELECT id, user_id, display_name, template, provider_url, contracts,
+            authority_state, authority_epoch, transferred_collection_id,
+            created_at
+     FROM hosted_collections
+     WHERE user_id = $1
+     ORDER BY display_name`,
+    [userId]
+  );
+  return result.rows.map(hostedEntry);
+}
+
+export async function resolveLocalCollection(
+  db: DatabaseQueryable,
+  authorityRowId: string
+): Promise<CollectionLocator | null> {
+  const result = await db.query<{
+    id: string;
+    local_id: string;
+    user_id: string;
+    connector_id: string;
+    display_name: string;
+    authority_state: string;
+    authority_epoch: string | number;
+  }>(
+    `SELECT id, local_id, user_id, connector_id, display_name,
+            authority_state, authority_epoch
+     FROM collections
+     WHERE id = $1`,
+    [authorityRowId]
+  );
+  const row = result.rows[0];
+  return row
+    ? {
+        collectionId: row.local_id,
+        authorityKind: "local",
+        authorityRowId: row.id,
+        ownerUserId: row.user_id,
+        authorityEpoch: Number(row.authority_epoch),
+        authorityState: row.authority_state,
+        displayName: row.display_name,
+        connectorId: row.connector_id
+      }
+    : null;
+}
+
+/**
+ * Owner-only today. Future membership expands this repository query; callers
+ * already consume logical catalog visibility instead of connector ownership.
+ */
+export async function listLocalCollectionsVisibleToUser(
+  db: DatabaseQueryable,
+  userId: string
+): Promise<CollectionLocator[]> {
+  const result = await db.query<{
+    id: string;
+    local_id: string;
+    user_id: string;
+    connector_id: string;
+    display_name: string;
+    authority_state: string;
+    authority_epoch: string | number;
+  }>(
+    `SELECT id, local_id, user_id, connector_id, display_name,
+            authority_state, authority_epoch
+     FROM collections
+     WHERE user_id = $1
+     ORDER BY display_name`,
+    [userId]
+  );
+  return result.rows.map((row) => ({
+    collectionId: row.local_id,
+    authorityKind: "local",
+    authorityRowId: row.id,
+    ownerUserId: row.user_id,
+    authorityEpoch: Number(row.authority_epoch),
+    authorityState: row.authority_state,
+    displayName: row.display_name,
+    connectorId: row.connector_id
+  }));
+}
+
+function hostedEntry(row: {
+  id: string;
+  user_id: string;
+  display_name: string;
+  template: HostedTemplate;
+  provider_url: string | null;
+  contracts: CollectionContractDescriptor[];
+  authority_state: string;
+  authority_epoch: string | number;
+  transferred_collection_id: string | null;
+  created_at: string | Date;
+}): HostedCollectionCatalogEntry {
+  return {
+    locator: {
+      collectionId: row.id,
+      authorityKind: "hosted",
+      authorityRowId: row.id,
+      ownerUserId: row.user_id,
+      authorityEpoch: Number(row.authority_epoch),
+      authorityState: row.authority_state,
+      displayName: row.display_name,
+      ...(row.provider_url ? { providerUrl: row.provider_url } : {})
+    },
+    template: row.template,
+    contracts: row.contracts,
+    transferredCollectionId: row.transferred_collection_id,
+    createdAt: row.created_at
+  };
+}

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -1,11 +1,19 @@
 import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   backfillExternalIdentityEmails,
   backfillSessionProviders,
   createDatabase,
+  openDatabase,
   revokeLegacyHostedBearerGrants
 } from "./db.js";
+import {
+  assertControlPlaneMigrationsCurrent,
+  runControlPlaneMigrations
+} from "./migrations.js";
 
 const resources: Array<() => Promise<void>> = [];
 
@@ -14,6 +22,90 @@ afterEach(async () => {
 });
 
 describe("database migrations", () => {
+  it("records the legacy baseline and applies ordered SQL migrations once", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+
+    const applied = await db.query<{ id: string }>(
+      "SELECT id FROM schema_migrations ORDER BY id"
+    );
+    expect(applied.rows.map(({ id }) => id)).toEqual([
+      "0000_legacy_baseline",
+      "0001_collaboration_foundations"
+    ]);
+    const columns = await db.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'hosted_replicas'
+         AND column_name = 'authorized_user_id'`
+    );
+    expect(columns.rows).toHaveLength(1);
+
+    await expect(assertControlPlaneMigrationsCurrent(db)).resolves.toBeUndefined();
+    await runControlPlaneMigrations(db);
+    const repeated = await db.query<{ id: string }>(
+      "SELECT id FROM schema_migrations ORDER BY id"
+    );
+    expect(repeated.rows).toEqual(applied.rows);
+  });
+
+  it("fails closed when an application starts before pre-deploy migration", async () => {
+    const db = await openDatabase("memory");
+    resources.push(() => db.end());
+    await expect(assertControlPlaneMigrationsCurrent(db))
+      .rejects.toThrow();
+  });
+
+  it("backfills the authorizing user for replicas created before attribution", async () => {
+    const db = await openDatabase("memory");
+    resources.push(() => db.end());
+    const { migrateLegacySchema } = await import("./db.js");
+    await migrateLegacySchema(db);
+    const userId = randomUUID();
+    const collectionId = randomUUID();
+    const replicaId = randomUUID();
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, $2, 'Owner')",
+      [userId, "replica-owner@example.com"]
+    );
+    await db.query(
+      `INSERT INTO hosted_collections (id, user_id, display_name, template)
+       VALUES ($1, $2, 'Existing', 'mdbase')`,
+      [collectionId, userId]
+    );
+    await db.query(
+      `INSERT INTO hosted_replicas (id, collection_id, name, mode)
+       VALUES ($1, $2, 'Old mirror', 'read_only')`,
+      [replicaId, collectionId]
+    );
+
+    await runControlPlaneMigrations(db);
+
+    const replica = await db.query<{ authorized_user_id: string }>(
+      "SELECT authorized_user_id FROM hosted_replicas WHERE id = $1",
+      [replicaId]
+    );
+    expect(replica.rows[0].authorized_user_id).toBe(userId);
+  });
+
+  it("rejects an applied migration whose contents changed", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "connect-migrations-"));
+    resources.push(() => rm(directory, { recursive: true, force: true }));
+    await writeFile(
+      join(directory, "0001_test.sql"),
+      "CREATE TABLE migration_fixture (id text PRIMARY KEY);\n"
+    );
+    const db = await openDatabase("memory");
+    resources.push(() => db.end());
+    await runControlPlaneMigrations(db, { directory });
+    await writeFile(
+      join(directory, "0001_test.sql"),
+      "CREATE TABLE changed_fixture (id text PRIMARY KEY);\n"
+    );
+
+    await expect(runControlPlaneMigrations(db, { directory }))
+      .rejects.toThrow("changed after it was applied");
+  });
+
   it("creates the account and operator foundation without changing existing data", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -17,7 +17,9 @@ export interface DatabasePool extends DatabaseQueryable {
   connect(): Promise<DatabaseConnection>;
 }
 
-export async function createDatabase(databaseUrl = process.env.DATABASE_URL): Promise<DatabasePool> {
+export async function openDatabase(
+  databaseUrl = process.env.DATABASE_URL
+): Promise<DatabasePool> {
   let pool: DatabasePool;
   if (!databaseUrl || databaseUrl === "memory") {
     const { DataType, newDb } = await import("pg-mem");
@@ -33,19 +35,31 @@ export async function createDatabase(databaseUrl = process.env.DATABASE_URL): Pr
   } else {
     pool = new pg.Pool({ connectionString: databaseUrl }) as Pool;
   }
-  const connection = await pool.connect();
-  const lockMigrations = Boolean(databaseUrl && databaseUrl !== "memory");
+  return pool;
+}
+
+export async function createDatabase(
+  databaseUrl = process.env.DATABASE_URL
+): Promise<DatabasePool> {
+  const pool = await openDatabase(databaseUrl);
   try {
-    if (lockMigrations) await connection.query("SELECT pg_advisory_lock($1)", [1_291_842_019]);
-    await migrate(connection);
-  } finally {
-    if (lockMigrations) await connection.query("SELECT pg_advisory_unlock($1)", [1_291_842_019]);
-    connection.release();
+    const { runControlPlaneMigrations } = await import("./migrations.js");
+    await runControlPlaneMigrations(pool, {
+      lock: Boolean(databaseUrl && databaseUrl !== "memory")
+    });
+  } catch (error) {
+    await pool.end();
+    throw error;
   }
   return pool;
 }
 
-export async function migrate(db: DatabaseQueryable): Promise<void> {
+/**
+ * Idempotent baseline retained while the pre-versioned schema is migrated to
+ * discrete SQL files. Production invokes this exactly once through the
+ * versioned migration ledger; tests and new databases use the same path.
+ */
+export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> {
   await db.query(`
     CREATE TABLE IF NOT EXISTS users (
       id uuid PRIMARY KEY,

--- a/services/server/src/grant-planner.test.ts
+++ b/services/server/src/grant-planner.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CollectionContractDescriptor,
+  CollectionOperation,
+  GrantScope
+} from "@mdbase/connect-protocol";
+import {
+  ownerAccess,
+  type CollectionAccessContext
+} from "./collection-access.js";
+import { planCollectionGrant } from "./grant-planner.js";
+
+const contract: CollectionContractDescriptor = {
+  id: "example.tasks",
+  version: "1.0.0",
+  digest: "a".repeat(64),
+  schema: {},
+  implementations: []
+};
+
+const owner = ownerAccess({
+  collectionId: "collection",
+  authorityKind: "hosted",
+  authorityRowId: "collection",
+  ownerUserId: "owner",
+  authorityEpoch: 3,
+  authorityState: "active",
+  displayName: "Tasks"
+}, "owner");
+
+describe("planCollectionGrant", () => {
+  it("intersects application, request, and human access ceilings", () => {
+    const result = planCollectionGrant({
+      requestedOperations: ["read", "update"],
+      applicationOperationCeiling: ["read", "query", "update"],
+      requirements: {
+        contracts: [{ id: contract.id, version: contract.version }]
+      },
+      availableContracts: [contract],
+      access: owner
+    });
+
+    expect(result).toEqual({
+      operations: ["read", "update"],
+      scope: { access: "contract", contracts: [contract] },
+      replicaMode: "read_write"
+    });
+  });
+
+  it("rejects an operation the application did not request", () => {
+    expect(() => planCollectionGrant({
+      requestedOperations: ["delete"],
+      applicationOperationCeiling: ["read"],
+      requirements: { contracts: [], access: "full_collection" },
+      availableContracts: [],
+      access: owner
+    })).toThrow("must be requested");
+  });
+
+  it("rejects an operation outside the approving user's ceiling", () => {
+    expect(() => planCollectionGrant({
+      requestedOperations: ["update"],
+      applicationOperationCeiling: ["update"],
+      requirements: { contracts: [], access: "full_collection" },
+      availableContracts: [],
+      access: restricted(owner, ["read"], owner.scopeCeiling)
+    })).toThrow("approving user");
+  });
+
+  it("rejects full-collection access from a contract-scoped member", () => {
+    expect(() => planCollectionGrant({
+      requestedOperations: ["read"],
+      applicationOperationCeiling: ["read"],
+      requirements: { contracts: [], access: "full_collection" },
+      availableContracts: [contract],
+      access: restricted(owner, ["read"], {
+        access: "contract",
+        contracts: [contract]
+      })
+    })).toThrow("full-collection");
+  });
+
+  it("rejects required contracts outside a member's scope", () => {
+    expect(() => planCollectionGrant({
+      requestedOperations: ["read"],
+      applicationOperationCeiling: ["read"],
+      requirements: {
+        contracts: [{ id: contract.id, version: contract.version }]
+      },
+      availableContracts: [contract],
+      access: restricted(owner, ["read"], {
+        access: "contract",
+        contracts: []
+      })
+    })).toThrow("required contracts");
+  });
+
+  it("does not treat a drifted contract digest as the same delegated scope", () => {
+    expect(() => planCollectionGrant({
+      requestedOperations: ["read"],
+      applicationOperationCeiling: ["read"],
+      requirements: {
+        contracts: [{ id: contract.id, version: contract.version }]
+      },
+      availableContracts: [contract],
+      access: restricted(owner, ["read"], {
+        access: "contract",
+        contracts: [{ ...contract, digest: "b".repeat(64) }]
+      })
+    })).toThrow("required contracts");
+  });
+});
+
+function restricted(
+  source: CollectionAccessContext,
+  operations: CollectionOperation[],
+  scopeCeiling: GrantScope
+): CollectionAccessContext {
+  return {
+    ...source,
+    relationship: "member",
+    operationCeiling: new Set(operations),
+    scopeCeiling
+  };
+}

--- a/services/server/src/grant-planner.ts
+++ b/services/server/src/grant-planner.ts
@@ -1,0 +1,147 @@
+import type {
+  ApplicationRequirements,
+  CollectionContractDescriptor,
+  CollectionOperation,
+  GrantScope
+} from "@mdbase/connect-protocol";
+import type { CollectionAccessContext } from "./collection-access.js";
+
+const FULL_COLLECTION_OPERATIONS = new Set<CollectionOperation>([
+  "validate",
+  "list_views",
+  "execute_view",
+  "read_type",
+  "create_type",
+  "update_type"
+]);
+
+const WRITE_OPERATIONS = new Set<CollectionOperation>([
+  "create",
+  "update",
+  "delete",
+  "rename",
+  "create_type",
+  "update_type",
+  "create_view_source",
+  "update_view_source",
+  "delete_view_source",
+  "put_timer",
+  "cancel_timer",
+  "reconcile_timers"
+]);
+
+export interface GrantPlan {
+  operations: CollectionOperation[];
+  scope: GrantScope;
+  replicaMode: "read_only" | "read_write";
+}
+
+/**
+ * Computes a capability from three independent ceilings: what the application
+ * requested, what its manifest permits, and what the approving user may grant.
+ * Keeping this pure makes future member roles an access-policy change rather
+ * than another authorization flow.
+ */
+export function planCollectionGrant(input: {
+  requestedOperations: readonly CollectionOperation[];
+  applicationOperationCeiling: readonly CollectionOperation[];
+  requirements: ApplicationRequirements;
+  availableContracts: readonly CollectionContractDescriptor[];
+  access: CollectionAccessContext;
+}): GrantPlan {
+  const operations = [...new Set(input.requestedOperations)];
+  if (operations.length === 0) {
+    throw new GrantPlanningError("At least one operation must be approved.");
+  }
+  const applicationOperations = new Set(input.applicationOperationCeiling);
+  if (operations.some((operation) => !applicationOperations.has(operation))) {
+    throw new GrantPlanningError(
+      "Approved operations must be requested by the application."
+    );
+  }
+  if (operations.some((operation) => !input.access.operationCeiling.has(operation))) {
+    throw new GrantPlanningError(
+      "The approving user may not grant one or more requested operations."
+    );
+  }
+  if (
+    input.requirements.access !== "full_collection"
+    && input.requirements.contracts.length === 0
+  ) {
+    throw new GrantPlanningError(
+      "Contract-scoped application manifests must declare at least one required contract; use full_collection for collection-wide access."
+    );
+  }
+  if (
+    input.requirements.access !== "full_collection"
+    && operations.some((operation) => FULL_COLLECTION_OPERATIONS.has(operation))
+  ) {
+    throw new GrantPlanningError(
+      "Saved views, collection-wide validation, and type definitions require the application manifest to request full collection access."
+    );
+  }
+
+  const applicationScope = scopeForRequirements(
+    input.requirements,
+    input.availableContracts
+  );
+  const scope = intersectScope(applicationScope, input.access.scopeCeiling);
+  return {
+    operations,
+    scope,
+    replicaMode: operations.some((operation) => WRITE_OPERATIONS.has(operation))
+      ? "read_write"
+      : "read_only"
+  };
+}
+
+function scopeForRequirements(
+  requirements: ApplicationRequirements,
+  available: readonly CollectionContractDescriptor[]
+): GrantScope {
+  if (requirements.access === "full_collection") {
+    return { access: "full_collection", contracts: [] };
+  }
+  const required = new Set(
+    requirements.contracts.map(({ id, version }) => `${id}@${version}`)
+  );
+  return {
+    access: "contract",
+    contracts: available.filter(({ id, version }) =>
+      required.has(`${id}@${version}`)
+    )
+  };
+}
+
+function intersectScope(application: GrantScope, user: GrantScope): GrantScope {
+  if (user.access === "full_collection") return application;
+  if (application.access === "full_collection") {
+    throw new GrantPlanningError(
+      "The approving user may not grant full-collection access."
+    );
+  }
+  const allowed = new Set(user.contracts.map(contractKey));
+  if (application.contracts.some((contract) => !allowed.has(contractKey(contract)))) {
+    throw new GrantPlanningError(
+      "The approving user may not grant one or more required contracts."
+    );
+  }
+  return application;
+}
+
+function contractKey(contract: CollectionContractDescriptor): string {
+  const implementations = contract.implementations
+    .map(({ type_name, type_version, digest }) =>
+      `${type_name}@${type_version}:${digest}`
+    )
+    .sort()
+    .join(",");
+  return `${contract.id}@${contract.version}:${contract.digest}:${implementations}`;
+}
+
+export class GrantPlanningError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GrantPlanningError";
+  }
+}

--- a/services/server/src/hosted-capability-lifecycle.test.ts
+++ b/services/server/src/hosted-capability-lifecycle.test.ts
@@ -1,0 +1,196 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDatabase, type DatabasePool } from "./db.js";
+import {
+  ProviderRevocationWorker,
+  queueHostedGrantRevocation
+} from "./hosted-capability-lifecycle.js";
+
+let database: DatabasePool | undefined;
+afterEach(async () => database?.end());
+
+describe("hosted capability lifecycle", () => {
+  it("revokes locally and durably queues provider cleanup in one transaction", async () => {
+    const fixture = await capabilityFixture();
+    const queued = await queueHostedGrantRevocation(
+      fixture.db,
+      fixture.userId,
+      fixture.grantId,
+      "user_request"
+    );
+
+    expect(queued).toMatchObject({
+      grantId: fixture.grantId,
+      replicaId: fixture.replicaId,
+      collectionId: fixture.collectionId
+    });
+    const state = await fixture.db.query(
+      `SELECT g.revoked_at AS grant_revoked_at,
+              replica.revoked_at AS replica_revoked_at,
+              access.revoked_at AS access_revoked_at,
+              refresh.revoked_at AS refresh_revoked_at,
+              job.state AS job_state, job.reason
+       FROM grants g
+       JOIN hosted_replicas replica ON replica.id = g.hosted_replica_id
+       JOIN access_tokens access ON access.grant_id = g.id
+       JOIN refresh_tokens refresh ON refresh.grant_id = g.id
+       JOIN provider_revocation_jobs job ON job.grant_id = g.id
+       WHERE g.id = $1`,
+      [fixture.grantId]
+    );
+    expect(state.rows[0]).toMatchObject({
+      job_state: "pending",
+      reason: "user_request"
+    });
+    expect(state.rows[0].grant_revoked_at).toBeTruthy();
+    expect(state.rows[0].replica_revoked_at).toBeTruthy();
+    expect(state.rows[0].access_revoked_at).toBeTruthy();
+    expect(state.rows[0].refresh_revoked_at).toBeTruthy();
+  });
+
+  it("delivers queued revocation to both provider capability surfaces", async () => {
+    const fixture = await capabilityFixture();
+    await queueHostedGrantRevocation(
+      fixture.db,
+      fixture.userId,
+      fixture.grantId,
+      "test"
+    );
+    const provider = {
+      revokeReplica: vi.fn(async () => undefined),
+      revokeNotificationGrant: vi.fn(async () => undefined)
+    };
+    const worker = new ProviderRevocationWorker(
+      fixture.db,
+      provider as never
+    );
+
+    expect(await worker.drain()).toBe(1);
+    expect(provider.revokeReplica).toHaveBeenCalledWith(fixture.replicaId);
+    expect(provider.revokeNotificationGrant).toHaveBeenCalledWith(
+      fixture.collectionId,
+      fixture.grantId
+    );
+    const job = await fixture.db.query(
+      "SELECT state, completed_at FROM provider_revocation_jobs"
+    );
+    expect(job.rows[0].state).toBe("completed");
+    expect(job.rows[0].completed_at).toBeTruthy();
+  });
+
+  it("cannot revoke another user's grant", async () => {
+    const fixture = await capabilityFixture();
+    expect(await queueHostedGrantRevocation(
+      fixture.db,
+      randomUUID(),
+      fixture.grantId,
+      "test"
+    )).toBeNull();
+  });
+
+  it("reclaims provider work after a worker loses its lease", async () => {
+    const fixture = await capabilityFixture();
+    await queueHostedGrantRevocation(
+      fixture.db,
+      fixture.userId,
+      fixture.grantId,
+      "test"
+    );
+    await fixture.db.query(
+      `UPDATE provider_revocation_jobs
+       SET state = 'sending', available_at = now() - interval '1 second'`
+    );
+    const provider = {
+      revokeReplica: vi.fn(async () => undefined),
+      revokeNotificationGrant: vi.fn(async () => undefined)
+    };
+
+    expect(await new ProviderRevocationWorker(
+      fixture.db,
+      provider as never
+    ).drain()).toBe(1);
+    const job = await fixture.db.query(
+      "SELECT state, attempts FROM provider_revocation_jobs"
+    );
+    expect(job.rows[0]).toMatchObject({ state: "completed", attempts: 1 });
+  });
+
+  it("serializes overlapping drains without delivering a job twice", async () => {
+    const fixture = await capabilityFixture();
+    await queueHostedGrantRevocation(
+      fixture.db,
+      fixture.userId,
+      fixture.grantId,
+      "test"
+    );
+    const provider = {
+      revokeReplica: vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }),
+      revokeNotificationGrant: vi.fn(async () => undefined)
+    };
+    const worker = new ProviderRevocationWorker(
+      fixture.db,
+      provider as never
+    );
+
+    expect(await Promise.all([worker.drain(), worker.drain()]))
+      .toEqual([1, 0]);
+    expect(provider.revokeReplica).toHaveBeenCalledTimes(1);
+    expect(provider.revokeNotificationGrant).toHaveBeenCalledTimes(1);
+  });
+});
+
+async function capabilityFixture(): Promise<{
+  db: DatabasePool;
+  userId: string;
+  collectionId: string;
+  replicaId: string;
+  grantId: string;
+}> {
+  database = await createDatabase("memory");
+  const userId = randomUUID();
+  const collectionId = randomUUID();
+  const replicaId = randomUUID();
+  const applicationId = randomUUID();
+  const grantId = randomUUID();
+  await database.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, $2, 'User')",
+    [userId, `${userId}@example.com`]
+  );
+  await database.query(
+    `INSERT INTO hosted_collections (id, user_id, display_name, template)
+     VALUES ($1, $2, 'Collection', 'mdbase')`,
+    [collectionId, userId]
+  );
+  await database.query(
+    `INSERT INTO hosted_replicas
+       (id, collection_id, authorized_user_id, name, purpose, mode)
+     VALUES ($1, $2, $3, 'Application', 'application', 'read_only')`,
+    [replicaId, collectionId, userId]
+  );
+  await database.query(
+    `INSERT INTO applications
+       (id, canonical_identity, name, homepage, redirect_uris)
+     VALUES ($1, $2, 'App', 'https://app.example', '[]'::jsonb)`,
+    [applicationId, `test:${applicationId}`]
+  );
+  await database.query(
+    `INSERT INTO grants
+       (id, user_id, application_id, hosted_collection_id,
+        hosted_replica_id, operations)
+     VALUES ($1, $2, $3, $4, $5, '["read"]'::jsonb)`,
+    [grantId, userId, applicationId, collectionId, replicaId]
+  );
+  await database.query(
+    `INSERT INTO access_tokens (id, token_hash, grant_id, expires_at)
+     VALUES ($1, $2, $3, now() + interval '1 hour')`,
+    [randomUUID(), randomUUID(), grantId]
+  );
+  await database.query(
+    `INSERT INTO refresh_tokens (id, token_hash, grant_id, expires_at)
+     VALUES ($1, $2, $3, now() + interval '1 hour')`,
+    [randomUUID(), randomUUID(), grantId]
+  );
+  return { db: database, userId, collectionId, replicaId, grantId };
+}

--- a/services/server/src/hosted-capability-lifecycle.ts
+++ b/services/server/src/hosted-capability-lifecycle.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+import type { DatabasePool, DatabaseQueryable } from "./db.js";
+import type { HostedProviderClient } from "./hosted-provider.js";
+
+interface RevocationJob {
+  id: string;
+  replica_id: string;
+  grant_id: string | null;
+  collection_id: string;
+  attempts: number;
+}
+
+export interface QueuedGrantRevocation {
+  grantId: string;
+  replicaId: string;
+  collectionId: string;
+  jobId: string;
+}
+
+/**
+ * Atomically makes a hosted capability unusable in Connect and records the
+ * provider-side cleanup as durable work. Provider availability can no longer
+ * prevent local revocation.
+ */
+export async function queueHostedGrantRevocation(
+  db: DatabasePool,
+  userId: string,
+  grantId: string,
+  reason: string
+): Promise<QueuedGrantRevocation | null> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const active = await connection.query<{
+      hosted_collection_id: string | null;
+      hosted_replica_id: string | null;
+    }>(
+      `SELECT hosted_collection_id, hosted_replica_id
+       FROM grants
+       WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+       FOR UPDATE`,
+      [grantId, userId]
+    );
+    const grant = active.rows[0];
+    if (
+      !grant
+      || !grant.hosted_collection_id
+      || !grant.hosted_replica_id
+    ) {
+      await connection.query("ROLLBACK");
+      return null;
+    }
+    const jobId = randomUUID();
+    await connection.query(
+      `UPDATE hosted_replicas
+       SET revoked_at = COALESCE(revoked_at, now()), token_hash = NULL
+       WHERE id = $1`,
+      [grant.hosted_replica_id]
+    );
+    await connection.query(
+      "UPDATE grants SET revoked_at = COALESCE(revoked_at, now()) WHERE id = $1",
+      [grantId]
+    );
+    await connection.query(
+      `UPDATE access_tokens
+       SET revoked_at = COALESCE(revoked_at, now())
+       WHERE grant_id = $1`,
+      [grantId]
+    );
+    await connection.query(
+      `UPDATE refresh_tokens
+       SET revoked_at = COALESCE(revoked_at, now())
+       WHERE grant_id = $1`,
+      [grantId]
+    );
+    await connection.query(
+      `INSERT INTO provider_revocation_jobs
+         (id, replica_id, grant_id, collection_id, reason)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [
+        jobId,
+        grant.hosted_replica_id,
+        grantId,
+        grant.hosted_collection_id,
+        reason
+      ]
+    );
+    await connection.query("COMMIT");
+    return {
+      grantId,
+      replicaId: grant.hosted_replica_id,
+      collectionId: grant.hosted_collection_id,
+      jobId
+    };
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+export class ProviderRevocationWorker {
+  private timer: NodeJS.Timeout | undefined;
+  private drainInFlight: Promise<number> | undefined;
+
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly provider: HostedProviderClient,
+    private readonly onError: (error: unknown) => void = () => undefined,
+    private readonly pollIntervalMs = 5_000
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.drain().catch(this.onError);
+    }, this.pollIntervalMs);
+    this.timer.unref();
+    void this.drain().catch(this.onError);
+  }
+
+  async close(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+    await this.drainInFlight;
+  }
+
+  async drain(limit = 25): Promise<number> {
+    while (this.drainInFlight) {
+      await this.drainInFlight;
+    }
+    const execution = this.drainAvailable(limit);
+    this.drainInFlight = execution;
+    let completed = 0;
+    try {
+      completed = await execution;
+      return completed;
+    } finally {
+      if (this.drainInFlight === execution) {
+        this.drainInFlight = undefined;
+      }
+    }
+  }
+
+  private async drainAvailable(limit: number): Promise<number> {
+    let completed = 0;
+    while (completed < limit) {
+      const job = await claimRevocationJob(this.db);
+      if (!job) break;
+      try {
+        await this.provider.revokeReplica(job.replica_id);
+        if (job.grant_id) {
+          await this.provider.revokeNotificationGrant(
+            job.collection_id,
+            job.grant_id
+          );
+        }
+        await this.db.query(
+          `UPDATE provider_revocation_jobs
+           SET state = 'completed', completed_at = now(), last_error = NULL
+           WHERE id = $1`,
+          [job.id]
+        );
+        completed += 1;
+      } catch (error) {
+        await rescheduleRevocationJob(this.db, job, error);
+        this.onError(error);
+        break;
+      }
+    }
+    return completed;
+  }
+}
+
+async function claimRevocationJob(
+  db: DatabasePool
+): Promise<RevocationJob | null> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const found = await connection.query<RevocationJob>(
+      `SELECT id, replica_id, grant_id, collection_id, attempts
+       FROM provider_revocation_jobs
+       WHERE completed_at IS NULL AND state IN ('pending', 'sending')
+         AND available_at <= now()
+       ORDER BY created_at
+       LIMIT 1
+       FOR UPDATE`
+    );
+    const job = found.rows[0];
+    if (!job) {
+      await connection.query("COMMIT");
+      return null;
+    }
+    await connection.query(
+      `UPDATE provider_revocation_jobs
+       SET state = 'sending', attempts = attempts + 1,
+           available_at = now() + interval '30 seconds'
+       WHERE id = $1`,
+      [job.id]
+    );
+    await connection.query("COMMIT");
+    return job;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+async function rescheduleRevocationJob(
+  db: DatabaseQueryable,
+  job: RevocationJob,
+  error: unknown
+): Promise<void> {
+  const delaySeconds = Math.min(300, 2 ** Math.min(job.attempts + 1, 8));
+  await db.query(
+    `UPDATE provider_revocation_jobs
+     SET state = 'pending',
+         available_at = now() + ($2 * interval '1 second'),
+         last_error = $3
+     WHERE id = $1`,
+    [
+      job.id,
+      delaySeconds,
+      error instanceof Error ? error.message.slice(0, 2_000) : String(error)
+    ]
+  );
+}

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import { buildApp } from "./app.js";
-import { createDatabase } from "./db.js";
+import { createDatabase, openDatabase } from "./db.js";
+import { assertControlPlaneMigrationsCurrent } from "./migrations.js";
 import { runtimeConfigFromEnv } from "./runtime-config.js";
 import { HostedProviderClient } from "./hosted-provider.js";
 import { createRelayBroker } from "./relay-broker.js";
@@ -11,7 +12,12 @@ import { ResendEmailTransport } from "./email.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const runtime = runtimeConfigFromEnv(process.env);
-const db = await createDatabase();
+const db = process.env.NODE_ENV === "production"
+  ? await openDatabase()
+  : await createDatabase();
+if (process.env.NODE_ENV === "production") {
+  await assertControlPlaneMigrationsCurrent(db);
+}
 const relayBroker = await createRelayBroker(runtime.relayBroker);
 const portalDist = process.env.PORTAL_DIST ?? resolve(import.meta.dirname, "../../../apps/portal/dist");
 const { app } = await buildApp({

--- a/services/server/src/migrate.ts
+++ b/services/server/src/migrate.ts
@@ -1,4 +1,14 @@
-import { createDatabase } from "./db.js";
+import { openDatabase } from "./db.js";
+import { runControlPlaneMigrations } from "./migrations.js";
 
-const db = await createDatabase();
-await db.end();
+const db = await openDatabase();
+try {
+  await runControlPlaneMigrations(db, {
+    lock: Boolean(
+      process.env.DATABASE_URL
+      && process.env.DATABASE_URL !== "memory"
+    )
+  });
+} finally {
+  await db.end();
+}

--- a/services/server/src/migrations.ts
+++ b/services/server/src/migrations.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type {
+  DatabaseConnection,
+  DatabasePool,
+  DatabaseQueryable
+} from "./db.js";
+import { migrateLegacySchema } from "./db.js";
+
+const MIGRATION_LOCK_ID = 1_291_842_019;
+const LEGACY_BASELINE_ID = "0000_legacy_baseline";
+const LEGACY_BASELINE_CHECKSUM = createHash("sha256")
+  .update("mdbase-connect-control-plane-legacy-baseline-v1")
+  .digest("hex");
+const NON_TRANSACTIONAL_DIRECTIVE = "-- mdbase:no-transaction";
+
+export interface MigrationOptions {
+  lock?: boolean;
+  directory?: string;
+}
+
+interface AppliedMigration {
+  id: string;
+  checksum: string;
+}
+
+export async function runControlPlaneMigrations(
+  pool: DatabasePool,
+  options: MigrationOptions = {}
+): Promise<void> {
+  const connection = await pool.connect();
+  try {
+    if (options.lock) {
+      await connection.query("SELECT pg_advisory_lock($1)", [MIGRATION_LOCK_ID]);
+    }
+    await ensureMigrationLedger(connection);
+    await establishLegacyBaseline(connection);
+    await applySqlMigrations(
+      connection,
+      options.directory ?? resolve(import.meta.dirname, "../migrations")
+    );
+  } finally {
+    if (options.lock) {
+      await connection
+        .query("SELECT pg_advisory_unlock($1)", [MIGRATION_LOCK_ID])
+        .catch(() => undefined);
+    }
+    connection.release();
+  }
+}
+
+export async function assertControlPlaneMigrationsCurrent(
+  db: DatabaseQueryable,
+  options: Pick<MigrationOptions, "directory"> = {}
+): Promise<void> {
+  const applied = await db.query<AppliedMigration>(
+    "SELECT id, checksum FROM schema_migrations"
+  );
+  const byId = new Map(applied.rows.map((migration) => [
+    migration.id,
+    migration
+  ]));
+  const baseline = byId.get(LEGACY_BASELINE_ID);
+  if (!baseline) {
+    throw new Error("The control-plane legacy baseline has not been migrated.");
+  }
+  assertChecksum(baseline, LEGACY_BASELINE_CHECKSUM);
+  for (const migration of await sqlMigrations(
+    options.directory ?? resolve(import.meta.dirname, "../migrations")
+  )) {
+    const existing = byId.get(migration.id);
+    if (!existing) {
+      throw new Error(
+        `Control-plane migration ${migration.id} has not been applied.`
+      );
+    }
+    assertChecksum(existing, migration.checksum);
+  }
+}
+
+async function ensureMigrationLedger(db: DatabaseQueryable): Promise<void> {
+  const existing = await db.query(
+    `SELECT table_name FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = 'schema_migrations'`
+  );
+  if (existing.rows[0]) return;
+  await db.query(`
+    CREATE TABLE schema_migrations (
+      id text PRIMARY KEY,
+      checksum text NOT NULL,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+async function establishLegacyBaseline(db: DatabaseQueryable): Promise<void> {
+  const applied = await db.query<AppliedMigration>(
+    "SELECT id, checksum FROM schema_migrations WHERE id = $1",
+    [LEGACY_BASELINE_ID]
+  );
+  if (applied.rows[0]) {
+    assertChecksum(applied.rows[0], LEGACY_BASELINE_CHECKSUM);
+    return;
+  }
+  const existingLegacySchema = await db.query(
+    `SELECT table_name FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = 'users'`
+  );
+  if (!existingLegacySchema.rows[0]) {
+    await migrateLegacySchema(db);
+  }
+  await db.query(
+    `INSERT INTO schema_migrations (id, checksum)
+     VALUES ($1, $2)
+     ON CONFLICT (id) DO NOTHING`,
+    [LEGACY_BASELINE_ID, LEGACY_BASELINE_CHECKSUM]
+  );
+}
+
+async function applySqlMigrations(
+  connection: DatabaseConnection,
+  directory: string
+): Promise<void> {
+  const migrations = await sqlMigrations(directory);
+  const applied = await connection.query<AppliedMigration>(
+    "SELECT id, checksum FROM schema_migrations"
+  );
+  const byId = new Map(applied.rows.map((migration) => [
+    migration.id,
+    migration
+  ]));
+
+  for (const migration of migrations) {
+    const { id, sql, checksum } = migration;
+    const existing = byId.get(id);
+    if (existing) {
+      assertChecksum(existing, checksum);
+      continue;
+    }
+    if (sql.trimStart().startsWith(NON_TRANSACTIONAL_DIRECTIVE)) {
+      await connection.query(sql);
+      await recordMigration(connection, id, checksum);
+      continue;
+    }
+    await connection.query("BEGIN");
+    try {
+      await connection.query(sql);
+      await recordMigration(connection, id, checksum);
+      await connection.query("COMMIT");
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+async function sqlMigrations(directory: string): Promise<Array<{
+  id: string;
+  sql: string;
+  checksum: string;
+}>> {
+  const entries = (await readdir(directory, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+    .map((entry) => entry.name)
+    .sort();
+  const migrations = [];
+  for (const filename of entries) {
+    const id = filename.slice(0, -4);
+    const sql = await readFile(resolve(directory, filename), "utf8");
+    const checksum = createHash("sha256").update(sql).digest("hex");
+    migrations.push({ id, sql, checksum });
+  }
+  return migrations;
+}
+
+async function recordMigration(
+  db: DatabaseQueryable,
+  id: string,
+  checksum: string
+): Promise<void> {
+  await db.query(
+    "INSERT INTO schema_migrations (id, checksum) VALUES ($1, $2)",
+    [id, checksum]
+  );
+}
+
+function assertChecksum(
+  applied: AppliedMigration,
+  expected: string
+): void {
+  if (applied.checksum !== expected) {
+    throw new Error(
+      `Control-plane migration ${applied.id} changed after it was applied.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- introduce an immutable, checksummed control-plane migration runner and fail-closed production startup
- centralize stable collection identity, visibility, authority, and access-policy decisions
- compute application grants from manifest, request, and user capability ceilings
- record authorizing users and source replicas for future member-scoped revocation and audit
- make hosted grant revocation locally atomic with durable, retryable provider cleanup
- expose explicit access and authority metadata and document the collaboration boundary

## Verification

- pnpm build
- pnpm typecheck
- pnpm test (all workspace suites; server: 38 files / 174 tests)
- pnpm package:audit
- cargo fmt --all -- --check
- cargo test --workspace
- pnpm e2e
- pnpm e2e:relay
- pnpm e2e:sync
- pnpm e2e:provider (real PostgreSQL provider/control-plane/browser/mirror/backup lifecycle)
- pnpm e2e:container (pre-deploy migration and fail-closed production startup)

## Test-harness note

pnpm e2e:desktop:container reaches the existing UI but times out on its old initial-route heading (Connect this computer). The current desktop source and its dedicated Electron smoke use Your local connection as the initial heading and navigate to Connect this computer from App access. This branch does not change desktop code or that pre-existing harness mismatch.