### PR TITLE
Open collections in mdbase editor from Connect

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -6,6 +6,7 @@ await build({
   entryPoints: [
     "src/main/main.ts",
     "src/main/preload.ts",
+    "src/main/editor-url.ts",
     "src/main/electron-update-backend.ts",
     "src/main/release-source.ts",
     "src/main/update-coordinator.ts",

--- a/apps/desktop/src/main/editor-url.ts
+++ b/apps/desktop/src/main/editor-url.ts
@@ -1,0 +1,16 @@
+const DEFAULT_EDITOR_URL = "https://editor.mdbase.dev/";
+
+export function buildEditorUrl(
+  collectionId: unknown,
+  baseUrl = process.env.MDBASE_EDITOR_URL ?? DEFAULT_EDITOR_URL
+): string {
+  if (typeof collectionId !== "string" || collectionId.trim().length === 0) {
+    throw new Error("Invalid collection ID.");
+  }
+  const url = new URL(baseUrl);
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error("The mdbase editor URL must be a credential-free HTTPS URL.");
+  }
+  url.searchParams.set("collection", collectionId);
+  return url.href;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -17,6 +17,7 @@ import { join, resolve } from "node:path";
 import { hostname } from "node:os";
 import { promisify } from "node:util";
 import { AgentControlError, requestAgent } from "./control-client";
+import { buildEditorUrl } from "./editor-url";
 import { ElectronUpdateBackend } from "./electron-update-backend";
 import { UpdateCoordinator } from "./update-coordinator";
 import { UpdateStateStore } from "./update-state";
@@ -344,6 +345,10 @@ function registerIpc(): void {
     )).find((candidate) => candidate.id === collectionId);
     if (!collection) throw new Error("That collection is not registered.");
     return shell.openPath(join(collection.path, "mdbase.yaml"));
+  });
+  ipcMain.handle("connect:editor:open", async (event, collectionId: unknown) => {
+    trustedIpc(event);
+    return shell.openExternal(buildEditorUrl(collectionId));
   });
   ipcMain.handle("connect:startup:get", async (event) => {
     trustedIpc(event);

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -30,6 +30,8 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
   openPath: (path: string) => ipcRenderer.invoke("connect:path:open", path),
   openCollectionConfig: (collectionId: string) =>
     ipcRenderer.invoke("connect:collections:open-config", collectionId),
+  openEditor: (collectionId: string) =>
+    ipcRenderer.invoke("connect:editor:open", collectionId),
   getLaunchAtLogin: () => ipcRenderer.invoke("connect:startup:get"),
   setLaunchAtLogin: (enabled: boolean) => ipcRenderer.invoke("connect:startup:set", enabled),
   getCloudConfig: () => ipcRenderer.invoke("connect:cloud:get"),

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -303,6 +303,7 @@ interface Window {
     removeCollection(collectionId: string): Promise<CollectionSummary>;
     openPath(path: string): Promise<string>;
     openCollectionConfig(collectionId: string): Promise<string>;
+    openEditor(collectionId: string): Promise<void>;
     getLaunchAtLogin(): Promise<StartupSetting>;
     setLaunchAtLogin(enabled: boolean): Promise<StartupSetting>;
     getCloudConfig(): Promise<CloudSetting>;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -432,27 +432,34 @@ function Collections({
           </div>
         </section>
       )}
-      {authorityConflicts.map((conflict) => (
-        <section className="copy-registration" aria-labelledby={`authority-${conflict.collection_id}`} key={conflict.collection_id}>
+      {authorityConflicts.map((conflict) => {
+        const selectedFolder = collections.find(
+          (collection) => collection.id === conflict.collection_id
+        )?.path ?? conflict.display_name;
+        return <section className="copy-registration" aria-labelledby={`authority-${conflict.collection_id}`} key={conflict.collection_id}>
           <div>
             <p className="eyebrow">Collection identity conflict</p>
-            <h2 id={`authority-${conflict.collection_id}`}>{conflict.display_name} is already active elsewhere.</h2>
-            <p>This folder has the same embedded collection ID as the copy on {conflict.active_connector_name}. Choose which identity this folder should keep.</p>
-            <small>Moving authority revokes the old computer’s application grants. Making this folder independent writes a new ID to only this folder’s <code>mdbase.yaml</code>.</small>
+            <h2 id={`authority-${conflict.collection_id}`}>Choose which copy of {conflict.display_name} to use.</h2>
+            <p>The selected folder and an existing connected copy share the same collection ID.</p>
+            <dl className="identity-conflict-details">
+              <div><dt>Selected folder</dt><dd><code title={selectedFolder}>{selectedFolder}</code></dd></div>
+              <div><dt>Currently active through</dt><dd>{conflict.active_connector_name}</dd></div>
+            </dl>
+            <small>Using the selected folder moves authority here and revokes application access through {conflict.active_connector_name}. Keeping both writes a new ID only to the selected folder’s <code>mdbase.yaml</code>.</small>
           </div>
           <div className="copy-registration-actions">
             <button className="button secondary" disabled={busy} onClick={() => void onAct(async () => {
               const independent = await window.mdbaseConnect.makeCollectionIndependent(conflict.collection_id);
               onNotice(`${independent.display_name} now has an independent collection identity.`);
-            })}>Make independent</button>
+            })}>Keep both copies</button>
             <button className="button primary" disabled={busy} onClick={() => void onAct(async () => {
-              if (!window.confirm(`Move ${conflict.display_name} authority from ${conflict.active_connector_name} to this computer? Existing application access through the old computer will be revoked.`)) return;
+              if (!window.confirm(`Use ${selectedFolder} as the authority for ${conflict.display_name}? Existing application access through ${conflict.active_connector_name} will be revoked.`)) return;
               await window.mdbaseConnect.takeCollectionAuthority(conflict.collection_id);
-              onNotice(`${conflict.display_name} now uses this computer as its authority.`);
-            })}>Use this computer</button>
+              onNotice(`${conflict.display_name} now uses ${selectedFolder} as its authoritative folder.`);
+            })}>Use selected folder</button>
           </div>
-        </section>
-      ))}
+        </section>;
+      })}
       <div className="collection-authority-group">
         <SectionHeading title="On this computer" note="These folders are authoritative here." count={collections.length} />
         {collections.length === 0 ? (

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -534,6 +534,13 @@ function CollectionRow({ collection, cloudConfigured, busy, onAct, onNotice }: {
         </div>
         <div className="collection-status"><StatusDot state={collection.enabled ? "connected" : "idle"} />{collection.enabled ? "Available" : "Disabled"}</div>
         <div className="row-actions">
+          <button
+            className="quiet-action"
+            disabled={busy}
+            onClick={() => void window.mdbaseConnect.openEditor(collection.id)}
+          >
+            Open in editor <span aria-hidden="true">↗</span>
+          </button>
           <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : "Details"}</button>
           <button className="quiet-action" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.setCollectionEnabled(collection.id, !collection.enabled); onNotice(collection.enabled ? `${collection.display_name} is no longer available to remote applications.` : `${collection.display_name} is available again.`); })}>{collection.enabled ? "Disable" : "Enable"}</button>
         </div>
@@ -623,6 +630,11 @@ function HostedCollectionRow({
   const [promotionStarting, setPromotionStarting] = useState(false);
   const mirror = mirrors.find((candidate) => candidate.collection_id === collection.id);
   const activeReplicas = collection.replicas.filter((replica) => replica.revoked_at === null);
+  const editorCollectionId = collection.authority_state === "active"
+    ? collection.id
+    : collection.authority_state === "transferred"
+      ? collection.transferred_collection_id
+      : null;
 
   useEffect(() => {
     if (openMirror) {
@@ -666,6 +678,13 @@ function HostedCollectionRow({
               : "Moving"}
         </div>
         <div className="row-actions">
+          {editorCollectionId && <button
+            className="quiet-action"
+            disabled={busy}
+            onClick={() => void window.mdbaseConnect.openEditor(editorCollectionId)}
+          >
+            Open in editor <span aria-hidden="true">↗</span>
+          </button>}
           <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : mirror ? "Mirror" : "Details"}</button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -155,6 +155,11 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .copy-registration p:not(.eyebrow) { max-width: 68ch; margin: 6px 0 10px; color: var(--muted); font-size: var(--type-supporting); line-height: 1.5; }
 .copy-registration code { display: block; max-width: 68ch; overflow-wrap: anywhere; color: var(--ink); font-size: var(--type-action); }
 .copy-registration small { display: block; margin-top: 8px; color: var(--muted); font-size: var(--type-action); }
+.identity-conflict-details { display: grid; max-width: 68ch; margin: 12px 0; border-top: 1px solid var(--line); }
+.identity-conflict-details > div { display: grid; grid-template-columns: 140px minmax(0, 1fr); align-items: center; gap: 14px; min-height: 34px; border-bottom: 1px solid var(--line); }
+.identity-conflict-details dt { color: var(--muted); font-size: var(--type-action); }
+.identity-conflict-details dd { min-width: 0; margin: 0; overflow: hidden; font-size: var(--type-supporting); font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
+.identity-conflict-details code { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .copy-registration-actions { display: flex; gap: 8px; }
 .empty-state { display: grid; justify-items: start; padding: 32px 0 28px; border-bottom: 1px solid var(--line); text-align: left; }
 .empty-folder { display: none; }
@@ -302,6 +307,7 @@ fieldset legend { margin-bottom: 6px; }
   .pairing-form .button { grid-column: 1; }
   .copy-registration { grid-template-columns: 1fr; gap: 16px; }
   .copy-registration-actions { justify-content: flex-end; }
+  .identity-conflict-details > div { grid-template-columns: 120px minmax(0, 1fr); }
 }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.001ms !important; animation-duration: 0.001ms !important; }

--- a/apps/desktop/test/editor-url.test.mjs
+++ b/apps/desktop/test/editor-url.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { buildEditorUrl } = require("../dist/main/editor-url.js");
+
+test("editor links carry the opaque collection identity", () => {
+  assert.equal(
+    buildEditorUrl("collection id/with punctuation", "https://editor.mdbase.dev/"),
+    "https://editor.mdbase.dev/?collection=collection+id%2Fwith+punctuation"
+  );
+  assert.equal(
+    buildEditorUrl("staging-collection", "https://editor-staging.mdbase.dev/?preview=1"),
+    "https://editor-staging.mdbase.dev/?preview=1&collection=staging-collection"
+  );
+});
+
+test("editor links reject invalid IDs and unsafe base URLs", () => {
+  assert.throws(() => buildEditorUrl("", "https://editor.mdbase.dev/"), /Invalid collection ID/);
+  assert.throws(
+    () => buildEditorUrl("collection", "http://editor.mdbase.dev/"),
+    /credential-free HTTPS URL/
+  );
+  assert.throws(
+    () => buildEditorUrl("collection", "https://user:secret@editor.mdbase.dev/"),
+    /credential-free HTTPS URL/
+  );
+});

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -35,6 +35,13 @@ import { SessionManager } from "./session-manager";
 import "./styles.css";
 
 const allOperations = ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate", "create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "read_type", "create_type", "update_type", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"];
+const editorBaseUrl = import.meta.env.VITE_MDBASE_EDITOR_URL ?? "https://editor.mdbase.dev/";
+
+function editorUrl(collectionId?: string): string {
+  const url = new URL(editorBaseUrl);
+  if (collectionId) url.searchParams.set("collection", collectionId);
+  return url.href;
+}
 
 function Portal() {
   const pairingId = location.pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
@@ -735,6 +742,16 @@ function Dashboard() {
         <div className="product-header-inner">
           <Brand productLabel />
           <div className="product-header-meta">
+            <a
+              className="portal-editor-link"
+              href={editorUrl()}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Open mdbase editor in a new tab"
+            >
+              <span className="portal-editor-link-label">Editor</span>
+              <span aria-hidden="true">↗</span>
+            </a>
             <ThemeSelect />
             <div className="product-header-meta-copy"><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></div>
             <span className="product-avatar" aria-hidden="true">{initials(data.user.name)}</span>
@@ -881,6 +898,11 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
   const [busy, setBusy] = useState(false);
   const isActive = collection.authority_state === "active";
   const activeReplicas = collection.replicas.filter((replica) => !replica.revoked_at);
+  const editorCollectionId = isActive
+    ? collection.id
+    : collection.authority_state === "transferred"
+      ? collection.transferred_collection_id
+      : null;
   useEffect(() => { if (panel !== "rename") setName(collection.display_name); }, [collection.display_name, panel]);
 
   async function rename(event: React.FormEvent) {
@@ -935,6 +957,14 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
       </span>
       <span className="replica-count">{activeReplicas.length} {activeReplicas.length === 1 ? "mirror" : "mirrors"}</span>
       <div className="computer-actions">
+        {editorCollectionId && <a
+          className="quiet-action"
+          href={editorUrl(editorCollectionId)}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Open in editor <span aria-hidden="true">↗</span>
+        </a>}
         {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Mirror</button>}
         {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button>}
         <button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button>

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -45,6 +45,24 @@ body,
   z-index: 10;
 }
 
+.portal-editor-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 2rem;
+  padding: 0 0.45rem;
+  border-radius: 3px;
+  color: var(--ink-soft);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.portal-editor-link:hover {
+  color: var(--ink);
+  background: var(--paper-hover);
+}
+
 .account-main {
   width: min(70rem, 100%);
   margin-inline: auto;
@@ -317,6 +335,7 @@ h1 {
 
 .computer-actions {
   display: flex !important;
+  flex-wrap: wrap;
   grid-auto-flow: column;
   align-items: center;
   gap: 0.15rem !important;
@@ -395,6 +414,9 @@ h1 {
 }
 
 .quiet-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   padding: 0.35rem 0.45rem;
   border: 0;
   border-radius: 3px;
@@ -403,6 +425,7 @@ h1 {
   font-size: 0.7rem;
   font-weight: 700;
   cursor: pointer;
+  text-decoration: none;
 }
 
 .quiet-action:hover,
@@ -1509,6 +1532,10 @@ select {
 }
 
 @media (max-width: 760px) {
+  .portal-editor-link-label {
+    display: none;
+  }
+
   .account-header .product-header-meta-copy {
     display: none;
   }

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2191,6 +2191,11 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     const collectionId = dashboard.hosted_collections.find(
       (collection) => collection.display_name === "Browser E2E collection"
     ).id;
+    await expect(row.getByRole("link", { name: "Open in editor" }))
+      .toHaveAttribute(
+        "href",
+        `https://editor.mdbase.dev/?collection=${collectionId}`
+      );
     await row.getByRole("button", { name: "Mirror" }).click();
     await expect(row.getByRole("link", { name: "Open mdbase connect" }))
       .toHaveAttribute("href", `mdbase-connect://mirror?collection=${collectionId}`);


### PR DESCRIPTION
## Summary

- add a quiet mdbase editor link to the portal header
- add contextual editor deep links to portal collection rows
- add matching editor actions for computer-owned and hosted collections in the Electron app
- open desktop links through a narrow, validated main-process IPC boundary
- clarify collection identity conflicts by naming the selected folder and active connector

## Why

The portal and desktop client already identify a user’s collections, but reaching the editor requires separate navigation and another collection-selection step. The authority conflict panel also relied on computer names such as “This computer,” which did not distinguish the selected folder from the currently active copy.

## User impact

Users can open the editor generally from the portal header or open a specific collection directly from either Connect surface. Collections in authority transfer do not show the action; completed transfers use the replacement collection ID. Identity conflicts now present the selected folder path and active connector as distinct roles, with explicit “Keep both copies” and “Use selected folder” actions.

## Validation

- `pnpm --filter @mdbase/connect-portal typecheck`
- `pnpm --filter @mdbase/connect-portal test`
- `pnpm --filter @mdbase/connect-portal build`
- `node --check scripts/hosted-provider-e2e.mjs`
- `pnpm --filter @mdbase/connect-desktop typecheck`
- `pnpm --filter @mdbase/connect-desktop test`
- `pnpm --filter @mdbase/connect-desktop build`
