### PR TITLE
Stabilize server cold-start test

### DIFF
--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -47,7 +47,7 @@ describe("mdbase connect server", () => {
       protocol_version: 1,
       revision: "ae3a8d9"
     });
-  });
+  }, 15_000);
 
   it("keeps malformed and oversized request bodies out of the server-error path", async () => {
     const db = await createDatabase("memory");


### PR DESCRIPTION
## Summary

- give the cold-start server integration test a 15-second timeout
- keep the wider Vitest timeout unchanged so unrelated hangs still fail quickly

## Context

The beta.10 desktop preflight's macOS Intel job completed this test in 5.059 seconds, narrowly exceeding Vitest's default 5-second timeout. The test initializes the in-memory PostgreSQL emulator and applies all control-plane migrations on a cold worker.

## Validation

- targeted test passed 5 consecutive runs
- `pnpm test`
- `pnpm typecheck`
- `git diff --check`
