### PR TITLE
Set server integration test timeout centrally

### DIFF
--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -47,7 +47,7 @@ describe("mdbase connect server", () => {
       protocol_version: 1,
       revision: "ae3a8d9"
     });
-  }, 15_000);
+  });
 
   it("keeps malformed and oversized request bodies out of the server-error path", async () => {
     const db = await createDatabase("memory");

--- a/services/server/vitest.config.ts
+++ b/services/server/vitest.config.ts
@@ -18,5 +18,8 @@ export default defineConfig({
       }
     ]
   },
-  test: { include: ["src/**/*.test.ts"] }
+  test: {
+    include: ["src/**/*.test.ts"],
+    testTimeout: 15_000
+  }
 });


### PR DESCRIPTION
## Summary

- configure a 15-second timeout for the server integration suite
- remove the now-redundant one-test timeout
- leave other workspace test suites on Vitest's stricter default

## Context

Two different migration-heavy server tests narrowly exceeded Vitest's 5-second default on the slower macOS Intel release runner. Both failures occurred in otherwise successful 174-test runs, and the same exact release commit passed the required Intel preflight.

The server suite repeatedly initializes an in-memory PostgreSQL implementation, applies the full migration ledger, and exercises Argon2-backed authentication. A server-local timeout gives that integration work appropriate headroom without weakening faster unit-test suites elsewhere.

## Validation

- both affected migration-heavy tests passed 5 consecutive paired runs
- `pnpm test`
- `pnpm typecheck`
- `git diff --check`
