### PR TITLE
Fix legacy database upgrade for instance administration

### DIFF
--- a/services/server/migrations/0002_instance_administration.sql
+++ b/services/server/migrations/0002_instance_administration.sql
@@ -1,0 +1,37 @@
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS client_name text;
+
+ALTER TABLE connectors
+  ADD COLUMN IF NOT EXISTS revoked_at timestamptz;
+
+ALTER TABLE pairing_requests
+  ADD COLUMN IF NOT EXISTS revoked_at timestamptz;
+
+ALTER TABLE mirror_pairing_requests
+  ADD COLUMN IF NOT EXISTS revoked_at timestamptz;
+
+ALTER TABLE authority_adoption_requests
+  ADD COLUMN IF NOT EXISTS revoked_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS sessions_user_idx
+  ON sessions(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS authentication_challenges_user_idx
+  ON authentication_challenges(user_id, purpose, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS audit_events_created_idx
+  ON audit_events(created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS audit_events_user_created_idx
+  ON audit_events(user_id, created_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS operator_operations (
+  operation_id uuid PRIMARY KEY,
+  action text NOT NULL,
+  target_type text NOT NULL,
+  target_id text NOT NULL,
+  actor text NOT NULL,
+  reason text NOT NULL,
+  result jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -7,9 +7,11 @@ import {
   backfillExternalIdentityEmails,
   backfillSessionProviders,
   createDatabase,
+  migrateLegacySchema,
   openDatabase,
   revokeLegacyHostedBearerGrants
 } from "./db.js";
+import { InstanceAdminService } from "./instance-admin.js";
 import {
   assertControlPlaneMigrationsCurrent,
   runControlPlaneMigrations
@@ -31,7 +33,8 @@ describe("database migrations", () => {
     );
     expect(applied.rows.map(({ id }) => id)).toEqual([
       "0000_legacy_baseline",
-      "0001_collaboration_foundations"
+      "0001_collaboration_foundations",
+      "0002_instance_administration"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -48,6 +51,75 @@ describe("database migrations", () => {
     expect(repeated.rows).toEqual(applied.rows);
   });
 
+  it("upgrades a beta legacy schema before instance administration runs", async () => {
+    const db = await openDatabase("memory");
+    resources.push(() => db.end());
+    await migrateLegacySchema(db);
+    const userId = randomUUID();
+    const connectorId = randomUUID();
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, $2, 'Existing user')",
+      [userId, "existing@example.com"]
+    );
+    await db.query(
+      `INSERT INTO connectors (id, user_id, name, token_hash)
+       VALUES ($1, $2, 'Existing computer', 'existing-connector')`,
+      [connectorId, userId]
+    );
+    const service = new InstanceAdminService(db);
+
+    await expect(service.listUsers())
+      .rejects.toThrow("revoked_at");
+
+    await runControlPlaneMigrations(db);
+
+    await expect(service.listUsers()).resolves.toMatchObject({
+      users: [{
+        id: userId,
+        status: "active",
+        active_connectors: 1
+      }]
+    });
+    await expect(service.suspendUser(userId, {
+      operationId: randomUUID(),
+      actor: "operator:test",
+      reason: "Exercise the upgraded containment schema"
+    })).resolves.toMatchObject({
+      user_id: userId,
+      status: "suspended",
+      changed: true,
+      revoked: {
+        connectors: 1
+      }
+    });
+    const upgradedColumns = await db.query<{
+      table_name: string;
+      column_name: string;
+    }>(
+      `SELECT table_name, column_name
+       FROM information_schema.columns
+       WHERE (table_name = 'sessions' AND column_name = 'client_name')
+          OR (table_name IN (
+            'connectors',
+            'pairing_requests',
+            'mirror_pairing_requests',
+            'authority_adoption_requests'
+          ) AND column_name = 'revoked_at')
+       ORDER BY table_name, column_name`
+    );
+    expect(upgradedColumns.rows).toEqual([
+      { table_name: "authority_adoption_requests", column_name: "revoked_at" },
+      { table_name: "connectors", column_name: "revoked_at" },
+      { table_name: "mirror_pairing_requests", column_name: "revoked_at" },
+      { table_name: "pairing_requests", column_name: "revoked_at" },
+      { table_name: "sessions", column_name: "client_name" }
+    ]);
+    const migration = await db.query<{ id: string }>(
+      "SELECT id FROM schema_migrations WHERE id = '0002_instance_administration'"
+    );
+    expect(migration.rows).toEqual([{ id: "0002_instance_administration" }]);
+  });
+
   it("fails closed when an application starts before pre-deploy migration", async () => {
     const db = await openDatabase("memory");
     resources.push(() => db.end());
@@ -58,7 +130,6 @@ describe("database migrations", () => {
   it("backfills the authorizing user for replicas created before attribution", async () => {
     const db = await openDatabase("memory");
     resources.push(() => db.end());
-    const { migrateLegacySchema } = await import("./db.js");
     await migrateLegacySchema(db);
     const userId = randomUUID();
     const collectionId = randomUUID();

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -163,8 +163,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
     CREATE INDEX IF NOT EXISTS authentication_challenges_expiry_idx
       ON authentication_challenges(expires_at)
       WHERE consumed_at IS NULL AND invalidated_at IS NULL;
-    CREATE INDEX IF NOT EXISTS authentication_challenges_user_idx
-      ON authentication_challenges(user_id, purpose, created_at DESC);
     CREATE TABLE IF NOT EXISTS auth_rate_limit_buckets (
       scope text NOT NULL,
       key_digest text NOT NULL,
@@ -221,17 +219,13 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       expires_at timestamptz NOT NULL,
       revoked_at timestamptz,
       last_seen_at timestamptz NOT NULL DEFAULT now(),
-      client_name text,
       created_at timestamptz NOT NULL DEFAULT now()
     );
-    CREATE INDEX IF NOT EXISTS sessions_user_idx
-      ON sessions(user_id, created_at DESC);
     CREATE TABLE IF NOT EXISTS connectors (
       id uuid PRIMARY KEY,
       user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       name text NOT NULL,
       token_hash text NOT NULL UNIQUE,
-      revoked_at timestamptz,
       relay_generation bigint NOT NULL DEFAULT 0,
       inventory_revision bigint NOT NULL DEFAULT 0,
       last_seen_at timestamptz,
@@ -293,7 +287,7 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       icon text,
       redirect_uris jsonb NOT NULL,
       requirements jsonb NOT NULL DEFAULT '{"contracts":[]}'::jsonb,
-      provisions jsonb NOT NULL DEFAULT '{"type_packs":[]}'::jsonb,
+      provisions jsonb NOT NULL DEFAULT '{"types":[]}'::jsonb,
       notifications jsonb NOT NULL DEFAULT '{"criteria":[]}'::jsonb,
       first_seen_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
@@ -362,7 +356,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       user_id uuid REFERENCES users(id) ON DELETE CASCADE,
       approved_at timestamptz,
       consumed_at timestamptz,
-      revoked_at timestamptz,
       expires_at timestamptz NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     );
@@ -377,7 +370,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       replica_id uuid UNIQUE,
       approved_at timestamptz,
       consumed_at timestamptz,
-      revoked_at timestamptz,
       expires_at timestamptz NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     );
@@ -402,7 +394,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       prepared_at timestamptz,
       completed_at timestamptz,
       cancelled_at timestamptz,
-      revoked_at timestamptz,
       cleanup_completed boolean NOT NULL DEFAULT false,
       created_at timestamptz NOT NULL DEFAULT now()
     );
@@ -467,20 +458,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       event_type text NOT NULL,
       subject_id text,
       metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
-      created_at timestamptz NOT NULL DEFAULT now()
-    );
-    CREATE INDEX IF NOT EXISTS audit_events_created_idx
-      ON audit_events(created_at DESC, id DESC);
-    CREATE INDEX IF NOT EXISTS audit_events_user_created_idx
-      ON audit_events(user_id, created_at DESC, id DESC);
-    CREATE TABLE IF NOT EXISTS operator_operations (
-      operation_id uuid PRIMARY KEY,
-      action text NOT NULL,
-      target_type text NOT NULL,
-      target_id text NOT NULL,
-      actor text NOT NULL,
-      reason text NOT NULL,
-      result jsonb NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     );
     CREATE TABLE IF NOT EXISTS push_channels (
@@ -595,19 +572,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
   await ensureNotNullable(db, "sessions", "last_seen_at");
   await ensureColumn(
     db,
-    "sessions",
-    "client_name",
-    "ALTER TABLE sessions ADD COLUMN client_name text"
-  );
-  await db.query(
-    "CREATE INDEX IF NOT EXISTS sessions_user_idx ON sessions(user_id, created_at DESC)"
-  );
-  await db.query(
-    `CREATE INDEX IF NOT EXISTS authentication_challenges_user_idx
-       ON authentication_challenges(user_id, purpose, created_at DESC)`
-  );
-  await ensureColumn(
-    db,
     "external_identities",
     "email_verified",
     "ALTER TABLE external_identities ADD COLUMN email_verified boolean NOT NULL DEFAULT false"
@@ -663,30 +627,6 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
     "connectors",
     "inventory_revision",
     "ALTER TABLE connectors ADD COLUMN inventory_revision bigint NOT NULL DEFAULT 0"
-  );
-  await ensureColumn(
-    db,
-    "pairing_requests",
-    "revoked_at",
-    "ALTER TABLE pairing_requests ADD COLUMN revoked_at timestamptz"
-  );
-  await ensureColumn(
-    db,
-    "mirror_pairing_requests",
-    "revoked_at",
-    "ALTER TABLE mirror_pairing_requests ADD COLUMN revoked_at timestamptz"
-  );
-  await ensureColumn(
-    db,
-    "authority_adoption_requests",
-    "revoked_at",
-    "ALTER TABLE authority_adoption_requests ADD COLUMN revoked_at timestamptz"
-  );
-  await ensureColumn(
-    db,
-    "connectors",
-    "revoked_at",
-    "ALTER TABLE connectors ADD COLUMN revoked_at timestamptz"
   );
   await ensureColumn(
     db,


### PR DESCRIPTION
## Summary

- add an additive `0002_instance_administration` migration for the operator schema introduced after the beta.9 baseline
- keep `migrateLegacySchema` frozen to the actual beta.9 schema so new migrations remain explicit and reviewable
- add a regression test that upgrades a beta.9-style database with an existing user and connector before exercising instance administration

## Why

The beta.10 staging deployment recorded the legacy baseline for an existing beta.9 database, but the post-baseline operator columns were embedded in the legacy schema builder rather than a versioned migration. As a result, deployment health checks passed while `mdbase-ops users list` failed on the missing `connectors.revoked_at` column.

This migration adds the complete instance-administration delta idempotently: revocation/client columns, operator lookup indexes, and the operator operation ledger.

## Verification

- server migration tests: 12 passed
- full test suite: 175 passed
- build and typecheck
- package audit
- browser E2E
- container E2E with PostgreSQL/NATS
- hosted-provider E2E
- disposable PostgreSQL 17 beta.9 upgrade rehearsal using the real migration and operator CLIs
- `git diff --check`

A beta.11 release will consume this change; the immutable beta.10 tag will not be moved.
