### PR TITLE
Release mdbase connect 0.1.0-beta.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 dependencies = [
  "chrono",
  "mdbase",

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -1,6 +1,6 @@
 # Deploy an immutable mdbase connect release checkout. This value labels the
 # locally built images and must match the checked-out tag without the leading v.
-MDBASE_CONNECT_VERSION=0.1.0-beta.10
+MDBASE_CONNECT_VERSION=0.1.0-beta.11
 
 CONNECT_PUBLIC_URL=https://connect.example.com
 CONNECT_BIND_PORT=8787

--- a/docs/portable-apps.md
+++ b/docs/portable-apps.md
@@ -112,7 +112,7 @@ Use an exact package version, copy the SHA-384 value from that version's
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/npm/@mdbase/connect@0.1.0-beta.10/dist/browser/mdbase-connect.min.js"
+  src="https://cdn.jsdelivr.net/npm/@mdbase/connect@0.1.0-beta.11/dist/browser/mdbase-connect.min.js"
   integrity="sha384-59o+Qu3oMjMb1kcDBWnSLTqTE3mf1sTMQEjsGN/KckEDkO/M6nTW6AgKghiJFh14"
   crossorigin="anonymous"></script>
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -106,10 +106,10 @@ services require a branch reference; deploy tooling separately verifies and
 deploys the exact tag commit:
 
 ```bash
-pnpm version:check v0.1.0-beta.10
-git branch releases/v0.1.0-beta.10
-git tag -a v0.1.0-beta.10 -m "mdbase connect 0.1.0-beta.10"
-git push origin releases/v0.1.0-beta.10 v0.1.0-beta.10
+pnpm version:check v0.1.0-beta.11
+git branch releases/v0.1.0-beta.11
+git tag -a v0.1.0-beta.11 -m "mdbase connect 0.1.0-beta.11"
+git push origin releases/v0.1.0-beta.11 v0.1.0-beta.11
 ```
 
 When platform publisher configuration is wholly absent, the workflow publishes

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -17,8 +17,8 @@ Production deployments must use a signed or annotated release tag, never
 ```bash
 git clone https://github.com/mdbase-dev/mdbase-connect.git
 cd mdbase-connect
-git checkout v0.1.0-beta.10
-test "$(git describe --tags --exact-match)" = "v0.1.0-beta.10"
+git checkout v0.1.0-beta.11
+test "$(git describe --tags --exact-match)" = "v0.1.0-beta.11"
 ```
 
 Copy the production environment template:
@@ -195,7 +195,7 @@ and update `MDBASE_CONNECT_VERSION` to match it:
 
 ```bash
 git fetch --tags
-git checkout v0.1.0-beta.10
+git checkout v0.1.0-beta.11
 docker compose --env-file deploy/self-host/.env \
   -f deploy/self-host/compose.yml \
   --profile hosted --profile mcp \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.10" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.11" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.10",
+  "version": "0.1.0-beta.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- advance every public package, service, Rust workspace crate, and self-hosting reference to `0.1.0-beta.11`
- update the MCP-advertised version
- verify the documented portable browser bundle SHA-384 against the exact beta.11 build output

## Why

This creates a new immutable beta release containing the explicit beta.9-to-instance-administration database migration from #107. The beta.10 release remains immutable; beta.11 is required so existing managed and self-hosted databases receive the additive operator schema before the application starts.

## Validation

- `pnpm version:check v0.1.0-beta.11`
- `pnpm build`, `pnpm typecheck`, `pnpm test` (server: 38 files, 175 tests), `pnpm package:audit`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `pnpm e2e`
- `pnpm e2e:relay`
- `pnpm e2e:sync`
- `pnpm e2e:provider`
- `pnpm e2e:container`
- `pnpm --filter @mdbase/connect-desktop package`
- recomputed and verified documented browser SRI against `packages/client/dist/browser/mdbase-connect.min.js`
- `git diff --check`
