### PR TITLE
Fix hosted sync capability authorization

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1026,6 +1026,15 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
     () => groupAuthorizationOperations(request.requested_operations),
     [request.requested_operations]
   );
+  const permissionCount = permissionGroups.reduce(
+    (count, group) => count + group.operations.length,
+    0
+  );
+  const selectedPermissionCount = permissionGroups.reduce(
+    (count, group) =>
+      count + group.operations.filter((operation) => operations.includes(operation.id)).length,
+    0
+  );
   useEffect(() => {
     if (!available.some((collection) => collection.id === collectionId)) {
       setCollectionId(available[0]?.id ?? "");
@@ -1097,7 +1106,7 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
           </div>
         </section>
         <section className="request-section">
-          <div><strong>Permissions</strong><small>{request.requested_operations.length} specific actions across {permissionGroups.length} {permissionGroups.length === 1 ? "category" : "categories"}.</small></div>
+          <div><strong>Permissions</strong><small>{permissionCount} specific actions across {permissionGroups.length} {permissionGroups.length === 1 ? "category" : "categories"}.</small></div>
           <RequestPermissionChoices groups={permissionGroups} selected={operations} onChange={setOperations} />
         </section>
         <NotificationAccess notifications={request.notifications} />
@@ -1107,7 +1116,7 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
             : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
           <div className="decision-actions">
             <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
-            <button className="button primary" disabled={busy || !selected || operations.length === 0} onClick={() => void onAct(async () => {
+            <button className="button primary" disabled={busy || !selected || selectedPermissionCount === 0} onClick={() => void onAct(async () => {
               if (selected?.kind === "hosted") {
                 await window.mdbaseConnect.approveHostedAuthorization({ requestId: request.id, collectionId, operations });
               } else {
@@ -1133,6 +1142,11 @@ function RequestPermissionChoices({
 }) {
   const selectedSet = new Set(selected);
   const total = groups.reduce((count, group) => count + group.operations.length, 0);
+  const selectedTotal = groups.reduce(
+    (count, group) =>
+      count + group.operations.filter((operation) => selectedSet.has(operation.id)).length,
+    0
+  );
   function toggle(operation: string, checked: boolean) {
     onChange(checked
       ? [...selected, operation]
@@ -1140,7 +1154,7 @@ function RequestPermissionChoices({
   }
   return (
     <details className="request-permission-review">
-      <summary><span><strong>{selected.length} of {total} selected</strong><small>Review or narrow individual actions</small></span><b>Review</b></summary>
+      <summary><span><strong>{selectedTotal} of {total} selected</strong><small>Review or narrow individual actions</small></span><b>Review</b></summary>
       <div className="request-permission-groups">{groups.map((group) => (
         <fieldset key={group.id}>
           <legend>{group.label}</legend>
@@ -1184,6 +1198,11 @@ function GrantEditor({ grant, busy, onAct, onNotice }: { grant: GrantSummary; bu
     () => groupAuthorizationOperations(allowedOperations),
     [allowedOperations]
   );
+  const selectedPermissionCount = permissionGroups.reduce(
+    (count, group) =>
+      count + group.operations.filter((operation) => operations.includes(operation.id)).length,
+    0
+  );
   const changed = useMemo(() => [...operations].sort().join(",") !== [...grant.operations].sort().join(","), [operations, grant.operations]);
   useEffect(() => setOperations(grant.operations), [grant.operations]);
   const authority = grant.collection_kind === "hosted" ? "Hosted by mdbase" : "On this computer";
@@ -1203,7 +1222,7 @@ function GrantEditor({ grant, busy, onAct, onNotice }: { grant: GrantSummary; bu
               else await window.mdbaseConnect.revokeGrant(grant.id);
               onNotice(`${grant.application_name} access was revoked.`);
             }); }}>Revoke</button>
-            <button className="button primary" disabled={busy || !changed || operations.length === 0} onClick={() => void onAct(async () => {
+            <button className="button primary" disabled={busy || !changed || selectedPermissionCount === 0} onClick={() => void onAct(async () => {
               if (grant.collection_kind === "hosted") await window.mdbaseConnect.updateHostedGrant({ grantId: grant.id, operations });
               else await window.mdbaseConnect.updateGrant({ grantId: grant.id, operations });
               onNotice(`${grant.application_name} permissions were updated.`);

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -1805,6 +1805,15 @@ function ApprovalForm({
     () => groupAuthorizationOperations(request.requested_operations),
     [request.requested_operations]
   );
+  const permissionCount = permissionGroups.reduce(
+    (count, group) => count + group.operations.length,
+    0
+  );
+  const selectedPermissionCount = permissionGroups.reduce(
+    (count, group) =>
+      count + group.operations.filter((operation) => operations.has(operation.id)).length,
+    0
+  );
 
   useEffect(() => {
     if (!compatible.some((choice) => choice.collection.id === collectionId)) {
@@ -1984,7 +1993,7 @@ function ApprovalForm({
       <section className="approval-section">
         <div className="approval-section-intro">
           <strong>Permissions</strong>
-          <small>{request.requested_operations.length} specific actions across {permissionGroups.length} {permissionGroups.length === 1 ? "category" : "categories"}.</small>
+          <small>{permissionCount} specific actions across {permissionGroups.length} {permissionGroups.length === 1 ? "category" : "categories"}.</small>
         </div>
         <PermissionChoices
           groups={permissionGroups}
@@ -2001,7 +2010,7 @@ function ApprovalForm({
           : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
         <div className="approval-actions">
           <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
-          <button className="button primary" type="button" disabled={submitting !== null || !collectionId || operations.size === 0} onClick={() => void decide("approved")}>{submitting === "approved" ? "Approving…" : `Allow ${request.application_name}`}</button>
+          <button className="button primary" type="button" disabled={submitting !== null || !collectionId || selectedPermissionCount === 0} onClick={() => void decide("approved")}>{submitting === "approved" ? "Approving…" : `Allow ${request.application_name}`}</button>
         </div>
       </footer>
     </div>
@@ -2065,10 +2074,15 @@ function PermissionChoices({
   onToggle(operation: string): void;
 }) {
   const total = groups.reduce((count, group) => count + group.operations.length, 0);
+  const selectedTotal = groups.reduce(
+    (count, group) =>
+      count + group.operations.filter((operation) => selected.has(operation.id)).length,
+    0
+  );
   return (
     <details className="permission-review">
       <summary>
-        <span><strong>{selected.size} of {total} selected</strong><small>Review or narrow individual actions</small></span>
+        <span><strong>{selectedTotal} of {total} selected</strong><small>Review or narrow individual actions</small></span>
         <b>Review</b>
       </summary>
       <div className="permission-groups">{groups.map((group) => (

--- a/packages/ui/access.test.ts
+++ b/packages/ui/access.test.ts
@@ -94,6 +94,16 @@ test("keeps unknown operations visible and readable", () => {
   assert.equal(authorizationOperationLabel("publish_archive"), "Publish archive");
 });
 
+test("keeps transport capabilities out of the user's permission checklist", () => {
+  assert.deepEqual(groupAuthorizationOperations(["read", "sync"]), [{
+    id: "view",
+    label: "View and find records",
+    description: "Read collection details, records, saved views, and type definitions.",
+    operations: [{ id: "read", label: "Read records" }]
+  }]);
+  assert.deepEqual(groupAuthorizationOperations(["sync"]), []);
+});
+
 test("keeps application timers in a distinct permission category", () => {
   assert.deepEqual(groupAuthorizationOperations(["list_timers", "put_timer"]), [{
     id: "schedule",

--- a/packages/ui/access.ts
+++ b/packages/ui/access.ts
@@ -97,6 +97,8 @@ const authorizationOperationLabels: Record<string, string> = {
   reconcile_timers: "Reconcile application timers"
 };
 
+const TRANSPORT_CAPABILITIES = new Set(["sync"]);
+
 export function groupApplicationAccess<Grant extends ApplicationAccessGrant>(
   grants: readonly Grant[]
 ): ApplicationAccessGroup<Grant>[] {
@@ -129,7 +131,10 @@ export function groupApplicationAccess<Grant extends ApplicationAccessGrant>(
 export function groupAuthorizationOperations(
   operations: readonly string[]
 ): AuthorizationOperationGroup[] {
-  const requested = new Set(operations);
+  const reviewable = operations.filter(
+    (operation) => !TRANSPORT_CAPABILITIES.has(operation)
+  );
+  const requested = new Set(reviewable);
   const groups: AuthorizationOperationGroup[] = authorizationOperationGroups
     .map((group) => ({
       id: group.id,
@@ -144,7 +149,7 @@ export function groupAuthorizationOperations(
     }))
     .filter((group) => group.operations.length > 0);
   const known = new Set<string>(authorizationOperationGroups.flatMap((group) => group.operations));
-  const other = operations.filter((operation) => !known.has(operation));
+  const other = reviewable.filter((operation) => !known.has(operation));
 
   if (other.length > 0) {
     groups.push({

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2018,7 +2018,7 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
   };
   document.querySelector("#connect").onclick = () => {
     manager.authorize({
-      operations: ["describe", "query", "create"],
+      operations: ["describe", "query", "create", "sync"],
       openVerification() {},
       onDeviceCode(authorization) {
         globalThis.portableHarness.authorization = authorization;
@@ -2040,6 +2040,7 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
         displayName: description.display_name,
         created: created.valid,
         records: records.result.results.length,
+        syncAvailable: connection.sync() !== null,
         connections: manager.connections().length
       };
     }).catch((error) => {
@@ -2090,7 +2091,7 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
         method: "POST",
         body: {
           collection_id: collectionId,
-          operations: ["describe", "query", "create"]
+          operations: ["describe", "query", "create", "sync"]
         }
       }
     );
@@ -2107,6 +2108,7 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
       displayName: "Hosted writing",
       created: true,
       records: 1,
+      syncAvailable: true,
       connections: 1
     });
     const captured = result.capturedRequest;

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1225,7 +1225,7 @@ describe("mdbase connect server", () => {
       },
       payload: new URLSearchParams({
         client_id: applicationId,
-        operations: "describe,query,create,update",
+        operations: "describe,query,create,update,sync",
         collection_hint: collectionId,
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
@@ -1257,7 +1257,7 @@ describe("mdbase connect server", () => {
       headers: { cookie },
       payload: {
         collection_id: collectionId,
-        operations: ["describe", "query", "create", "update"]
+        operations: ["describe", "query", "create", "update", "sync"]
       }
     });
     expect(approved.statusCode, JSON.stringify(approved.json())).toBe(200);
@@ -1280,7 +1280,7 @@ describe("mdbase connect server", () => {
     expect(token.json()).toMatchObject({
       collection_id: collectionId,
       application_origin: "null",
-      operations: ["describe", "query", "create", "update"],
+      operations: ["describe", "query", "create", "update", "sync"],
       encryption: null,
       authority: {
         operations_url: `https://sync.example/v1/authorities/${collectionId}/operations`,
@@ -1614,7 +1614,7 @@ describe("mdbase connect server", () => {
     const verifier = "hosted-unrestricted-verifier-that-is-long-enough-0001";
     const authorization = await app.inject({
       method: "GET",
-      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&operations=describe,query,create,update`,
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&operations=describe,query,create,update,sync`,
       headers: { cookie }
     });
     const requestId = authorization.headers.location!.split("/").at(-1)!;
@@ -1652,7 +1652,7 @@ describe("mdbase connect server", () => {
       headers: { cookie },
       payload: {
         collection_id: localControlCollectionId,
-        operations: ["describe", "query", "create", "update"]
+        operations: ["describe", "query", "create", "update", "sync"]
       }
     });
     expect(localApproval.statusCode).toBe(404);
@@ -1662,7 +1662,7 @@ describe("mdbase connect server", () => {
       headers: { authorization: `Bearer ${connector.token}` },
       payload: {
         collection_id: collectionId,
-        operations: ["describe", "query", "create", "update"]
+        operations: ["describe", "query", "create", "update", "sync"]
       }
     });
     expect(approved.statusCode).toBe(200);
@@ -1671,7 +1671,8 @@ describe("mdbase connect server", () => {
       expect.objectContaining({
         purpose: "application",
         allowedTypes: [],
-        fullCollection: true
+        fullCollection: true,
+        allowedOperations: ["describe", "query", "create", "update"]
       })
     );
 
@@ -1693,7 +1694,11 @@ describe("mdbase connect server", () => {
     expect(rediscovered.statusCode).toBe(200);
     expect(hostedProvider.updateApplicationReplica).toHaveBeenCalledWith(
       provisioned.rows[0].id,
-      expect.objectContaining({ allowedTypes: [], fullCollection: true })
+      expect.objectContaining({
+        allowedTypes: [],
+        fullCollection: true,
+        allowedOperations: ["describe", "query", "create", "update"]
+      })
     );
     const reconciled = await db.query<{ allowed_types: string[] }>(
       "SELECT allowed_types FROM hosted_replicas WHERE id = $1",
@@ -1711,10 +1716,10 @@ describe("mdbase connect server", () => {
       method: "PATCH",
       url: `/v1/connectors/hosted/grants/${grantId}`,
       headers: { authorization: `Bearer ${connector.token}` },
-      payload: { operations: ["describe", "query"] }
+      payload: { operations: ["describe", "query", "sync"] }
     });
     expect(narrowed.statusCode, JSON.stringify(narrowed.json())).toBe(200);
-    expect(narrowed.json().grant.operations).toEqual(["describe", "query"]);
+    expect(narrowed.json().grant.operations).toEqual(["describe", "query", "sync"]);
     expect(hostedProvider.updateApplicationReplica).toHaveBeenLastCalledWith(
       provisioned.rows[0].id,
       expect.objectContaining({ mode: "read_only", allowedOperations: ["describe", "query"] })
@@ -1723,7 +1728,7 @@ describe("mdbase connect server", () => {
       method: "PATCH",
       url: `/v1/connectors/hosted/grants/${grantId}`,
       headers: { authorization: `Bearer ${connector.token}` },
-      payload: { operations: ["describe", "query", "create"] }
+      payload: { operations: ["describe", "query", "create", "sync"] }
     });
     expect(broadened.statusCode).toBe(400);
     const revoked = await app.inject({

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -64,6 +64,7 @@ import {
   HostedProviderResponseError,
   HostedProviderUnavailableError
 } from "./hosted-provider.js";
+import { hostedReplicaCollectionOperations } from "./hosted-replica-policy.js";
 import {
   AuthorityProofError,
   verifyAuthorityRequestProof
@@ -4806,7 +4807,7 @@ export async function buildApp(options: BuildOptions) {
         ),
         contractScope: current.scope.access === "contract" ? current.scope.contracts : [],
         fullCollection: current.scope.access === "full_collection",
-        allowedOperations: operations
+        allowedOperations: hostedReplicaCollectionOperations(operations)
       });
     }
     const updated = await options.db.query<{ id: string; operations: string[] }>(
@@ -6111,7 +6112,7 @@ async function reconcileApplicationGrants(
           allowedTypes: desiredAllowedTypes,
           contractScope: desiredScope.access === "contract" ? desiredScope.contracts : [],
           fullCollection: application.requirements.access === "full_collection",
-          allowedOperations: grant.operations
+          allowedOperations: hostedReplicaCollectionOperations(grant.operations)
         });
         await db.query(
           "UPDATE hosted_replicas SET allowed_types = $2::jsonb, mode = $3 WHERE id = $1",
@@ -6970,7 +6971,7 @@ async function approveHostedAuthorization(
       allowedTypes,
       contractScope: scope.access === "contract" ? scope.contracts : [],
       fullCollection: scope.access === "full_collection",
-      allowedOperations: operations,
+      allowedOperations: hostedReplicaCollectionOperations(operations),
       allowedOrigin,
       proofPublicKey: pending.flow === "device_code"
         ? pending.application_public_key!
@@ -8313,7 +8314,7 @@ async function narrowHostedGrantForUser(
     ),
     contractScope: current.scope.access === "contract" ? current.scope.contracts : [],
     fullCollection: current.scope.access === "full_collection",
-    allowedOperations: operations
+    allowedOperations: hostedReplicaCollectionOperations(operations)
   });
   const updated = await options.db.query<{ id: string; operations: string[] }>(
     "UPDATE grants SET operations = $2::jsonb WHERE id = $1 RETURNING id, operations",

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -106,7 +106,7 @@ describe("hosted provider control client", () => {
       allowedTypes: ["task"],
       contractScope: [],
       fullCollection: false,
-      allowedOperations: ["read", "query"]
+      allowedOperations: ["read", "sync", "query"]
     });
     await provider.rotateReplicaToken("replica", "new-token", 3600);
     expect(fetchMock.mock.calls.map(([url, init]) => [url, init?.method, init?.body])).toEqual([

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -3,6 +3,7 @@ import type {
   GrantPolicy,
   TypePackProvision
 } from "@mdbase/connect-protocol";
+import { hostedReplicaCollectionOperations } from "./hosted-replica-policy.js";
 import { safeEqual } from "./security.js";
 
 export interface HostedProviderConfig {
@@ -121,7 +122,9 @@ export class HostedProviderClient {
         allowed_types: replica.allowedTypes,
         contract_scope: replica.contractScope ?? [],
         full_collection: replica.fullCollection ?? false,
-        allowed_operations: replica.allowedOperations ?? [],
+        allowed_operations: hostedReplicaCollectionOperations(
+          replica.allowedOperations ?? []
+        ),
         ...(replica.allowedOrigin ? { allowed_origin: replica.allowedOrigin } : {}),
         ...(replica.proofPublicKey ? { proof_public_key: replica.proofPublicKey } : {}),
         ...(replica.grantId ? { grant_id: replica.grantId } : {}),
@@ -167,7 +170,9 @@ export class HostedProviderClient {
         allowed_types: policy.allowedTypes,
         contract_scope: policy.contractScope,
         full_collection: policy.fullCollection,
-        allowed_operations: policy.allowedOperations
+        allowed_operations: hostedReplicaCollectionOperations(
+          policy.allowedOperations
+        )
       }
     );
   }

--- a/services/server/src/hosted-replica-policy.test.ts
+++ b/services/server/src/hosted-replica-policy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { hostedReplicaCollectionOperations } from "./hosted-replica-policy.js";
+
+describe("hosted replica policy", () => {
+  it("keeps transport capabilities on the grant side of the provider boundary", () => {
+    const grantOperations = ["read", "sync", "changes", "update"];
+
+    expect(hostedReplicaCollectionOperations(grantOperations)).toEqual([
+      "read",
+      "changes",
+      "update"
+    ]);
+    expect(grantOperations).toEqual(["read", "sync", "changes", "update"]);
+  });
+});

--- a/services/server/src/hosted-replica-policy.ts
+++ b/services/server/src/hosted-replica-policy.ts
@@ -1,0 +1,13 @@
+/**
+ * Application grants may include transport capabilities that are meaningful to
+ * the SDK but are not executable collection operations at the hosted provider.
+ *
+ * Hosted sync authorizes each snapshot, change read, and mutation through its
+ * underlying collection operation, so forwarding `sync` as an allowed
+ * operation both duplicates that policy and violates the provider contract.
+ */
+export function hostedReplicaCollectionOperations(
+  grantOperations: readonly string[]
+): string[] {
+  return grantOperations.filter((operation) => operation !== "sync");
+}


### PR DESCRIPTION
## Summary

- treat `sync` as an automatic SDK transport capability rather than a hosted collection operation
- keep `sync` in grants and tokens while projecting only granular collection operations into hosted replica policy
- hide transport capabilities from the portal and desktop permission checklists
- cover grant creation, narrowing, reconciliation, provider serialization, approval UI grouping, and the real browser/SDK hosted lifecycle

## Why

TaskNotes requests `sync` alongside its collection permissions. Connect was forwarding every granted capability to the Rust hosted provider as an `allowedOperations` entry. The provider correctly rejected `sync`, because it is not a collection operation, which made approval fail unless the user manually rejected sync.

This change establishes a single boundary projection: transport capabilities remain automatic Connect/SDK behavior, while provider authorization continues to use granular collection operations.

## Verification

- `pnpm typecheck`
- `pnpm test`
- `cargo test --workspace`
- `pnpm e2e:provider`
