### PR TITLE
Support beta.8 authentication upgrades

### DIFF
--- a/services/server/migrations/0001a_authentication_foundations.sql
+++ b/services/server/migrations/0001a_authentication_foundations.sql
@@ -1,0 +1,236 @@
+-- Compatibility foundation for installations upgrading directly from beta.8
+-- or another pre-password-authentication release. The filename intentionally
+-- orders this after collaboration foundations and before instance administration.
+-- mdbase:skip-if-table authentication_settings
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS suspended_at timestamptz;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS session_epoch bigint;
+
+UPDATE users
+SET session_epoch = 1
+WHERE session_epoch IS NULL;
+
+ALTER TABLE users
+  ALTER COLUMN session_epoch SET DEFAULT 1;
+
+ALTER TABLE users
+  ALTER COLUMN session_epoch SET NOT NULL;
+
+ALTER TABLE external_identities
+  ADD COLUMN IF NOT EXISTS email_verified boolean NOT NULL DEFAULT false;
+
+ALTER TABLE external_identities
+  ADD COLUMN IF NOT EXISTS normalized_email text;
+
+ALTER TABLE external_identities
+  ADD COLUMN IF NOT EXISTS email_normalization_version integer;
+
+-- Version 1 normalization lower-cases both parts and trims the address. SQL can
+-- reproduce it safely for legacy ASCII addresses; non-ASCII addresses remain
+-- unlinked until their identity provider next verifies them in application code.
+UPDATE external_identities
+SET normalized_email = lower(email),
+    email_normalization_version = 1
+WHERE email_verified = true
+  AND email IS NOT NULL
+  AND COALESCE(normalized_email, '') = ''
+  AND email LIKE '_%@_%'
+  AND email NOT LIKE '% %';
+
+CREATE INDEX IF NOT EXISTS external_identities_verified_email_idx
+  ON external_identities(normalized_email)
+  WHERE email_verified = true AND normalized_email IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS email_identities (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  email text NOT NULL,
+  normalized_email text NOT NULL,
+  normalization_version integer NOT NULL DEFAULT 1,
+  verified_at timestamptz,
+  is_primary boolean NOT NULL DEFAULT false,
+  retired_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS email_identities_active_email_idx
+  ON email_identities(normalized_email) WHERE retired_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS email_identities_primary_user_idx
+  ON email_identities(user_id) WHERE is_primary = true AND retired_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS email_identities_user_idx
+  ON email_identities(user_id);
+
+CREATE TABLE IF NOT EXISTS password_credentials (
+  user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  password_hash text NOT NULL,
+  credential_version bigint NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS account_agreements (
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  document text NOT NULL,
+  version text NOT NULL,
+  acceptance_method text NOT NULL,
+  accepted_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY(user_id, document, version)
+);
+
+CREATE TABLE IF NOT EXISTS invitations (
+  id uuid PRIMARY KEY,
+  email text NOT NULL,
+  normalized_email text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  created_by text NOT NULL,
+  terms_version text,
+  privacy_version text,
+  expires_at timestamptz NOT NULL,
+  accepted_by_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  accepted_at timestamptz,
+  revoked_at timestamptz,
+  revoked_by text,
+  revocation_reason text,
+  send_count integer NOT NULL DEFAULT 0,
+  last_sent_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS invitations_active_email_idx
+  ON invitations(normalized_email)
+  WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS invitations_expiry_idx
+  ON invitations(expires_at) WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS authentication_challenges (
+  id uuid PRIMARY KEY,
+  purpose text NOT NULL,
+  token_hash text NOT NULL UNIQUE,
+  normalized_email text NOT NULL,
+  user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+  invitation_id uuid REFERENCES invitations(id) ON DELETE CASCADE,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  invalidated_at timestamptz,
+  attempt_count integer NOT NULL DEFAULT 0,
+  max_attempts integer NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (attempt_count >= 0),
+  CHECK (max_attempts > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS authentication_challenges_active_email_idx
+  ON authentication_challenges(purpose, normalized_email)
+  WHERE consumed_at IS NULL AND invalidated_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS authentication_challenges_expiry_idx
+  ON authentication_challenges(expires_at)
+  WHERE consumed_at IS NULL AND invalidated_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS auth_rate_limit_buckets (
+  scope text NOT NULL,
+  key_digest text NOT NULL,
+  window_started_at timestamptz NOT NULL,
+  attempt_count integer NOT NULL DEFAULT 0,
+  blocked_until timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY(scope, key_digest),
+  CHECK (attempt_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS auth_rate_limit_buckets_updated_idx
+  ON auth_rate_limit_buckets(updated_at);
+
+CREATE TABLE IF NOT EXISTS authentication_settings (
+  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton = true),
+  registration_mode text NOT NULL
+    CHECK (registration_mode IN ('closed', 'invite', 'open')),
+  password_auth_enabled boolean NOT NULL DEFAULT false,
+  email_delivery_enabled boolean NOT NULL DEFAULT false,
+  terms_version text,
+  privacy_version text,
+  revision bigint NOT NULL DEFAULT 1,
+  updated_by text NOT NULL,
+  update_reason text NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS authentication_settings_history (
+  revision bigint PRIMARY KEY,
+  registration_mode text NOT NULL
+    CHECK (registration_mode IN ('closed', 'invite', 'open')),
+  password_auth_enabled boolean NOT NULL,
+  email_delivery_enabled boolean NOT NULL,
+  terms_version text,
+  privacy_version text,
+  updated_by text NOT NULL,
+  update_reason text NOT NULL,
+  updated_at timestamptz NOT NULL
+);
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS account_session_epoch bigint;
+
+UPDATE sessions
+SET account_session_epoch = 1
+WHERE account_session_epoch IS NULL;
+
+ALTER TABLE sessions
+  ALTER COLUMN account_session_epoch SET DEFAULT 1;
+
+ALTER TABLE sessions
+  ALTER COLUMN account_session_epoch SET NOT NULL;
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS revoked_at timestamptz;
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS last_seen_at timestamptz;
+
+UPDATE sessions
+SET last_seen_at = created_at
+WHERE last_seen_at IS NULL;
+
+ALTER TABLE sessions
+  ALTER COLUMN last_seen_at SET DEFAULT now();
+
+ALTER TABLE sessions
+  ALTER COLUMN last_seen_at SET NOT NULL;
+
+CREATE TABLE IF NOT EXISTS authority_adoption_requests (
+  id uuid PRIMARY KEY,
+  secret_hash text NOT NULL UNIQUE,
+  collection_id uuid NOT NULL,
+  display_name text NOT NULL,
+  source_name text NOT NULL,
+  retain_mirror boolean NOT NULL DEFAULT true,
+  mirror_name text,
+  user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+  state text NOT NULL DEFAULT 'requested'
+    CHECK (state IN (
+      'requested', 'approved', 'prepared', 'activating', 'completed',
+      'cancelled', 'expired'
+    )),
+  next_authority_epoch bigint NOT NULL DEFAULT 2,
+  final_head bigint,
+  manifest_digest text,
+  source_revision text,
+  contracts jsonb NOT NULL DEFAULT '[]'::jsonb,
+  expires_at timestamptz NOT NULL,
+  approved_at timestamptz,
+  prepared_at timestamptz,
+  completed_at timestamptz,
+  cancelled_at timestamptz,
+  cleanup_completed boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS authority_adoption_requests_collection_idx
+  ON authority_adoption_requests(collection_id, state);

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -34,6 +34,7 @@ describe("database migrations", () => {
     expect(applied.rows.map(({ id }) => id)).toEqual([
       "0000_legacy_baseline",
       "0001_collaboration_foundations",
+      "0001a_authentication_foundations",
       "0002_instance_administration"
     ]);
     const columns = await db.query<{ column_name: string }>(
@@ -118,6 +119,173 @@ describe("database migrations", () => {
       "SELECT id FROM schema_migrations WHERE id = '0002_instance_administration'"
     );
     expect(migration.rows).toEqual([{ id: "0002_instance_administration" }]);
+  });
+
+  it("upgrades a beta.8 schema without losing existing accounts or sessions", async () => {
+    const db = await openDatabase("memory");
+    resources.push(() => db.end());
+    await db.query(`
+      CREATE TABLE users (
+        id uuid PRIMARY KEY,
+        email text UNIQUE,
+        name text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE TABLE external_identities (
+        provider text NOT NULL,
+        subject text NOT NULL,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        login text,
+        email text,
+        email_verified boolean NOT NULL DEFAULT false,
+        avatar_url text,
+        last_login_at timestamptz,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        PRIMARY KEY(provider, subject),
+        UNIQUE(provider, user_id)
+      );
+      CREATE TABLE sessions (
+        id uuid PRIMARY KEY,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        token_hash text NOT NULL UNIQUE,
+        provider text NOT NULL DEFAULT 'session',
+        expires_at timestamptz NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE TABLE connectors (
+        id uuid PRIMARY KEY,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        name text NOT NULL,
+        token_hash text NOT NULL UNIQUE,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE TABLE pairing_requests (
+        id uuid PRIMARY KEY,
+        user_id uuid REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE TABLE mirror_pairing_requests (
+        id uuid PRIMARY KEY,
+        user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+        replica_id uuid
+      );
+      CREATE TABLE hosted_collections (
+        id uuid PRIMARY KEY,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE
+      );
+      CREATE TABLE hosted_replicas (
+        id uuid PRIMARY KEY,
+        collection_id uuid NOT NULL REFERENCES hosted_collections(id) ON DELETE CASCADE,
+        revoked_at timestamptz
+      );
+      CREATE TABLE grants (
+        id uuid PRIMARY KEY,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        hosted_replica_id uuid
+      );
+      CREATE TABLE audit_events (
+        id uuid PRIMARY KEY,
+        user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+    `);
+    const userId = randomUUID();
+    const sessionId = randomUUID();
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, $2, 'Existing user')",
+      [userId, "Person@Example.com"]
+    );
+    await db.query(
+      `INSERT INTO external_identities
+         (provider, subject, user_id, email, email_verified)
+       VALUES ('google', 'existing-subject', $1, $2, true)`,
+      [userId, "Person@Example.com"]
+    );
+    await db.query(
+      `INSERT INTO sessions (id, user_id, token_hash, expires_at)
+       VALUES ($1, $2, 'existing-session', now() + interval '30 days')`,
+      [sessionId, userId]
+    );
+
+    await runControlPlaneMigrations(db);
+
+    const account = await db.query<{
+      email: string;
+      suspended_at: Date | null;
+      session_epoch: number;
+    }>(
+      "SELECT email, suspended_at, session_epoch FROM users WHERE id = $1",
+      [userId]
+    );
+    expect(account.rows[0]).toMatchObject({
+      email: "Person@Example.com",
+      suspended_at: null,
+      session_epoch: 1
+    });
+    const identity = await db.query<{
+      normalized_email: string;
+      email_normalization_version: number;
+    }>(
+      `SELECT normalized_email, email_normalization_version
+       FROM external_identities WHERE user_id = $1`,
+      [userId]
+    );
+    expect(identity.rows[0]).toEqual({
+      normalized_email: "person@example.com",
+      email_normalization_version: 1
+    });
+    const session = await db.query<{
+      account_session_epoch: number;
+      revoked_at: Date | null;
+      last_seen_at: Date;
+    }>(
+      `SELECT account_session_epoch, revoked_at, last_seen_at
+       FROM sessions WHERE id = $1`,
+      [sessionId]
+    );
+    expect(session.rows[0]).toMatchObject({
+      account_session_epoch: 1,
+      revoked_at: null
+    });
+    expect(session.rows[0]?.last_seen_at).toBeInstanceOf(Date);
+    const authTables = await db.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_name IN (
+         'email_identities',
+         'password_credentials',
+         'account_agreements',
+         'invitations',
+         'authentication_challenges',
+         'auth_rate_limit_buckets',
+         'authentication_settings',
+         'authentication_settings_history',
+         'authority_adoption_requests',
+         'operator_operations'
+       )`
+    );
+    expect(new Set(authTables.rows.map(({ table_name }) => table_name))).toEqual(
+      new Set([
+        "email_identities",
+        "password_credentials",
+        "account_agreements",
+        "invitations",
+        "authentication_challenges",
+        "auth_rate_limit_buckets",
+        "authentication_settings",
+        "authentication_settings_history",
+        "authority_adoption_requests",
+        "operator_operations"
+      ])
+    );
+    const applied = await db.query<{ id: string }>(
+      "SELECT id FROM schema_migrations ORDER BY id"
+    );
+    expect(applied.rows.map(({ id }) => id)).toEqual([
+      "0000_legacy_baseline",
+      "0001_collaboration_foundations",
+      "0001a_authentication_foundations",
+      "0002_instance_administration"
+    ]);
   });
 
   it("fails closed when an application starts before pre-deploy migration", async () => {

--- a/services/server/src/migrations.ts
+++ b/services/server/src/migrations.ts
@@ -14,6 +14,7 @@ const LEGACY_BASELINE_CHECKSUM = createHash("sha256")
   .update("mdbase-connect-control-plane-legacy-baseline-v1")
   .digest("hex");
 const NON_TRANSACTIONAL_DIRECTIVE = "-- mdbase:no-transaction";
+const SKIP_IF_TABLE_DIRECTIVE = "-- mdbase:skip-if-table ";
 
 export interface MigrationOptions {
   lock?: boolean;
@@ -138,6 +139,14 @@ async function applySqlMigrations(
       assertChecksum(existing, checksum);
       continue;
     }
+    const skipIfTable = migrationDirectiveValue(
+      sql,
+      SKIP_IF_TABLE_DIRECTIVE
+    );
+    if (skipIfTable && await tableExists(connection, skipIfTable)) {
+      await recordMigration(connection, id, checksum);
+      continue;
+    }
     if (sql.trimStart().startsWith(NON_TRANSACTIONAL_DIRECTIVE)) {
       await connection.query(sql);
       await recordMigration(connection, id, checksum);
@@ -153,6 +162,36 @@ async function applySqlMigrations(
       throw error;
     }
   }
+}
+
+function migrationDirectiveValue(
+  sql: string,
+  directive: string
+): string | undefined {
+  for (const line of sql.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("--")) break;
+    if (trimmed.startsWith(directive)) {
+      const value = trimmed.slice(directive.length).trim();
+      if (!/^[a-z][a-z0-9_]*$/.test(value)) {
+        throw new Error(`Invalid migration directive: ${trimmed}`);
+      }
+      return value;
+    }
+  }
+  return undefined;
+}
+
+async function tableExists(
+  db: DatabaseQueryable,
+  tableName: string
+): Promise<boolean> {
+  const existing = await db.query(
+    `SELECT table_name FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = $1`,
+    [tableName]
+  );
+  return Boolean(existing.rows[0]);
 }
 
 async function sqlMigrations(directory: string): Promise<Array<{


### PR DESCRIPTION
## What changed

- add an immutable authentication-foundation migration ordered before instance administration
- preserve and backfill existing account, OAuth identity, and session data during a direct beta.8 upgrade
- let already-upgraded beta.9+ databases record the compatibility migration without replaying its schema DDL
- add a regression fixture for the beta.8 schema and migration ledger

## Why

Production is still on beta.8. A direct upgrade to beta.11 establishes the legacy baseline without replaying the beta.9 authentication schema, then reaches the instance-administration migration, which references tables that do not exist. That makes the production pre-deploy migration fail before services can be promoted.

## Impact

This makes direct beta.8-to-current upgrades safe while remaining idempotent for fresh databases and beta.9/beta.11 installations. Existing OAuth accounts and active sessions are retained; verified ASCII provider email identities receive the same version-1 normalization key used by application code.

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm e2e`
- PostgreSQL 16 rehearsal of a beta.8-shaped database, including existing user, verified Google identity, and session preservation
- PostgreSQL 16 fresh database migration and idempotent rerun
