### PR TITLE
Add session-oriented collection lifecycle SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -156,7 +156,7 @@ interface PendingAuthorization {
   user_code?: string;
   application_icon?: string;
   requested_operations: string[];
-  collection_hint?: string;
+  collection_id?: string;
   requirements: ApplicationRequirements;
   provisions: ApplicationProvisions;
   notifications: ApplicationNotifications;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1012,13 +1012,15 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
     request.provisions,
     request.requested_operations
   ]);
-  const [collectionId, setCollectionId] = useState(
-    available.some((collection) => collection.id === request.collection_hint)
-      ? request.collection_hint!
-      : available[0]?.id ?? ""
+  const selectable = useMemo(
+    () => request.collection_id
+      ? available.filter((collection) => collection.id === request.collection_id)
+      : available,
+    [available, request.collection_id]
   );
+  const [collectionId, setCollectionId] = useState(selectable[0]?.id ?? "");
   const [operations, setOperations] = useState(request.requested_operations);
-  const selected = available.find((collection) => collection.id === collectionId);
+  const selected = selectable.find((collection) => collection.id === collectionId);
   const setup = selected?.provisionable
     ? neededProvisions(request.requirements, request.provisions, selected)
     : [];
@@ -1036,10 +1038,10 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
     0
   );
   useEffect(() => {
-    if (!available.some((collection) => collection.id === collectionId)) {
-      setCollectionId(available[0]?.id ?? "");
+    if (!selectable.some((collection) => collection.id === collectionId)) {
+      setCollectionId(selectable[0]?.id ?? "");
     }
-  }, [collectionId, available]);
+  }, [collectionId, selectable]);
   async function createHostedCollection(event: React.FormEvent) {
     event.preventDefault();
     const displayName = hostedName.trim();
@@ -1061,11 +1063,11 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
       <div className="request-identity"><p className="eyebrow">Access request</p><h3>{request.application_name}</h3><code>{request.application_distribution === "portable" ? `Downloaded HTML file${request.application_project_url ? ` · ${host(request.application_project_url)}` : ""}` : host(request.application_homepage)}</code>{request.application_distribution === "portable" && <small className="portable-request-warning">Unverified file origin. Only allow it if you intentionally opened the file{request.user_code ? ` and it shows ${request.user_code}` : ""}.</small>}<small>Expires {relativeTime(request.expires_at)}</small>{request.requirements.contracts.length > 0 && <small>{scopeDescription(request.requirements.contracts)}</small>}</div>
       <div className="request-decision">
         <section className="request-section">
-          <div><strong>Collection</strong><small>Choose where {request.application_name} can work.</small></div>
+          <div><strong>Collection</strong><small>{request.collection_id ? `${request.application_name} requested this specific collection.` : `Choose where ${request.application_name} can work.`}</small></div>
           <div className="request-section-content">
-            <label><span>Collection</span><select value={collectionId} disabled={available.length === 0 || busy} onChange={(event) => setCollectionId(event.target.value)}>{available.length === 0 && <option value="">No compatible collection</option>}{available.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name} · {collection.kind === "hosted" ? "Hosted by mdbase" : "on this computer"}{collection.provisionable ? " · setup required" : ""}</option>)}</select></label>
-            {available.length === 0 && <small>No available local or hosted collection supports all requested operations and contracts.</small>}
-            {canCreateHosted && (creatingHosted ? (
+            <label><span>Collection</span><select value={collectionId} disabled={selectable.length === 0 || busy} onChange={(event) => setCollectionId(event.target.value)}>{selectable.length === 0 && <option value="">No compatible collection</option>}{selectable.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name} · {collection.kind === "hosted" ? "Hosted by mdbase" : "on this computer"}{collection.provisionable ? " · setup required" : ""}</option>)}</select></label>
+            {selectable.length === 0 && <small>{request.collection_id ? "The collection requested by this application is not available." : "No available local or hosted collection supports all requested operations and contracts."}</small>}
+            {canCreateHosted && !request.collection_id && (creatingHosted ? (
               <form
                 className="request-collection-create"
                 id={`create-hosted-${request.id}`}

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -119,7 +119,7 @@ export interface PendingAuthorization {
   flow: "authorization_code" | "device_code";
   user_code?: string | null;
   requested_operations: string[];
-  collection_hint?: string | null;
+  collection_id?: string | null;
   expires_at: string;
   application_id: string;
   application_name: string;

--- a/apps/portal/src/compatibility.ts
+++ b/apps/portal/src/compatibility.ts
@@ -60,7 +60,8 @@ const PORTABLE_PROFILE_OPERATIONS = new Set([
   "execute_view",
   "read_type",
   "create_type",
-  "update_type"
+  "update_type",
+  "install_type_pack"
 ]);
 
 function requiresMdbase03(operations: readonly string[]): boolean {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -1216,8 +1216,8 @@ function MirrorPairing({ pairingId }: { pairingId: string }) {
     pairing: {
       mirror_name: string;
       mode: "read_only" | "read_write";
-      collection_id: string | null;
       collection_hint?: string | null;
+      collection_id: string | null;
       approved_at: string | null;
       consumed_at: string | null;
     };
@@ -1775,9 +1775,15 @@ function ApprovalForm({
       compatibility: collectionCompatibility(request, collection)
     }));
   }, [collections, createdCollections, request]);
+  const visibleChoices = useMemo(
+    () => request.collection_id
+      ? choices.filter((choice) => choice.collection.id === request.collection_id)
+      : choices,
+    [choices, request.collection_id]
+  );
   const compatible = useMemo(
-    () => choices.filter((choice) => choice.compatibility.compatible),
-    [choices]
+    () => visibleChoices.filter((choice) => choice.compatibility.compatible),
+    [visibleChoices]
   );
   const collectionLocations = useMemo(
     () => disambiguatedCollectionLocations(
@@ -1786,13 +1792,11 @@ function ApprovalForm({
     [compatible]
   );
   const unavailable = useMemo(
-    () => choices.filter((choice) => !choice.compatibility.compatible),
-    [choices]
+    () => visibleChoices.filter((choice) => !choice.compatibility.compatible),
+    [visibleChoices]
   );
   const [collectionId, setCollectionId] = useState(
-    compatible.some((choice) => choice.collection.id === request.collection_hint)
-      ? request.collection_hint!
-      : compatible[0]?.collection.id ?? ""
+    compatible[0]?.collection.id ?? ""
   );
   const [operations, setOperations] = useState(() => new Set(request.requested_operations));
   const [submitting, setSubmitting] = useState<"approved" | "denied" | "creating" | null>(null);
@@ -1900,7 +1904,9 @@ function ApprovalForm({
       <section className="approval-section">
         <div className="approval-section-intro">
           <strong>Collection</strong>
-          <small>Choose where {request.application_name} can work.</small>
+          <small>{request.collection_id
+            ? `${request.application_name} requested this specific collection.`
+            : `Choose where ${request.application_name} can work.`}</small>
         </div>
         <div className="approval-section-content">
           {compatible.length > 0 && <fieldset className="collection-choice-field">
@@ -1937,7 +1943,7 @@ function ApprovalForm({
               ? `${connector.connector_name} has remote access paused.`
               : `${connector.connector_name} is offline.`).join(" ")} Those local collections cannot be selected until their computer is available.
           </div>}
-          {canCreateHosted && (creatingHosted ? (
+          {canCreateHosted && !request.collection_id && (creatingHosted ? (
             <form
               className="authorization-collection-create"
               id={`create-hosted-${request.id}`}
@@ -1986,7 +1992,13 @@ function ApprovalForm({
               >Create hosted collection</button>
             </div>
           ))}
-          {!canCreateHosted && compatible.length === 0 && <p className="field-note">No compatible collection is ready.</p>}
+          {(!canCreateHosted || Boolean(request.collection_id)) && compatible.length === 0 && (
+            <p className="field-note">
+              {request.collection_id
+                ? "The collection requested by this application is not available."
+                : "No compatible collection is ready."}
+            </p>
+          )}
           {setup.length > 0 && <p className="field-note">Setup needed: allowing access will add {provisionNames(setup)} to this collection through its live authority.</p>}
         </div>
       </section>

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -34,7 +34,7 @@ import { collectionCompatibility } from "./compatibility";
 import { SessionManager } from "./session-manager";
 import "./styles.css";
 
-const allOperations = ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate", "create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "read_type", "create_type", "update_type", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"];
+const allOperations = ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate", "create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "read_type", "create_type", "update_type", "install_type_pack", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"];
 const editorBaseUrl = import.meta.env.VITE_MDBASE_EDITOR_URL ?? "https://editor.mdbase.dev/";
 
 function editorUrl(collectionId?: string): string {

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -1481,10 +1481,14 @@ impl CollectionRegistry {
             "batch" => Err(ConnectError::AccessDenied(
                 "Batch operations require full collection access.".to_string(),
             )),
-            "list_types" | "read_type" | "create_type" | "update_type" => Err(
+            "list_types"
+            | "read_type"
+            | "create_type"
+            | "update_type"
+            | "install_type_pack" => Err(
                 ConnectError::AccessDenied(
-                "Type definitions can only be managed by an application with full collection access."
-                    .to_string(),
+                    "Collection schemas can only be managed by an application with full collection access."
+                        .to_string(),
                 ),
             ),
             other => Err(ConnectError::UnsupportedOperation(other.to_string())),
@@ -2913,6 +2917,27 @@ fn execute_loaded(
     input: &Value,
 ) -> Result<Value, ConnectError> {
     if collection.spec_profile() == SpecProfile::V03 {
+        if operation == "install_type_pack" {
+            let provision =
+                serde_json::from_value::<TypePackProvision>(input.clone()).map_err(|error| {
+                    ConnectError::InvalidInput(format!(
+                        "The type-pack provision is invalid: {error}"
+                    ))
+                })?;
+            let manifest = serde_json::to_value(&provision.manifest)?;
+            let resources = provision
+                .resources
+                .iter()
+                .map(|resource| mdbase::v03::TypePackResource {
+                    source: resource.source.clone(),
+                    document: resource.document.clone(),
+                })
+                .collect::<Vec<_>>();
+            return serde_json::to_value(
+                collection.install_type_pack(&manifest, &resources, false),
+            )
+            .map_err(ConnectError::from);
+        }
         let operations = collection
             .v03_operations()
             .map_err(|diagnostic| ConnectError::CollectionOpen(diagnostic.message.clone()))?;
@@ -3127,6 +3152,7 @@ fn is_collection_mutation(operation: &str) -> bool {
             | "rename"
             | "create_type"
             | "update_type"
+            | "install_type_pack"
             | "create_view_source"
             | "update_view_source"
             | "delete_view_source"
@@ -3149,6 +3175,7 @@ fn operation_invalidation(
         operation,
         "create_type"
             | "update_type"
+            | "install_type_pack"
             | "create_view_source"
             | "update_view_source"
             | "delete_view_source"
@@ -3206,6 +3233,7 @@ fn supported_operations(profile: SpecProfile) -> &'static [&'static str] {
         "read_type",
         "create_type",
         "update_type",
+        "install_type_pack",
         "list_timers",
         "put_timer",
         "cancel_timer",
@@ -4100,7 +4128,7 @@ schema:
     }
 
     #[test]
-    fn provisions_required_type_contracts_idempotently() {
+    fn installs_type_packs_as_full_collection_operations_and_provisions_idempotently() {
         let state = tempdir().unwrap();
         let collection_parent = tempdir().unwrap();
         let root = collection_parent.path().join("provisioned");
@@ -4202,6 +4230,29 @@ schema:
                 .collect(),
             provides: requirements.contracts.clone(),
         };
+        let installed = registry
+            .operation(
+                collection.id,
+                "install_type_pack",
+                &serde_json::to_value(&provision).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(installed["valid"], true, "{installed}");
+        assert_eq!(installed["result"]["id"], "example.workout");
+        assert_eq!(
+            installed["result"]["resources"].as_array().unwrap().len(),
+            3
+        );
+        assert!(matches!(
+            registry.scoped_operation(
+                collection.id,
+                "install_type_pack",
+                &serde_json::to_value(&provision).unwrap(),
+                &unavailable_contract_scope()
+            ),
+            Err(ConnectError::AccessDenied(_))
+        ));
+
         let provisions = [provision];
 
         let contracts = registry

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -2987,6 +2987,17 @@ impl HostedProvider {
                 self.write_type_operation(collection_id, operation, input)
                     .await
             }
+            "install_type_pack" => {
+                let provision =
+                    serde_json::from_value::<TypePackProvision>(input).map_err(|error| {
+                        ApiError::bad_request(
+                            "invalid_type_pack",
+                            format!("The type-pack provision is invalid: {error}"),
+                        )
+                    })?;
+                self.write_type_pack_operation(collection_id, &provision)
+                    .await
+            }
             "create_view_source" | "update_view_source" | "delete_view_source" => {
                 self.write_view_source_operation(collection_id, operation, input)
                     .await
@@ -5225,6 +5236,7 @@ fn is_full_collection_operation(operation: &str) -> bool {
             | "read_type"
             | "create_type"
             | "update_type"
+            | "install_type_pack"
             | "list_views"
             | "execute_view"
             | "read_view_source"
@@ -5248,6 +5260,7 @@ fn validate_operations(operations: &[String], mode: SyncReplicaMode) -> ApiResul
         "read_type",
         "create_type",
         "update_type",
+        "install_type_pack",
         "list_views",
         "execute_view",
         "read_view_source",
@@ -5266,6 +5279,7 @@ fn validate_operations(operations: &[String], mode: SyncReplicaMode) -> ApiResul
         "rename",
         "create_type",
         "update_type",
+        "install_type_pack",
         "create_view_source",
         "update_view_source",
         "delete_view_source",

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -893,7 +893,7 @@ pub struct PendingAuthorization {
     pub application_icon: Option<String>,
     pub requested_operations: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub collection_hint: Option<Uuid>,
+    pub collection_id: Option<Uuid>,
     #[serde(default)]
     pub requirements: ApplicationRequirements,
     #[serde(default)]

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.12"
+version = "0.1.0-beta.13"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,15 +66,19 @@ This is defense in depth: the folder marker prevents a same-folder/different-ID
 mistake locally, while the server prevents two active authorities for the same
 ID.
 
-The browser SDK is multi-collection by default. `MdbaseConnect` manages the
-saved authorization set, `MdbaseConnection` is permanently bound to one
-collection, and `MdbaseBrowserLocation` owns bookmark selection and OAuth
-return cleanup. It puts the stable server collection ID, not the mutable
-display name, in `?collection=<id>`, preserves explicit unavailable IDs, and
-auto-selects only when exactly one connection is saved. Authorization may carry
-that ID as a preselection hint, but the approval UI still requires an explicit
-compatible user choice. Collection IDs are non-secret locators and can appear
-in browser history and logs; grants remain the authorization boundary.
+The SDK is multi-collection by default. `MdbaseConnect` manages the saved
+authorization set, `MdbaseConnection` is permanently bound to one collection,
+and `MdbaseSession` owns the active selection and authorization lifecycle.
+Browser applications supply `MdbaseBrowserSelection`, which puts the stable
+server collection ID, not the mutable display name, in
+`?collection=<id>`. Session snapshots distinguish unselected, ready, and
+explicitly unavailable bookmarks; switching validates and publishes the new
+connection atomically without reloading the application.
+
+Authorization intent is explicit. A choose request accepts any compatible
+collection, while selected or exact-target requests must return the named
+collection. Collection IDs are non-secret locators and can appear in browser
+history and logs; grants remain the authorization boundary.
 
 ## Collaboration boundary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,7 @@ Connect protocol 1 exposes these grantable operations:
 - `describe`, `changes`
 - `read`, `query`, `validate`, `list_views`, `execute_view`
 - `create`, `update`, `delete`, `rename`
+- `read_type`, `create_type`, `update_type`, `install_type_pack`
 - `list_timers`, `put_timer`, `cancel_timer`, `reconcile_timers`
 
 mdbase operations retain the canonical `{ valid, result, diagnostics }`
@@ -168,8 +169,11 @@ transaction, reopens the collection, and verifies the exact contract and
 implementation digests before creating a grant. A pack contains the contract,
 every implementing type, and any referenced schemas; a failure writes none of
 them. This setup action does not give the application continuing `create_type`
-or `update_type` permission. Local collection paths and record payloads remain
-outside the control plane.
+or `update_type` permission. A full-collection application may separately
+request `install_type_pack`; each user-selected provision is digest-checked,
+validated, and installed atomically without allowing replacement of differing
+targets. Local collection paths and record payloads remain outside the control
+plane.
 
 `describe` returns the collection's spec version, supported operations, JSON
 Schemas, collection-relative type paths, complete portable type definitions,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -22,16 +22,19 @@ const mdbase = new MdbaseConnect({
   manifest: new URL(".well-known/mdbase-app.json", location.href).href,
   redirectUri: "https://workouts.example/auth/mdbase/callback"
 });
-const collectionLocation = new MdbaseBrowserLocation(mdbase);
-
-await mdbase.authorize({
+const session = mdbase.createSession({
   operations: ["describe", "changes", "read", "query", "update"],
-  collectionId: collectionLocation.selectedCollectionId() ?? undefined,
-  returnTo: collectionLocation.authorizationReturnTo()
+  selection: new MdbaseBrowserSelection()
 });
 
-// On the callback route:
-const connection = await collectionLocation.completeAuthorization();
+await session.start();
+if (session.getSnapshot().status === "unselected") {
+  await session.authorize("choose");
+}
+
+const snapshot = session.getSnapshot();
+if (snapshot.status !== "ready") throw new Error("Choose an authorized collection.");
+const connection = snapshot.connection;
 const description = await connection.describe();
 const workouts = await connection.query({ types: ["workout"] });
 await connection.update({
@@ -67,19 +70,39 @@ for await (const change of connection.watch()) {
 }
 ```
 
-`MdbaseConnect` is an application-level manager. It can retain several
-independently authorized collections; call `connections()` to list them and
-`connection(collectionId)` to obtain a client permanently bound to one. Pass
-that `MdbaseConnection` into repositories and feature code.
+`MdbaseConnect` is the application-level authorization registry.
+`MdbaseSession` is the normal application boundary: it owns active collection
+selection, authorization callback completion, access capabilities, and one
+reactive snapshot. Use `getSnapshot()` and `subscribe()` directly or through
+your framework's external-store integration. A snapshot is `unselected`,
+`ready`, or `unavailable`; an unavailable bookmark includes the explicit
+collection ID and reason instead of collapsing every recovery state to `null`.
 
-`MdbaseBrowserLocation` keeps the stable collection ID in
-`?collection=<id>`. It restores authorization callbacks safely, removes
-temporary OAuth parameters, auto-selects only when exactly one saved
-connection exists, and reports browser back/forward changes through
-`onChange()`. An explicit unavailable ID remains authoritative so the
-application can show its chooser or reconnect that exact collection. IDs are
-opaque locators that may appear in browser history and logs; they are not
-credentials. Collection names are display text and may change.
+`MdbaseBrowserSelection` keeps the stable collection ID in
+`?collection=<id>`, preserves unrelated path/query/hash and router state,
+restores authorization callbacks safely, and reports browser back/forward
+changes to the session. The session auto-selects only when exactly one saved
+connection exists. Switching is state-driven and must not reload the page:
+
+```ts
+session.select(collectionId, { history: "replace" });
+session.clearSelection();
+session.forget(collectionId);
+```
+
+Selection validates the saved authorization before changing the URL. Explicit
+unavailable IDs remain authoritative so applications can offer exact
+reauthorization or another collection:
+
+```ts
+await session.authorize("selected"); // exact bookmarked collection
+await session.authorize("choose");   // any compatible collection
+await session.authorize({ collectionId }); // exact adoption/migration target
+```
+
+Collection IDs are opaque non-secret locators that may appear in browser
+history and logs. Grants remain the authorization boundary, and names are
+display text that may change.
 
 Bundled v1 application manifests can declare runtime notification criteria.
 Register a service worker from a user gesture to receive standards-based Web

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -233,6 +233,19 @@ await connection.updateType({
 Request `read_type`, `create_type`, and `update_type` during authorization.
 Contract-scoped applications cannot manage collection-wide type definitions.
 
+To install a complete catalog pack without exposing its individual collection
+paths, request `install_type_pack`, fetch and verify the published provision,
+then pass it to the atomic collection operation:
+
+```ts
+const response = await fetch(pack.provisionUrl);
+const provision = await response.json();
+await connection.installTypePack(provision);
+```
+
+The caller remains responsible for verifying the catalog digest before sending
+the provision. Existing targets with different content are rejected.
+
 For a local collection, ask for same-computer access from a user gesture:
 
 ```ts

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -109,10 +109,29 @@ describe("provider-neutral collection client", () => {
       document: "---\nkind: mdbase.type\n---\n",
       if_revision: "sha256:one"
     });
+    await client.installTypePack({
+      manifest: {
+        kind: "mdbase.type-pack",
+        id: "example.tasks",
+        version: "1.0.0",
+        resources: [{
+          kind: "type",
+          source: "types/task.md",
+          target: "_types/task.md",
+          digest: `sha256:${"1".repeat(64)}`
+        }]
+      },
+      resources: [{
+        source: "types/task.md",
+        document: "---\nkind: mdbase.type\n---\n"
+      }],
+      provides: []
+    });
     expect(calls.map(({ operation }) => operation)).toEqual([
       "read_type",
       "create_type",
-      "update_type"
+      "update_type",
+      "install_type_pack"
     ]);
   });
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createPkce,
-  MdbaseBrowserLocation,
+  MdbaseBrowserSelection,
   MdbaseCollectionClient,
   MdbaseConnect,
   MdbaseConnectError,
@@ -930,6 +930,7 @@ describe("mobile notifications", () => {
   it("registers the selected criteria atomically for one browser installation", async () => {
     const storage = new MemoryStorage();
     storage.setItem(tokenKey, JSON.stringify({
+      version: 1,
       accessToken: "mdb_notifications",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
@@ -1013,6 +1014,7 @@ describe("mobile notifications", () => {
   it("rejects undeclared criteria before asking the browser for push permission", async () => {
     const storage = new MemoryStorage();
     storage.setItem(tokenKey, JSON.stringify({
+      version: 1,
       accessToken: "mdb_notifications",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
@@ -1081,6 +1083,7 @@ describe("mobile notifications", () => {
   it("registers an FCM installation without accepting a client-selected project", async () => {
     const storage = new MemoryStorage();
     storage.setItem(tokenKey, JSON.stringify({
+      version: 1,
       accessToken: "mdb_notifications",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
@@ -1156,6 +1159,7 @@ describe("mobile notifications", () => {
     const registrationKey =
       `mdbase-connect:${serverUrl}:${manifestSource}:notifications:${TEST_COLLECTION_ID}:fcm`;
     storage.setItem(tokenKey, JSON.stringify({
+      version: 1,
       accessToken: "expired",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: TEST_COLLECTION_ID,
@@ -1334,29 +1338,139 @@ describe("long mutation progress", () => {
   });
 });
 
-describe("browser collection locations", () => {
-  it("bookmarks the only saved collection but respects an explicit unknown identity", () => {
+describe("application sessions", () => {
+  it("selects the only saved collection during startup", async () => {
     const browser = installBrowser("https://tasks.example/today?filter=open#focus");
     const manager = managerWithConnections([TEST_COLLECTION_ID]);
-    const location = new MdbaseBrowserLocation(manager);
+    const session = manager.createSession({
+      operations: ["query"],
+      selection: new MdbaseBrowserSelection()
+    });
 
-    expect(location.activeConnection()?.collectionId).toBe(TEST_COLLECTION_ID);
+    await session.start();
+
+    expect(session.getSnapshot()).toMatchObject({
+      status: "ready",
+      collectionId: TEST_COLLECTION_ID
+    });
     expect(new URL(browser.href()).searchParams.get("collection")).toBe(TEST_COLLECTION_ID);
     expect(browser.replaceState).toHaveBeenCalledOnce();
-
-    browser.navigate("https://tasks.example/today?collection=not-authorized");
-    expect(location.activeConnection()).toBeNull();
-    expect(new URL(browser.href()).searchParams.get("collection")).toBe("not-authorized");
   });
 
-  it("keeps app navigation bookmarkable and strips temporary OAuth parameters", () => {
+  it("recovers atomically from a stale bookmark without reloading", async () => {
+    const browser = installBrowser("https://tasks.example/today?collection=not-authorized");
+    const manager = managerWithConnections([TEST_COLLECTION_ID]);
+    const session = manager.createSession({
+      operations: ["query"],
+      selection: new MdbaseBrowserSelection()
+    });
+    await session.start();
+    expect(session.getSnapshot()).toMatchObject({
+      status: "unavailable",
+      collectionId: "not-authorized",
+      reason: "not_authorized"
+    });
+
+    const snapshots: string[] = [];
+    session.subscribe(() => snapshots.push(session.getSnapshot().status));
+    const selected = session.select(TEST_COLLECTION_ID);
+
+    expect(selected.collectionId).toBe(TEST_COLLECTION_ID);
+    expect(session.getSnapshot()).toMatchObject({
+      status: "ready",
+      collectionId: TEST_COLLECTION_ID
+    });
+    expect(new URL(browser.href()).searchParams.get("collection")).toBe(TEST_COLLECTION_ID);
+    expect(snapshots).toEqual(["ready"]);
+  });
+
+  it("does not mutate selection when asked to open an unknown collection", async () => {
+    const browser = installBrowser(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`);
+    const manager = managerWithConnections([TEST_COLLECTION_ID]);
+    const session = manager.createSession({ selection: new MdbaseBrowserSelection() });
+    await session.start();
+
+    expect(() => session.select("not-authorized")).toThrowError(
+      expect.objectContaining({ code: "unknown_collection" })
+    );
+    expect(new URL(browser.href()).searchParams.get("collection")).toBe(TEST_COLLECTION_ID);
+    expect(session.getSnapshot()).toMatchObject({
+      status: "ready",
+      collectionId: TEST_COLLECTION_ID
+    });
+  });
+
+  it("publishes one unselected snapshot when forgetting the active collection", async () => {
+    installBrowser(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`);
+    const manager = managerWithConnections([TEST_COLLECTION_ID]);
+    const session = manager.createSession({ selection: new MdbaseBrowserSelection() });
+    await session.start();
+    const snapshots: string[] = [];
+    session.subscribe(() => snapshots.push(session.getSnapshot().status));
+
+    session.forget(TEST_COLLECTION_ID);
+
+    expect(session.getSnapshot()).toEqual({ status: "unselected", connections: [] });
+    expect(snapshots).toEqual(["unselected"]);
+  });
+
+  it("reports an incompatible persisted grant instead of silently treating it as absent", async () => {
+    installBrowser(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`);
+    const serverUrl = "https://connect.example";
+    const manifest = "https://tasks.example/manifest.json";
+    const storage = new MemoryStorage();
+    storage.setItem(storedTokenKey(serverUrl, manifest, TEST_COLLECTION_ID), JSON.stringify({
+      accessToken: "pre-release-token-without-a-storage-version"
+    }));
+    const manager = new MdbaseConnect({
+      serverUrl,
+      manifest,
+      redirectUri: "https://tasks.example/callback",
+      storage
+    });
+    const session = manager.createSession({ selection: new MdbaseBrowserSelection() });
+
+    await session.start();
+
+    expect(session.getSnapshot()).toMatchObject({
+      status: "unavailable",
+      collectionId: TEST_COLLECTION_ID,
+      reason: "invalid_stored_grant"
+    });
+  });
+
+  it("keeps choose and exact authorization intents distinct", async () => {
+    installBrowser(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`);
+    const manager = managerWithConnections([TEST_COLLECTION_ID]);
+    const authorize = vi.spyOn(manager, "authorize").mockResolvedValue({ kind: "redirecting" });
+    const session = manager.createSession({
+      operations: ["query", "update"],
+      selection: new MdbaseBrowserSelection()
+    });
+    await session.start();
+
+    await session.authorize("choose");
+    await session.authorize("selected");
+    await session.authorize({ collectionId: "adopted-collection" });
+
+    expect(authorize).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      target: { kind: "choose" }
+    }));
+    expect(authorize).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { kind: "collection", collectionId: TEST_COLLECTION_ID }
+    }));
+    expect(authorize).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      target: { kind: "collection", collectionId: "adopted-collection" }
+    }));
+  });
+
+  it("keeps app navigation bookmarkable, preserves history state, and strips OAuth parameters", () => {
     const browser = installBrowser(
       "https://tasks.example/today?filter=open&code=temporary&state=pending#focus"
     );
-    const manager = managerWithConnections([TEST_COLLECTION_ID]);
-    const location = new MdbaseBrowserLocation(manager);
+    const selection = new MdbaseBrowserSelection();
 
-    location.selectConnection(TEST_COLLECTION_ID);
+    selection.select(TEST_COLLECTION_ID, { history: "push" });
 
     const selected = new URL(browser.href());
     expect(selected.pathname).toBe("/today");
@@ -1365,8 +1479,13 @@ describe("browser collection locations", () => {
     expect(selected.searchParams.has("code")).toBe(false);
     expect(selected.searchParams.has("state")).toBe(false);
     expect(selected.hash).toBe("#focus");
-    expect(location.authorizationReturnTo()).toBe(
+    expect(selection.authorizationReturnTo()).toBe(
       `/today?filter=open&collection=${TEST_COLLECTION_ID}#focus`
+    );
+    expect(browser.pushState).toHaveBeenCalledWith(
+      { router: "preserved" },
+      "",
+      expect.any(URL)
     );
   });
 
@@ -1378,9 +1497,14 @@ describe("browser collection locations", () => {
       connection,
       returnTo: "/search?q=next&error=stale#result"
     });
-    const location = new MdbaseBrowserLocation(manager, { fallbackPath: "/app/" });
+    const session = manager.createSession({
+      selection: new MdbaseBrowserSelection({ fallbackPath: "/app/" })
+    });
 
-    await expect(location.completeAuthorization()).resolves.toBe(connection);
+    await expect(session.start()).resolves.toMatchObject({
+      status: "ready",
+      collectionId: TEST_COLLECTION_ID
+    });
     const completed = new URL(browser.href());
     expect(completed.pathname).toBe("/search");
     expect(completed.searchParams.get("q")).toBe("next");
@@ -1392,7 +1516,8 @@ describe("browser collection locations", () => {
       connection,
       returnTo: "https://other.example/steal"
     });
-    await location.completeAuthorization();
+    browser.navigate("https://tasks.example/auth/mdbase/callback?code=two&state=three");
+    await session.handleAuthorizationCallback(browser.href());
     expect(new URL(browser.href()).pathname).toBe("/app/");
   });
 
@@ -1402,35 +1527,42 @@ describe("browser collection locations", () => {
       `https://tasks.example/?collection=${TEST_COLLECTION_ID}`
     );
     const manager = managerWithConnections([TEST_COLLECTION_ID, secondId]);
-    const location = new MdbaseBrowserLocation(manager);
-    const changes: Array<string | null> = [];
-    const stop = location.onChange(({ connection }) => {
-      changes.push(connection?.collectionId ?? null);
+    const session = manager.createSession({
+      selection: new MdbaseBrowserSelection()
     });
+    const changes: Array<string | null> = [];
+    const stop = session.subscribe(() => {
+      const snapshot = session.getSnapshot();
+      changes.push(snapshot.status === "ready" ? snapshot.collectionId : null);
+    });
+    void session.start();
 
     browser.navigate(`https://tasks.example/?collection=${secondId}`, true);
-    expect(changes).toEqual([TEST_COLLECTION_ID, secondId]);
+    expect(changes).toEqual([secondId]);
 
     stop();
     browser.navigate(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`, true);
-    expect(changes).toEqual([TEST_COLLECTION_ID, secondId]);
+    expect(changes).toEqual([secondId]);
   });
 
   it("recognizes only authorization-shaped callbacks and cleans denied URLs", () => {
     const browser = installBrowser(
       "https://tasks.example/auth/mdbase/callback?error=access_denied&state=one"
     );
-    const location = new MdbaseBrowserLocation(managerWithConnections([]));
+    const selection = new MdbaseBrowserSelection();
 
-    expect(location.isAuthorizationCallback(browser.href())).toBe(true);
-    expect(location.isAuthorizationCallback("dev.tasks://auth/mdbase/callback?code=one")).toBe(true);
-    expect(location.isAuthorizationCallback("https://tasks.example/today")).toBe(false);
-    expect(location.isAuthorizationCallback("not a url")).toBe(false);
+    expect(selection.authorizationCallback()).toBe(browser.href());
 
-    location.clearAuthorizationCallback();
+    selection.clearAuthorizationCallback();
     const cleaned = new URL(browser.href());
     expect(cleaned.searchParams.has("error")).toBe(false);
     expect(cleaned.searchParams.has("state")).toBe(false);
+  });
+
+  it("does not treat an ordinary application error parameter as an authorization callback", () => {
+    installBrowser("https://tasks.example/search?error=no-results");
+
+    expect(new MdbaseBrowserSelection().authorizationCallback()).toBeNull();
   });
 });
 
@@ -1445,6 +1577,7 @@ describe("authorization renewal", () => {
       [secondId, "Studio tasks"]
     ]) {
       storage.setItem(storedTokenKey(serverUrl, manifestUrl, collectionId), JSON.stringify({
+        version: 1,
         accessToken: `token-${collectionId}`,
         clientId: "00000000-0000-0000-0000-000000000001",
         collectionId,
@@ -1457,7 +1590,7 @@ describe("authorization renewal", () => {
     }
     storage.setItem(
       `mdbase-connect:${serverUrl}:${manifestUrl}:connections`,
-      JSON.stringify([secondId, TEST_COLLECTION_ID])
+      storedConnectionIndex([secondId, TEST_COLLECTION_ID])
     );
     const manager = new MdbaseConnect({
       serverUrl,
@@ -1481,6 +1614,7 @@ describe("authorization renewal", () => {
     const manifestUrl = "https://tasks.example/manifest.json";
     const tokenKey = storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID);
     storage.setItem(tokenKey, JSON.stringify({
+      version: 1,
       accessToken: "legacy-token",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: TEST_COLLECTION_ID,
@@ -1491,7 +1625,7 @@ describe("authorization renewal", () => {
     }));
     storage.setItem(
       `mdbase-connect:${serverUrl}:${manifestUrl}:connections`,
-      JSON.stringify([TEST_COLLECTION_ID]),
+      storedConnectionIndex([TEST_COLLECTION_ID]),
     );
     const manager = new MdbaseConnect({
       serverUrl,
@@ -1505,7 +1639,7 @@ describe("authorization renewal", () => {
     expect(storage.getItem(tokenKey)).toBeNull();
   });
 
-  it("passes an exact collection hint and return location through authorization", async () => {
+  it("passes an exact collection target and return location through authorization", async () => {
     const storage = new MemoryStorage();
     const navigate = vi.fn();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
@@ -1532,13 +1666,13 @@ describe("authorization renewal", () => {
 
     void manager.authorize({
       operations: ["query"],
-      collectionId: TEST_COLLECTION_ID,
+      target: { kind: "collection", collectionId: TEST_COLLECTION_ID },
       returnTo: "/today?filter=open"
     });
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
 
     const authorization = new URL(navigate.mock.calls[0][0]);
-    expect(authorization.searchParams.get("collection_hint")).toBe(TEST_COLLECTION_ID);
+    expect(authorization.searchParams.get("collection_id")).toBe(TEST_COLLECTION_ID);
     const state = authorization.searchParams.get("state")!;
     expect(JSON.parse(storage.getItem(
       `mdbase-connect:https://connect.example:bundle:dev.tasks:pending:${state}`
@@ -1554,6 +1688,7 @@ describe("authorization renewal", () => {
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     const pendingKey = `mdbase-connect:${serverUrl}:${manifestUrl}:pending:denied-state`;
     storage.setItem(pendingKey, JSON.stringify({
+      version: 1,
       verifier: "pkce-verifier",
       state: "denied-state",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1562,6 +1697,7 @@ describe("authorization renewal", () => {
       returnTo: "/today"
     }));
     storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
       accessToken: "mdb_saved",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: TEST_COLLECTION_ID,
@@ -1573,7 +1709,7 @@ describe("authorization renewal", () => {
     }));
     storage.setItem(
       `mdbase-connect:${serverUrl}:${manifestUrl}:connections`,
-      JSON.stringify([TEST_COLLECTION_ID])
+      storedConnectionIndex([TEST_COLLECTION_ID])
     );
     const fetchMock = vi.spyOn(globalThis, "fetch");
     const manager = new MdbaseConnect({
@@ -1602,6 +1738,7 @@ describe("authorization renewal", () => {
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     storage.setItem(`mdbase-connect:${serverUrl}:${manifestUrl}:pending:callback-state`, JSON.stringify({
+      version: 1,
       verifier: "pkce-verifier",
       state: "callback-state",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1647,6 +1784,7 @@ describe("authorization renewal", () => {
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
       accessToken: "mdb_current",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1704,6 +1842,7 @@ describe("authorization renewal", () => {
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
       accessToken: "mdb_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
@@ -1773,6 +1912,7 @@ describe("authorization renewal", () => {
     const providerUrl = "https://provider.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
       accessToken: "mdb_control",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1788,6 +1928,7 @@ describe("authorization renewal", () => {
         operationsUrl: `${providerUrl}/v1/authorities/00000000-0000-0000-0000-000000000002/operations`,
         syncUrl: `${providerUrl}/v1/authorities/00000000-0000-0000-0000-000000000002/sync`,
         replicaId: "00000000-0000-0000-0000-000000000003",
+        version: 1,
         accessToken: "hsa_direct"
       }
     }));
@@ -1817,6 +1958,7 @@ describe("authorization renewal", () => {
     const providerUrl = "https://provider.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
       accessToken: "mdb_control",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1832,6 +1974,7 @@ describe("authorization renewal", () => {
         operationsUrl: `${providerUrl}/v1/authorities/00000000-0000-0000-0000-000000000002/operations`,
         syncUrl: `${providerUrl}/v1/authorities/00000000-0000-0000-0000-000000000002/sync`,
         replicaId: "00000000-0000-0000-0000-000000000003",
+        version: 1,
         accessToken: "hsa_direct"
       }
     }));
@@ -1874,6 +2017,7 @@ describe("authorization renewal", () => {
     const serverUrl = "https://connect.example";
     const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
     storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
       accessToken: "mdb_expired",
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
@@ -1939,6 +2083,7 @@ describe("authorization renewal", () => {
     };
     storage.setItem(tokenKey, JSON.stringify({
       ...baseToken,
+      version: 1,
       accessToken: "mdb_expired",
       refreshToken: "ref_old",
       expiresAt: Date.now() - 1
@@ -1947,6 +2092,7 @@ describe("authorization renewal", () => {
       .mockImplementationOnce(async () => {
         storage.setItem(tokenKey, JSON.stringify({
           ...baseToken,
+          version: 1,
           accessToken: "mdb_from_other_tab",
           refreshToken: "ref_from_other_tab",
           expiresAt: Date.now() + 3_600_000
@@ -2294,6 +2440,7 @@ async function encryptedConnection() {
   };
   const tokenKey = storedTokenKey(serverUrl, manifestUrl, collectionId);
   storage.setItem(tokenKey, JSON.stringify({
+    version: 1,
     accessToken: "mdb_current",
     refreshToken: "ref_current",
     clientId: "01922222-2222-7222-8222-222222222222",
@@ -2336,6 +2483,7 @@ function progressConnection() {
   const manifest = "https://tasks.example/manifest.json";
   const storage = new MemoryStorage();
   storage.setItem(storedTokenKey(serverUrl, manifest, TEST_COLLECTION_ID), JSON.stringify({
+    version: 1,
     accessToken: "progress",
     clientId: "00000000-0000-0000-0000-000000000001",
     collectionId: TEST_COLLECTION_ID,
@@ -2412,6 +2560,7 @@ function managerWithConnections(collectionIds: string[]): MdbaseConnect {
   const storage = new MemoryStorage();
   for (const collectionId of collectionIds) {
     storage.setItem(storedTokenKey(serverUrl, manifest, collectionId), JSON.stringify({
+      version: 1,
       accessToken: `token-${collectionId}`,
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId,
@@ -2424,7 +2573,7 @@ function managerWithConnections(collectionIds: string[]): MdbaseConnect {
   }
   storage.setItem(
     `mdbase-connect:${serverUrl}:${manifest}:connections`,
-    JSON.stringify(collectionIds)
+    storedConnectionIndex(collectionIds)
   );
   return new MdbaseConnect({
     serverUrl,
@@ -2432,6 +2581,10 @@ function managerWithConnections(collectionIds: string[]): MdbaseConnect {
     redirectUri: "https://tasks.example/auth/mdbase/callback",
     storage
   });
+}
+
+function storedConnectionIndex(collectionIds: string[]): string {
+  return JSON.stringify({ version: 1, collectionIds });
 }
 
 function installBrowser(initialUrl: string) {
@@ -2451,7 +2604,11 @@ function installBrowser(initialUrl: string) {
     get href() { return current.href; },
     get origin() { return current.origin; }
   });
-  vi.stubGlobal("history", { pushState, replaceState });
+  vi.stubGlobal("history", {
+    state: { router: "preserved" },
+    pushState,
+    replaceState
+  });
   vi.stubGlobal("window", {
     addEventListener: events.addEventListener.bind(events),
     removeEventListener: events.removeEventListener.bind(events)

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,6 +29,8 @@ import type {
   SyncMutationReceipt,
   SyncSession,
   SyncSnapshotPage,
+  TypePackInstallResult,
+  TypePackProvision,
   UpdateViewSourceInput
 } from "@mdbase/connect-protocol";
 import {
@@ -95,7 +97,9 @@ export type {
   ExecuteViewInput,
   TypePackManifest,
   TypePackManifestResource,
+  TypePackInstallResult,
   TypePackProvision,
+  TypePackResourceDiff,
   TypePackSourceResource
 } from "@mdbase/connect-protocol";
 
@@ -748,6 +752,10 @@ export class MdbaseCollectionClient<Frontmatter extends JsonObject = JsonObject>
 
   updateType(input: UpdateTypeInput): Promise<MdbaseOperationEnvelope<CollectionTypeDocument>> {
     return this.operation("update_type", input);
+  }
+
+  installTypePack(input: TypePackProvision): Promise<MdbaseOperationEnvelope<TypePackInstallResult>> {
+    return this.operation("install_type_pack", input);
   }
 
   listTimers(namespace: string): Promise<MdbaseTimerList> {
@@ -2731,6 +2739,10 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     return this.collectionClient.updateType(input);
   }
 
+  installTypePack(input: TypePackProvision): Promise<MdbaseOperationEnvelope<TypePackInstallResult>> {
+    return this.collectionClient.installTypePack(input);
+  }
+
   listTimers(namespace: string): Promise<MdbaseTimerList> {
     return this.collectionClient.listTimers(namespace);
   }
@@ -3499,6 +3511,7 @@ function isMutation(operation: CollectionOperation, input?: unknown): boolean {
     || operation === "rename"
     || operation === "create_type"
     || operation === "update_type"
+    || operation === "install_type_pack"
     || operation === "put_timer"
     || operation === "cancel_timer"
     || operation === "reconcile_timers";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -137,10 +137,14 @@ export interface MdbaseConnectionInfo {
   directAccess: DirectAccessStatus;
 }
 
+export type MdbaseAuthorizationTarget =
+  | { kind: "choose" }
+  | { kind: "collection"; collectionId: string };
+
 export interface MdbaseAuthorizeOptions {
   operations?: CollectionOperation[];
-  /** Preselect this collection without bypassing the user's approval. */
-  collectionId?: string;
+  /** Choose any compatible collection, or require one exact collection. */
+  target?: MdbaseAuthorizationTarget;
   /** App-local location to restore after the authorization callback. */
   returnTo?: string;
   /** Receives the short code even when the SDK also opens the approval page. */
@@ -177,6 +181,10 @@ export interface MdbaseAuthorizationResult<Frontmatter extends JsonObject = Json
   connection: MdbaseConnection<Frontmatter>;
   returnTo?: string;
 }
+
+export type MdbaseAuthorizationOutcome<Frontmatter extends JsonObject = JsonObject> =
+  | { kind: "redirecting" }
+  | ({ kind: "connected" } & MdbaseAuthorizationResult<Frontmatter>);
 
 export interface MdbaseDesiredTimer {
   /** Stable within the timer namespace. */
@@ -854,6 +862,7 @@ interface Application {
 }
 
 interface StoredAuthorization {
+  version: 1;
   verifier: string;
   state: string;
   clientId: string;
@@ -866,6 +875,7 @@ interface StoredAuthorization {
 }
 
 interface StoredToken {
+  version: 1;
   accessToken: string;
   refreshToken?: string;
   clientId: string;
@@ -887,6 +897,11 @@ interface StoredToken {
     accessToken: string;
     proofPublicKey?: string;
   };
+}
+
+interface StoredConnectionIndex {
+  version: 1;
+  collectionIds: string[];
 }
 
 interface PendingEncryptedMutation {
@@ -919,8 +934,12 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     return this.internals.register();
   }
 
-  authorize(options: MdbaseAuthorizeOptions = {}): Promise<MdbaseAuthorizationResult<Frontmatter>> {
+  authorize(options: MdbaseAuthorizeOptions = {}): Promise<MdbaseAuthorizationOutcome<Frontmatter>> {
     return this.internals.authorize(options);
+  }
+
+  createSession(options: MdbaseSessionOptions): MdbaseSession<Frontmatter> {
+    return new MdbaseSession(this, options);
   }
 
   environment(): MdbaseConnectEnvironment {
@@ -941,6 +960,10 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
     return this.internals.connection(collectionId);
   }
 
+  unavailableReason(collectionId: string): MdbaseUnavailableReason | null {
+    return this.internals.unavailableReason(collectionId);
+  }
+
   onConnectionsChange(
     listener: (connections: MdbaseConnectionInfo[]) => void
   ): () => void {
@@ -954,37 +977,31 @@ export class MdbaseConnect<Frontmatter extends JsonObject = JsonObject> {
   }
 }
 
-export interface MdbaseBrowserLocationOptions {
-  /** Query parameter used for the bookmarked collection identity. */
+export type MdbaseSelectionHistory = "push" | "replace";
+
+export interface MdbaseSessionSelection {
+  selectedCollectionId(): string | null;
+  select(collectionId: string | null, options?: { history?: MdbaseSelectionHistory }): void;
+  authorizationReturnTo(): string | undefined;
+  authorizationCallback(): string | null;
+  finishAuthorization(returnTo: string | undefined, collectionId: string): void;
+  clearAuthorizationCallback(returnTo?: string): void;
+  subscribe(listener: () => void): () => void;
+}
+
+export interface MdbaseBrowserSelectionOptions {
   collectionParameter?: string;
-  /** App-local location used when an authorization did not preserve one. */
   fallbackPath?: string;
 }
 
-export interface MdbaseBrowserLocationChange<Frontmatter extends JsonObject = JsonObject> {
-  connection: MdbaseConnection<Frontmatter> | null;
-  connections: MdbaseConnectionInfo[];
-  /** The explicit bookmarked identity, including one that is not currently authorized. */
-  collectionId: string | null;
-}
-
-/**
- * Keeps a multi-collection browser application's active Connect collection in
- * its URL. Collection identities are opaque locators, not credentials.
- */
-export class MdbaseBrowserLocation<Frontmatter extends JsonObject = JsonObject> {
+/** URL-backed collection selection for browser and browser-shell applications. */
+export class MdbaseBrowserSelection implements MdbaseSessionSelection {
   private readonly collectionParameter: string;
   private readonly fallbackPath: string;
-  private readonly listeners = new Set<
-    (change: MdbaseBrowserLocationChange<Frontmatter>) => void
-  >();
-  private stopConnectionEvents?: () => void;
+  private readonly listeners = new Set<() => void>();
   private readonly handlePopState = () => this.emit();
 
-  constructor(
-    private readonly connect: MdbaseConnect<Frontmatter>,
-    options: MdbaseBrowserLocationOptions = {}
-  ) {
+  constructor(options: MdbaseBrowserSelectionOptions = {}) {
     this.collectionParameter = options.collectionParameter ?? "collection";
     this.fallbackPath = options.fallbackPath ?? "/";
   }
@@ -993,17 +1010,19 @@ export class MdbaseBrowserLocation<Frontmatter extends JsonObject = JsonObject> 
     return this.currentUrl().searchParams.get(this.collectionParameter);
   }
 
-  activeConnection(): MdbaseConnection<Frontmatter> | null {
-    const selected = this.selectedCollectionId();
-    if (selected) return this.connect.connection(selected);
-    const connections = this.connect.connections();
-    if (connections.length !== 1) return null;
-    this.writeSelection(connections[0].collectionId, true);
-    return this.connect.connection(connections[0].collectionId);
-  }
-
-  selectConnection(collectionId: string, options: { replace?: boolean } = {}): void {
-    this.writeSelection(collectionId, options.replace ?? false);
+  select(
+    collectionId: string | null,
+    options: { history?: MdbaseSelectionHistory } = {}
+  ): void {
+    const url = cleanAuthorizationParameters(this.currentUrl());
+    if (collectionId) url.searchParams.set(this.collectionParameter, collectionId);
+    else url.searchParams.delete(this.collectionParameter);
+    const browserHistory = this.browserHistory();
+    browserHistory[options.history === "push" ? "pushState" : "replaceState"](
+      browserHistory.state,
+      "",
+      url
+    );
     this.emit();
   }
 
@@ -1012,76 +1031,43 @@ export class MdbaseBrowserLocation<Frontmatter extends JsonObject = JsonObject> 
     return `${url.pathname}${url.search}${url.hash}`;
   }
 
-  async completeAuthorization(
-    callbackUrl = this.currentUrl().href
-  ): Promise<MdbaseConnection<Frontmatter>> {
-    const result = await this.connect.completeAuthorization(callbackUrl);
-    const returnTo = this.safeAppUrl(result.returnTo ?? this.fallbackPath);
-    cleanAuthorizationParameters(returnTo);
-    returnTo.searchParams.set(this.collectionParameter, result.connection.collectionId);
-    this.browserHistory().replaceState(null, "", returnTo);
-    this.emit();
-    return result.connection;
+  authorizationCallback(): string | null {
+    const value = this.currentUrl().href;
+    return isAuthorizationCallbackUrl(value) ? value : null;
   }
 
-  isAuthorizationCallback(value: string): boolean {
-    let url: URL;
-    try {
-      url = new URL(value);
-    } catch {
-      return false;
-    }
-    return url.searchParams.has("code") || url.searchParams.has("error");
+  finishAuthorization(returnTo: string | undefined, collectionId: string): void {
+    const url = this.safeAppUrl(returnTo ?? this.fallbackPath);
+    cleanAuthorizationParameters(url);
+    url.searchParams.set(this.collectionParameter, collectionId);
+    const browserHistory = this.browserHistory();
+    browserHistory.replaceState(null, "", url);
+    this.emit();
   }
 
   clearAuthorizationCallback(returnTo?: string): void {
     const url = returnTo ? this.safeAppUrl(returnTo) : this.currentUrl();
-    this.browserHistory().replaceState(null, "", cleanAuthorizationParameters(url));
+    const browserHistory = this.browserHistory();
+    browserHistory.replaceState(browserHistory.state, "", cleanAuthorizationParameters(url));
     this.emit();
   }
 
-  onChange(
-    listener: (change: MdbaseBrowserLocationChange<Frontmatter>) => void
-  ): () => void {
-    const firstListener = this.listeners.size === 0;
+  subscribe(listener: () => void): () => void {
+    const first = this.listeners.size === 0;
     this.listeners.add(listener);
-    if (firstListener) {
-      this.stopConnectionEvents = this.connect.onConnectionsChange(() => this.emit());
-      if (typeof window !== "undefined") {
-        window.addEventListener("popstate", this.handlePopState);
-      }
-    } else {
-      listener(this.snapshot());
+    if (first && typeof window !== "undefined") {
+      window.addEventListener("popstate", this.handlePopState);
     }
     return () => {
       this.listeners.delete(listener);
-      if (this.listeners.size > 0) return;
-      this.stopConnectionEvents?.();
-      this.stopConnectionEvents = undefined;
-      if (typeof window !== "undefined") {
+      if (this.listeners.size === 0 && typeof window !== "undefined") {
         window.removeEventListener("popstate", this.handlePopState);
       }
     };
   }
 
-  private snapshot(): MdbaseBrowserLocationChange<Frontmatter> {
-    return {
-      connection: this.activeConnection(),
-      connections: this.connect.connections(),
-      collectionId: this.selectedCollectionId()
-    };
-  }
-
   private emit(): void {
-    if (!this.listeners.size) return;
-    const change = this.snapshot();
-    for (const listener of this.listeners) listener(change);
-  }
-
-  private writeSelection(collectionId: string, replace: boolean): void {
-    const url = cleanAuthorizationParameters(this.currentUrl());
-    url.searchParams.set(this.collectionParameter, collectionId);
-    this.browserHistory()[replace ? "replaceState" : "pushState"](null, "", url);
+    for (const listener of this.listeners) listener();
   }
 
   private safeAppUrl(value: string): URL {
@@ -1094,22 +1080,343 @@ export class MdbaseBrowserLocation<Frontmatter extends JsonObject = JsonObject> 
 
   private currentUrl(): URL {
     if (typeof location === "undefined") {
-      throw new MdbaseConnectError(
-        "browser_required",
-        "Collection URL selection requires a browser environment."
-      );
+      throw new MdbaseConnectError("browser_required", "Browser selection requires a browser environment.");
     }
     return new URL(location.href);
   }
 
   private browserHistory(): History {
     if (typeof history === "undefined") {
-      throw new MdbaseConnectError(
-        "browser_required",
-        "Collection URL selection requires a browser environment."
-      );
+      throw new MdbaseConnectError("browser_required", "Browser selection requires a browser environment.");
     }
     return history;
+  }
+}
+
+export class MdbaseMemorySelection implements MdbaseSessionSelection {
+  private collectionId: string | null = null;
+  private readonly listeners = new Set<() => void>();
+
+  selectedCollectionId(): string | null {
+    return this.collectionId;
+  }
+
+  select(collectionId: string | null): void {
+    if (collectionId === this.collectionId) return;
+    this.collectionId = collectionId;
+    for (const listener of this.listeners) listener();
+  }
+
+  authorizationReturnTo(): undefined {
+    return undefined;
+  }
+
+  authorizationCallback(): null {
+    return null;
+  }
+
+  finishAuthorization(_returnTo: string | undefined, collectionId: string): void {
+    this.select(collectionId);
+  }
+
+  clearAuthorizationCallback(): void {}
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}
+
+export interface MdbaseSessionOptions {
+  selection: MdbaseSessionSelection;
+  operations?: CollectionOperation[];
+  autoSelect?: "only" | "never";
+}
+
+export type MdbaseUnavailableReason =
+  | "not_authorized"
+  | "authorization_lost"
+  | "invalid_stored_grant";
+
+export type MdbaseSessionSnapshot<Frontmatter extends JsonObject = JsonObject> =
+  | {
+      status: "unselected";
+      connections: MdbaseConnectionInfo[];
+    }
+  | {
+      status: "ready";
+      collectionId: string;
+      connection: MdbaseConnection<Frontmatter>;
+      info: MdbaseConnectionInfo;
+      access: MdbaseAuthorizationCapabilities;
+      connections: MdbaseConnectionInfo[];
+    }
+  | {
+      status: "unavailable";
+      collectionId: string;
+      reason: MdbaseUnavailableReason;
+      connections: MdbaseConnectionInfo[];
+    };
+
+export class MdbaseSession<Frontmatter extends JsonObject = JsonObject> {
+  private readonly operations: CollectionOperation[];
+  private readonly selection: MdbaseSessionSelection;
+  private readonly autoSelect: "only" | "never";
+  private readonly listeners = new Set<() => void>();
+  private snapshot: MdbaseSessionSnapshot<Frontmatter>;
+  private snapshotKey = "";
+  private stopConnections?: () => void;
+  private stopSelection?: () => void;
+  private stopActiveConnection?: () => void;
+  private activeCollectionId: string | null = null;
+  private unavailableReason: MdbaseUnavailableReason = "not_authorized";
+  private started = false;
+  private refreshing = false;
+  private refreshQueued = false;
+  private transactionDepth = 0;
+  private callbackPromise: Promise<MdbaseConnection<Frontmatter>> | null = null;
+
+  constructor(
+    private readonly connect: MdbaseConnect<Frontmatter>,
+    options: MdbaseSessionOptions
+  ) {
+    this.operations = uniqueOperations(options.operations ?? DEFAULT_OPERATIONS);
+    this.selection = options.selection;
+    this.autoSelect = options.autoSelect ?? "only";
+    this.snapshot = { status: "unselected", connections: [] };
+    this.refresh();
+  }
+
+  async start(): Promise<MdbaseSessionSnapshot<Frontmatter>> {
+    if (!this.started) {
+      this.started = true;
+      this.stopConnections = this.connect.onConnectionsChange(() => this.refresh());
+      this.stopSelection = this.selection.subscribe(() => {
+        this.unavailableReason = "not_authorized";
+        this.refresh();
+      });
+    }
+    const callback = this.selection.authorizationCallback();
+    if (callback) await this.handleAuthorizationCallback(callback);
+    else this.autoSelectOnlyConnection();
+    this.refresh();
+    return this.snapshot;
+  }
+
+  destroy(): void {
+    this.stopConnections?.();
+    this.stopSelection?.();
+    this.stopActiveConnection?.();
+    this.stopConnections = undefined;
+    this.stopSelection = undefined;
+    this.stopActiveConnection = undefined;
+    this.activeCollectionId = null;
+    this.started = false;
+  }
+
+  getSnapshot(): MdbaseSessionSnapshot<Frontmatter> {
+    return this.snapshot;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  select(
+    collectionId: string,
+    options: { history?: MdbaseSelectionHistory } = {}
+  ): MdbaseConnection<Frontmatter> {
+    const connection = this.connect.connection(collectionId);
+    if (!connection) {
+      throw new MdbaseConnectError(
+        "unknown_collection",
+        "This collection is not authorized for this application."
+      );
+    }
+    this.unavailableReason = "not_authorized";
+    this.selection.select(collectionId, options);
+    this.refresh();
+    return connection;
+  }
+
+  clearSelection(options: { history?: MdbaseSelectionHistory } = {}): void {
+    this.unavailableReason = "not_authorized";
+    this.selection.select(null, options);
+    this.refresh();
+  }
+
+  forget(collectionId: string): void {
+    this.transactionDepth += 1;
+    try {
+      const selected = this.selection.selectedCollectionId() === collectionId;
+      this.connect.connection(collectionId)?.forget();
+      if (selected) this.selection.select(null, { history: "replace" });
+    } finally {
+      this.transactionDepth -= 1;
+      this.refresh();
+    }
+  }
+
+  async authorize(
+    target: "choose" | "selected" | { collectionId: string },
+    options: Omit<MdbaseAuthorizeOptions, "operations" | "returnTo" | "target"> = {}
+  ): Promise<MdbaseAuthorizationOutcome<Frontmatter>> {
+    const selectedCollectionId = this.selection.selectedCollectionId();
+    if (target === "selected" && !selectedCollectionId) {
+      throw new MdbaseConnectError("collection_not_selected", "Choose a collection before updating its access.");
+    }
+    const targetCollectionId = typeof target === "object"
+      ? target.collectionId
+      : target === "selected"
+        ? selectedCollectionId!
+        : null;
+    this.transactionDepth += 1;
+    try {
+      const outcome = await this.connect.authorize({
+        ...options,
+        operations: this.operations,
+        target: targetCollectionId === null
+          ? { kind: "choose" }
+          : { kind: "collection", collectionId: targetCollectionId },
+        returnTo: this.selection.authorizationReturnTo()
+      });
+      if (outcome.kind === "connected") {
+        this.selection.finishAuthorization(outcome.returnTo, outcome.connection.collectionId);
+      }
+      return outcome;
+    } finally {
+      this.transactionDepth -= 1;
+      this.refresh();
+    }
+  }
+
+  async ensureOperations(
+    requiredOperations: CollectionOperation[]
+  ): Promise<MdbaseAuthorizationOutcome<Frontmatter> | { kind: "unchanged"; connection: MdbaseConnection<Frontmatter> }> {
+    const current = this.snapshot;
+    if (current.status !== "ready") {
+      throw new MdbaseConnectError("collection_not_ready", "Choose an authorized collection first.");
+    }
+    const required = uniqueOperations(requiredOperations);
+    const capabilities = current.connection.authorizationCapabilities(required);
+    if (capabilities.sufficient) return { kind: "unchanged", connection: current.connection };
+    this.transactionDepth += 1;
+    try {
+      const outcome = await this.connect.authorize({
+        operations: uniqueOperations([...capabilities.grantedOperations, ...capabilities.missingOperations]),
+        target: { kind: "collection", collectionId: current.collectionId },
+        returnTo: this.selection.authorizationReturnTo()
+      });
+      if (outcome.kind === "connected") {
+        this.selection.finishAuthorization(outcome.returnTo, outcome.connection.collectionId);
+      }
+      return outcome;
+    } finally {
+      this.transactionDepth -= 1;
+      this.refresh();
+    }
+  }
+
+  handleAuthorizationCallback(
+    callbackUrl: string
+  ): Promise<MdbaseConnection<Frontmatter>> {
+    if (!isAuthorizationCallbackUrl(callbackUrl)) {
+      return Promise.reject(new MdbaseConnectError("invalid_callback", "This URL is not an authorization callback."));
+    }
+    if (this.callbackPromise) return this.callbackPromise;
+    this.transactionDepth += 1;
+    const completion = this.connect.completeAuthorization(callbackUrl)
+      .then((result) => {
+        this.unavailableReason = "not_authorized";
+        this.selection.finishAuthorization(result.returnTo, result.connection.collectionId);
+        this.refresh();
+        return result.connection;
+      })
+      .catch((error) => {
+        const returnTo = authorizationReturnToFromError(error);
+        this.selection.clearAuthorizationCallback(returnTo);
+        this.refresh();
+        throw error;
+      })
+      .finally(() => {
+        this.transactionDepth -= 1;
+        this.refresh();
+        if (this.callbackPromise === completion) this.callbackPromise = null;
+      });
+    this.callbackPromise = completion;
+    return completion;
+  }
+
+  private autoSelectOnlyConnection(): void {
+    if (this.autoSelect !== "only" || this.selection.selectedCollectionId()) return;
+    const connections = this.connect.connections();
+    if (connections.length === 1) {
+      this.selection.select(connections[0].collectionId, { history: "replace" });
+    }
+  }
+
+  private refresh(): void {
+    if (this.transactionDepth > 0) {
+      this.refreshQueued = true;
+      return;
+    }
+    if (this.refreshing) {
+      this.refreshQueued = true;
+      return;
+    }
+    this.refreshing = true;
+    try {
+      do {
+        this.refreshQueued = false;
+        this.refreshOnce();
+      } while (this.refreshQueued);
+    } finally {
+      this.refreshing = false;
+    }
+  }
+
+  private refreshOnce(): void {
+    const collectionId = this.selection.selectedCollectionId();
+    const connections = this.connect.connections();
+    const connection = collectionId ? this.connect.connection(collectionId) : null;
+    if (connection?.collectionId !== this.activeCollectionId) {
+      this.stopActiveConnection?.();
+      this.activeCollectionId = connection?.collectionId ?? null;
+      this.stopActiveConnection = connection?.onConnectionChange((info) => {
+        if (!info && this.selection.selectedCollectionId() === connection.collectionId) {
+          this.unavailableReason = "authorization_lost";
+        }
+        this.refresh();
+      });
+    }
+
+    let next: MdbaseSessionSnapshot<Frontmatter>;
+    if (!collectionId) {
+      next = { status: "unselected", connections };
+    } else if (!connection || !connection.info()) {
+      next = {
+        status: "unavailable",
+        collectionId,
+        reason: this.connect.unavailableReason(collectionId) ?? this.unavailableReason,
+        connections
+      };
+    } else {
+      const info = connection.info()!;
+      next = {
+        status: "ready",
+        collectionId,
+        connection,
+        info,
+        access: connection.authorizationCapabilities(this.operations),
+        connections
+      };
+    }
+    const key = sessionSnapshotKey(next);
+    if (key === this.snapshotKey) return;
+    this.snapshot = next;
+    this.snapshotKey = key;
+    for (const listener of this.listeners) listener();
   }
 }
 
@@ -1129,6 +1436,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
   private readonly completionPromises = new Map<string, Promise<MdbaseAuthorizationResult<Frontmatter>>>();
   private readonly connectionCache = new Map<string, MdbaseConnection<Frontmatter>>();
   private readonly listeners = new Set<(connections: MdbaseConnectionInfo[]) => void>();
+  private readonly invalidatedConnections = new Map<string, MdbaseUnavailableReason>();
 
   constructor(options: MdbaseConnectOptions) {
     this.serverUrl = stripTrailingSlash(options.serverUrl);
@@ -1228,7 +1536,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
 
   async authorize(
     options: MdbaseAuthorizeOptions = {}
-  ): Promise<MdbaseAuthorizationResult<Frontmatter>> {
+  ): Promise<MdbaseAuthorizationOutcome<Frontmatter>> {
     if (typeof location === "undefined" && !this.navigate && !options.openVerification) {
       throw new MdbaseConnectError(
         "browser_required",
@@ -1259,17 +1567,21 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     popup?.close();
     const { verifier, challenge } = await createPkce();
     const state = randomBase64Url(24);
+    const targetCollectionId = options.target?.kind === "collection"
+      ? options.target.collectionId
+      : undefined;
     const keyHandle = this.relayEncryption === "required"
       ? `grant:${application.id}:${state}`
       : undefined;
     const grantKey = keyHandle ? await this.keyStore.create(keyHandle) : undefined;
     const pending: StoredAuthorization = {
+      version: 1,
       verifier,
       state,
       clientId: application.id,
       redirectUri: this.redirectUri,
       relayEncryption: this.relayEncryption,
-      collectionId: options.collectionId,
+      collectionId: targetCollectionId,
       returnTo: options.returnTo,
       keyHandle,
       applicationPublicKey: grantKey?.publicKey
@@ -1285,8 +1597,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
       "operations",
       uniqueOperations(options.operations ?? DEFAULT_OPERATIONS).join(",")
     );
-    if (options.collectionId) {
-      authorize.searchParams.set("collection_hint", options.collectionId);
+    if (targetCollectionId) {
+      authorize.searchParams.set("collection_id", targetCollectionId);
     }
     if (grantKey) {
       authorize.searchParams.set("relay_protocol", "1");
@@ -1294,14 +1606,14 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     }
     if (this.navigate) await this.navigate(authorize.href);
     else location.assign(authorize.href);
-    return new Promise<MdbaseAuthorizationResult<Frontmatter>>(() => undefined);
+    return { kind: "redirecting" };
   }
 
   private async authorizePortable(
     application: Application,
     options: MdbaseAuthorizeOptions,
     popup: Window | null
-  ): Promise<MdbaseAuthorizationResult<Frontmatter>> {
+  ): Promise<MdbaseAuthorizationOutcome<Frontmatter>> {
     if (this.relayEncryption !== "required") {
       popup?.close();
       throw new MdbaseConnectError(
@@ -1321,7 +1633,9 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
         body: new URLSearchParams({
           client_id: application.id,
           operations: uniqueOperations(options.operations ?? DEFAULT_OPERATIONS).join(","),
-          ...(options.collectionId ? { collection_hint: options.collectionId } : {}),
+          ...(options.target?.kind === "collection"
+            ? { collection_id: options.target.collectionId }
+            : {}),
           code_challenge: challenge,
           code_challenge_method: "S256",
           relay_protocol: "1",
@@ -1457,7 +1771,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
           application.id,
           keyHandle
         );
-        if (options.collectionId && options.collectionId !== token.collectionId) {
+        if (options.target?.kind === "collection"
+            && options.target.collectionId !== token.collectionId) {
           this.removeToken(token.collectionId, token.keyHandle);
           throw new MdbaseConnectError(
             "collection_mismatch",
@@ -1466,6 +1781,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
         }
         popup?.close();
         return {
+          kind: "connected",
           connection: this.connection(token.collectionId)!,
           ...(options.returnTo ? { returnTo: options.returnTo } : {})
         };
@@ -1507,7 +1823,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     const code = callback.searchParams.get("code");
     const pendingKey = this.pendingKey(state);
     const pending = parseStored<StoredAuthorization>(this.storage.getItem(pendingKey));
-    if (!pending || state !== pending.state) {
+    if (!pending || pending.version !== 1 || state !== pending.state) {
       throw new MdbaseConnectError("invalid_callback", "Authorization callback is missing or does not match this browser session.");
     }
     if (callback.searchParams.has("error")) {
@@ -1604,6 +1920,10 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     return connection.info() ? connection : null;
   }
 
+  unavailableReason(collectionId: string): MdbaseUnavailableReason | null {
+    return this.invalidatedConnections.get(collectionId) ?? null;
+  }
+
   onConnectionsChange(listener: (connections: MdbaseConnectionInfo[]) => void): () => void {
     this.listeners.add(listener);
     listener(this.connections());
@@ -1631,6 +1951,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     const previous = parseStored<StoredToken>(this.storage.getItem(this.tokenKey(collectionId)));
     if (previous?.keyHandle && previous.keyHandle !== keyHandle) void this.keyStore.delete(previous.keyHandle);
     const token: StoredToken = {
+      version: 1,
       accessToken: body.access_token,
       refreshToken: body.refresh_token,
       clientId,
@@ -1657,12 +1978,18 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     };
     this.storage.setItem(this.tokenKey(collectionId), JSON.stringify(token));
     this.addConnectionId(collectionId);
+    this.invalidatedConnections.delete(collectionId);
     this.connectionCache.delete(collectionId);
     this.emitConnections();
     return token;
   }
 
-  removeToken(collectionId: string, keyHandle?: string): void {
+  removeToken(
+    collectionId: string,
+    keyHandle?: string,
+    reason: MdbaseUnavailableReason = "authorization_lost"
+  ): void {
+    this.invalidatedConnections.set(collectionId, reason);
     if (keyHandle) void this.keyStore.delete(keyHandle);
     this.storage.removeItem(this.tokenKey(collectionId));
     this.storage.removeItem(this.pendingMutationKey(collectionId));
@@ -1671,7 +1998,10 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     }
     this.storage.setItem(
       this.connectionsKey(),
-      JSON.stringify(this.connectionIds().filter((id) => id !== collectionId))
+      JSON.stringify({
+        version: 1,
+        collectionIds: this.connectionIds().filter((id) => id !== collectionId)
+      } satisfies StoredConnectionIndex)
     );
     this.connectionCache.delete(collectionId);
     this.emitConnections();
@@ -1729,13 +2059,20 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
   }
 
   private connectionIds(): string[] {
-    return parseStored<string[]>(this.storage.getItem(this.connectionsKey())) ?? [];
+    const index = parseStored<StoredConnectionIndex>(this.storage.getItem(this.connectionsKey()));
+    return index?.version === 1 && Array.isArray(index.collectionIds)
+      && index.collectionIds.every((collectionId) => typeof collectionId === "string")
+      ? index.collectionIds
+      : [];
   }
 
   private addConnectionId(collectionId: string): void {
     this.storage.setItem(
       this.connectionsKey(),
-      JSON.stringify([...new Set([...this.connectionIds(), collectionId])])
+      JSON.stringify({
+        version: 1,
+        collectionIds: [...new Set([...this.connectionIds(), collectionId])]
+      } satisfies StoredConnectionIndex)
     );
   }
 
@@ -1844,17 +2181,23 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
 
   authorize(
     options: MdbaseConnectionAuthorizeOptions = {}
-  ): Promise<MdbaseAuthorizationResult<Frontmatter>> {
-    return this.internals.authorize({ ...options, collectionId: this.collectionId });
+  ): Promise<MdbaseAuthorizationOutcome<Frontmatter>> {
+    return this.internals.authorize({
+      ...options,
+      target: { kind: "collection", collectionId: this.collectionId }
+    });
   }
 
   async requestOperations(
     requiredOperations: CollectionOperation[],
     options: Pick<MdbaseConnectionAuthorizeOptions, "returnTo"> = {}
-  ): Promise<void> {
+  ): Promise<
+    MdbaseAuthorizationOutcome<Frontmatter>
+    | { kind: "unchanged"; connection: MdbaseConnection<Frontmatter> }
+  > {
     const capabilities = this.authorizationCapabilities(requiredOperations);
-    if (capabilities.sufficient) return;
-    await this.authorize({
+    if (capabilities.sufficient) return { kind: "unchanged", connection: this };
+    return this.authorize({
       ...options,
       operations: uniqueOperations([
         ...capabilities.grantedOperations,
@@ -2193,7 +2536,7 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
 
   forget(): void {
     const token = this.currentToken();
-    this.internals.removeToken(this.collectionId, token?.keyHandle);
+    this.internals.removeToken(this.collectionId, token?.keyHandle, "not_authorized");
     this.setRoute("relay");
     this.emitConnection();
   }
@@ -2830,10 +3173,18 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
   }
 
   private currentToken(): StoredToken | null {
-    const token = parseStored<StoredToken>(this.storage.getItem(this.tokenKey()));
-    if (!token) return null;
+    const stored = this.storage.getItem(this.tokenKey());
+    const token = parseStored<StoredToken>(stored);
+    if (!token) {
+      if (stored) this.internals.removeToken(this.collectionId, undefined, "invalid_stored_grant");
+      return null;
+    }
+    if (token.version !== 1) {
+      this.internals.removeToken(this.collectionId, token.keyHandle, "invalid_stored_grant");
+      return null;
+    }
     if (!parseGrantScope(token.scope)) {
-      this.internals.removeToken(this.collectionId, token.keyHandle);
+      this.internals.removeToken(this.collectionId, token.keyHandle, "invalid_stored_grant");
       return null;
     }
     if (token.expiresAt <= Date.now()
@@ -3416,6 +3767,49 @@ function cleanAuthorizationParameters(url: URL): URL {
     url.searchParams.delete(parameter);
   }
   return url;
+}
+
+function isAuthorizationCallbackUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  return url.searchParams.has("state")
+    && (url.searchParams.has("code") || url.searchParams.has("error"));
+}
+
+function authorizationReturnToFromError(error: unknown): string | undefined {
+  if (!(error instanceof MdbaseConnectError)
+      || !error.details
+      || typeof error.details !== "object"
+      || Array.isArray(error.details)) return undefined;
+  const returnTo = (error.details as { returnTo?: unknown }).returnTo;
+  return typeof returnTo === "string" ? returnTo : undefined;
+}
+
+function sessionSnapshotKey<Frontmatter extends JsonObject>(
+  snapshot: MdbaseSessionSnapshot<Frontmatter>
+): string {
+  if (snapshot.status === "unselected") {
+    return JSON.stringify({ status: snapshot.status, connections: snapshot.connections });
+  }
+  if (snapshot.status === "unavailable") {
+    return JSON.stringify({
+      status: snapshot.status,
+      collectionId: snapshot.collectionId,
+      reason: snapshot.reason,
+      connections: snapshot.connections
+    });
+  }
+  return JSON.stringify({
+    status: snapshot.status,
+    collectionId: snapshot.collectionId,
+    info: snapshot.info,
+    access: snapshot.access,
+    connections: snapshot.connections
+  });
 }
 
 function parseGrantScope(value: unknown): GrantScope | null {

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -642,7 +642,7 @@ function sandboxDescription(value: Partial<CollectionDescription> = {}): Collect
     collection_id: value.collection_id ?? "01900000-0000-7000-8000-000000000001",
     display_name: value.display_name ?? "Developer sandbox",
     spec_version: value.spec_version ?? "0.3.0",
-    operations: value.operations ?? ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate", "create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "read_type", "create_type", "update_type"],
+    operations: value.operations ?? ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate", "create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "read_type", "create_type", "update_type", "install_type_pack"],
     change_cursor: value.change_cursor ?? 0,
     types: clone(value.types ?? []),
     contracts: clone(value.contracts ?? [])

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/schemas/connect-protocol.v1.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v1.schema.json
@@ -18,7 +18,7 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
     "operation": {
-      "enum": ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "create_view_source", "update_view_source", "delete_view_source", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type", "list_timers", "put_timer", "cancel_timer", "reconcile_timers", "sync"]
+      "enum": ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "create_view_source", "update_view_source", "delete_view_source", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type", "install_type_pack", "list_timers", "put_timer", "cancel_timer", "reconcile_timers", "sync"]
     },
     "contractRequirement": {
       "type": "object",

--- a/packages/protocol/schemas/encrypted-relay.v1.schema.json
+++ b/packages/protocol/schemas/encrypted-relay.v1.schema.json
@@ -14,7 +14,7 @@
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
     "operation": {
-      "enum": ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "create_view_source", "update_view_source", "delete_view_source", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"]
+      "enum": ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "create_view_source", "update_view_source", "delete_view_source", "validate", "create", "update", "delete", "rename", "read_type", "create_type", "update_type", "install_type_pack", "list_timers", "put_timer", "cancel_timer", "reconcile_timers"]
     },
     "envelope": {
       "type": "object",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -67,6 +67,7 @@ export type CollectionOperation =
   | "read_type"
   | "create_type"
   | "update_type"
+  | "install_type_pack"
   | "list_timers"
   | "put_timer"
   | "cancel_timer"
@@ -229,6 +230,19 @@ export interface TypePackProvision {
   resources: TypePackSourceResource[];
   /** Data contracts expected after the complete pack is installed. */
   provides: ContractRequirement[];
+}
+
+export interface TypePackResourceDiff {
+  target: string;
+  action: "create" | "replace" | "unchanged";
+  digest: string;
+}
+
+export interface TypePackInstallResult {
+  id: string;
+  version: string;
+  resources: TypePackResourceDiff[];
+  cleanup_deferred: boolean;
 }
 
 export interface ApplicationProvisions {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/access.ts
+++ b/packages/ui/access.ts
@@ -56,7 +56,8 @@ const authorizationOperationGroups = [
       "update_view_source",
       "delete_view_source",
       "create_type",
-      "update_type"
+      "update_type",
+      "install_type_pack"
     ]
   },
   {
@@ -91,6 +92,7 @@ const authorizationOperationLabels: Record<string, string> = {
   read_type: "Inspect type definitions",
   create_type: "Create type definitions",
   update_type: "Change type definitions",
+  install_type_pack: "Install type packs",
   list_timers: "List application timers",
   put_timer: "Create or update timers",
   cancel_timer: "Cancel timers",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -408,6 +408,7 @@ secret: connector scope test
   const sdkStorage = new MemoryStorage();
   const sdkStoragePrefix = `mdbase-connect:${serverUrl}:bundle:${manifest.applicationManifest.id}`;
   sdkStorage.setItem(`${sdkStoragePrefix}:token:${collection.id}`, JSON.stringify({
+    version: 1,
     accessToken,
     refreshToken: refreshed.body.refresh_token,
     clientId: appId,
@@ -424,7 +425,10 @@ secret: connector scope test
     keyHandle: "e2e-grant",
     savedAt: Date.now()
   }));
-  sdkStorage.setItem(`${sdkStoragePrefix}:connections`, JSON.stringify([collection.id]));
+  sdkStorage.setItem(`${sdkStoragePrefix}:connections`, JSON.stringify({
+    version: 1,
+    collectionIds: [collection.id]
+  }));
   const sdk = new MdbaseConnect({
     serverUrl,
     manifest: manifest.applicationManifest,
@@ -523,6 +527,7 @@ secret: connector scope test
       redirectUri: manifest.browserRedirectUri,
       loopbackUrl,
       token: {
+        version: 1,
         accessToken: browserToken.body.access_token,
         refreshToken: browserToken.body.refresh_token,
         clientId: browserAppId,
@@ -1081,7 +1086,7 @@ async function openApplicationServer(name, contracts, access) {
       );
       localStorage.setItem(
         \`\${storagePrefix}:connections\`,
-        JSON.stringify([config.token.collectionId])
+        JSON.stringify({ version: 1, collectionIds: [config.token.collectionId] })
       );
       const connect = new MdbaseConnect({
         serverUrl: config.serverUrl,

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -194,7 +194,7 @@ describe("mdbase MCP gateway", () => {
       url: `${new URL(reconnectUrl).pathname}${new URL(reconnectUrl).search}`
     });
     expect(reconnect.statusCode).toBe(302);
-    expect(new URL(reconnect.headers.location!).searchParams.get("collection_hint"))
+    expect(new URL(reconnect.headers.location!).searchParams.get("collection_id"))
       .toBe(connections[0].collection_id);
 
     const stored = await db.query<{ credentials_ciphertext: string }>(

--- a/services/mcp/src/db.ts
+++ b/services/mcp/src/db.ts
@@ -137,13 +137,14 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       token_hash text NOT NULL UNIQUE,
       connection_set_id uuid NOT NULL REFERENCES mcp_connection_sets(id) ON DELETE CASCADE,
       scopes jsonb NOT NULL,
-      collection_hint uuid,
+      collection_id uuid,
       expires_at timestamptz NOT NULL,
       used_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now()
     );
   `);
   await db.query(
-    "ALTER TABLE mcp_connection_tickets ADD COLUMN IF NOT EXISTS collection_hint uuid"
+    "ALTER TABLE mcp_connection_tickets ADD COLUMN IF NOT EXISTS collection_id uuid"
   );
+  await db.query("ALTER TABLE mcp_connection_tickets DROP COLUMN IF EXISTS collection_hint");
 }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.12" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.13" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/mcp/src/oauth.ts
+++ b/services/mcp/src/oauth.ts
@@ -304,7 +304,7 @@ export class OAuthService {
     context: McpAuthContext,
     connectionId?: string
   ): Promise<string> {
-    let collectionHint: string | null = null;
+    let collectionId: string | null = null;
     if (connectionId) {
       const selected = await this.db.query<{ collection_id: string }>(
         `SELECT collection_id FROM mcp_connections
@@ -314,19 +314,19 @@ export class OAuthService {
       if (!selected.rows[0]) {
         throw new OAuthError("invalid_request", "That collection connection is unavailable.");
       }
-      collectionHint = selected.rows[0].collection_id;
+      collectionId = selected.rows[0].collection_id;
     }
     const token = randomToken("add");
     await this.db.query(
       `INSERT INTO mcp_connection_tickets
-         (id, token_hash, connection_set_id, scopes, collection_hint, expires_at)
+         (id, token_hash, connection_set_id, scopes, collection_id, expires_at)
        VALUES ($1, $2, $3, $4::jsonb, $5, $6)`,
       [
         randomUUID(),
         tokenHash(token),
         context.connectionSetId,
         JSON.stringify(context.scopes),
-        collectionHint,
+        collectionId,
         new Date(Date.now() + 10 * 60_000)
       ]
     );
@@ -338,11 +338,11 @@ export class OAuthService {
       id: string;
       connection_set_id: string;
       scopes: McpScope[];
-      collection_hint: string | null;
+      collection_id: string | null;
     }>(
       `UPDATE mcp_connection_tickets SET used_at = now()
        WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now()
-       RETURNING id, connection_set_id, scopes, collection_hint`,
+       RETURNING id, connection_set_id, scopes, collection_id`,
       [tokenHash(token)]
     );
     const ticket = result.rows[0];
@@ -352,7 +352,7 @@ export class OAuthService {
       ticket.connection_set_id,
       ticket.scopes,
       null,
-      ticket.collection_hint
+      ticket.collection_id
     );
   }
 
@@ -361,7 +361,7 @@ export class OAuthService {
     connectionSetId: string,
     scopes: McpScope[],
     authorizationRequestId: string | null,
-    collectionHint: string | null
+    collectionId: string | null
   ): Promise<string> {
     const application = await this.gateway.registerApplication();
     const state = randomToken("state");
@@ -392,7 +392,7 @@ export class OAuthService {
     authorize.searchParams.set("code_challenge_method", "S256");
     authorize.searchParams.set("state", state);
     authorize.searchParams.set("operations", operationsForScopes(scopes).join(","));
-    if (collectionHint) authorize.searchParams.set("collection_hint", collectionHint);
+    if (collectionId) authorize.searchParams.set("collection_id", collectionId);
     authorize.searchParams.set("relay_protocol", "1");
     authorize.searchParams.set("application_public_key", key.publicKey);
     return authorize.href;

--- a/services/mcp/src/oauth.ts
+++ b/services/mcp/src/oauth.ts
@@ -9,7 +9,7 @@ export const MCP_SCOPES = ["mdbase:read", "mdbase:write"] as const;
 export type McpScope = typeof MCP_SCOPES[number];
 
 export const READ_OPERATIONS = ["describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate", "read_type"] as const;
-export const WRITE_OPERATIONS = ["create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "create_type", "update_type"] as const;
+export const WRITE_OPERATIONS = ["create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source", "create_type", "update_type", "install_type_pack"] as const;
 
 interface ClientRow {
   id: string;

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.12",
+  "version": "0.1.0-beta.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -504,7 +504,7 @@ describe("mdbase connect server", () => {
     const state = "test-state";
     const authorize = await app.inject({
       method: "GET",
-      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&state=${state}&operations=read,query&collection_hint=${collectionId}`,
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&state=${state}&operations=read,query&collection_id=${collectionId}`,
       headers: { cookie }
     });
     expect(authorize.statusCode).toBe(302);
@@ -517,7 +517,7 @@ describe("mdbase connect server", () => {
     });
     expect(pending.statusCode).toBe(200);
     expect(pending.json().authorization.application_name).toBe("Workout Tracker");
-    expect(pending.json().authorization.collection_hint).toBe(collectionId);
+    expect(pending.json().authorization.collection_id).toBe(collectionId);
     expect(pending.json().collections).toEqual([]);
     expect(pending.json().unavailable_connectors).toContainEqual(
       expect.objectContaining({
@@ -544,7 +544,7 @@ describe("mdbase connect server", () => {
     });
     expect(localControl.statusCode).toBe(200);
     expect(localControl.json().pending_authorizations[0].application_name).toBe("Workout Tracker");
-    expect(localControl.json().pending_authorizations[0].collection_hint).toBe(localCollectionId);
+    expect(localControl.json().pending_authorizations[0].collection_id).toBe(localCollectionId);
     expect(localControl.json().pending_authorizations[0].requirements).toEqual({
       contracts: [{ id: "workout.record", version: "1.0.0" }]
     });
@@ -556,7 +556,9 @@ describe("mdbase connect server", () => {
       payload: { collection_id: legacyLocalCollectionId, operations: ["read", "query"] }
     });
     expect(connectorLegacyApproval.statusCode).toBe(400);
-    expect(connectorLegacyApproval.json().error.message).toContain("does not support the query operation");
+    expect(connectorLegacyApproval.json().error.message).toContain(
+      "restricted to a different collection"
+    );
 
     const approved = await app.inject({
       method: "POST",
@@ -896,7 +898,7 @@ describe("mdbase connect server", () => {
       payload: new URLSearchParams({
         client_id: applicationId,
         operations: "describe, query,query",
-        collection_hint: collectionId,
+        collection_id: collectionId,
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
@@ -1226,7 +1228,7 @@ describe("mdbase connect server", () => {
       payload: new URLSearchParams({
         client_id: applicationId,
         operations: "describe,query,create,update,sync",
-        collection_hint: collectionId,
+        collection_id: collectionId,
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -2807,7 +2807,7 @@ export async function buildApp(options: BuildOptions) {
     );
     const pendingAuthorizations = await options.db.query(
       `SELECT ar.id, ar.flow, ar.user_code, ar.requested_operations,
-              ar.collection_hint, ar.expires_at,
+              ar.collection_id, ar.expires_at,
               a.id AS application_id, a.distribution, a.name AS application_name,
               a.homepage, a.project_url, a.icon,
               a.requirements, a.provisions, a.notifications
@@ -3783,12 +3783,12 @@ export async function buildApp(options: BuildOptions) {
               a.homepage AS application_homepage,
               a.project_url AS application_project_url, a.icon AS application_icon,
               ar.flow, ar.user_code,
-              ar.requested_operations, hinted.local_id AS collection_hint,
+              ar.requested_operations, hinted.local_id AS collection_id,
               ar.expires_at, a.requirements, a.provisions, a.notifications
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        LEFT JOIN collections hinted
-         ON hinted.id = ar.collection_hint AND hinted.connector_id = $2
+         ON hinted.id = ar.collection_id AND hinted.connector_id = $2
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
          AND ar.expires_at > now()
        ORDER BY ar.expires_at`,
@@ -4595,7 +4595,7 @@ export async function buildApp(options: BuildOptions) {
     const input = z.object({
       client_id: z.uuid(),
       operations: z.string().default("read,query"),
-      collection_hint: z.uuid().optional(),
+      collection_id: z.uuid().optional(),
       code_challenge: z.string().min(43).max(128),
       code_challenge_method: z.literal("S256"),
       relay_protocol: z.coerce.number().int(),
@@ -4644,7 +4644,7 @@ export async function buildApp(options: BuildOptions) {
     await options.db.query(
       `INSERT INTO authorization_requests
          (id, user_id, application_id, flow, redirect_uri, state, code_challenge,
-          requested_operations, collection_hint, relay_protocol,
+          requested_operations, collection_id, relay_protocol,
           application_public_key, device_code_hash, user_code, user_code_hash,
           poll_interval_seconds, expires_at)
        VALUES ($1, NULL, $2, 'device_code', NULL, NULL, $3, $4::jsonb, $5, $6,
@@ -4654,7 +4654,7 @@ export async function buildApp(options: BuildOptions) {
         input.client_id,
         input.code_challenge,
         JSON.stringify(requestedOperations),
-        input.collection_hint ?? null,
+        input.collection_id ?? null,
         ENCRYPTED_RELAY_PROTOCOL_VERSION,
         input.application_public_key,
         tokenHash(deviceCode),
@@ -4885,7 +4885,7 @@ export async function buildApp(options: BuildOptions) {
       code_challenge_method: z.literal("S256"),
       state: z.string().max(500).optional(),
       operations: z.string().default("read,query"),
-      collection_hint: z.uuid().optional(),
+      collection_id: z.uuid().optional(),
       relay_protocol: z.coerce.number().int().optional(),
       application_public_key: z.string().min(80).max(200).optional()
     }).parse(request.query);
@@ -4928,7 +4928,7 @@ export async function buildApp(options: BuildOptions) {
     await options.db.query(
       `INSERT INTO authorization_requests
          (id, user_id, application_id, redirect_uri, state, code_challenge,
-          requested_operations, collection_hint, relay_protocol, application_public_key, expires_at)
+          requested_operations, collection_id, relay_protocol, application_public_key, expires_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, now() + interval '10 minutes')`,
       [
         authorizationId,
@@ -4938,7 +4938,7 @@ export async function buildApp(options: BuildOptions) {
         query.state ?? null,
         query.code_challenge,
         JSON.stringify(requestedOperations),
-        query.collection_hint ?? null,
+        query.collection_id ?? null,
         query.relay_protocol ?? null,
         query.application_public_key ?? null
       ]
@@ -4996,7 +4996,7 @@ export async function buildApp(options: BuildOptions) {
     const { requestId } = z.object({ requestId: z.uuid() }).parse(request.params);
     const authorization = await options.db.query(
       `SELECT ar.id, ar.flow, ar.user_code, ar.requested_operations,
-              ar.collection_hint, ar.expires_at,
+              ar.collection_id, ar.expires_at,
               a.id AS application_id, a.distribution, a.name AS application_name,
               a.homepage, a.project_url, a.icon,
               a.requirements, a.provisions, a.notifications
@@ -6390,6 +6390,7 @@ async function approvePortalAuthorization(
       application_public_key: string | null;
       flow: "authorization_code" | "device_code";
       redirect_uri: string | null;
+      collection_id: string | null;
       grant_id: string | null;
       activation_started_at: string | Date | null;
     }>(
@@ -6398,7 +6399,7 @@ async function approvePortalAuthorization(
               a.project_url AS application_project_url, a.icon AS application_icon,
               ar.requested_operations, a.requirements, a.provisions, a.notifications,
               ar.relay_protocol, ar.application_public_key, ar.flow, ar.redirect_uri,
-              ar.grant_id, ar.activation_started_at
+              ar.collection_id, ar.grant_id, ar.activation_started_at
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
@@ -6410,6 +6411,11 @@ async function approvePortalAuthorization(
     if (!pending) {
       await connection.query("ROLLBACK");
       return false;
+    }
+    if (pending.collection_id && pending.collection_id !== input.collectionId) {
+      throw new RequestValidationError(
+        "This authorization request is restricted to a different collection."
+      );
     }
     if (pending.grant_id) {
       const started = pending.activation_started_at
@@ -6710,10 +6716,12 @@ async function approveAuthorization(
     application_public_key: string | null;
     flow: "authorization_code" | "device_code";
     redirect_uri: string | null;
+    collection_id: string | null;
   }>(
     `SELECT ar.application_id, a.distribution, a.homepage AS application_homepage,
             ar.requested_operations, a.requirements, a.notifications,
-            ar.relay_protocol, ar.application_public_key, ar.flow, ar.redirect_uri
+            ar.relay_protocol, ar.application_public_key, ar.flow, ar.redirect_uri,
+            ar.collection_id
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id
      WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
@@ -6725,6 +6733,11 @@ async function approveAuthorization(
     if (!pending) {
       await connection.query("ROLLBACK");
       return false;
+    }
+    if (pending.collection_id && pending.collection_id !== input.collectionId) {
+      throw new RequestValidationError(
+        "This authorization request is restricted to a different collection."
+      );
     }
     if (
       pending.distribution === "portable"
@@ -6870,12 +6883,14 @@ async function approveHostedAuthorization(
       relay_protocol: number | null;
       application_public_key: string | null;
       flow: "authorization_code" | "device_code";
+      collection_id: string | null;
     }>(
       `SELECT ar.application_id, a.name AS application_name,
               a.distribution, a.homepage AS application_homepage,
               ar.redirect_uri, ar.requested_operations,
               a.requirements, a.provisions, a.notifications,
-              ar.relay_protocol, ar.application_public_key, ar.flow
+              ar.relay_protocol, ar.application_public_key, ar.flow,
+              ar.collection_id
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        WHERE ar.id = $1 AND ar.user_id = $2 AND ar.completed_at IS NULL
@@ -6887,6 +6902,11 @@ async function approveHostedAuthorization(
     if (!pending) {
       await connection.query("ROLLBACK");
       return false;
+    }
+    if (pending.collection_id && pending.collection_id !== input.collectionId) {
+      throw new RequestValidationError(
+        "This authorization request is restricted to a different collection."
+      );
     }
     if (
       pending.distribution === "portable"
@@ -8044,7 +8064,7 @@ async function hostedControlSnapshot(
             a.project_url AS application_project_url,
             a.icon AS application_icon,
             ar.flow, ar.user_code, ar.requested_operations,
-            ar.collection_hint, ar.expires_at,
+            ar.collection_id, ar.expires_at,
             a.requirements, a.provisions, a.notifications
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -4798,7 +4798,7 @@ export async function buildApp(options: BuildOptions) {
       if (!options.hostedProvider) {
         return reply.code(503).send(apiError("hosted_provider_unavailable", "Hosted application access is temporarily unavailable."));
       }
-      const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type", "create_view_source", "update_view_source", "delete_view_source", "put_timer", "cancel_timer", "reconcile_timers"].includes(operation));
+      const write = operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type", "install_type_pack", "create_view_source", "update_view_source", "delete_view_source", "put_timer", "cancel_timer", "reconcile_timers"].includes(operation));
       await options.hostedProvider.updateApplicationReplica(current.hosted_replica_id, {
         grantId,
         mode: write ? "read_write" : "read_only",
@@ -6106,7 +6106,7 @@ async function reconcileApplicationGrants(
     if ((scopeMatches || mayNarrow) && collectionCompatible) {
       if (grant.hosted_replica_id) {
         if (!hostedProvider) throw new Error("Hosted provider unavailable during grant reconciliation.");
-        const write = grant.operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type", "create_view_source", "update_view_source", "delete_view_source", "put_timer", "cancel_timer", "reconcile_timers"].includes(operation));
+        const write = grant.operations.some((operation) => ["create", "update", "delete", "rename", "create_type", "update_type", "install_type_pack", "create_view_source", "update_view_source", "delete_view_source", "put_timer", "cancel_timer", "reconcile_timers"].includes(operation));
         await hostedProvider.updateApplicationReplica(grant.hosted_replica_id, {
           grantId: grant.id,
           mode: write ? "read_write" : "read_only",
@@ -7292,7 +7292,8 @@ const FULL_COLLECTION_OPERATIONS = new Set([
   "execute_view",
   "read_type",
   "create_type",
-  "update_type"
+  "update_type",
+  "install_type_pack"
 ]);
 
 const PORTABLE_PROFILE_OPERATIONS = new Set([
@@ -7301,7 +7302,8 @@ const PORTABLE_PROFILE_OPERATIONS = new Set([
   "execute_view",
   "read_type",
   "create_type",
-  "update_type"
+  "update_type",
+  "install_type_pack"
 ]);
 
 function collectionSupportsOperations(specVersion: string, operations: readonly string[]): boolean {
@@ -8319,6 +8321,7 @@ async function narrowHostedGrantForUser(
     "rename",
     "create_type",
     "update_type",
+    "install_type_pack",
     "create_view_source",
     "update_view_source",
     "delete_view_source",

--- a/services/server/src/collection-access.ts
+++ b/services/server/src/collection-access.ts
@@ -28,6 +28,7 @@ export const COLLECTION_OPERATIONS = [
   "read_type",
   "create_type",
   "update_type",
+  "install_type_pack",
   "list_timers",
   "put_timer",
   "cancel_timer",

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -321,7 +321,7 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
       state text,
       code_challenge text,
       requested_operations jsonb NOT NULL,
-      collection_hint uuid,
+      collection_id uuid,
       relay_protocol integer,
       application_public_key text,
       device_code_hash text UNIQUE,
@@ -776,7 +776,8 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
   await revokeLegacyHostedBearerGrants(db);
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
-  await ensureColumn(db, "authorization_requests", "collection_hint", "ALTER TABLE authorization_requests ADD COLUMN collection_hint uuid");
+  await ensureColumn(db, "authorization_requests", "collection_id", "ALTER TABLE authorization_requests ADD COLUMN collection_id uuid");
+  await db.query("ALTER TABLE authorization_requests DROP COLUMN IF EXISTS collection_hint");
   await ensureColumn(
     db,
     "authorization_requests",

--- a/services/server/src/grant-planner.ts
+++ b/services/server/src/grant-planner.ts
@@ -12,7 +12,8 @@ const FULL_COLLECTION_OPERATIONS = new Set<CollectionOperation>([
   "execute_view",
   "read_type",
   "create_type",
-  "update_type"
+  "update_type",
+  "install_type_pack"
 ]);
 
 const WRITE_OPERATIONS = new Set<CollectionOperation>([
@@ -22,6 +23,7 @@ const WRITE_OPERATIONS = new Set<CollectionOperation>([
   "rename",
   "create_type",
   "update_type",
+  "install_type_pack",
   "create_view_source",
   "update_view_source",
   "delete_view_source",


### PR DESCRIPTION
## Summary
- add `MdbaseSession` with explicit selection, authorization, callback, and recovery state
- replace the browser location helper with URL- and memory-backed selection adapters
- make exact collection authorization a server-enforced `collection_id` constraint across web, portable, desktop, and MCP flows
- version persisted SDK state without legacy compatibility and bump the prerelease to `0.1.0-beta.13`

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `node scripts/check-release-version.mjs`