### PR TITLE
Publish immutable signed server images

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -12,11 +12,9 @@ on:
       - "scripts/verify-windows-packages.ps1"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
-  workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: desktop-release-${{ github.ref }}
@@ -24,9 +22,11 @@ concurrency:
 
 jobs:
   build:
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/v')
     name: ${{ matrix.label }}
-    environment: desktop-release
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -409,6 +409,10 @@ jobs:
     name: Publish GitHub release
     needs: build
     runs-on: ubuntu-24.04
+    environment: desktop-release
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,131 @@
+name: Publish Server Images
+
+on:
+  workflow_run:
+    workflows:
+      - Server CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-server-images-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    name: Publish ${{ matrix.component }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: connect
+            package: mdbase-connect-server
+            dockerfile: deploy/docker/Dockerfile.server
+          - component: hosted-provider
+            package: mdbase-connect-hosted-provider
+            dockerfile: deploy/docker/Dockerfile.hosted-provider
+          - component: mcp
+            package: mdbase-connect-mcp
+            dockerfile: deploy/docker/Dockerfile.mcp
+    env:
+      IMAGE: ghcr.io/mdbase-dev/${{ matrix.package }}
+      SOURCE_COMMIT: ${{ github.event.workflow_run.head_sha }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.SOURCE_COMMIT }}
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - id: build
+        name: Build and push immutable image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}:sha-${{ env.SOURCE_COMMIT }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ env.SOURCE_COMMIT }}
+          cache-from: type=gha,scope=${{ matrix.package }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.package }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image and attest its release identity
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          COMPONENT: ${{ matrix.component }}
+        run: |
+          image_ref="$IMAGE@$DIGEST"
+          cosign sign --yes "$image_ref"
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg component "$COMPONENT" \
+            --arg image "$IMAGE" \
+            '{
+              repository:$repository,
+              commit:$commit,
+              component:$component,
+              image:$image
+            }' > "$RUNNER_TEMP/release-image.json"
+          cosign attest \
+            --yes \
+            --type https://mdbase.dev/attestations/release-image/v1 \
+            --predicate "$RUNNER_TEMP/release-image.json" \
+            "$image_ref"
+
+      - name: Make the release package publicly pullable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          gh api \
+            --method PATCH \
+            "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/$PACKAGE" \
+            --field visibility=public
+
+      - name: Record published digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          COMPONENT: ${{ matrix.component }}
+        run: |
+          jq -n \
+            --arg component "$COMPONENT" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg image "$IMAGE@$DIGEST" \
+            '{component:$component, commit:$commit, image:$image}' \
+            > "$RUNNER_TEMP/$COMPONENT.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-image-${{ matrix.component }}
+          path: ${{ runner.temp }}/${{ matrix.component }}.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -66,6 +66,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.IMAGE }}:sha-${{ env.SOURCE_COMMIT }}
+          build-args: MDBASE_CONNECT_REVISION=${{ env.SOURCE_COMMIT }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ env.SOURCE_COMMIT }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -102,16 +102,6 @@ jobs:
             --predicate "$RUNNER_TEMP/release-image.json" \
             "$image_ref"
 
-      - name: Make the release package publicly pullable
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PACKAGE: ${{ matrix.package }}
-        run: |
-          gh api \
-            --method PATCH \
-            "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/$PACKAGE" \
-            --field visibility=public
-
       - name: Record published digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -20,6 +20,7 @@ RUN cargo build --locked --release -p mdbase-connect-hosted-provider
 
 FROM debian:bookworm-slim AS runtime
 
+ARG MDBASE_CONNECT_REVISION
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/* \
@@ -29,7 +30,8 @@ COPY --from=build /build/mdbase-connect/target/release/mdbase-connect-hosted-pro
 
 ENV HOST=0.0.0.0 \
     PORT=8790 \
-    RUST_LOG=mdbase_connect_hosted_provider=info,tower_http=debug
+    RUST_LOG=mdbase_connect_hosted_provider=info,tower_http=debug \
+    RENDER_GIT_COMMIT=${MDBASE_CONNECT_REVISION}
 
 EXPOSE 8790
 USER mdbase

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -20,9 +20,11 @@ RUN pnpm --filter @mdbase/connect-protocol build \
 
 FROM node:24-bookworm-slim AS runtime
 
+ARG MDBASE_CONNECT_REVISION
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
-    PORT=8790
+    PORT=8790 \
+    RENDER_GIT_COMMIT=${MDBASE_CONNECT_REVISION}
 
 WORKDIR /app
 COPY --from=build /app /app

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -27,10 +27,12 @@ RUN pnpm --filter @mdbase/connect-protocol build \
 
 FROM node:24-bookworm-slim AS runtime
 
+ARG MDBASE_CONNECT_REVISION
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=8787 \
-    PORTAL_DIST=/app/apps/portal/dist
+    PORTAL_DIST=/app/apps/portal/dist \
+    RENDER_GIT_COMMIT=${MDBASE_CONNECT_REVISION}
 
 WORKDIR /app
 COPY --from=build /app /app


### PR DESCRIPTION
## What
- publish Connect, hosted-provider, and MCP images only after Server CI succeeds on main
- push linux/amd64 digest-addressable images with BuildKit SBOM and provenance
- sign each digest and attach a release identity attestation binding component and source commit
- make release packages public for credential-free Render pulls
- reduce desktop release deployment records to the single publish gate and remove duplicate manual full builds

## Why
Render currently rebuilds release branches, so promotion is not promotion of a previously verified artifact. Matrix release jobs also create four deployment records per release. This establishes the build-once side of digest promotion and makes GitHub deployment history reflect real release actions.

## Impact
No service is deployed by this PR. A successful main CI run publishes immutable server artifacts for the follow-up ops promotion change.

## Checks
- actionlint on publish-images.yml
- git diff --check