### PR TITLE
Make beta releases digest-native and rollback-safe

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -15,11 +15,54 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  changes:
     if: >-
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    outputs:
+      publish: ${{ steps.diff.outputs.publish }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+          persist-credentials: false
+
+      - id: diff
+        name: Detect managed runtime changes
+        env:
+          SOURCE_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          parent=$(git rev-parse "$SOURCE_COMMIT^")
+          if git diff --quiet "$parent" "$SOURCE_COMMIT" -- \
+            Cargo.toml \
+            apps/portal \
+            crates \
+            deploy/docker/Cargo.lock.hosted-provider \
+            deploy/docker/Dockerfile.hosted-provider \
+            deploy/docker/Dockerfile.mcp \
+            deploy/docker/Dockerfile.server \
+            deploy/docker/mdbase-rs-revision \
+            package.json \
+            packages/client \
+            packages/protocol \
+            packages/sync \
+            packages/ui \
+            pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            services/mcp \
+            services/server
+          then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: changes
+    if: needs.changes.outputs.publish == 'true'
     name: Publish ${{ matrix.component }}
     runs-on: ubuntu-24.04
     permissions:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,10 +5,10 @@ Rust `mdbase` daemon/CLI. A release is one tested unit; mixing desktop
 and daemon versions is unsupported.
 
 Until the stable `0.1.0` contract is ready, releases use
-`0.1.0-beta.N`. Beta tags and their matching `releases/v0.1.0-beta.N`
-branches are immutable test releases: increment `N` for every published build,
-including a rebuild made only to correct packaging. Production and managed
-test deployments pin the exact tag commit and never deploy `main`.
+`0.1.0-beta.N`. Beta tags are immutable test releases: increment `N` for every
+published desktop build. Production and managed test deployments promote the
+signed server image digests built from the exact tag commit and never build
+from a tag, release branch, or Render.
 
 ## Local package verification
 
@@ -88,29 +88,24 @@ the GitHub release. Upload it to the matching Partner Center submission. The
 Store replaces its build-time development signature with Microsoft's
 certificate after certification.
 
-Before creating a release tag, run the workflow manually from the commit that
-will be tagged:
+Before creating a release tag, require Server CI and `Publish Server Images` to
+pass for the main commit that will be tagged. That publisher builds each managed
+`linux/amd64` image once, attaches BuildKit SBOM and provenance attestations,
+and adds a keyless signature plus an mdbase release attestation that binds the
+component and source commit. Operations promotes those exact digests to staging
+and production; tag creation never rebuilds them.
+
+The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-gh workflow run desktop-release.yml --ref main
+pnpm version:check v0.1.0-beta.13
+git tag -a v0.1.0-beta.13 -m "mdbase connect 0.1.0-beta.13"
+git push origin v0.1.0-beta.13
 ```
 
-This preflight builds, verifies, signs provenance, and uploads
-all platform artifacts without creating a GitHub release. Require the macOS
-Apple Silicon, macOS Intel, Windows, Linux, and Windows Store smoke-test jobs to
-pass before tagging.
-
-The tag must exactly match every package and the Rust workspace version. Create
-an immutable release branch at the same commit because Git-backed Render
-services require a branch reference; deploy tooling separately verifies and
-deploys the exact tag commit:
-
-```bash
-pnpm version:check v0.1.0-beta.12
-git branch releases/v0.1.0-beta.12
-git tag -a v0.1.0-beta.12 -m "mdbase connect 0.1.0-beta.12"
-git push origin releases/v0.1.0-beta.12 v0.1.0-beta.12
-```
+The tag starts the only full desktop build. The four platform builders do not
+open deployment records; the single publish job enters the `desktop-release`
+environment, verifies every artifact, and creates one GitHub prerelease.
 
 When platform publisher configuration is wholly absent, the workflow publishes
 only explicitly labelled preview artifacts for that platform. Partially

--- a/services/mcp/src/db.ts
+++ b/services/mcp/src/db.ts
@@ -146,5 +146,7 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   await db.query(
     "ALTER TABLE mcp_connection_tickets ADD COLUMN IF NOT EXISTS collection_id uuid"
   );
-  await db.query("ALTER TABLE mcp_connection_tickets DROP COLUMN IF EXISTS collection_hint");
+  // Retain the unused legacy column until the previous release is outside the
+  // production rollback window. Runtime compatibility is not a license for a
+  // destructive deploy-time migration.
 }

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -777,7 +777,9 @@ export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> 
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
   await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
   await ensureColumn(db, "authorization_requests", "collection_id", "ALTER TABLE authorization_requests ADD COLUMN collection_id uuid");
-  await db.query("ALTER TABLE authorization_requests DROP COLUMN IF EXISTS collection_hint");
+  // Retain the unused legacy column until the previous release is outside the
+  // production rollback window. Runtime compatibility is not a license for a
+  // destructive deploy-time migration.
   await ensureColumn(
     db,
     "authorization_requests",


### PR DESCRIPTION
## What
- document tags as desktop identities and signed image digests as managed service artifacts
- remove obsolete manual desktop preflight and release-branch instructions
- publish managed images only when their runtime inputs change after green main CI
- retain two unused legacy database columns until the prior release leaves the rollback window

## Why
The old release documentation still described Git-backed Render rebuilds. The beta.13 migration delta also dropped columns during deploy, which would make rollback to beta.12 unsafe. This keeps the external pre-release contract clean while applying expand/contract discipline to the operational schema boundary.

## Impact
The next green main commit produces the definitive beta.13 image set. No API compatibility shim is added; only unused storage columns remain temporarily so rollback is safe.

## Checks
- actionlint on publish-images.yml
- pnpm build
- @mdbase/connect-server: 177 tests passed
- @mdbase/connect-mcp: 6 tests passed
- git diff --check