### PR TITLE
Make schema upgrades release-gated

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,0 +1,4 @@
+# Exact server image from the release immediately preceding this candidate.
+# Update this file as part of each release-preparation change.
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.13
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:dcccdedfc53e3202f144a7d4ac55aa5ea5b0ee9160891313e28626c01d3e5afb

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -89,6 +89,98 @@ jobs:
       - run: docker build --file deploy/docker/Dockerfile.nats --tag mdbase-connect-nats:test .
       - run: MDBASE_CONNECT_E2E_BUILD=0 node scripts/container-e2e.mjs
 
+  previous-release-upgrade:
+    name: Previous release upgrade and OAuth
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: mdbase_connect_upgrade
+          POSTGRES_USER: mdbase
+          POSTGRES_PASSWORD: previous-release-upgrade
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U mdbase -d mdbase_connect_upgrade"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://mdbase:previous-release-upgrade@127.0.0.1:5432/mdbase_connect_upgrade
+      CANDIDATE_IMAGE: mdbase-connect-server:upgrade-candidate
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build candidate server
+        run: >-
+          docker build
+          --file deploy/docker/Dockerfile.server
+          --tag "$CANDIDATE_IMAGE"
+          .
+
+      - name: Create the previous release schema
+        run: |
+          . .github/previous-release.env
+          docker pull "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE"
+          docker run --rm --network host \
+            --env DATABASE_URL \
+            "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE" \
+            node services/server/dist/migrate.js
+
+      - name: Upgrade with candidate migrations
+        run: |
+          docker run --rm --network host \
+            --env DATABASE_URL \
+            "$CANDIDATE_IMAGE" \
+            node services/server/dist/migrate.js
+
+      - name: Exercise the upgraded OAuth authorization write path
+        run: |
+          cleanup() {
+            docker logs mdbase-connect-upgrade-candidate || true
+            docker rm --force mdbase-connect-upgrade-candidate >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          docker run --detach --name mdbase-connect-upgrade-candidate \
+            --network host \
+            --env DATABASE_URL \
+            --env PUBLIC_URL=http://127.0.0.1:8787 \
+            --env MDBASE_CONNECT_DEV_AUTH=1 \
+            --env MDBASE_CONNECT_ALLOW_INSECURE_MANIFESTS=1 \
+            "$CANDIDATE_IMAGE" >/dev/null
+
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:8787/ready >/dev/null; then
+              break
+            fi
+            if [ "$attempt" = 30 ]; then
+              echo "Candidate server did not become ready." >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
+          application_id=$(curl --fail --silent --show-error \
+            --header 'content-type: application/json' \
+            --data '{"manifest":{"manifest_version":1,"id":"dev.mdbase.release-canary","name":"Release canary","homepage":"http://127.0.0.1:8787","redirect_uris":["http://127.0.0.1:8787/callback"],"requirements":{"contracts":[],"access":"full_collection"}}}' \
+            http://127.0.0.1:8787/v1/apps/register |
+            jq --raw-output '.application.id')
+          test -n "$application_id"
+
+          cookie_jar="$RUNNER_TEMP/oauth-cookie"
+          curl --fail --silent --show-error \
+            --cookie-jar "$cookie_jar" \
+            --header 'content-type: application/json' \
+            --data '{"name":"Release canary","email":"release-canary@example.com"}' \
+            http://127.0.0.1:8787/v1/dev/session >/dev/null
+          location=$(curl --silent --show-error \
+            --cookie "$cookie_jar" \
+            --output /dev/null \
+            --write-out '%{redirect_url}' \
+            "http://127.0.0.1:8787/oauth/authorize?client_id=$application_id&redirect_uri=http%3A%2F%2F127.0.0.1%3A8787%2Fcallback&code_challenge=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&code_challenge_method=S256&state=release-canary&operations=describe")
+          [[ "$location" == http://127.0.0.1:8787/authorize/* ]]
+
   hosted-provider:
     runs-on: ubuntu-latest
     defaults:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.13"
+version = "0.1.0-beta.14"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/control-plane-migrations.md
+++ b/docs/control-plane-migrations.md
@@ -11,9 +11,18 @@ files are immutable: the migration command fails if an existing filename has
 different contents. The runner takes a PostgreSQL advisory lock, so concurrent
 pre-deploy jobs serialize safely.
 
-The pre-versioned schema is recorded once as `0000_legacy_baseline`; new schema
-work must use a new numbered SQL file. Migrations are transactional unless the
-file starts with `-- mdbase:no-transaction`.
+The pre-versioned schema is recorded once as `0000_legacy_baseline`. Its
+bootstrap exists only to create an empty database or import an installation
+from before the ledger, and is frozen. Numbered SQL files are the sole
+authority for every subsequent schema change; do not add columns, tables,
+indexes, constraints, backfills, or type changes to the bootstrap. Migrations
+are transactional unless the file starts with `-- mdbase:no-transaction`.
+
+Server CI first creates a real PostgreSQL database with the exact server image
+from `.github/previous-release.env`, then runs the candidate migrations and
+exercises an authenticated OAuth authorization request against the upgraded
+database. Release preparation must advance that image to the immediately
+preceding release.
 
 Production changes follow expand-and-contract:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.13
-git tag -a v0.1.0-beta.13 -m "mdbase connect 0.1.0-beta.13"
-git push origin v0.1.0-beta.13
+pnpm version:check v0.1.0-beta.14
+git tag -a v0.1.0-beta.14 -m "mdbase connect 0.1.0-beta.14"
+git push origin v0.1.0-beta.14
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.13" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.14" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/migrations/0003_authorization_request_collection.sql
+++ b/services/server/migrations/0003_authorization_request_collection.sql
@@ -1,0 +1,5 @@
+-- Restore the optional collection selector used by both browser and device
+-- authorization. Some pre-ledger databases were baselined without receiving
+-- this column, so this migration must remain additive and idempotent.
+ALTER TABLE authorization_requests
+  ADD COLUMN IF NOT EXISTS collection_id uuid;

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.13",
+  "version": "0.1.0-beta.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -7,7 +7,7 @@ import {
   backfillExternalIdentityEmails,
   backfillSessionProviders,
   createDatabase,
-  migrateLegacySchema,
+  bootstrapLegacyBaseline,
   openDatabase,
   revokeLegacyHostedBearerGrants
 } from "./db.js";
@@ -35,7 +35,8 @@ describe("database migrations", () => {
       "0000_legacy_baseline",
       "0001_collaboration_foundations",
       "0001a_authentication_foundations",
-      "0002_instance_administration"
+      "0002_instance_administration",
+      "0003_authorization_request_collection"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -55,7 +56,7 @@ describe("database migrations", () => {
   it("upgrades a beta legacy schema before instance administration runs", async () => {
     const db = await openDatabase("memory");
     resources.push(() => db.end());
-    await migrateLegacySchema(db);
+    await bootstrapLegacyBaseline(db);
     const userId = randomUUID();
     const connectorId = randomUUID();
     await db.query(
@@ -188,6 +189,9 @@ describe("database migrations", () => {
         user_id uuid REFERENCES users(id) ON DELETE SET NULL,
         created_at timestamptz NOT NULL DEFAULT now()
       );
+      CREATE TABLE authorization_requests (
+        id uuid PRIMARY KEY
+      );
     `);
     const userId = randomUUID();
     const sessionId = randomUUID();
@@ -284,8 +288,31 @@ describe("database migrations", () => {
       "0000_legacy_baseline",
       "0001_collaboration_foundations",
       "0001a_authentication_foundations",
-      "0002_instance_administration"
+      "0002_instance_administration",
+      "0003_authorization_request_collection"
     ]);
+  });
+
+  it("repairs the beta.13 production authorization schema additively", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    await db.query(
+      "ALTER TABLE authorization_requests DROP COLUMN collection_id"
+    );
+    await db.query(
+      `DELETE FROM schema_migrations
+       WHERE id = '0003_authorization_request_collection'`
+    );
+
+    await runControlPlaneMigrations(db);
+
+    const columns = await db.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'authorization_requests'
+         AND column_name = 'collection_id'`
+    );
+    expect(columns.rows).toEqual([{ column_name: "collection_id" }]);
+    await expect(assertControlPlaneMigrationsCurrent(db)).resolves.toBeUndefined();
   });
 
   it("fails closed when an application starts before pre-deploy migration", async () => {
@@ -298,7 +325,7 @@ describe("database migrations", () => {
   it("backfills the authorizing user for replicas created before attribution", async () => {
     const db = await openDatabase("memory");
     resources.push(() => db.end());
-    await migrateLegacySchema(db);
+    await bootstrapLegacyBaseline(db);
     const userId = randomUUID();
     const collectionId = randomUUID();
     const replicaId = randomUUID();

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -55,11 +55,13 @@ export async function createDatabase(
 }
 
 /**
- * Idempotent baseline retained while the pre-versioned schema is migrated to
- * discrete SQL files. Production invokes this exactly once through the
- * versioned migration ledger; tests and new databases use the same path.
+ * Frozen bootstrap for an empty database and importer for installations that
+ * predate the migration ledger.
+ *
+ * Do not evolve this function for a new release. Every schema change after the
+ * legacy baseline must be an immutable numbered file in services/server/migrations.
  */
-export async function migrateLegacySchema(db: DatabaseQueryable): Promise<void> {
+export async function bootstrapLegacyBaseline(db: DatabaseQueryable): Promise<void> {
   await db.query(`
     CREATE TABLE IF NOT EXISTS users (
       id uuid PRIMARY KEY,

--- a/services/server/src/migrations.ts
+++ b/services/server/src/migrations.ts
@@ -6,7 +6,7 @@ import type {
   DatabasePool,
   DatabaseQueryable
 } from "./db.js";
-import { migrateLegacySchema } from "./db.js";
+import { bootstrapLegacyBaseline } from "./db.js";
 
 const MIGRATION_LOCK_ID = 1_291_842_019;
 const LEGACY_BASELINE_ID = "0000_legacy_baseline";
@@ -109,7 +109,7 @@ async function establishLegacyBaseline(db: DatabaseQueryable): Promise<void> {
      WHERE table_schema = 'public' AND table_name = 'users'`
   );
   if (!existingLegacySchema.rows[0]) {
-    await migrateLegacySchema(db);
+    await bootstrapLegacyBaseline(db);
   }
   await db.query(
     `INSERT INTO schema_migrations (id, checksum)


### PR DESCRIPTION
## What changed

- adds the additive `0003_authorization_request_collection` migration that repairs the production OAuth schema
- freezes the legacy bootstrap as the baseline and documents numbered SQL migrations as the only authority for later schema changes
- adds a regression test for the beta.13 production drift
- adds a real PostgreSQL previous-release upgrade job using the exact beta.13 server image
- exercises an authenticated OAuth authorization write against the upgraded candidate
- prepares version `0.1.0-beta.14`

## Why

Production had been assigned the legacy baseline marker without receiving `authorization_requests.collection_id`. Fresh staging databases got that column from the evolving bootstrap, so existing-database drift escaped CI and `/oauth/authorize` failed with HTTP 500.

## Impact

Candidate images cannot publish unless the prior immutable release upgrades successfully and OAuth can write through the upgraded schema. Application startup continues to fail closed when numbered migrations are missing or changed.

## Validation

- full workspace build and typecheck
- full workspace tests (including 178 server tests)
- package audit
- packaged beta.13 to beta.14 upgrade on PostgreSQL 17
- reproduced the missing column, applied the candidate migration, and completed an authenticated OAuth authorization request