### PR TITLE
Make desktop update discovery permanently recoverable

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,4 +1,4 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.13
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:dcccdedfc53e3202f144a7d4ac55aa5ea5b0ee9160891313e28626c01d3e5afb
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.14
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:9ce222df5dfc08a48d7d110317bc6c1f1c6b999d5f3da2a11c54c13a6a145757

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -425,7 +425,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Create and verify signed update manifest
+      - name: Create and verify permanent update bootstrap
         shell: bash
         env:
           UPDATE_ROLLOUT_PERCENTAGE: ${{ vars.UPDATE_ROLLOUT_PERCENTAGE }}
@@ -435,22 +435,32 @@ jobs:
           rollout="${UPDATE_ROLLOUT_PERCENTAGE:-100}"
           node scripts/generate-update-manifest.mjs \
             --directory release-artifacts \
-            --output release-artifacts/mdbase-connect-update.json \
+            --output release-artifacts/mdbase-connect-channel-v1.json \
             --version "$version" \
             --repository "$GITHUB_REPOSITORY" \
             --rollout "$rollout" \
             --blocked-versions "${UPDATE_BLOCKED_VERSIONS:-}"
+          cp \
+            release-artifacts/mdbase-connect-channel-v1.json \
+            release-artifacts/mdbase-connect-update.json
           find release-artifacts -maxdepth 1 -type f -name 'update-input-*.json' -delete
-          cosign sign-blob \
-            --yes \
-            --bundle release-artifacts/mdbase-connect-update.json.sigstore.json \
+          for manifest in \
+            release-artifacts/mdbase-connect-channel-v1.json \
             release-artifacts/mdbase-connect-update.json
-          cosign verify-blob \
-            --bundle release-artifacts/mdbase-connect-update.json.sigstore.json \
-            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/desktop-release.yml@${GITHUB_REF}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            release-artifacts/mdbase-connect-update.json
+          do
+            cosign sign-blob \
+              --yes \
+              --bundle "$manifest.sigstore.json" \
+              "$manifest"
+            cosign verify-blob \
+              --bundle "$manifest.sigstore.json" \
+              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/desktop-release.yml@${GITHUB_REF}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "$manifest"
+          done
           sha256sum \
+            release-artifacts/mdbase-connect-channel-v1.json \
+            release-artifacts/mdbase-connect-channel-v1.json.sigstore.json \
             release-artifacts/mdbase-connect-update.json \
             release-artifacts/mdbase-connect-update.json.sigstore.json \
             > release-artifacts/SHA256SUMS-update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/desktop/src/main/release-source.ts
+++ b/apps/desktop/src/main/release-source.ts
@@ -12,7 +12,10 @@ const REPOSITORY = "mdbase-dev/mdbase-connect";
 const WORKFLOW_IDENTITY_PREFIX =
   "https://github.com/mdbase-dev/mdbase-connect/.github/workflows/desktop-release.yml@refs/tags/";
 const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
-const MANIFEST_NAME = "mdbase-connect-update.json";
+// This versioned channel document is the permanent updater bootstrap. Its
+// schema stays intentionally small and frozen. Richer release metadata belongs
+// in separately versioned assets.
+const MANIFEST_NAME = "mdbase-connect-channel-v1.json";
 const MANIFEST_BUNDLE_NAME = `${MANIFEST_NAME}.sigstore.json`;
 const MAX_RELEASE_INDEX_BYTES = 2 * 1024 * 1024;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
@@ -57,7 +60,7 @@ export interface ReleaseSourceOptions {
 
 export async function findLatestRelease(options: ReleaseSourceOptions): Promise<ReleaseCandidate | null> {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const indexUrl = `${GITHUB_API}/repos/${REPOSITORY}/releases?per_page=20`;
+  const indexUrl = `${GITHUB_API}/repos/${REPOSITORY}/releases?per_page=100`;
   const response = await request(fetchImpl, indexUrl);
   const releases = parseReleaseIndex(
     JSON.parse((await readLimited(response, MAX_RELEASE_INDEX_BYTES)).toString("utf8"))
@@ -69,32 +72,57 @@ export async function findLatestRelease(options: ReleaseSourceOptions): Promise<
       /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(release.tag_name)
   );
   let best: ReleaseCandidate | null = null;
+  const rejected: Error[] = [];
   for (const release of matching) {
     const manifestAsset = release.assets.find((asset) => asset.name === MANIFEST_NAME);
     const bundleAsset = release.assets.find((asset) => asset.name === MANIFEST_BUNDLE_NAME);
     if (!manifestAsset || !bundleAsset) continue;
-    const [manifestResponse, bundleResponse] = await Promise.all([
-      request(fetchImpl, manifestAsset.browser_download_url),
-      request(fetchImpl, bundleAsset.browser_download_url)
-    ]);
-    const [manifestBytes, bundleBytes] = await Promise.all([
-      readLimited(manifestResponse, MAX_MANIFEST_BYTES),
-      readLimited(bundleResponse, MAX_BUNDLE_BYTES)
-    ]);
-    const identity = `${WORKFLOW_IDENTITY_PREFIX}${release.tag_name}`;
-    const verifyBundle = options.verifyBundle ?? verifyReleaseBundle;
-    await verifyBundle(JSON.parse(bundleBytes.toString("utf8")), manifestBytes, identity, options.trustCacheDirectory);
-    const manifest = parseUpdateManifest(JSON.parse(manifestBytes.toString("utf8")));
-    if (manifest.tag !== release.tag_name) throw new Error("Signed update manifest does not match its release tag.");
-    if (manifest.release_url !== new URL(release.html_url).href) {
-      throw new Error("Signed update manifest does not match its release page.");
+    try {
+      const [manifestResponse, bundleResponse] = await Promise.all([
+        request(fetchImpl, manifestAsset.browser_download_url),
+        request(fetchImpl, bundleAsset.browser_download_url)
+      ]);
+      const [manifestBytes, bundleBytes] = await Promise.all([
+        readLimited(manifestResponse, MAX_MANIFEST_BYTES),
+        readLimited(bundleResponse, MAX_BUNDLE_BYTES)
+      ]);
+      const identity = `${WORKFLOW_IDENTITY_PREFIX}${release.tag_name}`;
+      const verifyBundle = options.verifyBundle ?? verifyReleaseBundle;
+      await verifyBundle(
+        JSON.parse(bundleBytes.toString("utf8")),
+        manifestBytes,
+        identity,
+        options.trustCacheDirectory
+      );
+      const manifest = parseUpdateManifest(JSON.parse(manifestBytes.toString("utf8")));
+      if (manifest.tag !== release.tag_name) {
+        throw new Error("Signed update manifest does not match its release tag.");
+      }
+      if (manifest.release_url !== new URL(release.html_url).href) {
+        throw new Error("Signed update manifest does not match its release page.");
+      }
+      if (manifest.channel !== options.channel || channelForVersion(manifest.version) !== options.channel) {
+        throw new Error("Signed update manifest is published on the wrong channel.");
+      }
+      if (!best || compareVersions(manifest.version, best.manifest.version) > 0) {
+        best = { manifest, manifestBytes, release: { tag: release.tag_name, url: release.html_url } };
+      }
+    } catch (error) {
+      rejected.push(
+        new Error(
+          `Rejected update metadata for ${release.tag_name}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          { cause: error }
+        )
+      );
     }
-    if (manifest.channel !== options.channel || channelForVersion(manifest.version) !== options.channel) {
-      throw new Error("Signed update manifest is published on the wrong channel.");
-    }
-    if (!best || compareVersions(manifest.version, best.manifest.version) > 0) {
-      best = { manifest, manifestBytes, release: { tag: release.tag_name, url: release.html_url } };
-    }
+  }
+  if (!best && rejected.length > 0) {
+    throw new AggregateError(
+      rejected,
+      `No release had valid signed update metadata. ${rejected[0].message}`
+    );
   }
   return best;
 }

--- a/apps/desktop/test/release-source.test.mjs
+++ b/apps/desktop/test/release-source.test.mjs
@@ -6,7 +6,7 @@ const require = createRequire(import.meta.url);
 const { findLatestRelease } = require("../dist/main/release-source.js");
 
 const indexUrl =
-  "https://api.github.com/repos/mdbase-dev/mdbase-connect/releases?per_page=20";
+  "https://api.github.com/repos/mdbase-dev/mdbase-connect/releases?per_page=100";
 
 function manifest(version = "0.1.0-beta.9") {
   const tag = `v${version}`;
@@ -48,12 +48,12 @@ function release(version) {
     html_url: `https://github.com/mdbase-dev/mdbase-connect/releases/tag/${tag}`,
     assets: [
       {
-        name: "mdbase-connect-update.json",
+        name: "mdbase-connect-channel-v1.json",
         browser_download_url: `https://downloads.example/${tag}/manifest`,
         size: 1000
       },
       {
-        name: "mdbase-connect-update.json.sigstore.json",
+        name: "mdbase-connect-channel-v1.json.sigstore.json",
         browser_download_url: `https://downloads.example/${tag}/bundle`,
         size: 1000
       }
@@ -134,6 +134,28 @@ test("a manifest is not parsed or trusted when signature verification fails", as
     }),
     /untrusted signer/
   );
+});
+
+test("a malformed release cannot strand the updater when another signed release is valid", async () => {
+  const broken = release("0.1.0-beta.10");
+  const valid = release("0.1.0-beta.9");
+  const result = await findLatestRelease({
+    channel: "beta",
+    trustCacheDirectory: "/tmp/not-used",
+    fetchImpl: fetchMap({
+      [indexUrl]: [broken, valid],
+      [broken.assets[0].browser_download_url]: manifest("0.1.0-beta.10"),
+      [broken.assets[1].browser_download_url]: {},
+      [valid.assets[0].browser_download_url]: manifest("0.1.0-beta.9"),
+      [valid.assets[1].browser_download_url]: {}
+    }),
+    async verifyBundle(_bundle, payload) {
+      if (JSON.parse(payload).version === "0.1.0-beta.10") {
+        throw new Error("untrusted signer");
+      }
+    }
+  });
+  assert.equal(result.manifest.version, "0.1.0-beta.9");
 });
 
 test("signed metadata cannot claim a different GitHub release", async () => {

--- a/apps/desktop/test/update-workflow.test.mjs
+++ b/apps/desktop/test/update-workflow.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 
 const repositoryRoot = resolve(import.meta.dirname, "../../..");
 
-test("release workflow signs and verifies the update manifest before publication", async () => {
+test("release workflow signs the permanent channel document and legacy bootstrap", async () => {
   const workflow = await readFile(
     resolve(repositoryRoot, ".github/workflows/desktop-release.yml"),
     "utf8"
@@ -13,7 +13,7 @@ test("release workflow signs and verifies the update manifest before publication
   const generate = workflow.indexOf("scripts/generate-update-manifest.mjs");
   const sign = workflow.indexOf(
     "cosign sign-blob",
-    workflow.indexOf("Create and verify signed update manifest")
+    workflow.indexOf("Create and verify permanent update bootstrap")
   );
   const verify = workflow.indexOf("cosign verify-blob", sign);
   const publish = workflow.indexOf('gh release create "$GITHUB_REF_NAME"');
@@ -21,6 +21,8 @@ test("release workflow signs and verifies the update manifest before publication
   assert.ok(sign > generate);
   assert.ok(verify > sign);
   assert.ok(publish > verify);
+  assert.match(workflow, /mdbase-connect-channel-v1\.json/);
+  assert.match(workflow, /mdbase-connect-update\.json/);
   assert.match(
     workflow,
     /certificate-identity "https:\/\/github\.com\/\$\{GITHUB_REPOSITORY\}\/\.github\/workflows\/desktop-release\.yml@\$\{GITHUB_REF\}"/

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.14"
+version = "0.1.0-beta.15"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/desktop-updates.md
+++ b/docs/desktop-updates.md
@@ -11,13 +11,19 @@ The desktop checks the GitHub Releases API for its channel:
 - prerelease application versions use the `beta` channel;
 - versions without a prerelease suffix use the `stable` channel.
 
-Every release contains `mdbase-connect-update.json` and
-`mdbase-connect-update.json.sigstore.json`. Before parsing or acting on the
-manifest, the desktop verifies its Sigstore bundle against the public Sigstore
-roots, the GitHub Actions OIDC issuer, the exact release workflow, and the
-exact release tag.
+Every release contains a frozen updater bootstrap for two generations:
 
-The strict, versioned manifest binds each downloadable artifact to its name,
+- `mdbase-connect-channel-v1.json` is the permanent channel document used by
+  current and future desktop clients;
+- `mdbase-connect-update.json` preserves the exact beta.14 bootstrap shape so
+  an installed beta client can always reach a current updater.
+
+Both files contain the same minimal release description and have independent
+Sigstore bundles. Before parsing or acting on a document, the desktop verifies
+its bundle against the public Sigstore roots, the GitHub Actions OIDC issuer,
+the exact release workflow, and the exact release tag.
+
+The frozen, versioned channel document binds each downloadable artifact to its name,
 byte length, SHA-256 digest, Sigstore bundle, platform, architecture, release
 tag, and installation mode. Unknown fields, insecure URLs, mismatched tags,
 unsupported targets, unsafe filenames, and malformed versions fail closed.
@@ -25,7 +31,10 @@ Automatic artifacts are streamed to a private size-limited cache, checked
 against the signed digest, then independently verified against their own
 Sigstore bundle.
 
-The installation records the highest signed release it has observed. A replayed
+Discovery rejects a malformed or unverifiable release candidate without
+preventing another valid signed release from being considered. If no candidate
+can be verified, the check fails visibly. The installation records the highest
+signed release it has observed. A replayed
 older manifest cannot cause a downgrade. A release can name bad installed
 versions in `blocked_versions`; those installations bypass staged rollout so a
 signed recovery release reaches them immediately. A target must never block
@@ -121,5 +130,7 @@ Before enabling a non-zero automatic rollout:
 8. raise rollout gradually while watching privacy-minimal startup and recovery
    telemetry.
 
-Never repair a published manifest, reuse a tag, lower the trusted-version
-floor, or point an automatic target at an unsigned preview.
+Never repair a published manifest, reuse a tag, remove either bootstrap asset,
+change the v1 bootstrap shape, lower the trusted-version floor, or point an
+automatic target at an unsigned preview. Richer update metadata must use a new
+separately versioned asset; it must not alter the permanent bootstrap.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.14
-git tag -a v0.1.0-beta.14 -m "mdbase connect 0.1.0-beta.14"
-git push origin v0.1.0-beta.14
+pnpm version:check v0.1.0-beta.15
+git tag -a v0.1.0-beta.15 -m "mdbase connect 0.1.0-beta.15"
+git push origin v0.1.0-beta.15
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.14" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.15" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- freeze the beta.14 update manifest as a permanent legacy bootstrap
- add a separately named, signed `channel-v1` document for current and future updater discovery
- reject malformed release candidates independently so one bad release cannot strand every installed client
- prepare the coordinated updater bridge as v0.1.0-beta.15

## Verification

- `pnpm version:check v0.1.0-beta.15`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
