### PR TITLE
Stabilize the final v1 protocol

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,4 +1,4 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.14
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:9ce222df5dfc08a48d7d110317bc6c1f1c6b999d5f3da2a11c54c13a6a145757
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.15
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:1c58c73536dfea175991b5fa0eaae70029b39f549d0f0f2a7a84dc81ce8906e1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2000,6 +2000,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reqwest",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2 0.10.9",
  "sqlx",
@@ -2016,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"
@@ -35,6 +35,7 @@ notify = "8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
+serde_jcs = "0.1"
 serde_json = "1"
 serde_yaml = "0.9"
 semver = "1"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { chromium, _electron as electron } from "playwright-core";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -215,15 +215,22 @@ try {
   assert.match(token.access_token, /^mdb_/);
   assert.ok(token.grant_id);
 
+  const describeRequestId = randomUUID();
   const described = await jsonRequest(
     `/v1/authorities/${collection.id}/operations/describe`,
     {
       method: "POST",
       authorization: `Bearer ${token.access_token}`,
-      body: {}
+      body: {
+        protocol_version: 1,
+        request_id: describeRequestId,
+        input: {}
+      }
     }
   );
   assert.equal(described.response.status, 200);
+  assert.equal(described.body.protocol_version, 1);
+  assert.equal(described.body.request_id, describeRequestId);
   assert.equal(described.body.result.display_name, "Docker fixture");
   await connectedWindow.getByRole("button", { name: /App access/ }).click();
   await connectedWindow
@@ -257,7 +264,11 @@ try {
     {
       method: "POST",
       authorization: `Bearer ${token.access_token}`,
-      body: {}
+      body: {
+        protocol_version: 1,
+        request_id: randomUUID(),
+        input: {}
+      }
     }
   );
   assert.equal(revoked.response.status, 401);

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-agent/src/loopback.rs
+++ b/crates/connect-agent/src/loopback.rs
@@ -723,7 +723,7 @@ mod tests {
                 RelayBinding::from_grant(self.grant_id, self.application_id, &self.encryption);
             let keys = self
                 .application
-                .derive(&self.encryption.connector_public_key, &binding)
+                .derive(&self.encryption.connector_agreement_public_key, &binding)
                 .unwrap();
             let counter = counter.to_string();
             let metadata = RelayMetadata {
@@ -780,7 +780,7 @@ mod tests {
                 RelayBinding::from_grant(self.grant_id, self.application_id, &self.encryption);
             let keys = self
                 .application
-                .derive(&self.encryption.connector_public_key, &binding)
+                .derive(&self.encryption.connector_agreement_public_key, &binding)
                 .unwrap();
             let metadata = RelayMetadata {
                 binding: &binding,
@@ -815,8 +815,8 @@ mod tests {
             scope_epoch: 1,
             connector_id: Uuid::new_v4(),
             collection_id: collection.id,
-            application_public_key: application.public_key(),
-            connector_public_key: connector.public_key(),
+            application_agreement_public_key: application.public_key(),
+            connector_agreement_public_key: connector.public_key(),
         };
         registry
             .replace_grants(&[GrantPolicy {

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -1,6 +1,9 @@
 use crate::server::AgentState;
 use futures_util::{SinkExt, StreamExt};
-use mdbase_connect_protocol::{AgentConnectionState, RelayMessage};
+use mdbase_connect_protocol::{
+    AgentConnectionState, RelayMessage, CONTROL_PROTOCOL_VERSION, RELAY_CAPABILITIES,
+    RELAY_HANDSHAKE_TIMEOUT_SECONDS,
+};
 use reqwest::Client;
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,7 +41,42 @@ async fn connect_once(
         "authorization",
         HeaderValue::from_str(&format!("Bearer {connector_token}"))?,
     );
-    let (socket, _) = connect_async(request).await?;
+    let (mut socket, _) = connect_async(request).await?;
+    socket
+        .send(Message::Text(
+            serde_json::to_string(&RelayMessage::RelayHello {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                connector_version: env!("CARGO_PKG_VERSION").to_string(),
+                capabilities: RELAY_CAPABILITIES
+                    .iter()
+                    .map(|capability| (*capability).to_string())
+                    .collect(),
+            })?
+            .into(),
+        ))
+        .await?;
+    let welcome = tokio::time::timeout(
+        Duration::from_secs(RELAY_HANDSHAKE_TIMEOUT_SECONDS),
+        socket.next(),
+    )
+    .await
+    .map_err(|_| "relay handshake timed out")?
+    .ok_or("relay closed during handshake")??;
+    let Message::Text(welcome) = welcome else {
+        return Err("relay returned a non-text handshake response".into());
+    };
+    match serde_json::from_str::<RelayMessage>(welcome.as_ref())? {
+        RelayMessage::RelayWelcome {
+            protocol_version,
+            capabilities,
+            ..
+        } if protocol_version == CONTROL_PROTOCOL_VERSION
+            && RELAY_CAPABILITIES
+                .iter()
+                .all(|required| capabilities.iter().any(|value| value == required)) => {}
+        RelayMessage::RelayIncompatible { message, .. } => return Err(message.into()),
+        _ => return Err("relay returned an incompatible handshake response".into()),
+    }
     let (mut writer, mut reader) = socket.split();
     let (responses, mut response_rx) = tokio::sync::mpsc::channel::<RelayMessage>(64);
     let operation_slots = Arc::new(tokio::sync::Semaphore::new(16));
@@ -56,7 +94,11 @@ async fn connect_once(
                         if matches!(&relay_message, RelayMessage::PolicySnapshot { .. }) {
                             // Apply policy in receive order so every subsequently
                             // accepted operation sees the latest local grant state.
-                            state.handle_relay_message(relay_message);
+                            if let Some(response) = state.handle_relay_message(relay_message) {
+                                writer.send(Message::Text(
+                                    serde_json::to_string(&response)?.into()
+                                )).await?;
+                            }
                         } else {
                             let state_for_operation = state.clone();
                             let responses = responses.clone();

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -268,13 +268,54 @@ impl AgentState {
 
     pub fn handle_relay_message(&self, message: RelayMessage) -> Option<RelayMessage> {
         match message {
-            RelayMessage::PolicySnapshot { grants, .. } => {
-                if let Err(error) = self.registry.replace_grants(&grants) {
-                    tracing::error!(%error, "failed to apply relay policy snapshot");
-                } else {
-                    tracing::debug!(grants = grants.len(), "relay policy snapshot applied");
+            RelayMessage::PolicySnapshot {
+                protocol_version,
+                request_id,
+                revision,
+                grants,
+            } => {
+                if protocol_version != CONTROL_PROTOCOL_VERSION {
+                    return Some(RelayMessage::PolicyApplied {
+                        protocol_version: CONTROL_PROTOCOL_VERSION,
+                        request_id,
+                        revision,
+                        ok: false,
+                        error: Some(ControlError {
+                            code: "unsupported_protocol_version".to_string(),
+                            message: format!(
+                                "Relay protocol {protocol_version} is unsupported; expected {}.",
+                                CONTROL_PROTOCOL_VERSION
+                            ),
+                            details: None,
+                        }),
+                    });
                 }
-                None
+                match self.registry.replace_grants(&grants) {
+                    Ok(()) => {
+                        tracing::debug!(grants = grants.len(), %revision, "relay policy snapshot applied");
+                        Some(RelayMessage::PolicyApplied {
+                            protocol_version: CONTROL_PROTOCOL_VERSION,
+                            request_id,
+                            revision,
+                            ok: true,
+                            error: None,
+                        })
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, %revision, "failed to apply relay policy snapshot");
+                        Some(RelayMessage::PolicyApplied {
+                            protocol_version: CONTROL_PROTOCOL_VERSION,
+                            request_id,
+                            revision,
+                            ok: false,
+                            error: Some(ControlError {
+                                code: error.code().to_string(),
+                                message: error.to_string(),
+                                details: None,
+                            }),
+                        })
+                    }
+                }
             }
             RelayMessage::AuthorizationOfferRequest {
                 request_id,
@@ -526,7 +567,11 @@ impl AgentState {
             RelayMessage::EncryptedOperationRequest { envelope } => {
                 Some(self.handle_encrypted_operation(envelope))
             }
-            RelayMessage::OperationResponse { .. }
+            RelayMessage::RelayHello { .. }
+            | RelayMessage::RelayWelcome { .. }
+            | RelayMessage::RelayIncompatible { .. }
+            | RelayMessage::PolicyApplied { .. }
+            | RelayMessage::OperationResponse { .. }
             | RelayMessage::AuthorizationOfferResponse { .. }
             | RelayMessage::AuthorizationActivationResponse { .. }
             | RelayMessage::EncryptedOperationResponse { .. }
@@ -568,7 +613,7 @@ impl AgentState {
         };
         let Ok(keys) = self
             .relay_identity
-            .derive(&encryption.application_public_key, &binding)
+            .derive(&encryption.application_agreement_public_key, &binding)
         else {
             return rejected();
         };
@@ -1779,6 +1824,7 @@ mod tests {
                 requirements: ApplicationRequirements {
                     contracts: Vec::new(),
                     access: Some(ApplicationAccess::FullCollection),
+                    collection_kind: None,
                 },
                 provisions: ApplicationProvisions::default(),
                 grant: Box::new(grant.clone()),
@@ -1821,8 +1867,8 @@ mod tests {
             scope_epoch: 1,
             connector_id,
             collection_id: collection.id,
-            application_public_key: application_identity.public_key(),
-            connector_public_key: connector_identity.public_key(),
+            application_agreement_public_key: application_identity.public_key(),
+            connector_agreement_public_key: connector_identity.public_key(),
         };
         registry
             .replace_grants(&[GrantPolicy {
@@ -1846,7 +1892,7 @@ mod tests {
         let state = AgentState::with_identity(registry, watcher, None, connector_identity);
         let binding = RelayBinding::from_grant(grant_id, application_id, &encryption);
         let keys = application_identity
-            .derive(&encryption.connector_public_key, &binding)
+            .derive(&encryption.connector_agreement_public_key, &binding)
             .unwrap();
         let metadata = RelayMetadata {
             binding: &binding,

--- a/crates/connect-core/src/local_sync.rs
+++ b/crates/connect-core/src/local_sync.rs
@@ -4,7 +4,7 @@ use mdbase_connect_protocol::{
     authority_manifest_digest, AuthoritySnapshot, AuthoritySnapshotRecord, SyncChange,
     SyncChangesPage, SyncCollectionResources, SyncConflict, SyncMutation, SyncMutationOperation,
     SyncMutationReceipt, SyncRecord, SyncReplicaMode, SyncSession, SyncSnapshotPage,
-    CONTROL_PROTOCOL_VERSION,
+    SyncSnapshotRecord, CONTROL_PROTOCOL_VERSION,
 };
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use serde_json::Value;
@@ -424,16 +424,34 @@ impl LocalSyncStore {
         collection_id: Uuid,
         replica: &LocalReplica,
         resources: SyncCollectionResources,
+        collection_snapshot: &CollectionSnapshot,
     ) -> Result<SyncSession, ConnectError> {
         let mut connection = self.connection()?;
         let transaction =
             connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
         let replica = upsert_replica(&transaction, collection_id, replica)?;
         let state = required_collection_state(&transaction, collection_id)?;
+        let documents = collection_snapshot
+            .records
+            .iter()
+            .map(|record| (record.path.as_str(), record.document.as_str()))
+            .collect::<HashMap<_, _>>();
         let records = records(&transaction, collection_id)?
             .into_values()
             .filter(|record| visible(record, &replica.allowed_types))
-            .collect::<Vec<_>>();
+            .map(|record| {
+                let document = documents.get(record.path.as_str()).ok_or_else(|| {
+                    ConnectError::CollectionOpen(format!(
+                        "Local sync snapshot is missing exact Markdown for {}.",
+                        record.path
+                    ))
+                })?;
+                Ok(SyncSnapshotRecord {
+                    record,
+                    document: (*document).to_string(),
+                })
+            })
+            .collect::<Result<Vec<_>, ConnectError>>()?;
         let snapshot_id = Uuid::new_v4();
         transaction.execute(
             "DELETE FROM local_sync_snapshots WHERE expires_at <= CURRENT_TIMESTAMP",
@@ -512,7 +530,7 @@ impl LocalSyncStore {
                     "Snapshot expired or belongs to another replica.".to_string(),
                 )
             })?;
-        let records = serde_json::from_str::<Vec<SyncRecord>>(&row.2)?;
+        let records = serde_json::from_str::<Vec<SyncSnapshotRecord>>(&row.2)?;
         if offset > records.len() {
             return Err(ConnectError::AccessDenied(
                 "Snapshot page is outside the result set.".to_string(),

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -1117,7 +1117,7 @@ impl CollectionRegistry {
                 "open_session" => {
                     let description = self.describe_loaded(&registered, collection)?;
                     let resources = sync_resources(&snapshot, description, &replica.allowed_types);
-                    serde_json::to_value(store.open_session(id, &replica, resources)?)
+                    serde_json::to_value(store.open_session(id, &replica, resources, &snapshot)?)
                         .map_err(Into::into)
                 }
                 "snapshot" => {
@@ -5280,8 +5280,8 @@ views:
                 scope_epoch: 1,
                 connector_id: Uuid::new_v4(),
                 collection_id: Uuid::new_v4(),
-                application_public_key: "application-key".to_string(),
-                connector_public_key: "connector-key".to_string(),
+                application_agreement_public_key: "application-key".to_string(),
+                connector_agreement_public_key: "connector-key".to_string(),
             }),
         };
         registry

--- a/crates/connect-hosted-provider/Cargo.toml
+++ b/crates/connect-hosted-provider/Cargo.toml
@@ -21,6 +21,7 @@ p256.workspace = true
 rand_core.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+serde_jcs.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 sqlx.workspace = true

--- a/crates/connect-hosted-provider/migrations/0014_operation_requests.sql
+++ b/crates/connect-hosted-provider/migrations/0014_operation_requests.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS hosted_provider_operation_requests (
+  replica_id uuid NOT NULL REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
+  request_id uuid NOT NULL,
+  operation text NOT NULL,
+  request_hash bytea NOT NULL,
+  prepared_mutation_ciphertext bytea,
+  response_ciphertext bytea,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  PRIMARY KEY (replica_id, request_id)
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_operation_requests_created_idx
+  ON hosted_provider_operation_requests (created_at);

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -11,10 +11,11 @@ use axum::{
     Json, Router,
 };
 use mdbase_connect_protocol::{
-    AuthorityImportManifest, AuthorityImportRecordPage, GrantSummary, SyncChangesPage,
-    SyncMutation, SyncMutationReceipt, SyncSession, SyncSnapshotPage, TypePackProvision,
-    AUTHORITY_PROOF_NONCE_HEADER, AUTHORITY_PROOF_SIGNATURE_HEADER,
-    AUTHORITY_PROOF_TIMESTAMP_HEADER, AUTHORITY_PROOF_VERSION_HEADER,
+    AuthorityImportManifest, AuthorityImportRecordPage, GrantSummary, OperationRequest,
+    OperationResponse, SyncChangesPage, SyncMutation, SyncMutationReceipt, SyncSession,
+    SyncSnapshotPage, TypePackProvision, AUTHORITY_PROOF_NONCE_HEADER,
+    AUTHORITY_PROOF_SIGNATURE_HEADER, AUTHORITY_PROOF_TIMESTAMP_HEADER,
+    AUTHORITY_PROOF_VERSION_HEADER, CONTROL_PROTOCOL_VERSION,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -691,14 +692,43 @@ async fn operation(
         .provider
         .authorize_request(collection_id, token, origin, proof.as_ref())
         .await?;
-    let input = serde_json::from_slice::<Value>(&body).map_err(|_| {
+    let request = serde_json::from_slice::<OperationRequest>(&body).map_err(|_| {
         ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
     })?;
+    if request.protocol_version != CONTROL_PROTOCOL_VERSION {
+        return Err(ApiError::bad_request(
+            "unsupported_protocol_version",
+            format!(
+                "Operation protocol {} is unsupported; expected {}.",
+                request.protocol_version, CONTROL_PROTOCOL_VERSION
+            ),
+        ));
+    }
     let result = state
         .provider
-        .operation(collection_id, token, &operation, input, origin)
+        .operation(
+            collection_id,
+            token,
+            &operation,
+            request.request_id,
+            request.input,
+            origin,
+        )
         .await?;
-    Ok(Json(json!({ "ok": true, "result": result })))
+    Ok(Json(
+        serde_json::to_value(OperationResponse {
+            protocol_version: CONTROL_PROTOCOL_VERSION,
+            request_id: request.request_id,
+            ok: true,
+            result: Some(result),
+            error: None,
+        })
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "Hosted operation response could not serialize: {error}"
+            ))
+        })?,
+    ))
 }
 
 fn request_origin(headers: &HeaderMap) -> Option<&str> {

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -13,8 +13,9 @@ use mdbase_connect_protocol::{
     CollectionChangesPage, CollectionContractDescriptor, CollectionDescription, GrantSummary,
     SyncChange, SyncChangesPage, SyncCollectionResources, SyncConflict, SyncMutation,
     SyncMutationError, SyncMutationOperation, SyncMutationReceipt, SyncRecord, SyncReplicaMode,
-    SyncResourceDocument, SyncSession, SyncSnapshotPage, TypePackProvision, AUTHORITY_PROOF_DOMAIN,
-    AUTHORITY_PROOF_VERSION, CONTROL_PROTOCOL_VERSION, SYNC_PROTOCOL_VERSION,
+    SyncResourceDocument, SyncSession, SyncSnapshotPage, SyncSnapshotRecord, TypePackProvision,
+    AUTHORITY_PROOF_DOMAIN, AUTHORITY_PROOF_VERSION, CONTROL_PROTOCOL_VERSION,
+    SYNC_PROTOCOL_VERSION,
 };
 use mdbase_connect_runtime::contract_scope::{ContractScope, ContractSelector};
 use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
@@ -209,6 +210,18 @@ pub struct AuthorityRequestProof {
 struct PersistedRecord {
     record: SyncRecord,
     document: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PreparedRecordOperation {
+    mutation: SyncMutation,
+    previous_path: Option<String>,
+    include_document: bool,
+}
+
+enum StoredRecordOperation {
+    Prepared(PreparedRecordOperation),
+    Completed(Value),
 }
 
 struct CachedCollection {
@@ -2119,7 +2132,10 @@ impl HostedProvider {
                     row.get("payload_ciphertext"),
                     &record_version_aad(collection_id, row.get("record_id"), sequence),
                 )?;
-                Ok(payload.record)
+                Ok(SyncSnapshotRecord {
+                    record: payload.record,
+                    document: payload.document,
+                })
             })
             .collect::<ApiResult<Vec<_>>>()?;
         if next_page.is_none() {
@@ -2359,6 +2375,13 @@ impl HostedProvider {
                 "Mutation belongs to another replica.",
             ));
         }
+        // Serialize a replica's mutation stream before consulting its receipt
+        // table. A concurrent retry must observe the first transaction's
+        // committed receipt instead of executing the same effect twice.
+        sqlx::query("SELECT id FROM hosted_provider_replicas WHERE id = $1 FOR UPDATE")
+            .bind(replica.id)
+            .fetch_one(&mut *transaction)
+            .await?;
         let wrapped_data_key: Vec<u8> = sqlx::query_scalar(
             "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
         )
@@ -2851,6 +2874,7 @@ impl HostedProvider {
         collection_id: Uuid,
         token: &str,
         operation: &str,
+        request_id: Uuid,
         input: Value,
         request_origin: Option<&str>,
     ) -> ApiResult<Value> {
@@ -2918,15 +2942,37 @@ impl HostedProvider {
                 }
             }
             "create" | "update" | "delete" | "rename" => {
-                let (input, selector) = if let Some(scope) = &contract_scope {
+                let request_input = input;
+                let stored = self
+                    .load_record_operation(
+                        collection_id,
+                        &replica,
+                        operation,
+                        request_id,
+                        &request_input,
+                    )
+                    .await?;
+                let prepared = match stored {
+                    Some(StoredRecordOperation::Completed(result)) => return Ok(result),
+                    Some(StoredRecordOperation::Prepared(prepared)) => Some(prepared),
+                    None => None,
+                };
+                let (input, selector) = if prepared.is_some() {
+                    let selector = contract_scope
+                        .as_ref()
+                        .map(|scope| scope.selector(&request_input).map_err(scope_error))
+                        .transpose()?
+                        .flatten();
+                    (request_input.clone(), selector)
+                } else if let Some(scope) = &contract_scope {
                     let (scoped_input, selected) = if matches!(operation, "create" | "update") {
                         let (mapped, selector) = scope
-                            .map_write_input(&input, operation == "create")
+                            .map_write_input(&request_input, operation == "create")
                             .map_err(scope_error)?;
                         (mapped, Some(selector))
                     } else {
                         let (identity, selector) =
-                            scope.identity_input(&input).map_err(scope_error)?;
+                            scope.identity_input(&request_input).map_err(scope_error)?;
                         (identity, selector)
                     };
                     if operation != "create" {
@@ -2957,10 +3003,19 @@ impl HostedProvider {
                     }
                     (scoped_input, selected)
                 } else {
-                    (input, None)
+                    (request_input.clone(), None)
                 };
                 let result = self
-                    .write_operation(collection_id, token, &replica, operation, input)
+                    .write_operation(
+                        collection_id,
+                        token,
+                        &replica,
+                        operation,
+                        request_id,
+                        &request_input,
+                        input,
+                        prepared,
+                    )
                     .await?;
                 if operation == "delete" {
                     return Ok(result);
@@ -3400,22 +3455,142 @@ impl HostedProvider {
         Ok(result)
     }
 
-    async fn write_operation(
+    async fn load_record_operation(
         &self,
         collection_id: Uuid,
-        token: &str,
         replica: &Replica,
         operation: &str,
+        request_id: Uuid,
+        input: &Value,
+    ) -> ApiResult<Option<StoredRecordOperation>> {
+        let Some(row) = sqlx::query(
+            r#"SELECT request.operation, request.request_hash,
+                      request.prepared_mutation_ciphertext,
+                      request.response_ciphertext, collection.wrapped_data_key
+               FROM hosted_provider_operation_requests request
+               JOIN hosted_provider_replicas replica ON replica.id = request.replica_id
+               JOIN hosted_provider_collections collection
+                 ON collection.id = replica.collection_id
+               WHERE request.replica_id = $1 AND request.request_id = $2
+                 AND replica.collection_id = $3"#,
+        )
+        .bind(replica.id)
+        .bind(request_id)
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let submitted_hash = operation_request_hash(operation, input)?;
+        let stored_hash: Vec<u8> = row.get("request_hash");
+        if row.get::<String, _>("operation") != operation
+            || !bool::from(stored_hash.ct_eq(&submitted_hash))
+        {
+            return Err(ApiError::conflict(
+                "operation_request_id_reused",
+                "Operation request ID was already used for a different operation.",
+            ));
+        }
+        let wrapped_data_key: Vec<u8> = row.get("wrapped_data_key");
+        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        if let Some(ciphertext) = row.get::<Option<Vec<u8>>, _>("response_ciphertext") {
+            let response = self.crypto.decrypt_json(
+                &data_key,
+                &ciphertext,
+                &operation_response_aad(replica.id, request_id),
+            )?;
+            return Ok(Some(StoredRecordOperation::Completed(response)));
+        }
+        let ciphertext = row
+            .get::<Option<Vec<u8>>, _>("prepared_mutation_ciphertext")
+            .ok_or_else(|| {
+                ApiError::internal("The hosted operation request has no prepared mutation.")
+            })?;
+        let prepared = self.crypto.decrypt_json(
+            &data_key,
+            &ciphertext,
+            &operation_prepared_aad(replica.id, request_id),
+        )?;
+        Ok(Some(StoredRecordOperation::Prepared(prepared)))
+    }
+
+    async fn prepare_record_operation(
+        &self,
+        collection_id: Uuid,
+        replica: &Replica,
+        operation: &str,
+        request_id: Uuid,
+        request_input: &Value,
         input: Value,
-    ) -> ApiResult<Value> {
+    ) -> ApiResult<PreparedRecordOperation> {
         let mut operation_input = input.as_object().cloned().ok_or_else(|| {
             ApiError::bad_request(
                 "invalid_operation_input",
                 "Hosted operation input must be an object.",
             )
         })?;
+        let mut transaction = self.pool.begin().await?;
+        let replica_collection: Option<Uuid> = sqlx::query_scalar(
+            "SELECT collection_id FROM hosted_provider_replicas WHERE id = $1 FOR UPDATE",
+        )
+        .bind(replica.id)
+        .fetch_optional(&mut *transaction)
+        .await?;
+        if replica_collection != Some(collection_id) {
+            return Err(ApiError::forbidden(
+                "replica_scope_denied",
+                "Operation belongs to another hosted collection.",
+            ));
+        }
+        let wrapped_data_key: Vec<u8> = sqlx::query_scalar(
+            "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
+        )
+        .bind(collection_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        let request_hash = operation_request_hash(operation, request_input)?;
+        if let Some(row) = sqlx::query(
+            r#"SELECT operation, request_hash, prepared_mutation_ciphertext
+               FROM hosted_provider_operation_requests
+               WHERE replica_id = $1 AND request_id = $2"#,
+        )
+        .bind(replica.id)
+        .bind(request_id)
+        .fetch_optional(&mut *transaction)
+        .await?
+        {
+            let stored_hash: Vec<u8> = row.get("request_hash");
+            if row.get::<String, _>("operation") != operation
+                || !bool::from(stored_hash.ct_eq(&request_hash))
+            {
+                return Err(ApiError::conflict(
+                    "operation_request_id_reused",
+                    "Operation request ID was already used for a different operation.",
+                ));
+            }
+            let ciphertext = row
+                .get::<Option<Vec<u8>>, _>("prepared_mutation_ciphertext")
+                .ok_or_else(|| {
+                    ApiError::internal("The hosted operation request has no prepared mutation.")
+                })?;
+            let prepared = self.crypto.decrypt_json(
+                &data_key,
+                &ciphertext,
+                &operation_prepared_aad(replica.id, request_id),
+            )?;
+            transaction.commit().await?;
+            return Ok(prepared);
+        }
         let (mutation_operation, record_id, base_revision, previous_path) = match operation {
-            "create" => (SyncMutationOperation::Create, Uuid::new_v4(), None, None),
+            "create" => (SyncMutationOperation::Create, request_id, None, None),
             "update" | "delete" | "rename" => {
                 let path_key = if operation == "rename" {
                     "from"
@@ -3432,26 +3607,13 @@ impl HostedProvider {
                         )
                     })?
                     .to_string();
-                let wrapped_data_key: Vec<u8> = sqlx::query_scalar(
-                    "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
-                )
-                .bind(collection_id)
-                .fetch_optional(&self.pool)
-                .await?
-                .ok_or_else(|| {
-                    ApiError::not_found(
-                        "hosted_collection_not_found",
-                        "Hosted collection not found.",
-                    )
-                })?;
-                let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
                 let current = sqlx::query(
                     r#"SELECT record_id, revision, types FROM hosted_provider_records
                        WHERE collection_id = $1 AND path_token = $2"#,
                 )
                 .bind(collection_id)
                 .bind(path_token(&data_key, &path))
-                .fetch_optional(&self.pool)
+                .fetch_optional(&mut *transaction)
                 .await?
                 .ok_or_else(|| {
                     ApiError::not_found("record_not_found", "The hosted record does not exist.")
@@ -3512,32 +3674,153 @@ impl HostedProvider {
             }
             _ => unreachable!(),
         };
-        if operation_input.get("dry_run").and_then(Value::as_bool) == Some(true) {
-            let result = self
-                .execute_read_operation(collection_id, operation, &Value::Object(operation_input))
-                .await?;
-            return serde_json::to_value(result).map_err(|error| {
-                ApiError::internal(format!(
-                    "Hosted operation preflight could not serialize: {error}"
-                ))
-            });
-        }
         let include_document = operation_input
             .get("include_document")
             .and_then(Value::as_bool)
             == Some(true)
             || operation_input.contains_key("document");
-        let mutation = SyncMutation {
-            mutation_id: Uuid::new_v4(),
-            replica_id: replica.id,
-            scope_epoch: replica.scope_epoch,
-            operation: mutation_operation,
-            record_id,
-            base_revision,
-            input: operation_input,
-            created_at: Utc::now().to_rfc3339(),
-            causal_predecessor: None,
+        let prepared = PreparedRecordOperation {
+            mutation: SyncMutation {
+                mutation_id: request_id,
+                replica_id: replica.id,
+                scope_epoch: replica.scope_epoch,
+                operation: mutation_operation,
+                record_id,
+                base_revision,
+                input: operation_input,
+                created_at: Utc::now().to_rfc3339(),
+                causal_predecessor: None,
+            },
+            previous_path,
+            include_document,
         };
+        if prepared
+            .mutation
+            .input
+            .get("dry_run")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
+            let ciphertext = self.crypto.encrypt_json(
+                &data_key,
+                &prepared,
+                &operation_prepared_aad(replica.id, request_id),
+            )?;
+            sqlx::query(
+                r#"INSERT INTO hosted_provider_operation_requests
+                     (replica_id, request_id, operation, request_hash,
+                      prepared_mutation_ciphertext)
+                   VALUES ($1, $2, $3, $4, $5)"#,
+            )
+            .bind(replica.id)
+            .bind(request_id)
+            .bind(operation)
+            .bind(request_hash)
+            .bind(ciphertext)
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+        Ok(prepared)
+    }
+
+    async fn complete_record_operation(
+        &self,
+        collection_id: Uuid,
+        replica_id: Uuid,
+        operation: &str,
+        request_id: Uuid,
+        input: &Value,
+        response: &Value,
+    ) -> ApiResult<()> {
+        let wrapped_data_key: Vec<u8> = sqlx::query_scalar(
+            "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1",
+        )
+        .bind(collection_id)
+        .fetch_one(&self.pool)
+        .await?;
+        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        let request_hash = operation_request_hash(operation, input)?;
+        let response_ciphertext = self.crypto.encrypt_json(
+            &data_key,
+            response,
+            &operation_response_aad(replica_id, request_id),
+        )?;
+        let updated = sqlx::query(
+            r#"UPDATE hosted_provider_operation_requests
+               SET response_ciphertext = $5, completed_at = now()
+               WHERE replica_id = $1 AND request_id = $2
+                 AND operation = $3 AND request_hash = $4"#,
+        )
+        .bind(replica_id)
+        .bind(request_id)
+        .bind(operation)
+        .bind(request_hash)
+        .bind(response_ciphertext)
+        .execute(&self.pool)
+        .await?
+        .rows_affected();
+        if updated != 1 {
+            return Err(ApiError::conflict(
+                "operation_request_id_reused",
+                "Operation request ID was already used for a different operation.",
+            ));
+        }
+        Ok(())
+    }
+
+    async fn write_operation(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        replica: &Replica,
+        operation: &str,
+        request_id: Uuid,
+        request_input: &Value,
+        input: Value,
+        prepared: Option<PreparedRecordOperation>,
+    ) -> ApiResult<Value> {
+        let prepared = match prepared {
+            Some(prepared) => prepared,
+            None => {
+                let prepared = self
+                    .prepare_record_operation(
+                        collection_id,
+                        replica,
+                        operation,
+                        request_id,
+                        request_input,
+                        input,
+                    )
+                    .await?;
+                if prepared
+                    .mutation
+                    .input
+                    .get("dry_run")
+                    .and_then(Value::as_bool)
+                    == Some(true)
+                {
+                    let result = self
+                        .execute_read_operation(
+                            collection_id,
+                            operation,
+                            &Value::Object(prepared.mutation.input),
+                        )
+                        .await?;
+                    return serde_json::to_value(result).map_err(|error| {
+                        ApiError::internal(format!(
+                            "Hosted operation preflight could not serialize: {error}"
+                        ))
+                    });
+                }
+                prepared
+            }
+        };
+        let PreparedRecordOperation {
+            mutation,
+            previous_path,
+            include_document,
+        } = prepared;
         let receipt = self
             .mutate_for(collection_id, token, mutation, ReplicaPurpose::Application)
             .await?;
@@ -3598,9 +3881,19 @@ impl HostedProvider {
                 Some(json!({ "current_revision": conflict.current_revision })),
             ),
         };
-        serde_json::to_value(result).map_err(|error| {
+        let result = serde_json::to_value(result).map_err(|error| {
             ApiError::internal(format!("Hosted operation could not serialize: {error}"))
-        })
+        })?;
+        self.complete_record_operation(
+            collection_id,
+            replica.id,
+            operation,
+            request_id,
+            request_input,
+            &result,
+        )
+        .await?;
+        Ok(result)
     }
 
     async fn write_type_operation(
@@ -5579,29 +5872,36 @@ fn authority_manifest_digest(
     resources: Vec<(String, String)>,
     records: BTreeMap<Uuid, PersistedRecord>,
 ) -> String {
-    let mut entries = BTreeMap::<(String, String), String>::new();
+    let mut entries = BTreeMap::<(String, String), (String, String)>::new();
     for (path, document) in resources {
         entries.insert(
             ("resource".to_string(), path),
-            sha256_hex(document.as_bytes()),
+            (String::new(), sha256_hex(document.as_bytes())),
         );
     }
     for persisted in records.into_values() {
         entries.insert(
             ("record".to_string(), persisted.record.path),
-            persisted.record.revision,
+            (
+                persisted.record.record_id.to_string(),
+                sha256_hex(persisted.document.as_bytes()),
+            ),
         );
     }
     authority_manifest_digest_from_hashes(entries)
 }
 
-fn authority_manifest_digest_from_hashes(entries: BTreeMap<(String, String), String>) -> String {
+fn authority_manifest_digest_from_hashes(
+    entries: BTreeMap<(String, String), (String, String)>,
+) -> String {
     let mut manifest = Sha256::new();
     manifest.update(b"mdbase-authority-manifest-v1\n");
-    for ((kind, path), document_hash) in entries {
+    for ((kind, path), (identity, document_hash)) in entries {
         manifest.update(kind.as_bytes());
         manifest.update(b"\0");
         manifest.update(path.as_bytes());
+        manifest.update(b"\0");
+        manifest.update(identity.as_bytes());
         manifest.update(b"\0");
         manifest.update(document_hash.as_bytes());
         manifest.update(b"\n");
@@ -5634,10 +5934,31 @@ fn path_token(data_key: &[u8; 32], path: &str) -> Vec<u8> {
 }
 
 fn mutation_hash(mutation: &SyncMutation) -> ApiResult<Vec<u8>> {
-    let bytes = serde_json::to_vec(mutation).map_err(|error| {
+    let bytes = serde_jcs::to_vec(mutation).map_err(|error| {
         ApiError::internal(format!("Hosted mutation could not serialize: {error}"))
     })?;
     Ok(Sha256::digest(bytes).to_vec())
+}
+
+fn operation_request_hash(operation: &str, input: &Value) -> ApiResult<Vec<u8>> {
+    let bytes = serde_jcs::to_vec(&json!({
+        "operation": operation,
+        "input": input,
+    }))
+    .map_err(|error| {
+        ApiError::internal(format!(
+            "Hosted operation request could not serialize: {error}"
+        ))
+    })?;
+    Ok(Sha256::digest(bytes).to_vec())
+}
+
+fn operation_prepared_aad(replica_id: Uuid, request_id: Uuid) -> Vec<u8> {
+    format!("hosted-provider/operation-prepared/v1/{replica_id}/{request_id}").into_bytes()
+}
+
+fn operation_response_aad(replica_id: Uuid, request_id: Uuid) -> Vec<u8> {
+    format!("hosted-provider/operation-response/v1/{replica_id}/{request_id}").into_bytes()
 }
 
 fn number(value: i64, name: &'static str) -> ApiResult<u64> {
@@ -5674,16 +5995,19 @@ mod tests {
         let entries = BTreeMap::from([
             (
                 ("record".to_string(), "tasks/a.md".to_string()),
-                "00".repeat(32),
+                (
+                    "01911111-1111-7111-8111-111111111111".to_string(),
+                    "00".repeat(32),
+                ),
             ),
             (
                 ("resource".to_string(), "mdbase.yaml".to_string()),
-                "ff".repeat(32),
+                (String::new(), "ff".repeat(32)),
             ),
         ]);
         assert_eq!(
             authority_manifest_digest_from_hashes(entries),
-            "c3a6c98f15ed143bf4b9642e32c9f4c775ca8ad4978a42a4dbd69f79f6fc5e0f"
+            "5f4d35b7381929c7a60d2c45ff310899d9b4c0d891a2ada573fb6dc10fc8c51a"
         );
     }
 

--- a/crates/connect-mirror/src/lib.rs
+++ b/crates/connect-mirror/src/lib.rs
@@ -8,7 +8,8 @@ use mdbase_connect_protocol::{
     authority_manifest_digest, AuthoritySnapshotRecord, MirrorConflictSummary, MirrorLocalIssue,
     MirrorResolution, MirrorState as MirrorStatusState, SyncChange, SyncChangesPage,
     SyncCollectionResources, SyncMutation, SyncMutationOperation, SyncMutationReceipt, SyncRecord,
-    SyncReplicaMode, SyncResourceDocument, SyncSession, SyncSnapshotPage, SYNC_PROTOCOL_VERSION,
+    SyncReplicaMode, SyncResourceDocument, SyncSession, SyncSnapshotPage, SyncSnapshotRecord,
+    SYNC_PROTOCOL_VERSION,
 };
 use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
@@ -251,7 +252,7 @@ struct DurableRebuildPlan {
     replica_id: Uuid,
     mode: SyncReplicaMode,
     session: SyncSession,
-    records: Vec<SyncRecord>,
+    records: Vec<SyncSnapshotRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     prior: Option<DurableMirrorState>,
 }
@@ -539,12 +540,19 @@ impl DirectoryMirror {
         let records = state
             .records
             .values()
-            .filter_map(|entry| entry.record.clone())
-            .map(|record| AuthoritySnapshotRecord {
-                record,
-                document: String::new(),
+            .filter_map(|entry| entry.record.clone().map(|record| (entry, record)))
+            .map(|(entry, record)| {
+                Ok(AuthoritySnapshotRecord {
+                    record,
+                    document: self.read_file(&entry.path)?.ok_or_else(|| {
+                        MirrorError::new(
+                            "mirror_diverged",
+                            format!("Authority record {} is missing.", entry.path),
+                        )
+                    })?,
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, MirrorError>>()?;
         Ok(AuthorityPromotionManifest {
             cursor: state.cursor,
             digest: authority_manifest_digest(&resource_documents, &records),
@@ -719,7 +727,11 @@ impl DirectoryMirror {
             .documents
             .iter()
             .map(|resource| resource.path.clone())
-            .chain(plan.records.iter().map(|record| record.path.clone()))
+            .chain(
+                plan.records
+                    .iter()
+                    .map(|snapshot| snapshot.record.path.clone()),
+            )
             .collect::<HashSet<_>>();
         let mut state = DurableMirrorState {
             protocol_version: SYNC_PROTOCOL_VERSION,
@@ -746,15 +758,15 @@ impl DirectoryMirror {
                 },
             );
         }
-        for record in &plan.records {
-            let document = record_markdown_document(record)?;
-            self.write_file(&record.path, document.as_bytes())?;
+        for snapshot in &plan.records {
+            let record = &snapshot.record;
+            self.write_file(&record.path, snapshot.document.as_bytes())?;
             state.records.insert(
                 record.record_id,
                 MirrorEntry {
                     path: record.path.clone(),
                     revision: record.revision.clone(),
-                    hash: digest(&document),
+                    hash: digest(&snapshot.document),
                     record: (self.mode == SyncReplicaMode::ReadWrite).then_some(record.clone()),
                 },
             );
@@ -790,20 +802,20 @@ impl DirectoryMirror {
     fn target_paths(
         &self,
         resources: &SyncCollectionResources,
-        records: &[SyncRecord],
+        records: &[SyncSnapshotRecord],
     ) -> HashSet<String> {
         resources
             .documents
             .iter()
             .map(|resource| resource.path.clone())
-            .chain(records.iter().map(|record| record.path.clone()))
+            .chain(records.iter().map(|snapshot| snapshot.record.path.clone()))
             .collect()
     }
 
     fn validate_snapshot_shape(
         &self,
         resources: &SyncCollectionResources,
-        records: &[SyncRecord],
+        records: &[SyncSnapshotRecord],
     ) -> Result<(), MirrorError> {
         let mut paths = HashSet::<String>::new();
         for resource in &resources.documents {
@@ -816,7 +828,8 @@ impl DirectoryMirror {
             }
         }
         let mut record_ids = HashSet::new();
-        for record in records {
+        for snapshot in records {
+            let record = &snapshot.record;
             safe_path(&self.root, &record.path)?;
             if !record_ids.insert(record.record_id) || !paths.insert(record.path.clone()) {
                 return Err(MirrorError::new(
@@ -834,7 +847,7 @@ impl DirectoryMirror {
     fn preflight_rebuild(
         &self,
         resources: &SyncCollectionResources,
-        records: &[SyncRecord],
+        records: &[SyncSnapshotRecord],
         prior: Option<&DurableMirrorState>,
     ) -> Result<(), MirrorError> {
         let prior_paths = self.prior_managed_paths(prior);
@@ -850,8 +863,9 @@ impl DirectoryMirror {
                 collisions.insert(resource.path.clone());
             }
         }
-        for record in records {
-            let document = record_markdown_document(record)?;
+        for snapshot in records {
+            let record = &snapshot.record;
+            let document = &snapshot.document;
             let local = self.read_file(&record.path)?;
             let managed = prior_paths.get(record.path.as_str());
             if local.as_deref().is_some_and(|local| {

--- a/crates/connect-mirror/src/tests.rs
+++ b/crates/connect-mirror/src/tests.rs
@@ -173,7 +173,17 @@ impl SyncTransport for FakeAuthority {
             snapshot_id,
             scope_epoch: self.session.scope_epoch,
             cursor: self.session.head,
-            records: self.records.lock().unwrap().values().cloned().collect(),
+            records: self
+                .records
+                .lock()
+                .unwrap()
+                .values()
+                .cloned()
+                .map(|record| mdbase_connect_protocol::SyncSnapshotRecord {
+                    document: record_markdown_document(&record).unwrap(),
+                    record,
+                })
+                .collect(),
             next_page: None,
         })
     }
@@ -285,6 +295,13 @@ fn record(path: &str, title: &str) -> SyncRecord {
         frontmatter: object([("title", Value::String(title.to_string()))]),
         body: format!("# {title}\n"),
         types: Vec::new(),
+    }
+}
+
+fn snapshot_record(record: SyncRecord) -> mdbase_connect_protocol::SyncSnapshotRecord {
+    mdbase_connect_protocol::SyncSnapshotRecord {
+        document: record_markdown_document(&record).unwrap(),
+        record,
     }
 }
 
@@ -493,7 +510,10 @@ async fn interrupted_initial_snapshot_resumes_from_its_durable_plan() {
         replica_id: authority.session.replica_id,
         mode: SyncReplicaMode::ReadOnly,
         session: authority.session.clone(),
-        records: vec![first.clone(), second.clone()],
+        records: vec![
+            snapshot_record(first.clone()),
+            snapshot_record(second.clone()),
+        ],
         prior: None,
     };
     mirror.write_rebuild_plan(&plan).unwrap();
@@ -542,7 +562,7 @@ async fn reset_snapshot_removes_old_paths_after_a_remote_rename_and_delete() {
         replica_id: authority.session.replica_id,
         mode: SyncReplicaMode::ReadOnly,
         session,
-        records: vec![renamed.clone()],
+        records: vec![snapshot_record(renamed.clone())],
         prior: mirror.read_state().unwrap(),
     };
     mirror.write_rebuild_plan(&plan).unwrap();
@@ -585,7 +605,10 @@ async fn reset_snapshot_can_atomically_swap_managed_record_paths() {
         replica_id: authority.session.replica_id,
         mode: SyncReplicaMode::ReadOnly,
         session,
-        records: vec![swapped_first.clone(), swapped_second.clone()],
+        records: vec![
+            snapshot_record(swapped_first.clone()),
+            snapshot_record(swapped_second.clone()),
+        ],
         prior: mirror.read_state().unwrap(),
     };
     mirror.write_rebuild_plan(&plan).unwrap();

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -12,6 +12,10 @@ pub const ENCRYPTED_RELAY_PROTOCOL_VERSION: u32 = 1;
 pub const LOOPBACK_PROTOCOL_VERSION: u32 = 1;
 pub const DEFAULT_LOOPBACK_PORT: u16 = 28_485;
 pub const SYNC_PROTOCOL_VERSION: u32 = 1;
+pub const RELAY_HANDSHAKE_TIMEOUT_SECONDS: u64 = 5;
+pub const RELAY_INCOMPATIBLE_CLOSE_CODE: u16 = 4406;
+pub const RELAY_CAPABILITIES: &[&str] =
+    &["authorization-activation", "encrypted-relay", "policy-ack"];
 pub const RELAY_ENCRYPTION_SUITE: &str = "P256-HKDF-SHA256-AES256GCM";
 pub const AUTHORITY_PROOF_VERSION: u32 = 1;
 pub const AUTHORITY_PROOF_ALGORITHM: &str = "P256-SHA256";
@@ -432,6 +436,24 @@ pub struct CollectionChangesPage {
     pub reset: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationRequest {
+    pub protocol_version: u32,
+    pub request_id: Uuid,
+    pub input: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationResponse {
+    pub protocol_version: u32,
+    pub request_id: Uuid,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<ControlError>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyncRecord {
     pub record_id: Uuid,
@@ -510,27 +532,35 @@ pub fn authority_manifest_digest(
     resources: &[SyncResourceDocument],
     records: &[AuthoritySnapshotRecord],
 ) -> String {
-    let mut entries = BTreeMap::<(&str, &str), String>::new();
+    let mut entries = BTreeMap::<(&str, &str), (String, String)>::new();
     for resource in resources {
         entries.insert(
             ("resource", resource.path.as_str()),
-            hex_digest(&Sha256::digest(resource.document.as_bytes())),
+            (
+                String::new(),
+                hex_digest(&Sha256::digest(resource.document.as_bytes())),
+            ),
         );
     }
     for record in records {
         entries.insert(
             ("record", record.record.path.as_str()),
-            record.record.revision.clone(),
+            (
+                record.record.record_id.to_string(),
+                hex_digest(&Sha256::digest(record.document.as_bytes())),
+            ),
         );
     }
     let mut manifest = Sha256::new();
     manifest.update(b"mdbase-authority-manifest-v1\n");
-    for ((kind, path), revision) in entries {
+    for ((kind, path), (identity, document_hash)) in entries {
         manifest.update(kind.as_bytes());
         manifest.update(b"\0");
         manifest.update(path.as_bytes());
         manifest.update(b"\0");
-        manifest.update(revision.as_bytes());
+        manifest.update(identity.as_bytes());
+        manifest.update(b"\0");
+        manifest.update(document_hash.as_bytes());
         manifest.update(b"\n");
     }
     hex_digest(&manifest.finalize())
@@ -625,9 +655,16 @@ pub struct SyncSnapshotPage {
     pub snapshot_id: Uuid,
     pub scope_epoch: u64,
     pub cursor: u64,
-    pub records: Vec<SyncRecord>,
+    pub records: Vec<SyncSnapshotRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_page: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyncSnapshotRecord {
+    #[serde(flatten)]
+    pub record: SyncRecord,
+    pub document: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -748,6 +785,8 @@ pub struct ApplicationRequirements {
     pub contracts: Vec<ContractRequirement>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub access: Option<ApplicationAccess>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection_kind: Option<ApplicationCollectionKind>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -755,6 +794,12 @@ pub struct ApplicationRequirements {
 pub enum ApplicationAccess {
     Contract,
     FullCollection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplicationCollectionKind {
+    Hosted,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -995,8 +1040,8 @@ pub struct GrantEncryption {
     pub scope_epoch: u64,
     pub connector_id: Uuid,
     pub collection_id: Uuid,
-    pub application_public_key: String,
-    pub connector_public_key: String,
+    pub application_agreement_public_key: String,
+    pub connector_agreement_public_key: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1034,9 +1079,35 @@ fn default_collection_name() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RelayMessage {
+    RelayHello {
+        protocol_version: u32,
+        connector_version: String,
+        capabilities: Vec<String>,
+    },
+    RelayWelcome {
+        protocol_version: u32,
+        session_id: String,
+        capabilities: Vec<String>,
+    },
+    RelayIncompatible {
+        protocol_version: u32,
+        code: String,
+        message: String,
+        update_url: String,
+    },
     PolicySnapshot {
         protocol_version: u32,
+        request_id: Uuid,
+        revision: String,
         grants: Vec<GrantPolicy>,
+    },
+    PolicyApplied {
+        protocol_version: u32,
+        request_id: Uuid,
+        revision: String,
+        ok: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<ControlError>,
     },
     AuthorizationOfferRequest {
         protocol_version: u32,
@@ -1224,6 +1295,29 @@ mod tests {
             Uuid::parse_str("01944444-4444-7444-8444-444444444444").unwrap(),
         ];
         for message in [
+            RelayMessage::RelayHello {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                connector_version: "0.1.0-beta.16".to_string(),
+                capabilities: RELAY_CAPABILITIES
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect(),
+            },
+            RelayMessage::RelayWelcome {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                session_id: "42".to_string(),
+                capabilities: RELAY_CAPABILITIES
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect(),
+            },
+            RelayMessage::RelayIncompatible {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                code: "connector_upgrade_required".to_string(),
+                message: "Update required.".to_string(),
+                update_url: "https://github.com/mdbase-dev/mdbase-connect/releases/latest"
+                    .to_string(),
+            },
             RelayMessage::AuthorizationOfferRequest {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
                 request_id: ids[0],
@@ -1265,6 +1359,8 @@ mod tests {
             },
             RelayMessage::PolicySnapshot {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: ids[0],
+                revision: format!("sha256:{}", "0".repeat(64)),
                 grants: vec![GrantPolicy {
                     id: ids[1],
                     application_id: ids[3],
@@ -1283,6 +1379,13 @@ mod tests {
                     encryption: None,
                 }],
             },
+            RelayMessage::PolicyApplied {
+                protocol_version: CONTROL_PROTOCOL_VERSION,
+                request_id: ids[0],
+                revision: format!("sha256:{}", "0".repeat(64)),
+                ok: true,
+                error: None,
+            },
         ] {
             assert_schema("", serde_json::to_value(message).unwrap());
         }
@@ -1298,6 +1401,8 @@ mod tests {
         ];
         let message = RelayMessage::PolicySnapshot {
             protocol_version: CONTROL_PROTOCOL_VERSION,
+            request_id: ids[3],
+            revision: format!("sha256:{}", "0".repeat(64)),
             grants: vec![GrantPolicy {
                 id: ids[0],
                 application_id: ids[1],
@@ -1320,8 +1425,8 @@ mod tests {
                     scope_epoch: 1,
                     connector_id: ids[3],
                     collection_id: ids[2],
-                    application_public_key: "A".repeat(87),
-                    connector_public_key: "B".repeat(87),
+                    application_agreement_public_key: "A".repeat(87),
+                    connector_agreement_public_key: "B".repeat(87),
                 }),
             }],
         };
@@ -1439,7 +1544,10 @@ mod tests {
                     snapshot_id,
                     scope_epoch: 1,
                     cursor: 1,
-                    records: vec![record.clone()],
+                    records: vec![SyncSnapshotRecord {
+                        record: record.clone(),
+                        document: "---\ntitle: Task\n---\nDo it.\n".to_string(),
+                    }],
                     next_page: None,
                 })
                 .unwrap(),

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 dependencies = [
  "chrono",
  "mdbase",

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2000,6 +2000,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reqwest",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2 0.10.9",
  "sqlx",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -280,12 +280,13 @@ record scope for one named collection.
 
 Downloaded HTML applications use the v1 portable distribution profile described
 in [portable-apps.md](portable-apps.md). They make no web-origin claim and use a
-single-use OAuth device code plus PKCE and the existing per-grant P-256 key.
+single-use OAuth device code plus PKCE and independent per-grant P-256
+agreement and signing keys.
 Their browser origin is the exact opaque value `null`, tokens and non-extractable
 keys are memory-only by default. A local connector requires a matching
 encrypted grant for every operation. A hosted provider instead receives a
 short-lived capability bound to the exact grant, collection, operation set,
-record scope, expiry, opaque `null` origin, and application public key. Every
+record scope, expiry, opaque `null` origin, and application signing public key. Every
 hosted request and refresh carries a replay-protected ECDSA proof over its
 method, target, body, credential, timestamp, and nonce. The SDK exposes the same
 connection API for both routes.
@@ -318,7 +319,7 @@ private deployments, and emergency computer revocation.
 ## Direct local transport
 
 Local-authority grants synchronize the application's exact approved origin to
-the connector. The browser SDK can then send the existing protocol-3 envelope
+the connector. The browser SDK can then send the v1 encrypted operation envelope
 to `http://127.0.0.1:28485/v1/operations`. The fixed endpoint reveals only
 generic protocol readiness. It is separate from the Unix socket or Windows
 pipe used for desktop administration and exposes all grantable collection
@@ -327,7 +328,7 @@ operations through the same connector handler as the relay.
 The loopback listener binds only IPv4 and IPv6 loopback, validates the exact
 `Host` and grant origin, returns exact-origin CORS headers, omits ambient
 credentials, requires `application/mdbase-connect+json`, and bounds request
-size, concurrency, execution time, and per-origin rate. Protocol-3 key proof
+size, concurrency, execution time, and per-origin rate. The v1 cryptographic binding
 remains the operation authority; CORS is an additional browser boundary.
 
 Chrome's Local Network Access permission is requested from an explicit app

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -110,19 +110,21 @@ private key is stored in the agent state directory with owner-only file
 permissions on Unix; its public key is registered when the connector
 synchronizes. Platform keystore integration remains to be implemented.
 
-Each browser application installation creates P-256 material for an
-authorization. The SDK reimports the private key as non-extractable and stores
-its `CryptoKey` plus an atomic message counter in origin-scoped IndexedDB.
+Each browser application installation creates independent P-256 ECDH agreement
+and P-256 ECDSA signing keypairs for an authorization. The SDK reimports both
+private keys as non-extractable and stores them with an atomic message counter
+in origin-scoped IndexedDB. Reusing one keypair for both purposes is rejected.
 Native application key storage remains to be implemented with platform
 keystores.
 
-The authorization request carries the application's public key. Approval binds
+The authorization request carries both application public keys. Approval binds
 these values together:
 
 - protocol and encryption-suite version;
 - grant and application identity;
 - connector and collection identity;
-- application and connector public keys;
+- application agreement and signing public keys and the connector agreement
+  public key;
 - operations and contract scope;
 - creation time and revocation state.
 
@@ -211,7 +213,7 @@ payloads as an incidental message archive.
 
 ### Direct loopback delivery
 
-The same protocol-3 request and response envelopes are used on the connector's
+The same v1 encrypted request and response envelopes are used on the connector's
 browser-only loopback service. This preserves grant binding, key proof, replay
 handling, and response authentication while avoiding control-plane payload
 delivery for same-computer applications. Exact-origin CORS, loopback `Host`

--- a/docs/portable-apps.md
+++ b/docs/portable-apps.md
@@ -39,8 +39,8 @@ any compatible local or hosted collection.
 
 The SDK uses OAuth device authorization with PKCE:
 
-1. The file registers its inline manifest and generates a non-extractable P-256
-   grant key.
+1. The file registers its inline manifest and generates independent,
+   non-extractable P-256 ECDH agreement and ECDSA signing keys.
 2. Connect returns a random, short-lived device code and an eight-character
    user code.
 3. The SDK opens Connect's approval page in a popup and also returns the code
@@ -50,9 +50,9 @@ The SDK uses OAuth device authorization with PKCE:
    the operations.
 5. The SDK polls at the server-provided interval. Every successful response is
    bound to the opaque application origin `null`. A local grant must also
-   contain the same application public key and encrypted relay protocol 1; a
-   hosted grant instead contains a scoped provider capability bound to the same
-   public key.
+   contain the application agreement public key and encrypted relay protocol 1;
+   a hosted grant instead contains a scoped provider capability bound to the
+   application signing public key.
 
 Device codes expire after ten minutes, are stored only as hashes by the control
 plane, are rate limited, and can be consumed once. Polling faster than the
@@ -68,10 +68,10 @@ and ciphertext.
 For a hosted collection, the SDK sends operations directly to the hosted data
 provider. Its short-lived bearer capability selects one replica, collection,
 grant, operation set, record scope, and expiry. Every request additionally
-carries an ECDSA proof from the approved P-256 key over the method, target, body,
+carries an ECDSA proof from the approved signing key over the method, target, body,
 credential, timestamp, and a one-use nonce. The provider requires the exact
 `Origin: null`, verifies the signature, and persists the nonce before serving
-the operation. Refreshing is signed by the same key and rotates both the Connect
+the operation. Refreshing is signed by that key and rotates both the Connect
 credential and provider capability. A copied bearer or refresh token is
 therefore insufficient, and CORS permission alone is never an operation
 capability.
@@ -79,17 +79,18 @@ capability.
 ## Storage and `file://`
 
 All local files have an opaque browser origin serialized as `null`. A portable
-SDK instance therefore uses process-memory token storage and a non-extractable
-process-memory private key by default. Portable hosted capabilities keep that
-key for request and refresh signing. Another downloaded file cannot inherit the
+SDK instance therefore uses process-memory token storage and non-extractable
+process-memory private keys by default. Portable hosted capabilities keep the
+signing key for request and refresh proofs. Another downloaded file cannot inherit the
 credentials through
 `localStorage` or IndexedDB. Reloading or reopening the file requires
 authorization again.
 
 An embedding shell may inject custom `storage` and `keyStore` adapters. That is
-an explicit trust decision by the application. A custom key store used with
-portable hosted collections must preserve and return the `signingKey` included
-in `GrantKeyRecord`; existing local-collection adapters remain compatible.
+an explicit trust decision by the application. A custom key store must preserve
+all four `GrantKeyRecord` fields: `agreementPublicKey`,
+`agreementPrivateKey`, `signingPublicKey`, and `signingPrivateKey`. This is the
+only pre-release v1 shape; legacy key-store records are intentionally rejected.
 `connect.environment()` reports whether the defaults are `memory`, `persistent`,
 or `custom`.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.15
-git tag -a v0.1.0-beta.15 -m "mdbase connect 0.1.0-beta.15"
-git push origin v0.1.0-beta.15
+pnpm version:check v0.1.0-beta.16
+git tag -a v0.1.0-beta.16 -m "mdbase connect 0.1.0-beta.16"
+git push origin v0.1.0-beta.16
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -381,11 +381,12 @@ scheme must match the declaration ID. PKCE remains mandatory. Call
 link.
 
 New authorizations require encrypted relay protocol 1 by default. The SDK keeps
-a non-extractable per-authorization P-256 key and atomic message counter in
-IndexedDB, encrypts operation inputs for the connector, and decrypts connector
-results locally. Set `relayEncryption: "disabled"` only for development where
-end-to-end relay encryption is intentionally unavailable; an encrypted grant
-never falls back to plaintext.
+independent non-extractable P-256 ECDH agreement and ECDSA signing keys plus an
+atomic message counter in IndexedDB. It encrypts operation inputs for the
+connector, decrypts connector results locally, and signs hosted authority
+requests with the independent signing key. Set `relayEncryption: "disabled"`
+only for development where end-to-end relay encryption is intentionally
+unavailable; an encrypted grant never falls back to plaintext.
 
 For a hosted collection, the same authorization exchange returns a short-lived,
 grant-bound provider capability. The SDK routes operations directly to the

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/crypto.test.ts
+++ b/packages/client/src/crypto.test.ts
@@ -107,6 +107,23 @@ describe("encrypted relay client", () => {
     )).rejects.toEqual(expect.objectContaining<Partial<RelayCryptoError>>({ code: "invalid_public_key" }));
   });
 
+  it("rejects relay bindings with non-protocol identities", async () => {
+    const { applicationStore, encryption } = await fixture();
+    await expect(encryptRelayRequest(
+      applicationStore,
+      "grant",
+      {
+        grantId: ids.grant,
+        applicationId: ids.application,
+        encryption: { ...encryption, connector_id: "stale-connector-id" }
+      },
+      "read",
+      {}
+    )).rejects.toEqual(expect.objectContaining<Partial<RelayCryptoError>>({
+      code: "unsupported_encryption"
+    }));
+  });
+
   it("uses an independent non-extractable P-256 key for authority proofs", async () => {
     const store = new MemoryGrantKeyStore();
     const record = await store.create("authority");

--- a/packages/client/src/crypto.test.ts
+++ b/packages/client/src/crypto.test.ts
@@ -29,8 +29,8 @@ async function fixture() {
     scope_epoch: 1,
     connector_id: ids.connector,
     collection_id: ids.collection,
-    application_public_key: application.publicKey,
-    connector_public_key: connector.publicKey
+    application_agreement_public_key: application.agreementPublicKey,
+    connector_agreement_public_key: connector.agreementPublicKey
   };
   return { applicationStore, encryption };
 }
@@ -39,7 +39,7 @@ describe("encrypted relay client", () => {
   it("keeps private keys non-extractable and emits only ciphertext plus bound metadata", async () => {
     const { applicationStore, encryption } = await fixture();
     const key = await applicationStore.get("grant");
-    expect(key?.privateKey.extractable).toBe(false);
+    expect(key?.agreementPrivateKey.extractable).toBe(false);
     const request = await encryptRelayRequest(
       applicationStore,
       "grant",
@@ -100,22 +100,24 @@ describe("encrypted relay client", () => {
       {
         grantId: ids.grant,
         applicationId: ids.application,
-        encryption: { ...encryption, connector_public_key: "not-a-p256-key" }
+        encryption: { ...encryption, connector_agreement_public_key: "not-a-p256-key" }
       },
       "read",
       {}
     )).rejects.toEqual(expect.objectContaining<Partial<RelayCryptoError>>({ code: "invalid_public_key" }));
   });
 
-  it("uses the same non-extractable P-256 key for remote authority proofs", async () => {
+  it("uses an independent non-extractable P-256 key for authority proofs", async () => {
     const store = new MemoryGrantKeyStore();
     const record = await store.create("authority");
-    expect(record.privateKey.algorithm.name).toBe("ECDH");
-    expect(record.signingKey?.algorithm.name).toBe("ECDSA");
-    expect(record.signingKey?.extractable).toBe(false);
+    expect(record.agreementPrivateKey.algorithm.name).toBe("ECDH");
+    expect(record.signingPrivateKey.algorithm.name).toBe("ECDSA");
+    expect(record.agreementPrivateKey.extractable).toBe(false);
+    expect(record.signingPrivateKey.extractable).toBe(false);
+    expect(record.signingPublicKey).not.toBe(record.agreementPublicKey);
     const timestamp = 1_785_000_000;
     const nonce = "01955555-5555-4555-8555-555555555555";
-    const headers = await signAuthorityRequest(store, "authority", record.publicKey, {
+    const headers = await signAuthorityRequest(store, "authority", record.signingPublicKey, {
       method: "POST",
       target: "/v1/authorities/one/operations/create",
       body: "{\"title\":\"proof\"}",
@@ -125,7 +127,7 @@ describe("encrypted relay client", () => {
     });
     const publicKey = await crypto.subtle.importKey(
       "raw",
-      base64UrlBytes(record.publicKey),
+      base64UrlBytes(record.signingPublicKey),
       { name: "ECDSA", namedCurve: "P-256" },
       false,
       ["verify"]

--- a/packages/client/src/crypto.ts
+++ b/packages/client/src/crypto.ts
@@ -15,6 +15,8 @@ const STORE_NAME = "grant-keys";
 const MAX_U64 = 18_446_744_073_709_551_615n;
 const REQUEST_INFO = "mdbase-connect relay request key v1";
 const RESPONSE_INFO = "mdbase-connect relay response key v1";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export interface GrantKeyRecord {
   handle: string;
@@ -236,7 +238,7 @@ export async function encryptRelayRequest(
   input: unknown,
   requestId: string = crypto.randomUUID()
 ): Promise<EncryptedRelayOperationRequest> {
-  validateEncryption(binding.encryption);
+  validateGrantEncryption(binding.encryption);
   const record = await requireAgreementKey(
     store,
     handle,
@@ -468,14 +470,27 @@ function sameEnvelopeMetadata(
     && request.counter === response.counter;
 }
 
-function validateEncryption(encryption: GrantEncryption): void {
+export function validateGrantEncryption(encryption: GrantEncryption): void {
   if (encryption.protocol_version !== ENCRYPTED_RELAY_PROTOCOL_VERSION
       || encryption.suite !== RELAY_ENCRYPTION_SUITE
       || !Number.isSafeInteger(encryption.scope_epoch)
       || encryption.scope_epoch <= 0
-      || !encryption.key_id
+      || typeof encryption.key_id !== "string"
+      || encryption.key_id.length === 0
+      || encryption.key_id.length > 200
       || encryption.key_id.includes("|")) {
     throw new RelayCryptoError("unsupported_encryption", "The grant uses an unsupported relay encryption profile.");
+  }
+  if (
+    typeof encryption.connector_id !== "string"
+    || !UUID_PATTERN.test(encryption.connector_id)
+    || typeof encryption.collection_id !== "string"
+    || !UUID_PATTERN.test(encryption.collection_id)
+  ) {
+    throw new RelayCryptoError(
+      "unsupported_encryption",
+      "The grant uses invalid encrypted relay identities."
+    );
   }
   p256PublicKey(encryption.application_agreement_public_key);
   p256PublicKey(encryption.connector_agreement_public_key);

--- a/packages/client/src/crypto.ts
+++ b/packages/client/src/crypto.ts
@@ -18,9 +18,10 @@ const RESPONSE_INFO = "mdbase-connect relay response key v1";
 
 export interface GrantKeyRecord {
   handle: string;
-  privateKey: CryptoKey;
-  signingKey?: CryptoKey;
-  publicKey: string;
+  agreementPrivateKey: CryptoKey;
+  agreementPublicKey: string;
+  signingPrivateKey: CryptoKey;
+  signingPublicKey: string;
 }
 
 export interface GrantKeyStore {
@@ -52,9 +53,10 @@ export class IndexedDbGrantKeyStore implements GrantKeyStore {
     );
     return value ? {
       handle: value.handle,
-      privateKey: value.privateKey,
-      signingKey: value.signingKey,
-      publicKey: value.publicKey
+      agreementPrivateKey: value.agreementPrivateKey,
+      agreementPublicKey: value.agreementPublicKey,
+      signingPrivateKey: value.signingPrivateKey,
+      signingPublicKey: value.signingPublicKey
     } : null;
   }
 
@@ -134,9 +136,10 @@ export class MemoryGrantKeyStore implements GrantKeyStore {
     const value = this.records.get(handle);
     return value ? {
       handle: value.handle,
-      privateKey: value.privateKey,
-      signingKey: value.signingKey,
-      publicKey: value.publicKey
+      agreementPrivateKey: value.agreementPrivateKey,
+      agreementPublicKey: value.agreementPublicKey,
+      signingPrivateKey: value.signingPrivateKey,
+      signingPublicKey: value.signingPublicKey
     } : null;
   }
 
@@ -184,19 +187,13 @@ export async function signAuthorityRequest(
   expectedPublicKey: string,
   input: AuthorityProofInput
 ): Promise<Record<string, string>> {
-  const record = await requireKey(store, handle, expectedPublicKey);
-  if (!record.signingKey) {
-    throw new RelayCryptoError(
-      "missing_grant_key",
-      "The remote authority grant signing key is unavailable. Reconnect this application."
-    );
-  }
+  const record = await requireSigningKey(store, handle, expectedPublicKey);
   const timestamp = input.timestamp ?? Math.floor(Date.now() / 1_000);
   const nonce = input.nonce ?? crypto.randomUUID();
   const message = await authorityProofMessage({ ...input, timestamp, nonce });
   const signature = await crypto.subtle.sign(
     { name: "ECDSA", hash: "SHA-256" },
-    record.signingKey,
+    record.signingPrivateKey,
     new TextEncoder().encode(message)
   );
   return {
@@ -237,13 +234,17 @@ export async function encryptRelayRequest(
   binding: RelayBinding,
   operation: CollectionOperation,
   input: unknown,
-  requestId = crypto.randomUUID()
+  requestId: string = crypto.randomUUID()
 ): Promise<EncryptedRelayOperationRequest> {
   validateEncryption(binding.encryption);
-  const record = await requireKey(store, handle, binding.encryption.application_public_key);
+  const record = await requireAgreementKey(
+    store,
+    handle,
+    binding.encryption.application_agreement_public_key
+  );
   const counter = await store.nextCounter(handle);
   const metadata = { binding, requestId, operation, counter };
-  const key = await deriveDirectionalKey(record.privateKey, binding, "request");
+  const key = await deriveDirectionalKey(record.agreementPrivateKey, binding, "request");
   const plaintext = new TextEncoder().encode(JSON.stringify(input ?? {}));
   const ciphertext = await crypto.subtle.encrypt({
     name: "AES-GCM",
@@ -268,14 +269,18 @@ export async function decryptRelayResponse<Result>(
   if (!sameEnvelopeMetadata(request, response)) {
     throw new RelayCryptoError("invalid_encrypted_response", "Encrypted response metadata does not match its request.");
   }
-  const record = await requireKey(store, handle, binding.encryption.application_public_key);
+  const record = await requireAgreementKey(
+    store,
+    handle,
+    binding.encryption.application_agreement_public_key
+  );
   const metadata = {
     binding,
     requestId: request.request_id,
     operation: request.operation,
     counter: request.counter
   };
-  const key = await deriveDirectionalKey(record.privateKey, binding, "response");
+  const key = await deriveDirectionalKey(record.agreementPrivateKey, binding, "response");
   try {
     const plaintext = await crypto.subtle.decrypt({
       name: "AES-GCM",
@@ -302,36 +307,70 @@ export class RelayCryptoError extends Error {
 }
 
 async function generateGrantKey(handle: string): Promise<GrantKeyRecord> {
-  const generated = await crypto.subtle.generateKey(
-    { name: "ECDSA", namedCurve: "P-256" },
+  const agreement = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
     true,
-    ["sign", "verify"]
+    ["deriveBits"]
   ) as CryptoKeyPair;
-  const publicKey = bytesToBase64Url(new Uint8Array(
-    await crypto.subtle.exportKey("raw", generated.publicKey)
+  const agreementPublicKey = bytesToBase64Url(new Uint8Array(
+    await crypto.subtle.exportKey("raw", agreement.publicKey)
   ));
-  const privatePkcs8 = await crypto.subtle.exportKey("pkcs8", generated.privateKey);
-  const privateKey = await crypto.subtle.importKey(
+  const agreementPkcs8 = await crypto.subtle.exportKey("pkcs8", agreement.privateKey);
+  const agreementPrivateKey = await crypto.subtle.importKey(
     "pkcs8",
-    privatePkcs8,
+    agreementPkcs8,
     { name: "ECDH", namedCurve: "P-256" },
     false,
     ["deriveBits"]
   );
-  const signingKey = await crypto.subtle.importKey(
+  const signing = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"]
+  ) as CryptoKeyPair;
+  const signingPublicKey = bytesToBase64Url(new Uint8Array(
+    await crypto.subtle.exportKey("raw", signing.publicKey)
+  ));
+  const signingPkcs8 = await crypto.subtle.exportKey("pkcs8", signing.privateKey);
+  const signingPrivateKey = await crypto.subtle.importKey(
     "pkcs8",
-    privatePkcs8,
+    signingPkcs8,
     { name: "ECDSA", namedCurve: "P-256" },
     false,
     ["sign"]
   );
-  return { handle, privateKey, signingKey, publicKey };
+  return {
+    handle,
+    agreementPrivateKey,
+    agreementPublicKey,
+    signingPrivateKey,
+    signingPublicKey
+  };
 }
 
-async function requireKey(store: GrantKeyStore, handle: string, expectedPublicKey: string): Promise<GrantKeyRecord> {
+async function requireAgreementKey(
+  store: GrantKeyStore,
+  handle: string,
+  expectedPublicKey: string
+): Promise<GrantKeyRecord> {
   const record = await store.get(handle);
-  if (!record || record.publicKey !== expectedPublicKey) {
+  if (!record || record.agreementPublicKey !== expectedPublicKey) {
     throw new RelayCryptoError("missing_grant_key", "The encrypted grant key is unavailable or does not match the grant.");
+  }
+  return record;
+}
+
+async function requireSigningKey(
+  store: GrantKeyStore,
+  handle: string,
+  expectedPublicKey: string
+): Promise<GrantKeyRecord> {
+  const record = await store.get(handle);
+  if (!record || record.signingPublicKey !== expectedPublicKey) {
+    throw new RelayCryptoError(
+      "missing_grant_key",
+      "The remote authority signing key is unavailable or does not match the grant."
+    );
   }
   return record;
 }
@@ -346,7 +385,7 @@ async function deriveDirectionalKey(
   try {
     peer = await crypto.subtle.importKey(
       "raw",
-      toArrayBuffer(p256PublicKey(binding.encryption.connector_public_key)),
+      toArrayBuffer(p256PublicKey(binding.encryption.connector_agreement_public_key)),
       { name: "ECDH", namedCurve: "P-256" },
       false,
       []
@@ -438,8 +477,8 @@ function validateEncryption(encryption: GrantEncryption): void {
       || encryption.key_id.includes("|")) {
     throw new RelayCryptoError("unsupported_encryption", "The grant uses an unsupported relay encryption profile.");
   }
-  p256PublicKey(encryption.application_public_key);
-  p256PublicKey(encryption.connector_public_key);
+  p256PublicKey(encryption.application_agreement_public_key);
+  p256PublicKey(encryption.connector_agreement_public_key);
 }
 
 function nonce(counter: string): Uint8Array<ArrayBuffer> {

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -494,7 +494,7 @@ describe("provider-neutral collection client", () => {
     const keyStore = new MemoryGrantKeyStore();
     const opened = vi.fn();
     const shown: string[] = [];
-    let applicationPublicKey = "";
+    let applicationAgreementPublicKey = "";
     let polls = 0;
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
       const url = String(request);
@@ -510,7 +510,7 @@ describe("provider-neutral collection client", () => {
       }
       if (url.endsWith("/oauth/device_authorization")) {
         const form = new URLSearchParams(String(init?.body));
-        applicationPublicKey = form.get("application_public_key")!;
+        applicationAgreementPublicKey = form.get("application_agreement_public_key")!;
         expect(form.get("relay_protocol")).toBe("1");
         expect(form.get("operations")).toBe("describe,query");
         return jsonResponse({
@@ -552,8 +552,8 @@ describe("provider-neutral collection client", () => {
             scope_epoch: 1,
             connector_id: "00000000-0000-0000-0000-000000000004",
             collection_id: TEST_COLLECTION_ID,
-            application_public_key: applicationPublicKey,
-            connector_public_key: "BFmPz3M5jSOhCzJfU3NTx_JYnNsIs_L-9fY0m7yRLJKPiGNmzF8NYdylXsClXhuDl1nlueHBMWtZGLnEorD_g18"
+            application_agreement_public_key: applicationAgreementPublicKey,
+            connector_agreement_public_key: "BFmPz3M5jSOhCzJfU3NTx_JYnNsIs_L-9fY0m7yRLJKPiGNmzF8NYdylXsClXhuDl1nlueHBMWtZGLnEorD_g18"
           }
         });
       }
@@ -588,7 +588,7 @@ describe("provider-neutral collection client", () => {
     const keyStore = new MemoryGrantKeyStore();
     const deleteKey = vi.spyOn(keyStore, "delete");
     const opened = vi.fn();
-    let applicationPublicKey = "";
+    let applicationSigningPublicKey = "";
     let providerHeaders: Record<string, string> | undefined;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
       const url = String(request);
@@ -602,8 +602,8 @@ describe("provider-neutral collection client", () => {
         });
       }
       if (url.endsWith("/oauth/device_authorization")) {
-        applicationPublicKey = new URLSearchParams(String(init?.body))
-          .get("application_public_key")!;
+        applicationSigningPublicKey = new URLSearchParams(String(init?.body))
+          .get("application_signing_public_key")!;
         return jsonResponse({
           device_code: "hosted-device-secret",
           user_code: "HOST-CODE",
@@ -632,13 +632,16 @@ describe("provider-neutral collection client", () => {
             sync_url: "https://provider.example/v1/authorities/00000000-0000-0000-0000-000000000002/sync",
             replica_id: "00000000-0000-0000-0000-000000000005",
             access_token: "hsa_portable_hosted",
-            proof_public_key: applicationPublicKey
+            proof_public_key: applicationSigningPublicKey
           }
         });
       }
       if (url.includes("/operations/query")) {
         providerHeaders = init?.headers as Record<string, string>;
+        const operation = JSON.parse(String(init?.body));
         return jsonResponse({
+          protocol_version: 1,
+          request_id: operation.request_id,
           ok: true,
           result: { valid: true, result: { results: [] }, diagnostics: [] }
         });
@@ -714,7 +717,7 @@ describe("provider-neutral collection client", () => {
 
   it("rejects a portable token that is not bound to encrypted relay protocol v1", async () => {
     vi.useFakeTimers();
-    let applicationPublicKey = "";
+    let applicationAgreementPublicKey = "";
     const opened = vi.fn();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
       const url = String(request);
@@ -728,8 +731,8 @@ describe("provider-neutral collection client", () => {
         });
       }
       if (url.endsWith("/oauth/device_authorization")) {
-        applicationPublicKey = new URLSearchParams(String(init?.body))
-          .get("application_public_key")!;
+        applicationAgreementPublicKey = new URLSearchParams(String(init?.body))
+          .get("application_agreement_public_key")!;
         return jsonResponse({
           device_code: "device-secret",
           user_code: "ABCD-EFGH",
@@ -758,8 +761,8 @@ describe("provider-neutral collection client", () => {
             scope_epoch: 1,
             connector_id: "00000000-0000-0000-0000-000000000004",
             collection_id: TEST_COLLECTION_ID,
-            application_public_key: applicationPublicKey,
-            connector_public_key: "BFmPz3M5jSOhCzJfU3NTx_JYnNsIs_L-9fY0m7yRLJKPiGNmzF8NYdylXsClXhuDl1nlueHBMWtZGLnEorD_g18"
+            application_agreement_public_key: applicationAgreementPublicKey,
+            connector_agreement_public_key: "BFmPz3M5jSOhCzJfU3NTx_JYnNsIs_L-9fY0m7yRLJKPiGNmzF8NYdylXsClXhuDl1nlueHBMWtZGLnEorD_g18"
           }
         });
       }
@@ -786,7 +789,7 @@ describe("provider-neutral collection client", () => {
 
   it("rejects a remote authority capability served over non-loopback HTTP", async () => {
     vi.useFakeTimers();
-    let applicationPublicKey = "";
+    let applicationSigningPublicKey = "";
     const opened = vi.fn();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
       const url = String(request);
@@ -800,8 +803,8 @@ describe("provider-neutral collection client", () => {
         });
       }
       if (url.endsWith("/oauth/device_authorization")) {
-        applicationPublicKey = new URLSearchParams(String(init?.body))
-          .get("application_public_key")!;
+        applicationSigningPublicKey = new URLSearchParams(String(init?.body))
+          .get("application_signing_public_key")!;
         return jsonResponse({
           device_code: "device-secret",
           user_code: "ABCD-EFGH",
@@ -829,7 +832,7 @@ describe("provider-neutral collection client", () => {
             sync_url: `http://provider.example/v1/authorities/${TEST_COLLECTION_ID}/sync`,
             replica_id: "00000000-0000-0000-0000-000000000005",
             access_token: "authority_access",
-            proof_public_key: applicationPublicKey
+            proof_public_key: applicationSigningPublicKey
           }
         });
       }
@@ -1951,10 +1954,15 @@ describe("authorization renewal", () => {
         accessToken: "hsa_direct"
       }
     }));
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
-      ok: true,
-      result: { valid: true, result: { results: [] }, diagnostics: [] }
-    }), { status: 200, headers: { "content-type": "application/json" } }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      const operation = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({
+        protocol_version: 1,
+        request_id: operation.request_id,
+        ok: true,
+        result: { valid: true, result: { results: [] }, diagnostics: [] }
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    });
     const manager = new MdbaseConnect({
       serverUrl,
       manifest: manifestUrl,
@@ -2062,10 +2070,15 @@ describe("authorization renewal", () => {
           access: "contract",
         }
       }), { status: 200, headers: { "content-type": "application/json" } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({
-        ok: true,
-        result: { valid: true, result: { results: [] }, diagnostics: [] }
-      }), { status: 200, headers: { "content-type": "application/json" } }));
+      .mockImplementationOnce(async (_request, init) => {
+        const operation = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({
+          protocol_version: 1,
+          request_id: operation.request_id,
+          ok: true,
+          result: { valid: true, result: { results: [] }, diagnostics: [] }
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      });
 
     const manager = new MdbaseConnect({
       serverUrl,
@@ -2120,10 +2133,15 @@ describe("authorization renewal", () => {
           error: { code: "invalid_grant", message: "Refresh token has already been used." }
         }), { status: 400, headers: { "content-type": "application/json" } });
       })
-      .mockResolvedValueOnce(new Response(JSON.stringify({
-        ok: true,
-        result: { valid: true, result: { results: [] }, diagnostics: [] }
-      }), { status: 200, headers: { "content-type": "application/json" } }));
+      .mockImplementationOnce(async (_request, init) => {
+        const operation = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({
+          protocol_version: 1,
+          request_id: operation.request_id,
+          ok: true,
+          result: { valid: true, result: { results: [] }, diagnostics: [] }
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      });
 
     const manager = new MdbaseConnect({
       serverUrl,
@@ -2454,8 +2472,8 @@ async function encryptedConnection() {
     scope_epoch: 1,
     connector_id: "01933333-3333-7333-8333-333333333333",
     collection_id: collectionId,
-    application_public_key: application.publicKey,
-    connector_public_key: connector.publicKey
+    application_agreement_public_key: application.agreementPublicKey,
+    connector_agreement_public_key: connector.agreementPublicKey
   };
   const tokenKey = storedTokenKey(serverUrl, manifestUrl, collectionId);
   storage.setItem(tokenKey, JSON.stringify({
@@ -2518,8 +2536,8 @@ function progressConnection() {
       scope_epoch: 1,
       connector_id: "00000000-0000-0000-0000-000000000004",
       collection_id: TEST_COLLECTION_ID,
-      application_public_key: "04".padEnd(130, "1"),
-      connector_public_key: "04".padEnd(130, "2")
+      application_agreement_public_key: "04".padEnd(130, "1"),
+      connector_agreement_public_key: "04".padEnd(130, "2")
     },
     keyHandle: "progress-key",
     savedAt: Date.now()

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -490,6 +490,7 @@ describe("provider-neutral collection client", () => {
 
   it("completes key-bound device authorization without redirecting the portable page", async () => {
     vi.useFakeTimers();
+    const portableCollectionId = "01944444-4444-7444-8444-444444444444";
     const storage = new MemoryStorage();
     const keyStore = new MemoryGrantKeyStore();
     const opened = vi.fn();
@@ -539,7 +540,7 @@ describe("provider-neutral collection client", () => {
           token_type: "Bearer",
           expires_in: 900,
           refresh_expires_in: 86_400,
-          collection_id: TEST_COLLECTION_ID,
+          collection_id: portableCollectionId,
           collection_name: "Portable notes",
           operations: ["describe", "query"],
           scope: { contracts: [], access: "full_collection" },
@@ -550,8 +551,8 @@ describe("provider-neutral collection client", () => {
             suite: "P256-HKDF-SHA256-AES256GCM",
             key_id: "portable-key",
             scope_epoch: 1,
-            connector_id: "00000000-0000-0000-0000-000000000004",
-            collection_id: TEST_COLLECTION_ID,
+            connector_id: "01933333-3333-7333-8333-333333333333",
+            collection_id: portableCollectionId,
             application_agreement_public_key: applicationAgreementPublicKey,
             connector_agreement_public_key: "BFmPz3M5jSOhCzJfU3NTx_JYnNsIs_L-9fY0m7yRLJKPiGNmzF8NYdylXsClXhuDl1nlueHBMWtZGLnEorD_g18"
           }
@@ -577,7 +578,7 @@ describe("provider-neutral collection client", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     await expect(authorization).resolves.toMatchObject({
-      connection: { collectionId: TEST_COLLECTION_ID }
+      connection: { collectionId: portableCollectionId }
     });
     expect(connect.connections()).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledTimes(4);
@@ -956,6 +957,7 @@ describe("mobile notifications", () => {
       accessToken: "mdb_notifications",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: { contracts: [], access: "full_collection" },
       expiresAt: Date.now() + 60_000
@@ -1002,7 +1004,8 @@ describe("mobile notifications", () => {
       serverUrl,
       manifest,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
 
@@ -1040,6 +1043,7 @@ describe("mobile notifications", () => {
       accessToken: "mdb_notifications",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: { contracts: [], access: "full_collection" },
       expiresAt: Date.now() + 60_000
@@ -1057,7 +1061,8 @@ describe("mobile notifications", () => {
       serverUrl,
       manifest,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
 
@@ -1109,6 +1114,7 @@ describe("mobile notifications", () => {
       accessToken: "mdb_notifications",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: { contracts: [], access: "full_collection" },
       expiresAt: Date.now() + 60_000
@@ -1149,7 +1155,8 @@ describe("mobile notifications", () => {
       serverUrl,
       manifest,
       redirectUri: "dev.worklog.app://auth/mdbase/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
 
@@ -1201,7 +1208,8 @@ describe("mobile notifications", () => {
       serverUrl,
       manifest,
       redirectUri: "dev.worklog.app://auth/mdbase/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
     storage.removeItem(tokenKey);
@@ -1461,6 +1469,61 @@ describe("application sessions", () => {
     });
   });
 
+  it("invalidates a pre-final relay grant before reading obsolete key fields", async () => {
+    installBrowser(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`);
+    const serverUrl = "https://connect.example";
+    const manifest = "https://tasks.example/manifest.json";
+    const storage = new MemoryStorage();
+    storage.setItem(storedTokenKey(serverUrl, manifest, TEST_COLLECTION_ID), JSON.stringify({
+      version: 1,
+      accessToken: "pre-final-relay-token",
+      refreshToken: "pre-final-refresh-token",
+      clientId: "00000000-0000-0000-0000-000000000001",
+      collectionId: TEST_COLLECTION_ID,
+      collectionName: "Stale relay collection",
+      operations: ["describe", "query"],
+      scope: { contracts: [], access: "full_collection" },
+      expiresAt: Date.now() + 60_000,
+      grantId: "00000000-0000-0000-0000-000000000003",
+      encryption: {
+        protocol_version: 1,
+        suite: "P256-HKDF-SHA256-AES256GCM",
+        key_id: "pre-final-key",
+        scope_epoch: 1,
+        connector_id: "00000000-0000-0000-0000-000000000004",
+        collection_id: TEST_COLLECTION_ID,
+        application_public_key: "obsolete",
+        connector_public_key: "obsolete"
+      },
+      keyHandle: "pre-final-key",
+      savedAt: Date.now()
+    }));
+    storage.setItem(
+      `mdbase-connect:${serverUrl}:${manifest}:connections`,
+      storedConnectionIndex([TEST_COLLECTION_ID])
+    );
+    const manager = new MdbaseConnect({
+      serverUrl,
+      manifest,
+      redirectUri: "https://tasks.example/callback",
+      storage
+    });
+    const session = manager.createSession({
+      selection: new MdbaseBrowserSelection()
+    });
+
+    await session.start();
+
+    expect(session.getSnapshot()).toMatchObject({
+      status: "unavailable",
+      collectionId: TEST_COLLECTION_ID,
+      reason: "invalid_stored_grant"
+    });
+    expect(
+      storage.getItem(storedTokenKey(serverUrl, manifest, TEST_COLLECTION_ID))
+    ).toBeNull();
+  });
+
   it("keeps choose and exact authorization intents distinct", async () => {
     installBrowser(`https://tasks.example/?collection=${TEST_COLLECTION_ID}`);
     const manager = managerWithConnections([TEST_COLLECTION_ID]);
@@ -1618,7 +1681,8 @@ describe("authorization renewal", () => {
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
 
     expect(manager.connections().map(({ displayName }) => displayName)).toEqual([
@@ -1811,6 +1875,7 @@ describe("authorization renewal", () => {
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query", "read"],
       scope: { contracts: [], access: "full_collection" },
       expiresAt: Date.now() + 60_000,
@@ -1868,6 +1933,7 @@ describe("authorization renewal", () => {
       accessToken: "mdb_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: { contracts: [], access: "full_collection" },
       expiresAt: Date.now() + 60_000
@@ -1876,7 +1942,8 @@ describe("authorization renewal", () => {
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
 
@@ -1939,6 +2006,7 @@ describe("authorization renewal", () => {
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: {
         contracts: [WORK_ITEM_CONTRACT],
@@ -1967,7 +2035,8 @@ describe("authorization renewal", () => {
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
 
@@ -1990,6 +2059,7 @@ describe("authorization renewal", () => {
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query", "create", "update", "delete"],
       scope: {
         contracts: [WORK_ITEM_CONTRACT],
@@ -2021,7 +2091,8 @@ describe("authorization renewal", () => {
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
 
@@ -2049,6 +2120,7 @@ describe("authorization renewal", () => {
       refreshToken: "ref_current",
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: {
         contracts: [WORK_ITEM_CONTRACT],
@@ -2084,7 +2156,8 @@ describe("authorization renewal", () => {
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
     const result = await connect.query();
@@ -2106,6 +2179,7 @@ describe("authorization renewal", () => {
     const baseToken = {
       clientId: "00000000-0000-0000-0000-000000000001",
       collectionId: "00000000-0000-0000-0000-000000000002",
+      collectionName: "Worklog",
       operations: ["query"],
       scope: {
         contracts: [WORK_ITEM_CONTRACT],
@@ -2147,7 +2221,8 @@ describe("authorization renewal", () => {
       serverUrl,
       manifest: manifestUrl,
       redirectUri: "https://tasks.example/callback",
-      storage
+      storage,
+      relayEncryption: "disabled"
     });
     const connect = manager.connection(TEST_COLLECTION_ID)!;
     const result = await connect.query();
@@ -2547,7 +2622,8 @@ function progressConnection() {
     manifest,
     redirectUri: "https://tasks.example/callback",
     storage,
-    keyStore: new MemoryGrantKeyStore()
+    keyStore: new MemoryGrantKeyStore(),
+    relayEncryption: "disabled"
   });
   return manager.connection(TEST_COLLECTION_ID)!;
 }
@@ -2616,7 +2692,8 @@ function managerWithConnections(collectionIds: string[]): MdbaseConnect {
     serverUrl,
     manifest,
     redirectUri: "https://tasks.example/auth/mdbase/callback",
-    storage
+    storage,
+    relayEncryption: "disabled"
   });
 }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -18,6 +18,7 @@ import type {
   MdbaseAppManifest,
   MdbaseDiagnostic,
   MdbaseOperationEnvelope,
+  MdbaseOperationRequest,
   QueryRecord,
   RecordDocument,
   ReadViewSourceInput,
@@ -879,7 +880,8 @@ interface StoredAuthorization {
   collectionId?: string;
   returnTo?: string;
   keyHandle?: string;
-  applicationPublicKey?: string;
+  applicationAgreementPublicKey?: string;
+  applicationSigningPublicKey?: string;
 }
 
 interface StoredToken {
@@ -912,17 +914,20 @@ interface StoredConnectionIndex {
   collectionIds: string[];
 }
 
-interface PendingEncryptedMutation {
-  grantId: string;
-  keyId: string;
+interface PendingMutation {
+  collectionId: string;
+  grantId?: string;
+  keyId?: string;
   operation: CollectionOperation;
   inputFingerprint: string;
-  envelope: EncryptedRelayOperationRequest;
+  requestId: string;
+  envelope?: EncryptedRelayOperationRequest;
   createdAt: number;
 }
 
 interface OperationAttempt {
   response: Response;
+  requestId: string;
   encryptedRequest?: Awaited<ReturnType<typeof encryptRelayRequest>>;
   directDeliveryUncertain?: boolean;
   pendingMutation?: boolean;
@@ -1592,7 +1597,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
       collectionId: targetCollectionId,
       returnTo: options.returnTo,
       keyHandle,
-      applicationPublicKey: grantKey?.publicKey
+      applicationAgreementPublicKey: grantKey?.agreementPublicKey,
+      applicationSigningPublicKey: grantKey?.signingPublicKey
     };
     this.storage.setItem(this.pendingKey(state), JSON.stringify(pending));
     const authorize = new URL(`${this.serverUrl}/oauth/authorize`);
@@ -1610,7 +1616,14 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     }
     if (grantKey) {
       authorize.searchParams.set("relay_protocol", "1");
-      authorize.searchParams.set("application_public_key", grantKey.publicKey);
+      authorize.searchParams.set(
+        "application_agreement_public_key",
+        grantKey.agreementPublicKey
+      );
+      authorize.searchParams.set(
+        "application_signing_public_key",
+        grantKey.signingPublicKey
+      );
     }
     if (this.navigate) await this.navigate(authorize.href);
     else location.assign(authorize.href);
@@ -1647,7 +1660,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
           code_challenge: challenge,
           code_challenge_method: "S256",
           relay_protocol: "1",
-          application_public_key: grantKey.publicKey
+          application_agreement_public_key: grantKey.agreementPublicKey,
+          application_signing_public_key: grantKey.signingPublicKey
         })
       });
       body = await response.json();
@@ -1748,7 +1762,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
         const localEncryption = tokenBody.encryption
           && tokenBody.encryption.protocol_version === ENCRYPTED_RELAY_PROTOCOL_VERSION
           && tokenBody.encryption.suite === RELAY_ENCRYPTION_SUITE
-          && tokenBody.encryption.application_public_key === grantKey.publicKey;
+          && tokenBody.encryption.application_agreement_public_key
+            === grantKey.agreementPublicKey;
         if (tokenBody.application_origin !== "null") {
           throw new MdbaseConnectError(
             "invalid_token_response",
@@ -1760,7 +1775,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
           && (
             !authority
             || tokenBody.encryption != null
-            || tokenBody.authority.proof_public_key !== grantKey.publicKey
+            || tokenBody.authority.proof_public_key !== grantKey.signingPublicKey
           )
         ) {
           throw new MdbaseConnectError(
@@ -1862,7 +1877,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     if (pending.relayEncryption === "required" && !body.authority && (
       !body.encryption
       || !pending.keyHandle
-      || body.encryption.application_public_key !== pending.applicationPublicKey
+      || body.encryption.application_agreement_public_key
+        !== pending.applicationAgreementPublicKey
     )) {
       if (pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
       this.storage.removeItem(pendingKey);
@@ -1874,8 +1890,8 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     if (body.authority?.proof_public_key) {
       if (
         !pending.keyHandle
-        || !pending.applicationPublicKey
-        || body.authority.proof_public_key !== pending.applicationPublicKey
+        || !pending.applicationSigningPublicKey
+        || body.authority.proof_public_key !== pending.applicationSigningPublicKey
       ) {
         if (pending.keyHandle) await this.keyStore.delete(pending.keyHandle);
         this.storage.removeItem(pendingKey);
@@ -2700,11 +2716,12 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
   }
 
   pendingMutation(): PendingMutationSummary | null {
-    const pending = parseStored<PendingEncryptedMutation>(this.storage.getItem(this.pendingMutationKey()));
+    const pending = parseStored<PendingMutation>(this.storage.getItem(this.pendingMutationKey()));
     const token = this.currentToken();
-    if (!pending || !token?.grantId || !token.encryption
+    if (!pending || !token
+        || pending.collectionId !== token.collectionId
         || pending.grantId !== token.grantId
-        || pending.keyId !== token.encryption.key_id) return null;
+        || pending.keyId !== token.encryption?.key_id) return null;
     return { operation: pending.operation, createdAt: pending.createdAt, resumable: true };
   }
 
@@ -2817,7 +2834,9 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     const staleBinding = response.status === 409
       && (await response.clone().json().catch(() => null))?.error?.code === "encryption_binding_stale";
     if ((response.status === 401 || staleBinding) && token.refreshToken) {
-      if (attempt.pendingMutation && (attempt.directDeliveryUncertain || attempt.resumingMutation)) {
+      if (attempt.pendingMutation
+          && (attempt.directDeliveryUncertain
+            || (attempt.encryptedRequest && attempt.resumingMutation))) {
         throw new MdbaseConnectError(
           "direct_outcome_unknown",
           "The direct operation may have completed, but its encrypted grant changed before the response could be recovered. Refresh before making another change."
@@ -2836,10 +2855,12 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     const body = await response.json();
     if (!response.ok) {
       const error = apiError(body, "operation_failed", "Collection operation failed.", response.status);
-      if (attempt.pendingMutation && (attempt.directDeliveryUncertain || attempt.resumingMutation)) {
+      if (attempt.pendingMutation
+          && (attempt.directDeliveryUncertain
+            || (attempt.encryptedRequest && attempt.resumingMutation))) {
         throw uncertainDirectMutation(error);
       }
-      if (attempt.pendingMutation && !attempt.directDeliveryUncertain && !attempt.resumingMutation) {
+      if (attempt.pendingMutation && !attempt.directDeliveryUncertain) {
         this.clearPendingMutation();
       }
       if (error.code === "direct_operation_rejected" && error.status === 403) {
@@ -2872,6 +2893,13 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
         throw error;
       }
     }
+    if (body?.protocol_version !== 1 || body?.request_id !== attempt.requestId) {
+      throw new MdbaseConnectError(
+        "invalid_operation_response",
+        "The collection authority returned a response for a different protocol request."
+      );
+    }
+    if (attempt.pendingMutation) this.clearPendingMutation();
     return body.result as Result;
   }
 
@@ -2946,46 +2974,64 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
     let encryptedRequest: Awaited<ReturnType<typeof encryptRelayRequest>> | undefined;
     let pendingMutation = false;
     let resumingMutation = false;
+    let requestId: string = crypto.randomUUID();
+    let pending: PendingMutation | null = null;
+    let inputFingerprint: string | undefined;
+    if (isMutation(operation, input)) {
+      inputFingerprint = await operationFingerprint(operation, input);
+      pending = parseStored<PendingMutation>(
+        this.storage.getItem(this.pendingMutationKey())
+      );
+      if (pending) {
+        if (pending.collectionId !== token.collectionId
+            || pending.grantId !== token.grantId
+            || pending.keyId !== token.encryption?.key_id
+            || pending.operation !== operation
+            || pending.inputFingerprint !== inputFingerprint) {
+          throw new MdbaseConnectError(
+            "pending_mutation_unresolved",
+            "A previous write still has an unknown outcome. Retry that exact write before making another change."
+          );
+        }
+        requestId = pending.requestId;
+        resumingMutation = true;
+      }
+      pendingMutation = true;
+    }
     if (token.encryption && !token.authority) {
       if (!token.grantId || !token.keyHandle) {
         throw new MdbaseConnectError("missing_grant_key", "Reconnect this application to restore encrypted access.");
       }
       try {
-        if (isMutation(operation, input)) {
-          const inputFingerprint = await operationFingerprint(operation, input);
-          const pending = parseStored<PendingEncryptedMutation>(
-            this.storage.getItem(this.pendingMutationKey())
-          );
+        if (pendingMutation) {
           if (pending) {
-            if (pending.grantId !== token.grantId
-                || pending.keyId !== token.encryption.key_id
-                || pending.operation !== operation
-                || pending.inputFingerprint !== inputFingerprint) {
+            if (!pending.envelope) {
               throw new MdbaseConnectError(
                 "pending_mutation_unresolved",
-                "A previous direct write still has an unknown outcome. Retry that same write before making another change."
+                "The pending write belongs to a different transport. Reconnect before retrying it."
               );
             }
             encryptedRequest = pending.envelope;
-            resumingMutation = true;
           } else {
             encryptedRequest = await encryptRelayRequest(
               this.keyStore,
               token.keyHandle,
               { grantId: token.grantId, applicationId: token.clientId, encryption: token.encryption },
               operation,
-              input
+              input,
+              requestId
             );
             this.storage.setItem(this.pendingMutationKey(), JSON.stringify({
-              grantId: token.grantId,
+              collectionId: token.collectionId,
+              ...(token.grantId ? { grantId: token.grantId } : {}),
               keyId: token.encryption.key_id,
               operation,
-              inputFingerprint,
+              inputFingerprint: inputFingerprint!,
+              requestId,
               envelope: encryptedRequest,
               createdAt: Date.now()
-            } satisfies PendingEncryptedMutation));
+            } satisfies PendingMutation));
           }
-          pendingMutation = true;
         } else {
           encryptedRequest = await encryptRelayRequest(
             this.keyStore,
@@ -3000,6 +3046,23 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
         throw error;
       }
       body = encryptedRequest;
+    } else {
+      const request: MdbaseOperationRequest = {
+        protocol_version: 1,
+        request_id: requestId,
+        input: body
+      };
+      body = request;
+      if (pendingMutation && !pending) {
+        this.storage.setItem(this.pendingMutationKey(), JSON.stringify({
+          collectionId: token.collectionId,
+          ...(token.grantId ? { grantId: token.grantId } : {}),
+          operation,
+          inputFingerprint: inputFingerprint!,
+          requestId,
+          createdAt: Date.now()
+        } satisfies PendingMutation));
+      }
     }
     if (tryDirect && encryptedRequest && !token.authority) {
       let directDeliveryUncertain = false;
@@ -3015,7 +3078,13 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
             this.markDirectAvailable();
             this.setRoute("direct");
           }
-          return { response, encryptedRequest, pendingMutation, resumingMutation };
+          return {
+            response,
+            requestId,
+            encryptedRequest,
+            pendingMutation,
+            resumingMutation
+          };
         }
         directDeliveryUncertain = response.status >= 500;
         this.markDirectUnavailable();
@@ -3053,7 +3122,14 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
         throw error;
       }
       if (response.ok) this.setRoute("relay");
-      return { response, encryptedRequest, directDeliveryUncertain, pendingMutation, resumingMutation };
+      return {
+        response,
+        requestId,
+        encryptedRequest,
+        directDeliveryUncertain,
+        pendingMutation,
+        resumingMutation
+      };
     }
     const operationUrl = token.authority
       ? `${token.authority.operationsUrl}/${operation}`
@@ -3079,7 +3155,7 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
         signal: options.signal
       });
     if (response.ok) this.setRoute(token.authority ? "remote" : "relay");
-    return { response, encryptedRequest, pendingMutation, resumingMutation };
+    return { response, requestId, encryptedRequest, pendingMutation, resumingMutation };
   }
 
   private directCapable(token: StoredToken | null): boolean {
@@ -3093,7 +3169,7 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
 
   private hasResumableMutationTransport(): boolean {
     const token = this.currentToken();
-    return Boolean(token?.encryption && !token.authority && token.grantId && token.keyHandle);
+    return Boolean(token);
   }
 
   private directEligible(token: StoredToken | null): token is StoredToken {
@@ -3629,7 +3705,7 @@ function sortJson(value: unknown): unknown {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
         .filter(([, item]) => item !== undefined)
-        .sort(([left], [right]) => left.localeCompare(right))
+        .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
         .map(([key, item]) => [key, sortJson(item)])
     );
   }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -46,6 +46,7 @@ import {
   MemoryGrantKeyStore,
   RelayCryptoError,
   signAuthorityRequest,
+  validateGrantEncryption,
   type GrantKeyStore
 } from "./crypto.js";
 
@@ -1972,8 +1973,36 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
         "Authorization returned an invalid remote authority capability."
       );
     }
+    if (body.authority && body.encryption) {
+      throw new MdbaseConnectError(
+        "invalid_token_response",
+        "Authorization returned conflicting collection transports."
+      );
+    }
+    if (body.encryption) {
+      try {
+        validateGrantEncryption(body.encryption);
+      } catch {
+        throw new MdbaseConnectError(
+          "invalid_token_response",
+          "Authorization returned an invalid encrypted relay binding."
+        );
+      }
+      if (
+        body.encryption.collection_id !== collectionId
+        || typeof body.grant_id !== "string"
+        || body.grant_id.length === 0
+      ) {
+        throw new MdbaseConnectError(
+          "invalid_token_response",
+          "Authorization returned an encrypted relay binding for another grant."
+        );
+      }
+    }
     const previous = parseStored<StoredToken>(this.storage.getItem(this.tokenKey(collectionId)));
-    if (previous?.keyHandle && previous.keyHandle !== keyHandle) void this.keyStore.delete(previous.keyHandle);
+    if (previous?.keyHandle && previous.keyHandle !== keyHandle) {
+      void this.keyStore.delete(previous.keyHandle).catch(() => undefined);
+    }
     const token: StoredToken = {
       version: 1,
       accessToken: body.access_token,
@@ -2014,7 +2043,7 @@ class MdbaseConnectInternals<Frontmatter extends JsonObject> {
     reason: MdbaseUnavailableReason = "authorization_lost"
   ): void {
     this.invalidatedConnections.set(collectionId, reason);
-    if (keyHandle) void this.keyStore.delete(keyHandle);
+    if (keyHandle) void this.keyStore.delete(keyHandle).catch(() => undefined);
     this.storage.removeItem(this.tokenKey(collectionId));
     this.storage.removeItem(this.pendingMutationKey(collectionId));
     for (const transport of ["web_push", "fcm"] as const) {
@@ -3263,17 +3292,69 @@ export class MdbaseConnection<Frontmatter extends JsonObject = JsonObject> {
   private currentToken(): StoredToken | null {
     const stored = this.storage.getItem(this.tokenKey());
     const token = parseStored<StoredToken>(stored);
+    const invalidate = (keyHandle?: unknown): null => {
+      this.internals.removeToken(
+        this.collectionId,
+        typeof keyHandle === "string" ? keyHandle : undefined,
+        "invalid_stored_grant"
+      );
+      return null;
+    };
     if (!token) {
-      if (stored) this.internals.removeToken(this.collectionId, undefined, "invalid_stored_grant");
+      if (stored) invalidate();
       return null;
     }
-    if (token.version !== 1) {
-      this.internals.removeToken(this.collectionId, token.keyHandle, "invalid_stored_grant");
-      return null;
-    }
+    if (
+      token.version !== 1
+      || typeof token.accessToken !== "string"
+      || token.accessToken.length === 0
+      || typeof token.clientId !== "string"
+      || token.clientId.length === 0
+      || token.collectionId !== this.collectionId
+      || typeof token.collectionName !== "string"
+      || token.collectionName.length === 0
+      || !Array.isArray(token.operations)
+      || token.operations.some((operation) => typeof operation !== "string")
+      || typeof token.expiresAt !== "number"
+      || !Number.isFinite(token.expiresAt)
+      || (
+        token.refreshToken !== undefined
+        && (
+          typeof token.refreshToken !== "string"
+          || token.refreshToken.length === 0
+        )
+      )
+      || (
+        token.refreshExpiresAt !== undefined
+        && (
+          typeof token.refreshExpiresAt !== "number"
+          || !Number.isFinite(token.refreshExpiresAt)
+        )
+      )
+    ) return invalidate(token.keyHandle);
     if (!parseGrantScope(token.scope)) {
-      this.internals.removeToken(this.collectionId, token.keyHandle, "invalid_stored_grant");
-      return null;
+      return invalidate(token.keyHandle);
+    }
+    if (
+      token.authority
+      && !validStoredAuthority(token.authority, token.collectionId)
+    ) {
+      return invalidate(token.keyHandle);
+    }
+    if (this.internals.relayEncryption === "required") {
+      if (token.authority) {
+        if (!token.keyHandle || !token.authority.proofPublicKey) {
+          return invalidate(token.keyHandle);
+        }
+      } else {
+        if (
+          !token.grantId
+          || !token.keyHandle
+          || !validStoredEncryption(token.encryption, token.collectionId)
+        ) {
+          return invalidate(token.keyHandle);
+        }
+      }
     }
     if (token.expiresAt <= Date.now()
         && (!token.refreshToken || (token.refreshExpiresAt ?? 0) <= Date.now())) {
@@ -3772,7 +3853,13 @@ function validAuthorityTokenResponse(value: unknown, collectionId: unknown): boo
     || authority.replica_id.length === 0
     || typeof authority.access_token !== "string"
     || authority.access_token.length === 0
-    || (authority.proof_public_key !== undefined && typeof authority.proof_public_key !== "string")
+    || (
+      authority.proof_public_key !== undefined
+      && (
+        typeof authority.proof_public_key !== "string"
+        || authority.proof_public_key.length === 0
+      )
+    )
   ) return false;
   try {
     const operations = new URL(authority.operations_url);
@@ -3795,6 +3882,35 @@ function validAuthorityTokenResponse(value: unknown, collectionId: unknown): boo
       && operations.origin === sync.origin
       && operations.pathname.split("/")[3] === collectionId
       && sync.pathname.split("/")[3] === collectionId;
+  } catch {
+    return false;
+  }
+}
+
+function validStoredAuthority(
+  authority: StoredToken["authority"],
+  collectionId: string
+): boolean {
+  return validAuthorityTokenResponse({
+    operations_url: authority?.operationsUrl,
+    sync_url: authority?.syncUrl,
+    replica_id: authority?.replicaId,
+    access_token: authority?.accessToken,
+    proof_public_key: authority?.proofPublicKey
+  }, collectionId);
+}
+
+function validStoredEncryption(
+  encryption: StoredToken["encryption"],
+  collectionId: string
+): encryption is GrantEncryption {
+  if (!encryption || typeof encryption !== "object" || Array.isArray(encryption)) {
+    return false;
+  }
+  if (encryption.collection_id !== collectionId) return false;
+  try {
+    validateGrantEncryption(encryption);
+    return true;
   } catch {
     return false;
   }

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/schemas/connect-protocol.v1.schema.json
+++ b/packages/protocol/schemas/connect-protocol.v1.schema.json
@@ -4,9 +4,13 @@
   "title": "mdbase connect protocol 1",
   "description": "Canonical wire shapes shared by applications, the control plane, and connectors.",
   "oneOf": [
+    { "$ref": "#/$defs/relayHello" },
+    { "$ref": "#/$defs/relayWelcome" },
+    { "$ref": "#/$defs/relayIncompatible" },
     { "$ref": "#/$defs/relayOperationRequest" },
     { "$ref": "#/$defs/relayOperationResponse" },
     { "$ref": "#/$defs/relayPolicySnapshot" },
+    { "$ref": "#/$defs/relayPolicyApplied" },
     { "$ref": "#/$defs/authorizationOfferRequest" },
     { "$ref": "#/$defs/authorizationOfferResponse" },
     { "$ref": "#/$defs/authorizationActivationRequest" },
@@ -75,6 +79,48 @@
         "diagnostics": { "type": "array", "items": { "$ref": "#/$defs/diagnostic" } }
       }
     },
+    "relayHello": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "connector_version", "capabilities"],
+      "properties": {
+        "type": { "const": "relay_hello" },
+        "protocol_version": { "const": 1 },
+        "connector_version": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "capabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "maxLength": 100 }
+        }
+      }
+    },
+    "relayWelcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "session_id", "capabilities"],
+      "properties": {
+        "type": { "const": "relay_welcome" },
+        "protocol_version": { "const": 1 },
+        "session_id": { "type": "string", "minLength": 1, "maxLength": 100 },
+        "capabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "maxLength": 100 }
+        }
+      }
+    },
+    "relayIncompatible": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "code", "message", "update_url"],
+      "properties": {
+        "type": { "const": "relay_incompatible" },
+        "protocol_version": { "const": 1 },
+        "code": { "const": "connector_upgrade_required" },
+        "message": { "type": "string", "minLength": 1 },
+        "update_url": { "type": "string", "format": "uri", "pattern": "^https://" }
+      }
+    },
     "relayOperationRequest": {
       "type": "object",
       "additionalProperties": false,
@@ -89,6 +135,50 @@
         "operation": { "$ref": "#/$defs/operation" },
         "input": true
       }
+    },
+    "operationHttpRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["protocol_version", "request_id", "input"],
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "input": true
+      }
+    },
+    "operationHttpResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["protocol_version", "request_id", "ok"],
+      "properties": {
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "ok": { "type": "boolean" },
+        "result": true,
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message"],
+          "properties": {
+            "code": { "type": "string", "minLength": 1 },
+            "message": { "type": "string" },
+            "details": true
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "ok": { "const": true } }, "required": ["ok"] },
+          "then": {
+            "required": ["result"],
+            "not": { "properties": { "error": true }, "required": ["error"] }
+          },
+          "else": {
+            "required": ["error"],
+            "not": { "properties": { "result": true }, "required": ["result"] }
+          }
+        }
+      ]
     },
     "relayOperationResponse": {
       "type": "object",
@@ -182,7 +272,8 @@
           "maxItems": 20,
           "items": { "$ref": "#/$defs/contractRequirement" }
         },
-        "access": { "enum": ["contract", "full_collection"] }
+        "access": { "enum": ["contract", "full_collection"] },
+        "collection_kind": { "const": "hosted" }
       }
     },
     "typePackProvision": {
@@ -363,7 +454,7 @@
     "grantEncryption": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["protocol_version", "suite", "key_id", "scope_epoch", "connector_id", "collection_id", "application_public_key", "connector_public_key"],
+      "required": ["protocol_version", "suite", "key_id", "scope_epoch", "connector_id", "collection_id", "application_agreement_public_key", "connector_agreement_public_key"],
       "properties": {
         "protocol_version": { "const": 1 },
         "suite": { "const": "P256-HKDF-SHA256-AES256GCM" },
@@ -371,19 +462,50 @@
         "scope_epoch": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
         "connector_id": { "$ref": "#/$defs/uuid" },
         "collection_id": { "$ref": "#/$defs/uuid" },
-        "application_public_key": { "type": "string", "minLength": 80, "maxLength": 200, "pattern": "^[A-Za-z0-9_-]+$" },
-        "connector_public_key": { "type": "string", "minLength": 80, "maxLength": 200, "pattern": "^[A-Za-z0-9_-]+$" }
+        "application_agreement_public_key": { "type": "string", "minLength": 80, "maxLength": 200, "pattern": "^[A-Za-z0-9_-]+$" },
+        "connector_agreement_public_key": { "type": "string", "minLength": 80, "maxLength": 200, "pattern": "^[A-Za-z0-9_-]+$" }
       }
     },
     "relayPolicySnapshot": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "protocol_version", "grants"],
+      "required": ["type", "protocol_version", "request_id", "revision", "grants"],
       "properties": {
         "type": { "const": "policy_snapshot" },
         "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "revision": { "$ref": "#/$defs/digest" },
         "grants": { "type": "array", "items": { "$ref": "#/$defs/grantPolicy" } }
       }
+    },
+    "relayPolicyApplied": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "protocol_version", "request_id", "revision", "ok"],
+      "properties": {
+        "type": { "const": "policy_applied" },
+        "protocol_version": { "const": 1 },
+        "request_id": { "$ref": "#/$defs/uuid" },
+        "revision": { "$ref": "#/$defs/digest" },
+        "ok": { "type": "boolean" },
+        "error": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code", "message"],
+          "properties": {
+            "code": { "type": "string", "minLength": 1 },
+            "message": { "type": "string" },
+            "details": true
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "ok": { "const": true } }, "required": ["ok"] },
+          "then": { "not": { "properties": { "error": true }, "required": ["error"] } },
+          "else": { "required": ["error"] }
+        }
+      ]
     },
     "collectionDescription": {
       "type": "object",

--- a/packages/protocol/schemas/sync.v1.schema.json
+++ b/packages/protocol/schemas/sync.v1.schema.json
@@ -103,6 +103,20 @@
         "types": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } }
       }
     },
+    "snapshotRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "path", "revision", "frontmatter", "body", "types", "document"],
+      "properties": {
+        "record_id": { "$ref": "#/$defs/uuid" },
+        "path": { "type": "string", "minLength": 1 },
+        "revision": { "type": "string", "minLength": 1 },
+        "frontmatter": { "type": "object" },
+        "body": { "type": "string" },
+        "types": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+        "document": { "type": "string" }
+      }
+    },
     "session": {
       "type": "object",
       "additionalProperties": false,
@@ -129,7 +143,7 @@
         "snapshot_id": { "$ref": "#/$defs/uuid" },
         "scope_epoch": { "type": "integer", "minimum": 1 },
         "cursor": { "type": "integer", "minimum": 0 },
-        "records": { "type": "array", "items": { "$ref": "#/$defs/record" } },
+        "records": { "type": "array", "items": { "$ref": "#/$defs/snapshotRecord" } },
         "next_page": { "type": "string", "pattern": "^[1-9][0-9]*$" }
       }
     },

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -4,6 +4,11 @@ export const LOOPBACK_PROTOCOL_VERSION = 1 as const;
 export const DEFAULT_LOOPBACK_PORT = 28_485 as const;
 export const RELAY_ENCRYPTION_SUITE = "P256-HKDF-SHA256-AES256GCM" as const;
 export const SYNC_PROTOCOL_VERSION = 1 as const;
+export const RELAY_CAPABILITIES = [
+  "authorization-activation",
+  "encrypted-relay",
+  "policy-ack"
+] as const;
 export const AUTHORITY_PROOF_VERSION = 1 as const;
 export const AUTHORITY_PROOF_ALGORITHM = "P256-SHA256" as const;
 export const AUTHORITY_PROOF_DOMAIN = "mdbase-authority-request-proof-v1" as const;
@@ -282,6 +287,30 @@ export interface RelayOperationResponse {
   };
 }
 
+export interface MdbaseOperationRequest<Input = unknown> {
+  protocol_version: 1;
+  request_id: string;
+  input: Input;
+}
+
+export type MdbaseOperationResponse<Result = unknown> =
+  | {
+      protocol_version: 1;
+      request_id: string;
+      ok: true;
+      result: Result;
+    }
+  | {
+      protocol_version: 1;
+      request_id: string;
+      ok: false;
+      error: {
+        code: string;
+        message: string;
+        details?: unknown;
+      };
+    };
+
 export interface GrantPolicy {
   id: string;
   application_id: string;
@@ -311,8 +340,8 @@ export interface GrantEncryption {
   scope_epoch: number;
   connector_id: string;
   collection_id: string;
-  application_public_key: string;
-  connector_public_key: string;
+  application_agreement_public_key: string;
+  connector_agreement_public_key: string;
 }
 
 export interface EncryptedRelayEnvelope {
@@ -419,8 +448,13 @@ export interface SyncSnapshotPage<Frontmatter extends JsonObject = JsonObject> {
   snapshot_id: string;
   scope_epoch: number;
   cursor: number;
-  records: Array<SyncRecord<Frontmatter>>;
+  records: Array<SyncSnapshotRecord<Frontmatter>>;
   next_page?: string;
+}
+
+export interface SyncSnapshotRecord<Frontmatter extends JsonObject = JsonObject>
+  extends SyncRecord<Frontmatter> {
+  document: string;
 }
 
 export type SyncChange<Frontmatter extends JsonObject = JsonObject> =
@@ -472,7 +506,44 @@ export type EncryptedRelayOperationResponse = EncryptedRelayEnvelope & {
 export interface RelayPolicySnapshot {
   type: "policy_snapshot";
   protocol_version: 1;
+  request_id: string;
+  revision: string;
   grants: GrantPolicy[];
+}
+
+export interface RelayHello {
+  type: "relay_hello";
+  protocol_version: 1;
+  connector_version: string;
+  capabilities: string[];
+}
+
+export interface RelayWelcome {
+  type: "relay_welcome";
+  protocol_version: 1;
+  session_id: string;
+  capabilities: string[];
+}
+
+export interface RelayIncompatible {
+  type: "relay_incompatible";
+  protocol_version: 1;
+  code: "connector_upgrade_required";
+  message: string;
+  update_url: string;
+}
+
+export interface RelayPolicyApplied {
+  type: "policy_applied";
+  protocol_version: 1;
+  request_id: string;
+  revision: string;
+  ok: boolean;
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
 }
 
 export interface AuthorizationCollectionOffer {

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -308,6 +308,28 @@ test("sync wire objects are independently addressable", () => {
   assert.equal(validateSession(session), true, JSON.stringify(validateSession.errors));
   assert.equal(validateWireObject(session), true, JSON.stringify(validateWireObject.errors));
   assert.equal(validateSession({ ...session, resources: { ...session.resources, revision: "" } }), false);
+
+  const validateSnapshot = validator(`${syncSchema.$id}#/$defs/snapshotPage`);
+  const snapshot = {
+    protocol_version: 1,
+    snapshot_id: session.snapshot_id,
+    scope_epoch: 1,
+    cursor: 0,
+    records: [{
+      record_id: "01977777-7777-7777-8777-777777777777",
+      path: "tasks/one.md",
+      revision: "record:1",
+      frontmatter: { type: "task", title: "One" },
+      body: "Do it.\n",
+      types: ["task"],
+      document: "---\ntype: task\ntitle: One\n---\nDo it.\n"
+    }]
+  };
+  assert.equal(validateSnapshot(snapshot), true, JSON.stringify(validateSnapshot.errors));
+  assert.equal(validateSnapshot({
+    ...snapshot,
+    records: snapshot.records.map(({ document: _, ...record }) => record)
+  }), false);
 });
 
 test("encrypted relay envelopes expose routing metadata and reject payload-shaped fields", () => {
@@ -335,6 +357,26 @@ test("encrypted relay envelopes expose routing metadata and reject payload-shape
 
 test("relay request and response discriminators reject malformed wire messages", () => {
   const validate = validator(schema.$id);
+  const hello = {
+    type: "relay_hello",
+    protocol_version: 1,
+    connector_version: "0.1.0-beta.16",
+    capabilities: [
+      "authorization-activation",
+      "encrypted-relay",
+      "policy-ack"
+    ]
+  };
+  assert.equal(validate(hello), true, JSON.stringify(validate.errors));
+  assert.equal(validate({ ...hello, capabilities: ["policy-ack", "policy-ack"] }), false);
+  const welcome = {
+    type: "relay_welcome",
+    protocol_version: 1,
+    session_id: "42",
+    capabilities: hello.capabilities
+  };
+  assert.equal(validate(welcome), true, JSON.stringify(validate.errors));
+
   const request = {
     type: "operation_request",
     protocol_version: 1,
@@ -389,6 +431,23 @@ test("relay request and response discriminators reject malformed wire messages",
     ...activation,
     ok: false
   }), false);
+
+  const policy = {
+    type: "policy_snapshot",
+    protocol_version: 1,
+    request_id: request.request_id,
+    revision: `sha256:${"0".repeat(64)}`,
+    grants: []
+  };
+  assert.equal(validate(policy), true, JSON.stringify(validate.errors));
+  assert.equal(validate({ ...policy, revision: "latest" }), false);
+  assert.equal(validate({
+    type: "policy_applied",
+    protocol_version: 1,
+    request_id: request.request_id,
+    revision: policy.revision,
+    ok: true
+  }), true, JSON.stringify(validate.errors));
 });
 
 test("collection descriptions and operation envelopes have addressable schemas", () => {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/src/adoption.ts
+++ b/packages/sync/src/adoption.ts
@@ -690,12 +690,14 @@ export function buildPortableAuthoritySnapshot(
     ...resources.map(({ path, document }) => ({
       kind: "resource" as const,
       path,
+      identity: "",
       document_hash: bytesToHex(sha256(utf8.encode(document)))
     })),
     ...records.map((record) => ({
       kind: "record" as const,
       path: record.path,
-      document_hash: documentRevision(record.document)
+      identity: record.record_id,
+      document_hash: bytesToHex(sha256(utf8.encode(record.document)))
     }))
   ]);
   return {

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -7,8 +7,10 @@ import type {
   SyncMutationReceipt,
   SyncRecord,
   SyncSession,
-  SyncSnapshotPage
+  SyncSnapshotPage,
+  SyncSnapshotRecord
 } from "@mdbase/connect-protocol";
+import { stringify } from "yaml";
 
 export type {
   SyncChange,
@@ -19,7 +21,8 @@ export type {
   SyncMutationReceipt,
   SyncRecord,
   SyncSession,
-  SyncSnapshotPage
+  SyncSnapshotPage,
+  SyncSnapshotRecord
 } from "@mdbase/connect-protocol";
 
 export interface SyncTransport<Frontmatter extends JsonObject = JsonObject> {
@@ -83,7 +86,7 @@ interface SnapshotState<Frontmatter extends JsonObject> {
   replicaId: string;
   scopeEpoch: number;
   cursor: number;
-  records: Array<SyncRecord<Frontmatter>>;
+  records: Array<SyncSnapshotRecord<Frontmatter>>;
 }
 
 /** Executable protocol model used by SDK tests and local developer sandboxes. */
@@ -231,7 +234,10 @@ export class MemoryAuthority<Frontmatter extends JsonObject = JsonObject> {
       records: [...this.records.values()]
         .filter((record) => visible(record, replica))
         .sort((left, right) => left.path.localeCompare(right.path))
-        .map(clone)
+        .map((record) => ({
+          ...clone(record),
+          document: memoryRecordMarkdownDocument(record)
+        }))
     };
     this.snapshots.set(snapshot.id, snapshot);
     return {
@@ -424,6 +430,16 @@ export class MemoryAuthority<Frontmatter extends JsonObject = JsonObject> {
     if (replica.revoked) throw new SyncError("replica_revoked", "Replica access was revoked.");
     return replica;
   }
+}
+
+function memoryRecordMarkdownDocument(record: SyncRecord): string {
+  if (Object.keys(record.frontmatter).length === 0) {
+    return record.body;
+  }
+
+  const yaml = stringify(record.frontmatter, { lineWidth: 0 }).trimEnd();
+  const body = record.body ? `\n${record.body.replace(/^\n/, "")}` : "";
+  return `---\n${yaml}\n---\n${body}`;
 }
 
 export interface ReplicaData<Frontmatter extends JsonObject = JsonObject> {

--- a/packages/sync/src/mirror.test.ts
+++ b/packages/sync/src/mirror.test.ts
@@ -93,6 +93,39 @@ describe("platform-neutral directory mirror", () => {
     }
   });
 
+  it("materializes the authority's exact snapshot Markdown bytes", async () => {
+    const hosted = new MemoryAuthority();
+    hosted.seed([{
+      record_id: "exact-record",
+      path: "exact.md",
+      frontmatter: { type: "note", title: "Exact" },
+      body: "Exact body.\n",
+      types: ["note"]
+    }]);
+    const replicaId = hosted.registerReplica({ name: "Exact mirror", mode: "read_only" });
+    const base = hosted.transport(replicaId);
+    const exactDocument = "---\ntitle: Exact\ntype: note\n---\n\nExact body.\n";
+    const fileSystem = new TestFileSystem();
+    const mirror = new DirectoryMirror(replicaId, {
+      ...base,
+      snapshot: async (snapshotId, page) => {
+        const snapshot = await base.snapshot(snapshotId, page);
+        return {
+          ...snapshot,
+          records: snapshot.records.map((record) => ({ ...record, document: exactDocument }))
+        };
+      }
+    }, {
+      fileSystem,
+      stateStore: new MemoryMirrorStateStore(),
+      runtime: deterministicRuntime()
+    });
+
+    await mirror.sync();
+
+    expect(fileSystem.files.get("exact.md")).toBe(exactDocument);
+  });
+
   it("materializes through injected adapters and keeps receive-only state compact", async () => {
     const hosted = new MemoryAuthority({ snapshotPageSize: 2 });
     hosted.seed(records(5));

--- a/packages/sync/src/mirror.ts
+++ b/packages/sync/src/mirror.ts
@@ -1,7 +1,13 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex } from "@noble/hashes/utils.js";
 import { parse, stringify } from "yaml";
-import type { JsonObject, SyncMutation, SyncMutationReceipt, SyncRecord } from "@mdbase/connect-protocol";
+import type {
+  JsonObject,
+  SyncMutation,
+  SyncMutationReceipt,
+  SyncRecord,
+  SyncSnapshotRecord
+} from "@mdbase/connect-protocol";
 import type { SyncTransport } from "./index.js";
 import { SyncError } from "./index.js";
 
@@ -314,7 +320,8 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
 
   /**
    * Prove that this directory is an exact, complete copy of its last applied
-   * authority cursor. The digest contains no paths or record content.
+   * authority cursor. The digest commits to paths, stable record identities,
+   * and exact document hashes without exposing those values to the control plane.
    */
   async authorityPromotionManifest(): Promise<AuthorityPromotionManifest> {
     return this.lease.runExclusive(() => this.authorityPromotionManifestUnlocked());
@@ -361,16 +368,14 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
         ...Object.entries(state.resources ?? {}).map(([path, entry]) => ({
           kind: "resource" as const,
           path,
-          document_hash: entry.hash
+          identity: "",
+          document_hash: authorityDocumentHash(entry.hash)
         })),
-        ...Object.values(state.records).map((entry) => ({
+        ...Object.entries(state.records).map(([recordId, entry]) => ({
           kind: "record" as const,
           path: entry.path,
-          // A remote authority may normalize equivalent Markdown when it executes
-          // a mutation. The authority-issued revision is the shared content
-          // identity; assertUndiverged above separately proves the local bytes
-          // still match the exact document materialized for that revision.
-          document_hash: entry.revision
+          identity: recordId,
+          document_hash: authorityDocumentHash(entry.hash)
         }))
       ])
     };
@@ -405,7 +410,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     }
     await this.visitSnapshotPages(session, async (records) => {
       for (const record of records) {
-        await compareDocument(record.path, recordMarkdownDocument(record));
+        await compareDocument(record.path, record.document);
       }
     });
     const localMarkdown = await this.fileSystem.listMarkdown(new Set(resources.map((resource) => resource.path)));
@@ -469,8 +474,8 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
     }> = [];
     const remoteRecordIds = prior ? new Set<string>() : null;
     await this.visitSnapshotPages(session, async (pageRecords) => {
-      for (const record of pageRecords) {
-        const document = recordMarkdownDocument(record);
+      for (const snapshotRecord of pageRecords) {
+        const { document, ...record } = snapshotRecord;
         const local = await this.fileSystem.read(record.path);
         const managed = prior?.records[record.record_id];
         if (
@@ -554,7 +559,7 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
 
   private async visitSnapshotPages(
     session: Awaited<ReturnType<SyncTransport<Frontmatter>["openSession"]>>,
-    visitor: (records: Array<SyncRecord<Frontmatter>>) => Promise<void>
+    visitor: (records: Array<SyncSnapshotRecord<Frontmatter>>) => Promise<void>
   ): Promise<void> {
     let page: string | undefined;
     do {
@@ -1209,6 +1214,7 @@ function frontmatterPatch(before: JsonObject, after: JsonObject): JsonObject {
 export function authorityManifestDigest(entries: Array<{
   kind: "record" | "resource";
   path: string;
+  identity: string;
   document_hash: string;
 }>): string {
   const manifest = sha256.create().update(utf8.encode("mdbase-authority-manifest-v1\n"));
@@ -1220,10 +1226,23 @@ export function authorityManifestDigest(entries: Array<{
     manifest.update(Uint8Array.of(0));
     manifest.update(utf8.encode(entry.path));
     manifest.update(Uint8Array.of(0));
+    manifest.update(utf8.encode(entry.identity));
+    manifest.update(Uint8Array.of(0));
     manifest.update(utf8.encode(entry.document_hash));
     manifest.update(Uint8Array.of(10));
   }
   return bytesToHex(manifest.digest());
+}
+
+function authorityDocumentHash(revision: string): string {
+  const hash = revision.startsWith("sha256:") ? revision.slice("sha256:".length) : revision;
+  if (!/^[a-f0-9]{64}$/.test(hash)) {
+    throw new SyncError(
+      "invalid_authority_snapshot",
+      "Authority manifests require exact SHA-256 document hashes."
+    );
+  }
+  return hash;
 }
 
 function compareBytes(left: Uint8Array, right: Uint8Array): number {

--- a/packages/sync/src/node.test.ts
+++ b/packages/sync/src/node.test.ts
@@ -217,27 +217,31 @@ describe("writable Markdown mirror", () => {
       {
         kind: "resource",
         path: "mdbase.yaml",
+        identity: "",
         document_hash: "ff".repeat(32)
       },
       {
         kind: "record",
         path: "tasks/a.md",
+        identity: "01911111-1111-7111-8111-111111111111",
         document_hash: "00".repeat(32)
       }
-    ])).toBe("c3a6c98f15ed143bf4b9642e32c9f4c775ca8ad4978a42a4dbd69f79f6fc5e0f");
+    ])).toBe("5f4d35b7381929c7a60d2c45ff310899d9b4c0d891a2ada573fb6dc10fc8c51a");
 
     expect(authorityManifestDigest([
       {
         kind: "record",
         path: "zulu.md",
+        identity: "01911111-1111-7111-8111-111111111111",
         document_hash: "aa".repeat(32)
       },
       {
         kind: "record",
         path: "äther.md",
+        identity: "01922222-2222-7222-8222-222222222222",
         document_hash: "bb".repeat(32)
       }
-    ])).toBe("5f1f72e19ba871d569231de5cd71a4e1703fbc28e39d9357081f1a870d1fc7a9");
+    ])).toBe("b0bb3266ca6b5a833700ca04dfb3e918b405293d1b3e4a54f48e596c4c88fdb2");
 
     const hosted = new MemoryAuthority({
       resources: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -193,7 +193,7 @@ secret: connector scope test
   const verifier = "end-to-end-pkce-verifier-with-forty-three-characters";
   const challenge = createHash("sha256").update(verifier).digest("base64url");
   const authorize = await fetch(
-    `${serverUrl}/oauth/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(manifest.redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256&state=e2e&operations=describe,changes,read,query,create,update&relay_protocol=1&application_public_key=${encodeURIComponent(applicationKey.publicKey)}`,
+    `${serverUrl}/oauth/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(manifest.redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256&state=e2e&operations=describe,changes,read,query,create,update&relay_protocol=1&application_agreement_public_key=${encodeURIComponent(applicationKey.agreementPublicKey)}&application_signing_public_key=${encodeURIComponent(applicationKey.signingPublicKey)}`,
     { headers: { cookie }, redirect: "manual" }
   );
   if (authorize.status !== 302) throw new Error(`Authorization start returned HTTP ${authorize.status}`);
@@ -228,7 +228,7 @@ secret: connector scope test
     throw new Error(`Authorization did not return contract scope and refresh token: ${JSON.stringify(token.body)}`);
   }
   if (token.body.encryption?.protocol_version !== 1
-      || token.body.encryption?.application_public_key !== applicationKey.publicKey
+      || token.body.encryption?.application_agreement_public_key !== applicationKey.agreementPublicKey
       || !token.body.grant_id) {
     throw new Error(`Authorization did not establish encrypted relay protocol 1: ${JSON.stringify(token.body)}`);
   }
@@ -359,7 +359,11 @@ secret: connector scope test
         authorization: `Bearer ${portalToken.body.access_token}`,
         "content-type": "application/json"
       },
-      body: "{}"
+      body: JSON.stringify({
+        protocol_version: 1,
+        request_id: crypto.randomUUID(),
+        input: {}
+      })
     }
   );
   const portalDescriptionBody = await portalDescription.json();
@@ -468,8 +472,11 @@ secret: connector scope test
     await browserContext.grantPermissions(["local-network-access"], { origin: manifest.browserOrigin });
     const page = await browserContext.newPage();
     await page.goto(`${manifest.browserOrigin}/browser-e2e`);
-    await page.waitForFunction(() => Boolean(globalThis.directHarness?.publicKey));
-    const browserPublicKey = await page.evaluate(() => globalThis.directHarness.publicKey);
+    await page.waitForFunction(() => Boolean(globalThis.directHarness?.agreementPublicKey));
+    const browserKeys = await page.evaluate(() => ({
+      agreementPublicKey: globalThis.directHarness.agreementPublicKey,
+      signingPublicKey: globalThis.directHarness.signingPublicKey
+    }));
     const browserApplication = await request("/v1/apps/register", {
       method: "POST",
       body: { manifest: manifest.browserApplicationManifest }
@@ -482,7 +489,7 @@ secret: connector scope test
       "read_type", "create_type", "update_type", "list_views", "execute_view"
     ];
     const browserAuthorize = await fetch(
-      `${serverUrl}/oauth/authorize?client_id=${browserAppId}&redirect_uri=${encodeURIComponent(manifest.browserRedirectUri)}&code_challenge=${browserChallenge}&code_challenge_method=S256&state=browser-e2e&operations=${browserOperations.join(",")}&relay_protocol=1&application_public_key=${encodeURIComponent(browserPublicKey)}`,
+      `${serverUrl}/oauth/authorize?client_id=${browserAppId}&redirect_uri=${encodeURIComponent(manifest.browserRedirectUri)}&code_challenge=${browserChallenge}&code_challenge_method=S256&state=browser-e2e&operations=${browserOperations.join(",")}&relay_protocol=1&application_agreement_public_key=${encodeURIComponent(browserKeys.agreementPublicKey)}&application_signing_public_key=${encodeURIComponent(browserKeys.signingPublicKey)}`,
       { headers: { cookie }, redirect: "manual" }
     );
     if (browserAuthorize.status !== 302) {
@@ -1077,7 +1084,8 @@ async function openApplicationServer(name, contracts, access) {
   const keyStore = new MemoryGrantKeyStore();
   const key = await keyStore.create("browser-e2e-grant");
   globalThis.directHarness = {
-    publicKey: key.publicKey,
+    agreementPublicKey: key.agreementPublicKey,
+    signingPublicKey: key.signingPublicKey,
     async exercise(config) {
       const storagePrefix = \`mdbase-connect:\${config.serverUrl}:bundle:\${config.manifest.id}\`;
       localStorage.setItem(

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -417,7 +417,7 @@ secret: connector scope test
     refreshToken: refreshed.body.refresh_token,
     clientId: appId,
     collectionId: collection.id,
-    collectionName: collection.name,
+    collectionName: collection.display_name,
     operations: refreshed.body.operations,
     scope: refreshed.body.scope,
     // Direct access remains usable while the cloud access token needs renewal.

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -169,7 +169,7 @@ try {
         allowed_types: [],
         contract_scope: [],
         full_collection: true,
-        allowed_operations: ["create"],
+        allowed_operations: ["create", "rename", "delete"],
         grant_id: crypto.randomUUID(),
         token: fullReplicaToken
       }
@@ -196,6 +196,95 @@ try {
     );
     assert.equal(created.status, 200, JSON.stringify(created.body));
   }
+  const exactOnceCreateId = crypto.randomUUID();
+  const exactOnceCreateInput = {
+    path: "retry-target.md",
+    frontmatter: { type: "workout", title: "Exactly once", status: "open" }
+  };
+  const firstCreate = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/create`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: exactOnceCreateId,
+      body: exactOnceCreateInput
+    }
+  );
+  const replayedCreate = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/create`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: exactOnceCreateId,
+      body: exactOnceCreateInput
+    }
+  );
+  assert.equal(firstCreate.status, 200, JSON.stringify(firstCreate.body));
+  assert.deepEqual(replayedCreate.body, firstCreate.body);
+  const reusedRequest = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/create`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: exactOnceCreateId,
+      body: { ...exactOnceCreateInput, path: "different.md" }
+    }
+  );
+  assert.equal(reusedRequest.status, 409, JSON.stringify(reusedRequest.body));
+  assert.equal(reusedRequest.body.error.code, "operation_request_id_reused");
+
+  const renameRequestId = crypto.randomUUID();
+  const renameInput = { from: "retry-target.md", to: "retry-renamed.md" };
+  const firstRename = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/rename`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: renameRequestId,
+      body: renameInput
+    }
+  );
+  const replayedRename = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/rename`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: renameRequestId,
+      body: renameInput
+    }
+  );
+  assert.equal(firstRename.status, 200, JSON.stringify(firstRename.body));
+  assert.deepEqual(replayedRename.body, firstRename.body);
+
+  const deleteRequestId = crypto.randomUUID();
+  const deleteInput = { path: "retry-renamed.md" };
+  const firstDelete = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/delete`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: deleteRequestId,
+      body: deleteInput
+    }
+  );
+  const replayedDelete = await rawRequest(
+    provider.url,
+    `/v1/authorities/${provisionCollectionId}/operations/delete`,
+    {
+      method: "POST",
+      token: fullReplicaToken,
+      requestId: deleteRequestId,
+      body: deleteInput
+    }
+  );
+  assert.equal(firstDelete.status, 200, JSON.stringify(firstDelete.body));
+  assert.deepEqual(replayedDelete.body, firstDelete.body);
 
   const contractReplicaToken = `contract-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(
@@ -852,46 +941,24 @@ try {
     authoritySyncUrl(provider.url, genericCollectionId)
   );
   assert.equal(storedHostedToken.encryption, undefined);
-  const appToken = storedHostedToken.authority.accessToken;
   const appReplicaId = storedHostedToken.authority.replicaId;
-  const appSync = await rawRequest(provider.url, syncPath(genericCollectionId, "sessions"), {
-    method: "POST",
-    token: appToken,
-    headers: { origin: manifest.origin }
-  });
-  assert.equal(appSync.status, 200);
-  assert.equal(appSync.body.replica_id, appReplicaId);
-  const wrongSyncOrigin = await rawRequest(
-    provider.url,
-    syncPath(genericCollectionId, "sessions"),
-    {
-      method: "POST",
-      token: appToken,
-      headers: { origin: "https://evil.example" }
-    }
-  );
-  assert.equal(wrongSyncOrigin.status, 403);
-  assert.equal(wrongSyncOrigin.body.error.code, "origin_denied");
-  const wrongOrigin = await rawRequest(
-    provider.url,
-    `/v1/authorities/${genericCollectionId}/operations/query`,
-    {
-      method: "POST",
-      token: appToken,
-      headers: { origin: "https://evil.example" },
-      body: {}
-    }
-  );
-  assert.equal(wrongOrigin.status, 403);
-  assert.equal(wrongOrigin.body.error.code, "origin_denied");
   const originalFetch = globalThis.fetch;
+  let providerOrigin = manifest.origin;
   globalThis.fetch = (input, init = {}) => {
     const url = String(input);
     if (!url.startsWith(`${provider.url}/v1/authorities/`)) return originalFetch(input, init);
     const headers = new Headers(init.headers);
-    headers.set("origin", manifest.origin);
+    headers.set("origin", providerOrigin);
     return originalFetch(input, { ...init, headers });
   };
+  const hostedSync = hostedConnection.sync();
+  assert.ok(hostedSync);
+  const appSync = await hostedSync.transport.openSession();
+  assert.equal(appSync.replica_id, appReplicaId);
+  providerOrigin = "https://evil.example";
+  await assert.rejects(() => hostedSync.transport.openSession());
+  await assert.rejects(() => hostedConnection.query());
+  providerOrigin = manifest.origin;
   const description = await hostedConnection.describe();
   assert.equal(description.display_name, "Hosted writing");
   assert.deepEqual(description.contracts, []);
@@ -1065,7 +1132,6 @@ schema:
     .find((record) => record.record_id === offlinePlain.record_id);
   assert.deepEqual(offlinePlainSynced.frontmatter, {});
   assert.equal(offlinePlainSynced.body, "# Offline plain Markdown");
-  globalThis.fetch = originalFetch;
   const dashboardWithApp = await controlRequest(controlUrl, "/v1/me", cookie);
   const hostedGrant = dashboardWithApp.grants.find((grant) => grant.collection_id === genericCollectionId);
   assert.ok(hostedGrant);
@@ -1086,39 +1152,23 @@ schema:
     method: "PATCH",
     body: { operations: ["describe", "read", "query"] }
   });
-  const deniedWrite = await rawRequest(
-    provider.url,
-    `/v1/authorities/${genericCollectionId}/operations/create`,
-    {
-      method: "POST",
-      token: appToken,
-      headers: { origin: manifest.origin },
-      body: {
-        path: "permission-expansion.md",
-        frontmatter: { title: "Must not exist" }
-      }
-    }
+  await assert.rejects(
+    () => hostedConnection.create({
+      path: "permission-expansion.md",
+      frontmatter: { title: "Must not exist" }
+    }),
+    (error) => error?.code === "insufficient_access"
   );
-  assert.equal(deniedWrite.status, 403);
-  assert.equal(deniedWrite.body.error.code, "insufficient_access");
-  const deniedChanges = await rawRequest(
-    provider.url,
-    `${syncPath(genericCollectionId, "changes")}?after=0&limit=10`,
-    {
-      method: "GET",
-      token: appToken,
-      headers: { origin: manifest.origin }
-    }
+  await assert.rejects(
+    () => hostedSync.transport.changes(0, 10),
+    (error) => error?.code === "insufficient_access"
   );
-  assert.equal(deniedChanges.status, 403);
-  assert.equal(deniedChanges.body.error.code, "insufficient_access");
   await controlRequest(controlUrl, `/v1/grants/${hostedGrant.id}`, cookie, { method: "DELETE" });
-  const revokedApp = await rawRequest(
-    provider.url,
-    `/v1/authorities/${genericCollectionId}/operations/query`,
-    { method: "POST", token: appToken, headers: { origin: manifest.origin }, body: {} }
+  await assert.rejects(
+    () => hostedConnection.query(),
+    (error) => error?.code === "invalid_grant"
   );
-  assert.equal(revokedApp.status, 401);
+  globalThis.fetch = originalFetch;
 
   phase("authorizing a real file URL directly against the hosted data plane");
   await portableHostedFileE2E(controlUrl, cookie, genericCollectionId, portableRoot);
@@ -1611,7 +1661,28 @@ schema:
   assert.equal(fencedMutation.body.error.code, "hosted_collection_not_found");
   await authorityMirror.sync();
   const authorityProof = await authorityMirror.authorityPromotionManifest();
+  const proofSession = await authorityTransport.openSession();
+  const proofRecords = await snapshotAll(authorityTransport, proofSession);
+  const proofEntries = (proofSession.resources.documents ?? []).map((resource) => ({
+    kind: "resource",
+    path: resource.path,
+    identity: "",
+    document_hash: sha256Hex(resource.document)
+  }));
+  for (const record of proofRecords) {
+    proofEntries.push({
+      kind: "record",
+      path: record.path,
+      identity: record.record_id,
+      document_hash: sha256Hex(
+        await readFile(join(authorityMirrorRoot, record.path), "utf8")
+      )
+    });
+  }
+  const snapshotProof = authorityManifestDigest(proofEntries);
   assert.equal(authorityProof.cursor, preparedTransfer.final_head);
+  assert.equal(snapshotProof, preparedTransfer.manifest_digest);
+  assert.equal(authorityProof.digest, snapshotProof);
   assert.equal(authorityProof.digest, preparedTransfer.manifest_digest);
   const mismatchedProof = await rawRequest(
     provider.url,
@@ -2921,12 +2992,14 @@ function localAuthoritySnapshot(collectionId, recordCount) {
     ...resources.map((resource) => ({
       kind: "resource",
       path: resource.path,
+      identity: "",
       document_hash: sha256Hex(resource.document)
     })),
     ...records.map((record) => ({
       kind: "record",
       path: record.path,
-      document_hash: `sha256:${sha256Hex(record.document)}`
+      identity: record.record_id,
+      document_hash: sha256Hex(record.document)
     }))
   ]);
   return {
@@ -3578,7 +3651,14 @@ async function rawRequest(url, path, options = {}) {
     body = options.bodyText;
     headers["content-type"] = "application/json";
   } else if (options.body !== undefined) {
-    body = JSON.stringify(options.body);
+    const value = path.includes("/operations/")
+      ? {
+          protocol_version: 1,
+          request_id: options.requestId ?? crypto.randomUUID(),
+          input: options.body
+        }
+      : options.body;
+    body = JSON.stringify(value);
     headers["content-type"] = "application/json";
   }
   const response = await fetch(`${url}${path}`, {

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -4,6 +4,10 @@ import { createServer } from "node:net";
 import { resolve } from "node:path";
 import { createRequire } from "node:module";
 import { promisify } from "node:util";
+import {
+  CONTROL_PROTOCOL_VERSION,
+  RELAY_CAPABILITIES
+} from "../packages/protocol/dist/index.js";
 
 process.env.NODE_ENV = "test";
 const run = promisify(execFile);
@@ -175,8 +179,8 @@ try {
     scope_epoch: 1,
     connector_id: fixture.connectorId,
     collection_id: fixture.localCollectionId,
-    application_public_key: Buffer.concat([Buffer.from([4]), randomBytes(64)]).toString("base64url"),
-    connector_public_key: Buffer.concat([Buffer.from([4]), randomBytes(64)]).toString("base64url")
+    application_agreement_public_key: Buffer.concat([Buffer.from([4]), randomBytes(64)]).toString("base64url"),
+    connector_agreement_public_key: Buffer.concat([Buffer.from([4]), randomBytes(64)]).toString("base64url")
   };
   await database.query("UPDATE grants SET encryption = $2::jsonb WHERE id = $1", [
     fixture.grantId,
@@ -368,8 +372,9 @@ async function seed(db, hash) {
   );
   await db.query(
     `INSERT INTO grants
-       (id, user_id, application_id, collection_id, operations, scope, application_origin)
-     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)`,
+       (id, user_id, application_id, collection_id, operations, scope,
+        application_origin, activated_at)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, now())`,
     [
       grantId,
       userId,
@@ -401,11 +406,30 @@ async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner
     headers: { authorization: `Bearer ${token}` }
   });
   const policies = [];
+  const messageTypes = [];
+  let closeDetails;
   let policyWaiter;
+  let welcomeWaiter;
+  socket.on("close", (code, reason) => {
+    closeDetails = { code, reason: reason.toString() };
+  });
   socket.on("message", (raw) => {
     const message = JSON.parse(raw.toString());
+    messageTypes.push(message.type);
+    if (message.type === "relay_welcome") {
+      welcomeWaiter?.();
+      welcomeWaiter = undefined;
+      return;
+    }
     if (message.type === "policy_snapshot") {
       policies.push(message);
+      socket.send(JSON.stringify({
+        type: "policy_applied",
+        protocol_version: CONTROL_PROTOCOL_VERSION,
+        request_id: message.request_id,
+        revision: message.revision,
+        ok: true
+      }));
       policyWaiter?.();
       policyWaiter = undefined;
       return;
@@ -441,16 +465,39 @@ async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner
     }));
   });
   await new Promise((resolveOpen, reject) => {
-    socket.once("open", resolveOpen);
+    socket.once("open", () => {
+      socket.send(JSON.stringify({
+        type: "relay_hello",
+        protocol_version: CONTROL_PROTOCOL_VERSION,
+        connector_version: "0.1.0-e2e",
+        capabilities: [...RELAY_CAPABILITIES]
+      }));
+      resolveOpen();
+    });
     socket.once("error", reject);
   });
+  if (!messageTypes.includes("relay_welcome")) {
+    await new Promise((resolveWelcome, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`Connector ${owner} did not receive relay_welcome`)),
+        10_000
+      );
+      welcomeWaiter = () => {
+        clearTimeout(timer);
+        resolveWelcome();
+      };
+    });
+  }
   return {
     socket,
     policies,
     async waitForPolicy() {
       if (policies.length > 0) return;
       await new Promise((resolvePolicy, reject) => {
-        const timer = setTimeout(() => reject(new Error("Connector did not receive a policy snapshot")), 10_000);
+        const timer = setTimeout(() => reject(new Error(
+          `Connector ${owner} did not receive a policy snapshot: `
+          + JSON.stringify({ messageTypes, closeDetails })
+        )), 10_000);
         policyWaiter = () => {
           clearTimeout(timer);
           resolvePolicy();
@@ -461,15 +508,22 @@ async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner
 }
 
 async function operation(serverUrl, fixture, operationName, input) {
+  const body = input?.type === "encrypted_operation_request"
+    ? input
+    : {
+        protocol_version: CONTROL_PROTOCOL_VERSION,
+        request_id: randomUUID(),
+        input
+      };
   const response = await fetch(
-    `${serverUrl}/v1/authorities/${fixture.collectionId}/operations/${operationName}`,
+    `${serverUrl}/v1/authorities/${fixture.localCollectionId}/operations/${operationName}`,
     {
       method: "POST",
       headers: {
         authorization: `Bearer ${fixture.accessToken}`,
         "content-type": "application/json"
       },
-      body: JSON.stringify(input)
+      body: JSON.stringify(body)
     }
   );
   return { status: response.status, body: await response.json() };

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -110,7 +110,12 @@ describe("mdbase MCP gateway", () => {
     expect(firstUpstream.origin).toBe("https://connect.example");
     expect(firstUpstream.searchParams.get("operations")).toContain("create");
     expect(firstUpstream.searchParams.get("relay_protocol")).toBe("1");
-    upstream.applicationPublicKeys.push(firstUpstream.searchParams.get("application_public_key")!);
+    upstream.applicationAgreementPublicKeys.push(
+      firstUpstream.searchParams.get("application_agreement_public_key")!
+    );
+    upstream.applicationSigningPublicKeys.push(
+      firstUpstream.searchParams.get("application_signing_public_key")!
+    );
 
     const firstCallback = await app.inject({
       method: "GET",
@@ -172,7 +177,12 @@ describe("mdbase MCP gateway", () => {
     const additional = await app.inject({ method: "GET", url: `${new URL(addUrl).pathname}${new URL(addUrl).search}` });
     expect(additional.statusCode).toBe(302);
     const secondUpstream = new URL(additional.headers.location!);
-    upstream.applicationPublicKeys.push(secondUpstream.searchParams.get("application_public_key")!);
+    upstream.applicationAgreementPublicKeys.push(
+      secondUpstream.searchParams.get("application_agreement_public_key")!
+    );
+    upstream.applicationSigningPublicKeys.push(
+      secondUpstream.searchParams.get("application_signing_public_key")!
+    );
     const secondCallback = await app.inject({
       method: "GET",
       url: `/oauth/connect/callback?${new URLSearchParams({
@@ -260,7 +270,8 @@ function testConfig(): McpRuntimeConfig {
 }
 
 async function fakeUpstream(realFetch: typeof fetch) {
-  const applicationPublicKeys: string[] = [];
+  const applicationAgreementPublicKeys: string[] = [];
+  const applicationSigningPublicKeys: string[] = [];
   const operationAuthorizations: string[] = [];
   const operationOrigins: string[] = [];
   const localInputs: unknown[] = [];
@@ -298,14 +309,15 @@ async function fakeUpstream(realFetch: typeof fetch) {
           scope_epoch: 1,
           connector_id: "50000000-0000-4000-8000-000000000001",
           collection_id: firstCollectionId,
-          application_public_key: applicationPublicKeys[0],
-          connector_public_key: connectorPublicKey
+          application_agreement_public_key: applicationAgreementPublicKeys[0],
+          connector_agreement_public_key: connectorPublicKey
         },
         ...(second ? { authority: {
           operations_url: `https://sync.example/v1/authorities/${secondCollectionId}/operations`,
           sync_url: `https://sync.example/v1/authorities/${secondCollectionId}/sync`,
           replica_id: "40000000-0000-4000-8000-000000000002",
-          access_token: "hosted-access-two"
+          access_token: "hosted-access-two",
+          proof_public_key: applicationSigningPublicKeys[1]
         } } : {})
       });
     }
@@ -314,9 +326,13 @@ async function fakeUpstream(realFetch: typeof fetch) {
       operationAuthorizations.push(headers.get("authorization")!);
       operationOrigins.push(headers.get("origin")!);
       const envelope = JSON.parse(String(init?.body));
-      const input = await decryptConnectorRequest(connectorKeys.privateKey, applicationPublicKeys[0], envelope);
+      const input = await decryptConnectorRequest(
+        connectorKeys.privateKey,
+        applicationAgreementPublicKeys[0],
+        envelope
+      );
       localInputs.push(input);
-      const responseEnvelope = await encryptConnectorResponse(connectorKeys.privateKey, applicationPublicKeys[0], envelope, {
+      const responseEnvelope = await encryptConnectorResponse(connectorKeys.privateKey, applicationAgreementPublicKeys[0], envelope, {
         valid: true,
         result: { results: [{ path: "notes/local.md", frontmatter: { title: "Local" }, types: ["note"] }] },
         diagnostics: []
@@ -338,7 +354,14 @@ async function fakeUpstream(realFetch: typeof fetch) {
     if (url.hostname === "127.0.0.1") return realFetch(input, init);
     return Response.json({ error: { code: "unexpected_fetch", message: url.href } }, { status: 500 });
   });
-  return { fetch: fetchMock, applicationPublicKeys, operationAuthorizations, operationOrigins, localInputs };
+  return {
+    fetch: fetchMock,
+    applicationAgreementPublicKeys,
+    applicationSigningPublicKeys,
+    operationAuthorizations,
+    operationOrigins,
+    localInputs
+  };
 }
 
 async function decryptConnectorRequest(privateKey: CryptoKey, applicationPublicKey: string, envelope: any): Promise<unknown> {

--- a/services/mcp/src/connect.ts
+++ b/services/mcp/src/connect.ts
@@ -22,8 +22,8 @@ const grantEncryptionSchema = z.object({
   scope_epoch: z.number().int().positive(),
   connector_id: z.uuid(),
   collection_id: z.uuid(),
-  application_public_key: z.string().min(80),
-  connector_public_key: z.string().min(80)
+  application_agreement_public_key: z.string().min(80),
+  connector_agreement_public_key: z.string().min(80)
 }).strict();
 
 const tokenResponseSchema = z.object({
@@ -44,7 +44,8 @@ const tokenResponseSchema = z.object({
     operations_url: z.url(),
     sync_url: z.url(),
     replica_id: z.uuid(),
-    access_token: z.string().min(1)
+    access_token: z.string().min(1),
+    proof_public_key: z.string().min(80).max(200)
   }).optional()
 }).passthrough();
 
@@ -317,12 +318,28 @@ export class ConnectGateway {
     keyHandle: string | null,
     applicationId: string
   ): Promise<void> {
-    if (token.authority) return;
+    if (token.authority) {
+      const key = keyHandle ? await this.keyStore.get(keyHandle) : null;
+      if (
+        !key
+        || token.authority.proof_public_key !== key.signingPublicKey
+      ) {
+        throw new GatewayOperationError(
+          "grant_key_mismatch",
+          "Connect returned a remote authority grant for a different signing key."
+        );
+      }
+      return;
+    }
     if (!token.encryption || !keyHandle) {
       throw new GatewayOperationError("encryption_required", "Connect did not establish encrypted local access.");
     }
     const key = await this.keyStore.get(keyHandle);
-    if (!key || key.publicKey !== token.encryption.application_public_key) {
+    if (
+      !key
+      || key.agreementPublicKey
+        !== token.encryption.application_agreement_public_key
+    ) {
       throw new GatewayOperationError("grant_key_mismatch", "Connect returned a grant for a different encryption key.");
     }
     if (token.encryption.connector_id.length === 0 || applicationId.length === 0) {

--- a/services/mcp/src/db.ts
+++ b/services/mcp/src/db.ts
@@ -74,6 +74,10 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
       handle text PRIMARY KEY,
       public_key text NOT NULL,
       private_key_ciphertext text NOT NULL,
+      agreement_public_key text,
+      agreement_private_key_ciphertext text,
+      signing_public_key text,
+      signing_private_key_ciphertext text,
       counter numeric(20, 0) NOT NULL DEFAULT 0,
       created_at timestamptz NOT NULL DEFAULT now()
     );
@@ -145,6 +149,18 @@ export async function migrate(db: DatabaseQueryable): Promise<void> {
   `);
   await db.query(
     "ALTER TABLE mcp_connection_tickets ADD COLUMN IF NOT EXISTS collection_id uuid"
+  );
+  await db.query(
+    "ALTER TABLE mcp_grant_keys ADD COLUMN IF NOT EXISTS agreement_public_key text"
+  );
+  await db.query(
+    "ALTER TABLE mcp_grant_keys ADD COLUMN IF NOT EXISTS agreement_private_key_ciphertext text"
+  );
+  await db.query(
+    "ALTER TABLE mcp_grant_keys ADD COLUMN IF NOT EXISTS signing_public_key text"
+  );
+  await db.query(
+    "ALTER TABLE mcp_grant_keys ADD COLUMN IF NOT EXISTS signing_private_key_ciphertext text"
   );
   // Retain the unused legacy column until the previous release is outside the
   // production rollback window. Runtime compatibility is not a license for a

--- a/services/mcp/src/key-store.test.ts
+++ b/services/mcp/src/key-store.test.ts
@@ -8,14 +8,26 @@ describe("PostgresGrantKeyStore", () => {
     const db = await createDatabase("memory");
     const store = new PostgresGrantKeyStore(db, new SecretBox(Buffer.alloc(32, 9)));
     const created = await store.create("grant:test");
-    expect(created.publicKey).toMatch(/^[A-Za-z0-9_-]+$/);
-    const persisted = await db.query<{ private_key_ciphertext: string }>(
-      "SELECT private_key_ciphertext FROM mcp_grant_keys WHERE handle = $1",
+    expect(created.agreementPublicKey).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(created.signingPublicKey).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(created.signingPublicKey).not.toBe(created.agreementPublicKey);
+    expect(created.agreementPrivateKey.extractable).toBe(false);
+    expect(created.signingPrivateKey.extractable).toBe(false);
+    const persisted = await db.query<{
+      agreement_private_key_ciphertext: string;
+      signing_private_key_ciphertext: string;
+    }>(
+      `SELECT agreement_private_key_ciphertext, signing_private_key_ciphertext
+       FROM mcp_grant_keys WHERE handle = $1`,
       ["grant:test"]
     );
-    expect(persisted.rows[0].private_key_ciphertext).not.toContain(created.publicKey);
+    expect(persisted.rows[0].agreement_private_key_ciphertext)
+      .not.toContain(created.agreementPublicKey);
+    expect(persisted.rows[0].signing_private_key_ciphertext)
+      .not.toContain(created.signingPublicKey);
     const loaded = await store.get("grant:test");
-    expect(loaded?.publicKey).toBe(created.publicKey);
+    expect(loaded?.agreementPublicKey).toBe(created.agreementPublicKey);
+    expect(loaded?.signingPublicKey).toBe(created.signingPublicKey);
     expect(await Promise.all([store.nextCounter("grant:test"), store.nextCounter("grant:test")])).toEqual(["1", "2"]);
     await store.delete("grant:test");
     expect(await store.get("grant:test")).toBeNull();

--- a/services/mcp/src/key-store.ts
+++ b/services/mcp/src/key-store.ts
@@ -11,37 +11,74 @@ export class PostgresGrantKeyStore implements GrantKeyStore {
   ) {}
 
   async create(handle: string): Promise<GrantKeyRecord> {
-    const generated = await crypto.subtle.generateKey(
+    const agreement = await crypto.subtle.generateKey(
       { name: "ECDH", namedCurve: "P-256" },
       true,
       ["deriveBits"]
     ) as CryptoKeyPair;
-    const publicKey = Buffer.from(await crypto.subtle.exportKey("raw", generated.publicKey)).toString("base64url");
-    const privatePkcs8 = Buffer.from(await crypto.subtle.exportKey("pkcs8", generated.privateKey));
+    const signing = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"]
+    ) as CryptoKeyPair;
+    const agreementPublicKey = await exportPublicKey(agreement.publicKey);
+    const agreementPkcs8 = await exportPrivateKey(agreement.privateKey);
+    const signingPublicKey = await exportPublicKey(signing.publicKey);
+    const signingPkcs8 = await exportPrivateKey(signing.privateKey);
     await this.db.query(
-      `INSERT INTO mcp_grant_keys (handle, public_key, private_key_ciphertext)
-       VALUES ($1, $2, $3)`,
-      [handle, publicKey, this.secrets.encrypt(privatePkcs8.toString("base64url"))]
+      `INSERT INTO mcp_grant_keys
+         (handle, public_key, private_key_ciphertext,
+          agreement_public_key, agreement_private_key_ciphertext,
+          signing_public_key, signing_private_key_ciphertext)
+       VALUES ($1, $2, $3, $2, $3, $4, $5)`,
+      [
+        handle,
+        agreementPublicKey,
+        this.secrets.encrypt(agreementPkcs8.toString("base64url")),
+        signingPublicKey,
+        this.secrets.encrypt(signingPkcs8.toString("base64url"))
+      ]
     );
     return {
       handle,
-      publicKey,
-      privateKey: await importPrivateKey(privatePkcs8)
+      agreementPublicKey,
+      agreementPrivateKey: await importAgreementPrivateKey(agreementPkcs8),
+      signingPublicKey,
+      signingPrivateKey: await importSigningPrivateKey(signingPkcs8)
     };
   }
 
   async get(handle: string): Promise<GrantKeyRecord | null> {
-    const result = await this.db.query<{ public_key: string; private_key_ciphertext: string }>(
-      "SELECT public_key, private_key_ciphertext FROM mcp_grant_keys WHERE handle = $1",
+    const result = await this.db.query<{
+      agreement_public_key: string | null;
+      agreement_private_key_ciphertext: string | null;
+      signing_public_key: string | null;
+      signing_private_key_ciphertext: string | null;
+    }>(
+      `SELECT agreement_public_key, agreement_private_key_ciphertext,
+              signing_public_key, signing_private_key_ciphertext
+       FROM mcp_grant_keys WHERE handle = $1`,
       [handle]
     );
     const row = result.rows[0];
-    if (!row) return null;
-    const privatePkcs8 = Buffer.from(this.secrets.decrypt(row.private_key_ciphertext), "base64url");
+    if (!row?.agreement_public_key
+        || !row.agreement_private_key_ciphertext
+        || !row.signing_public_key
+        || !row.signing_private_key_ciphertext) return null;
+    const agreementPkcs8 = Buffer.from(
+      this.secrets.decrypt(row.agreement_private_key_ciphertext),
+      "base64url"
+    );
+    const signingPkcs8 = Buffer.from(
+      this.secrets.decrypt(row.signing_private_key_ciphertext),
+      "base64url"
+    );
     return {
       handle,
-      publicKey: row.public_key,
-      privateKey: await importPrivateKey(privatePkcs8)
+      agreementPublicKey: row.agreement_public_key,
+      agreementPrivateKey: await importAgreementPrivateKey(agreementPkcs8),
+      signingPublicKey: row.signing_public_key,
+      signingPrivateKey: await importSigningPrivateKey(signingPkcs8)
     };
   }
 
@@ -61,12 +98,32 @@ export class PostgresGrantKeyStore implements GrantKeyStore {
   }
 }
 
-function importPrivateKey(pkcs8: Buffer): Promise<CryptoKey> {
+function exportPublicKey(key: CryptoKey): Promise<string> {
+  return crypto.subtle.exportKey("raw", key)
+    .then((value) => Buffer.from(value).toString("base64url"));
+}
+
+function exportPrivateKey(key: CryptoKey): Promise<Buffer> {
+  return crypto.subtle.exportKey("pkcs8", key)
+    .then((value) => Buffer.from(value));
+}
+
+function importAgreementPrivateKey(pkcs8: Buffer): Promise<CryptoKey> {
   return crypto.subtle.importKey(
     "pkcs8",
     Uint8Array.from(pkcs8).buffer,
     { name: "ECDH", namedCurve: "P-256" },
     false,
     ["deriveBits"]
+  );
+}
+
+function importSigningPrivateKey(pkcs8: Buffer): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "pkcs8",
+    Uint8Array.from(pkcs8).buffer,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
   );
 }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.15" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.16" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/mcp/src/oauth.ts
+++ b/services/mcp/src/oauth.ts
@@ -394,7 +394,14 @@ export class OAuthService {
     authorize.searchParams.set("operations", operationsForScopes(scopes).join(","));
     if (collectionId) authorize.searchParams.set("collection_id", collectionId);
     authorize.searchParams.set("relay_protocol", "1");
-    authorize.searchParams.set("application_public_key", key.publicKey);
+    authorize.searchParams.set(
+      "application_agreement_public_key",
+      key.agreementPublicKey
+    );
+    authorize.searchParams.set(
+      "application_signing_public_key",
+      key.signingPublicKey
+    );
     return authorize.href;
   }
 

--- a/services/server/migrations/0004_separate_application_keys.sql
+++ b/services/server/migrations/0004_separate_application_keys.sql
@@ -1,0 +1,8 @@
+-- Draft v1 uses independent ECDH agreement and ECDSA signing keypairs.
+-- Existing pre-release authorization requests are intentionally not migrated:
+-- they must restart authorization and prove possession of both new keys.
+ALTER TABLE authorization_requests
+  ADD COLUMN IF NOT EXISTS application_agreement_public_key text;
+
+ALTER TABLE authorization_requests
+  ADD COLUMN IF NOT EXISTS application_signing_public_key text;

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -22,6 +22,16 @@ import { pkceChallenge, tokenHash } from "./security.js";
 
 const resources: Array<() => Promise<void>> = [];
 
+function p256PublicKey(): string {
+  const keys = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const jwk = keys.publicKey.export({ format: "jwk" });
+  return Buffer.concat([
+    Buffer.from([4]),
+    Buffer.from(jwk.x!, "base64url"),
+    Buffer.from(jwk.y!, "base64url")
+  ]).toString("base64url");
+}
+
 afterEach(async () => {
   while (resources.length) await resources.pop()?.();
 });
@@ -407,6 +417,12 @@ describe("mdbase connect server", () => {
     });
     expect(synchronized.statusCode).toBe(200);
     const collectionId = synchronized.json().collections[0].id as string;
+    const authorityRows = await db.query<{ id: string; local_id: string }>(
+      "SELECT id, local_id FROM collections WHERE connector_id = $1",
+      [connector.connector.id]
+    );
+    const authorityId = (localId: string) =>
+      authorityRows.rows.find((collection) => collection.local_id === localId)!.id;
 
     const manifestServer = applicationManifestFixture();
     const discovered = await app.inject({
@@ -421,11 +437,19 @@ describe("mdbase connect server", () => {
     const applicationId = discovered.json().application.id as string;
     const invalidEncryption = await app.inject({
       method: "GET",
-      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${"a".repeat(43)}&code_challenge_method=S256&relay_protocol=3&application_public_key=${"A".repeat(87)}`,
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${"a".repeat(43)}&code_challenge_method=S256&relay_protocol=3&application_agreement_public_key=${"A".repeat(87)}`,
       headers: { cookie }
     });
     expect(invalidEncryption.statusCode).toBe(400);
     expect(invalidEncryption.json().error.code).toBe("invalid_encryption_request");
+    const reusedApplicationKey = p256PublicKey();
+    const reusedEncryptionKey = await app.inject({
+      method: "GET",
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${"a".repeat(43)}&code_challenge_method=S256&relay_protocol=1&application_agreement_public_key=${reusedApplicationKey}&application_signing_public_key=${reusedApplicationKey}`,
+      headers: { cookie }
+    });
+    expect(reusedEncryptionKey.statusCode).toBe(400);
+    expect(reusedEncryptionKey.json().error.code).toBe("invalid_encryption_request");
     const legacyCompatibleGrantId = "325cc8cf-dad5-4fc9-b0bc-a1c92e99f3ed";
     const legacyIncompatibleGrantId = "425cc8cf-dad5-4fc9-b0bc-a1c92e99f3ed";
     const user = await db.query<{ id: string }>("SELECT id FROM users WHERE email = $1", [
@@ -439,11 +463,11 @@ describe("mdbase connect server", () => {
         legacyCompatibleGrantId,
         user.rows[0].id,
         applicationId,
-        collectionId,
+        authorityId(localCollectionId),
         JSON.stringify(["read"]),
         JSON.stringify({ contracts: [] }),
         legacyIncompatibleGrantId,
-        synchronized.json().collections[1].id,
+        authorityId(incompatibleLocalCollectionId),
         JSON.stringify({ contracts: [contractDescriptor()] })
       ]
     );
@@ -669,7 +693,11 @@ describe("mdbase connect server", () => {
       method: "POST",
       url: `/v1/authorities/${collectionId}/operations/query`,
       headers: { authorization: `Bearer ${refreshed.json().access_token}` },
-      payload: { types: ["workout"] }
+      payload: {
+        protocol_version: 1,
+        request_id: "01911111-1111-7111-8111-111111111111",
+        input: { types: ["workout"] }
+      }
     });
     expect(operation.statusCode).toBe(503);
     expect(operation.json().error.code).toBe("connector_offline");
@@ -880,13 +908,8 @@ describe("mdbase connect server", () => {
     });
     const applicationId = registration.json().application.id as string;
 
-    const applicationKeys = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
-    const applicationJwk = applicationKeys.publicKey.export({ format: "jwk" });
-    const applicationPublicKey = Buffer.concat([
-      Buffer.from([4]),
-      Buffer.from(applicationJwk.x!, "base64url"),
-      Buffer.from(applicationJwk.y!, "base64url")
-    ]).toString("base64url");
+    const applicationAgreementPublicKey = p256PublicKey();
+    const applicationSigningPublicKey = p256PublicKey();
     const verifier = "portable-verifier-that-is-long-enough-for-pkce-0001";
     const device = await app.inject({
       method: "POST",
@@ -902,7 +925,8 @@ describe("mdbase connect server", () => {
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
-        application_public_key: applicationPublicKey
+        application_agreement_public_key: applicationAgreementPublicKey,
+        application_signing_public_key: applicationSigningPublicKey
       }).toString()
     });
     expect(device.statusCode, JSON.stringify(device.json())).toBe(200);
@@ -1057,7 +1081,7 @@ describe("mdbase connect server", () => {
         protocol_version: 1,
         connector_id: connector.connector.id,
         collection_id: localCollectionId,
-        application_public_key: applicationPublicKey
+        application_agreement_public_key: applicationAgreementPublicKey
       }
     });
     const policy = await app.inject({
@@ -1100,9 +1124,10 @@ describe("mdbase connect server", () => {
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
-        application_public_key: deniedKey
+        application_agreement_public_key: deniedKey
           .getPublicKey(undefined, "uncompressed")
-          .toString("base64url")
+          .toString("base64url"),
+        application_signing_public_key: p256PublicKey()
       }).toString()
     });
     const deniedLookup = await app.inject({
@@ -1134,9 +1159,10 @@ describe("mdbase connect server", () => {
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
-        application_public_key: expiringKey
+        application_agreement_public_key: expiringKey
           .getPublicKey(undefined, "uncompressed")
-          .toString("base64url")
+          .toString("base64url"),
+        application_signing_public_key: p256PublicKey()
       }).toString()
     });
     await db.query(
@@ -1210,12 +1236,17 @@ describe("mdbase connect server", () => {
     });
     expect(registration.statusCode, JSON.stringify(registration.json())).toBe(200);
     const applicationId = registration.json().application.id as string;
-    const applicationKeys = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
-    const applicationJwk = applicationKeys.publicKey.export({ format: "jwk" });
-    const applicationPublicKey = Buffer.concat([
+    const applicationAgreementPublicKey = p256PublicKey();
+    const applicationSigningKeys = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1"
+    });
+    const applicationSigningJwk = applicationSigningKeys.publicKey.export({
+      format: "jwk"
+    });
+    const applicationSigningPublicKey = Buffer.concat([
       Buffer.from([4]),
-      Buffer.from(applicationJwk.x!, "base64url"),
-      Buffer.from(applicationJwk.y!, "base64url")
+      Buffer.from(applicationSigningJwk.x!, "base64url"),
+      Buffer.from(applicationSigningJwk.y!, "base64url")
     ]).toString("base64url");
     const verifier = "portable-hosted-verifier-that-is-long-enough-0001";
     const device = await app.inject({
@@ -1232,7 +1263,8 @@ describe("mdbase connect server", () => {
         code_challenge: pkceChallenge(verifier),
         code_challenge_method: "S256",
         relay_protocol: "1",
-        application_public_key: applicationPublicKey
+        application_agreement_public_key: applicationAgreementPublicKey,
+        application_signing_public_key: applicationSigningPublicKey
       }).toString()
     });
     expect(device.statusCode, JSON.stringify(device.json())).toBe(200);
@@ -1270,7 +1302,7 @@ describe("mdbase connect server", () => {
         fullCollection: true,
         allowedOperations: ["describe", "query", "create", "update"],
         allowedOrigin: "null",
-        proofPublicKey: applicationPublicKey
+        proofPublicKey: applicationSigningPublicKey
       })
     );
     const token = await pollDeviceToken(app, {
@@ -1287,7 +1319,7 @@ describe("mdbase connect server", () => {
       authority: {
         operations_url: `https://sync.example/v1/authorities/${collectionId}/operations`,
         sync_url: `https://sync.example/v1/authorities/${collectionId}/sync`,
-        proof_public_key: applicationPublicKey
+        proof_public_key: applicationSigningPublicKey
       }
     });
     expect(token.json().authority.replica_id).toMatch(
@@ -1328,7 +1360,7 @@ describe("mdbase connect server", () => {
         timestamp: proofTimestamp,
         nonce: proofNonce
       })),
-      { key: applicationKeys.privateKey, dsaEncoding: "ieee-p1363" }
+      { key: applicationSigningKeys.privateKey, dsaEncoding: "ieee-p1363" }
     ).toString("base64url");
     const refreshed = await app.inject({
       method: "POST",
@@ -1352,7 +1384,7 @@ describe("mdbase connect server", () => {
         operations_url: `https://sync.example/v1/authorities/${collectionId}/operations`,
         sync_url: `https://sync.example/v1/authorities/${collectionId}/sync`,
         replica_id: token.json().authority.replica_id,
-        proof_public_key: applicationPublicKey
+        proof_public_key: applicationSigningPublicKey
       }
     });
     expect(refreshed.json().authority.access_token).not.toBe(token.json().authority.access_token);
@@ -1367,7 +1399,7 @@ describe("mdbase connect server", () => {
     expect(grant.rows[0]).toEqual({
       application_origin: "null",
       encryption: null,
-      proof_public_key: applicationPublicKey
+      proof_public_key: applicationSigningPublicKey
     });
   });
 
@@ -1614,9 +1646,11 @@ describe("mdbase connect server", () => {
     });
     const applicationId = discovered.json().application.id as string;
     const verifier = "hosted-unrestricted-verifier-that-is-long-enough-0001";
+    const applicationAgreementPublicKey = p256PublicKey();
+    const applicationSigningPublicKey = p256PublicKey();
     const authorization = await app.inject({
       method: "GET",
-      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&operations=describe,query,create,update,sync`,
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge(verifier)}&code_challenge_method=S256&operations=describe,query,create,update,sync&relay_protocol=1&application_agreement_public_key=${applicationAgreementPublicKey}&application_signing_public_key=${applicationSigningPublicKey}`,
       headers: { cookie }
     });
     const requestId = authorization.headers.location!.split("/").at(-1)!;
@@ -1812,9 +1846,11 @@ describe("mdbase connect server", () => {
     const applicationId = discovered.json().application.id as string;
     expect(discovered.json().application.provisions.type_packs[0].manifest.id)
       .toBe("example.workouts");
+    const applicationAgreementPublicKey = p256PublicKey();
+    const applicationSigningPublicKey = p256PublicKey();
     const authorization = await app.inject({
       method: "GET",
-      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge("hosted-provision-verifier-that-is-long-enough-0001")}&code_challenge_method=S256&operations=read,query,create`,
+      url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${pkceChallenge("hosted-provision-verifier-that-is-long-enough-0001")}&code_challenge_method=S256&operations=read,query,create&relay_protocol=1&application_agreement_public_key=${applicationAgreementPublicKey}&application_signing_public_key=${applicationSigningPublicKey}`,
       headers: { cookie }
     });
     const requestId = authorization.headers.location!.split("/").at(-1)!;

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -25,6 +25,7 @@ import type {
   TypePackProvision
 } from "@mdbase/connect-protocol";
 import {
+  CONTROL_PROTOCOL_VERSION,
   ENCRYPTED_RELAY_PROTOCOL_VERSION,
   RELAY_ENCRYPTION_SUITE
 } from "@mdbase/connect-protocol";
@@ -237,6 +238,11 @@ const encryptedRelayRequestSchema = z.object({
   key_id: z.string().min(1).max(200),
   counter: z.string().regex(/^[1-9][0-9]{0,19}$/),
   ciphertext: z.string().min(1).max(2_800_000).regex(/^[A-Za-z0-9_-]+$/)
+}).strict();
+const operationRequestSchema = z.object({
+  protocol_version: z.literal(CONTROL_PROTOCOL_VERSION),
+  request_id: z.uuid(),
+  input: z.unknown()
 }).strict();
 const syncMutationSchema = z.object({
   mutation_id: z.uuid(),
@@ -2789,7 +2795,7 @@ export async function buildApp(options: BuildOptions) {
       `SELECT g.id, g.operations, g.scope, g.created_at, g.revoked_at,
               CASE WHEN g.application_origin = '' THEN a.homepage
                    ELSE g.application_origin END AS application_origin,
-              COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
+              COALESCE(col.local_id, g.hosted_collection_id) AS collection_id,
               a.id AS application_id,
               a.family_identity AS application_family_id,
               a.distribution, a.name AS application_name,
@@ -2835,12 +2841,12 @@ export async function buildApp(options: BuildOptions) {
         );
         return {
           ...collection,
+          id: collection.local_id,
           ...(access ? {
             access: accessView(access),
             authority: {
               kind: "local",
               collection_id: access.collection.collectionId,
-              row_id: access.collection.authorityRowId,
               epoch: access.collection.authorityEpoch,
               state: access.collection.authorityState
             }
@@ -3083,7 +3089,8 @@ export async function buildApp(options: BuildOptions) {
           ]
         );
         synchronized.push({
-          ...row.rows[0],
+          id: row.rows[0].local_id,
+          authority_state: row.rows[0].authority_state,
           authority_epoch: Number(row.rows[0].authority_epoch)
         });
       }
@@ -3788,7 +3795,7 @@ export async function buildApp(options: BuildOptions) {
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
        LEFT JOIN collections hinted
-         ON hinted.id = ar.collection_id AND hinted.connector_id = $2
+         ON hinted.local_id = ar.collection_id AND hinted.connector_id = $2
        WHERE ar.user_id = $1 AND ar.completed_at IS NULL AND ar.denied_at IS NULL
          AND ar.expires_at > now()
        ORDER BY ar.expires_at`,
@@ -4570,12 +4577,13 @@ export async function buildApp(options: BuildOptions) {
   });
 
   app.get("/v1/relay", { websocket: true }, async (socket, request) => {
+    const handshake = relay.beginHandshake(socket);
     const connector = await connectorFromRequest(request, options.db);
     if (!connector) {
       socket.close(4003, "Invalid connector credential");
       return;
     }
-    await relay.attach(connector.id, socket);
+    await relay.attach(connector.id, socket, handshake);
   });
 
   app.post("/v1/apps/register", async (request) => {
@@ -4599,15 +4607,18 @@ export async function buildApp(options: BuildOptions) {
       code_challenge: z.string().min(43).max(128),
       code_challenge_method: z.literal("S256"),
       relay_protocol: z.coerce.number().int(),
-      application_public_key: z.string().min(80).max(200)
+      application_agreement_public_key: z.string().min(80).max(200),
+      application_signing_public_key: z.string().min(80).max(200)
     }).strict().parse(request.body);
     if (
       input.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
-      || !isP256PublicKey(input.application_public_key)
+      || !isP256PublicKey(input.application_agreement_public_key)
+      || !isP256PublicKey(input.application_signing_public_key)
+      || input.application_agreement_public_key === input.application_signing_public_key
     ) {
       return reply.code(400).send(apiError(
         "invalid_encryption_request",
-        "Portable authorization requires encrypted relay protocol 1 and a valid P-256 public key."
+        "Portable authorization requires encrypted relay protocol 1 and independent P-256 agreement and signing keys."
       ));
     }
     const application = await options.db.query<{
@@ -4645,10 +4656,11 @@ export async function buildApp(options: BuildOptions) {
       `INSERT INTO authorization_requests
          (id, user_id, application_id, flow, redirect_uri, state, code_challenge,
           requested_operations, collection_id, relay_protocol,
-          application_public_key, device_code_hash, user_code, user_code_hash,
+          application_agreement_public_key, application_signing_public_key,
+          device_code_hash, user_code, user_code_hash,
           poll_interval_seconds, expires_at)
        VALUES ($1, NULL, $2, 'device_code', NULL, NULL, $3, $4::jsonb, $5, $6,
-               $7, $8, $9, $10, $11, now() + interval '10 minutes')`,
+               $7, $8, $9, $10, $11, $12, now() + interval '10 minutes')`,
       [
         authorizationId,
         input.client_id,
@@ -4656,7 +4668,8 @@ export async function buildApp(options: BuildOptions) {
         JSON.stringify(requestedOperations),
         input.collection_id ?? null,
         ENCRYPTED_RELAY_PROTOCOL_VERSION,
-        input.application_public_key,
+        input.application_agreement_public_key,
+        input.application_signing_public_key,
         tokenHash(deviceCode),
         userCode,
         tokenHash(canonicalUserCode(userCode)),
@@ -4682,16 +4695,18 @@ export async function buildApp(options: BuildOptions) {
       collection_id: z.uuid(),
       operations: z.array(operationSchema).min(1)
     }).parse(request.body);
-    const ownership = await options.db.query<{ connector_id: string; contracts: CollectionContractDescriptor[]; spec_version: string }>(
-      `SELECT col.connector_id, col.contracts, col.spec_version FROM collections col
+    const ownership = await options.db.query<{ id: string; connector_id: string; contracts: CollectionContractDescriptor[]; spec_version: string }>(
+      `SELECT col.id, col.connector_id, col.contracts, col.spec_version FROM collections col
        JOIN connectors c ON c.id = col.connector_id
-       WHERE col.id = $1 AND c.revoked_at IS NULL`,
-      [input.collection_id]
+       WHERE col.local_id = $1 AND col.user_id = $2
+         AND col.authority_state = 'active' AND col.present = true
+         AND c.revoked_at IS NULL`,
+      [input.collection_id, user.id]
     );
     const collectionAccess = await resolveLocalCollectionAccess(
       options.db,
       user.id,
-      input.collection_id
+      ownership.rows[0]?.id ?? input.collection_id
     );
     if (
       !ownership.rows[0]
@@ -4745,7 +4760,7 @@ export async function buildApp(options: BuildOptions) {
     const grant = await createOrUpdateGrant(options.db, {
       userId: user.id,
       applicationId: input.application_id,
-      collectionId: input.collection_id,
+      collectionId: ownership.rows[0].id,
       operations: plan.operations,
       scope: plan.scope,
       applicationOrigin: new URL(application.rows[0].homepage).origin,
@@ -4887,18 +4902,23 @@ export async function buildApp(options: BuildOptions) {
       operations: z.string().default("read,query"),
       collection_id: z.uuid().optional(),
       relay_protocol: z.coerce.number().int().optional(),
-      application_public_key: z.string().min(80).max(200).optional()
+      application_agreement_public_key: z.string().min(80).max(200).optional(),
+      application_signing_public_key: z.string().min(80).max(200).optional()
     }).parse(request.query);
     const encryptionRequested = query.relay_protocol !== undefined
-      || query.application_public_key !== undefined;
+      || query.application_agreement_public_key !== undefined
+      || query.application_signing_public_key !== undefined;
     if (encryptionRequested && (
       query.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
-      || !query.application_public_key
-      || !isP256PublicKey(query.application_public_key)
+      || !query.application_agreement_public_key
+      || !isP256PublicKey(query.application_agreement_public_key)
+      || !query.application_signing_public_key
+      || !isP256PublicKey(query.application_signing_public_key)
+      || query.application_agreement_public_key === query.application_signing_public_key
     )) {
       return reply.code(400).send(apiError(
         "invalid_encryption_request",
-        "Encrypted relay authorization requires protocol 1 and a valid P-256 public key."
+        "Encrypted relay authorization requires protocol 1 and independent P-256 agreement and signing keys."
       ));
     }
     const application = await options.db.query<{
@@ -4928,8 +4948,11 @@ export async function buildApp(options: BuildOptions) {
     await options.db.query(
       `INSERT INTO authorization_requests
          (id, user_id, application_id, redirect_uri, state, code_challenge,
-          requested_operations, collection_id, relay_protocol, application_public_key, expires_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, now() + interval '10 minutes')`,
+          requested_operations, collection_id, relay_protocol,
+          application_agreement_public_key, application_signing_public_key,
+          expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11,
+               now() + interval '10 minutes')`,
       [
         authorizationId,
         user.id,
@@ -4940,7 +4963,8 @@ export async function buildApp(options: BuildOptions) {
         JSON.stringify(requestedOperations),
         query.collection_id ?? null,
         query.relay_protocol ?? null,
-        query.application_public_key ?? null
+        query.application_agreement_public_key ?? null,
+        query.application_signing_public_key ?? null
       ]
     );
     return reply.redirect(`/authorize/${authorizationId}`);
@@ -5731,7 +5755,7 @@ export async function buildApp(options: BuildOptions) {
        WHERE tok.token_hash = $1 AND tok.expires_at > now() AND tok.revoked_at IS NULL
          AND g.revoked_at IS NULL AND g.activated_at IS NOT NULL
          AND u.suspended_at IS NULL
-         AND col.id = $2 AND col.enabled = true AND col.present = true
+         AND col.local_id = $2 AND col.enabled = true AND col.present = true
          AND col.authority_state = 'active'`,
       [tokenHash(bearer), params.collectionId]
     );
@@ -5778,15 +5802,22 @@ export async function buildApp(options: BuildOptions) {
           "This grant was not authorized for encrypted relay protocol 1."
         ));
       }
+      const operationRequest = operationRequestSchema.parse(request.body);
       const result = await relay.route({
         connectorId: grant.connector_id,
         localCollectionId: grant.local_id,
+        requestId: operationRequest.request_id,
         grantId: grant.grant_id,
         applicationId: grant.application_id,
         operation: params.operation,
-        operationInput: request.body ?? {}
+        operationInput: operationRequest.input
       });
-      return { ok: true, result };
+      return {
+        protocol_version: CONTROL_PROTOCOL_VERSION,
+        request_id: operationRequest.request_id,
+        ok: true,
+        result
+      };
     } catch (error) {
       if (error instanceof RelayUnavailableError) {
         return reply.code(503).send(apiError("connector_offline", error.message));
@@ -6332,7 +6363,7 @@ async function liveAuthorizationCollections(
       );
       if (!access || !access.actions.has("application.authorize")) continue;
       collections.push({
-        id: collection.id,
+        id: offered.collection_id,
         offer_id: offer.rows[0].id,
         kind: "local",
         connector_name: connector.name,
@@ -6369,6 +6400,7 @@ async function approvePortalAuthorization(
   const grantId = randomUUID();
   let connectorId = "";
   let localCollectionId = "";
+  let authorityRowId = "";
   let requirements: ApplicationRequirements;
   let provisions: ApplicationProvisions;
   let grant: GrantPolicy;
@@ -6387,7 +6419,8 @@ async function approvePortalAuthorization(
       provisions: ApplicationProvisions;
       notifications: ApplicationNotifications;
       relay_protocol: number | null;
-      application_public_key: string | null;
+      application_agreement_public_key: string | null;
+      application_signing_public_key: string | null;
       flow: "authorization_code" | "device_code";
       redirect_uri: string | null;
       collection_id: string | null;
@@ -6398,7 +6431,8 @@ async function approvePortalAuthorization(
               a.distribution, a.homepage AS application_homepage,
               a.project_url AS application_project_url, a.icon AS application_icon,
               ar.requested_operations, a.requirements, a.provisions, a.notifications,
-              ar.relay_protocol, ar.application_public_key, ar.flow, ar.redirect_uri,
+              ar.relay_protocol, ar.application_agreement_public_key,
+              ar.application_signing_public_key, ar.flow, ar.redirect_uri,
               ar.collection_id, ar.grant_id, ar.activation_started_at
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
@@ -6442,7 +6476,8 @@ async function approvePortalAuthorization(
       && (
         pending.flow !== "device_code"
         || pending.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
-        || !pending.application_public_key
+        || !pending.application_agreement_public_key
+        || !pending.application_signing_public_key
       )
     ) {
       throw new RequestValidationError(
@@ -6459,6 +6494,7 @@ async function approvePortalAuthorization(
     }
     const offer = await connection.query<{
       connector_id: string;
+      authority_row_id: string;
       local_id: string;
       display_name: string;
       spec_version: string;
@@ -6466,13 +6502,14 @@ async function approvePortalAuthorization(
       relay_public_key: string | null;
       authority_epoch: string | number;
     }>(
-      `SELECT offer.connector_id, offer.local_id, col.display_name, col.spec_version,
+      `SELECT offer.connector_id, offer.collection_id AS authority_row_id,
+              offer.local_id, col.display_name, col.spec_version,
               col.contracts, con.relay_public_key, col.authority_epoch
        FROM authorization_collection_offers offer
        JOIN collections col ON col.id = offer.collection_id
        JOIN connectors con ON con.id = offer.connector_id
        WHERE offer.id = $1 AND offer.authorization_id = $2
-         AND offer.user_id = $3 AND offer.collection_id = $4
+         AND offer.user_id = $3 AND offer.local_id = $4
          AND offer.consumed_at IS NULL AND offer.expires_at > now()
          AND col.present = true AND col.enabled = true
          AND col.authority_state = 'active'
@@ -6492,7 +6529,7 @@ async function approvePortalAuthorization(
       await resolveLocalCollectionAccess(
         connection,
         input.userId,
-        input.collectionId
+        selected.authority_row_id
       ),
       "application.authorize"
     );
@@ -6509,7 +6546,7 @@ async function approvePortalAuthorization(
     const scope = plan.scope;
     let encryption: GrantEncryption | undefined;
     if (pending.relay_protocol === ENCRYPTED_RELAY_PROTOCOL_VERSION) {
-      if (!pending.application_public_key || !selected.relay_public_key) {
+      if (!pending.application_agreement_public_key || !selected.relay_public_key) {
         throw new RequestValidationError(
           "Encrypted relay protocol 1 requires an up-to-date connector."
         );
@@ -6521,8 +6558,8 @@ async function approvePortalAuthorization(
         scope_epoch: 1,
         connector_id: selected.connector_id,
         collection_id: selected.local_id,
-        application_public_key: pending.application_public_key,
-        connector_public_key: selected.relay_public_key
+        application_agreement_public_key: pending.application_agreement_public_key,
+        connector_agreement_public_key: selected.relay_public_key
       };
     }
     const applicationOrigin = pending.flow === "device_code"
@@ -6541,7 +6578,7 @@ async function approvePortalAuthorization(
         grantId,
         input.userId,
         pending.application_id,
-        input.collectionId,
+        selected.authority_row_id,
         JSON.stringify(operations),
         JSON.stringify(scope),
         encryption ? JSON.stringify(encryption) : null,
@@ -6557,6 +6594,7 @@ async function approvePortalAuthorization(
     );
     connectorId = selected.connector_id;
     localCollectionId = selected.local_id;
+    authorityRowId = selected.authority_row_id;
     requirements = pending.requirements;
     provisions = pending.provisions;
     grant = {
@@ -6639,7 +6677,7 @@ async function approvePortalAuthorization(
     await finalize.query(
       `UPDATE collections SET contracts = $2::jsonb, last_seen_at = now()
        WHERE id = $1`,
-      [input.collectionId, JSON.stringify(activation.contracts)]
+      [authorityRowId, JSON.stringify(activation.contracts)]
     );
     await finalize.query("COMMIT");
   } catch (error) {
@@ -6713,14 +6751,16 @@ async function approveAuthorization(
     requirements: ApplicationRequirements;
     notifications: ApplicationNotifications;
     relay_protocol: number | null;
-    application_public_key: string | null;
+    application_agreement_public_key: string | null;
+    application_signing_public_key: string | null;
     flow: "authorization_code" | "device_code";
     redirect_uri: string | null;
     collection_id: string | null;
   }>(
     `SELECT ar.application_id, a.distribution, a.homepage AS application_homepage,
             ar.requested_operations, a.requirements, a.notifications,
-            ar.relay_protocol, ar.application_public_key, ar.flow, ar.redirect_uri,
+            ar.relay_protocol, ar.application_agreement_public_key,
+            ar.application_signing_public_key, ar.flow, ar.redirect_uri,
             ar.collection_id
      FROM authorization_requests ar
      JOIN applications a ON a.id = ar.application_id
@@ -6734,17 +6774,13 @@ async function approveAuthorization(
       await connection.query("ROLLBACK");
       return false;
     }
-    if (pending.collection_id && pending.collection_id !== input.collectionId) {
-      throw new RequestValidationError(
-        "This authorization request is restricted to a different collection."
-      );
-    }
     if (
       pending.distribution === "portable"
       && (
         pending.flow !== "device_code"
         || pending.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
-        || !pending.application_public_key
+        || !pending.application_agreement_public_key
+        || !pending.application_signing_public_key
       )
     ) {
       throw new RequestValidationError(
@@ -6785,6 +6821,14 @@ async function approveAuthorization(
         "This collection does not provide the contracts required by the application."
       );
     }
+    if (
+      pending.collection_id
+      && pending.collection_id !== collection.rows[0].local_id
+    ) {
+      throw new RequestValidationError(
+        "This authorization request is restricted to a different collection."
+      );
+    }
     assertCollectionSupportsOperations(collection.rows[0].spec_version, input.operations);
     if (!contractsSatisfy(
       collection.rows[0].contracts,
@@ -6796,7 +6840,7 @@ async function approveAuthorization(
     }
     let encryption: GrantEncryption | null = null;
     if (pending.relay_protocol === ENCRYPTED_RELAY_PROTOCOL_VERSION) {
-      if (!pending.application_public_key || !collection.rows[0].relay_public_key) {
+      if (!pending.application_agreement_public_key || !collection.rows[0].relay_public_key) {
         throw new RequestValidationError(
           "Encrypted relay protocol 1 requires an up-to-date connector."
         );
@@ -6808,8 +6852,8 @@ async function approveAuthorization(
         scope_epoch: 1,
         connector_id: input.connectorId,
         collection_id: collection.rows[0].local_id,
-        application_public_key: pending.application_public_key,
-        connector_public_key: collection.rows[0].relay_public_key
+        application_agreement_public_key: pending.application_agreement_public_key,
+        connector_agreement_public_key: collection.rows[0].relay_public_key
       };
     }
     await connection.query(
@@ -6881,7 +6925,8 @@ async function approveHostedAuthorization(
       provisions: ApplicationProvisions;
       notifications: ApplicationNotifications;
       relay_protocol: number | null;
-      application_public_key: string | null;
+      application_agreement_public_key: string | null;
+      application_signing_public_key: string | null;
       flow: "authorization_code" | "device_code";
       collection_id: string | null;
     }>(
@@ -6889,7 +6934,8 @@ async function approveHostedAuthorization(
               a.distribution, a.homepage AS application_homepage,
               ar.redirect_uri, ar.requested_operations,
               a.requirements, a.provisions, a.notifications,
-              ar.relay_protocol, ar.application_public_key, ar.flow,
+              ar.relay_protocol, ar.application_agreement_public_key,
+              ar.application_signing_public_key, ar.flow,
               ar.collection_id
        FROM authorization_requests ar
        JOIN applications a ON a.id = ar.application_id
@@ -6913,7 +6959,8 @@ async function approveHostedAuthorization(
       && (
         pending.flow !== "device_code"
         || pending.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
-        || !pending.application_public_key
+        || !pending.application_agreement_public_key
+        || !pending.application_signing_public_key
       )
     ) {
       throw new RequestValidationError(
@@ -6923,6 +6970,15 @@ async function approveHostedAuthorization(
     if (pending.flow === "device_code" && pending.distribution !== "portable") {
       throw new RequestValidationError(
         "Device authorization is reserved for downloaded applications."
+      );
+    }
+    if (
+      pending.relay_protocol !== ENCRYPTED_RELAY_PROTOCOL_VERSION
+      || !pending.application_agreement_public_key
+      || !pending.application_signing_public_key
+    ) {
+      throw new RequestValidationError(
+        "Remote authority access requires independent agreement and signing keys."
       );
     }
     const requiredContracts = requiredContractsForRequirements(pending.requirements);
@@ -6994,9 +7050,7 @@ async function approveHostedAuthorization(
       fullCollection: scope.access === "full_collection",
       allowedOperations: hostedReplicaCollectionOperations(operations),
       allowedOrigin,
-      proofPublicKey: pending.flow === "device_code"
-        ? pending.application_public_key!
-        : undefined,
+      proofPublicKey: pending.application_signing_public_key!,
       grantId,
       token: bootstrapToken,
       tokenTtlSeconds: 3_600
@@ -7029,7 +7083,7 @@ async function approveHostedAuthorization(
         replicaId,
         JSON.stringify(operations),
         JSON.stringify(scope),
-        pending.flow === "device_code" ? pending.application_public_key : null,
+        pending.application_signing_public_key,
         applicationOrigin,
         JSON.stringify(pending.notifications.criteria)
       ]
@@ -7169,7 +7223,7 @@ async function issueApplicationTokens(
     application_origin: string;
   }>(
     `SELECT g.user_id,
-            COALESCE(g.collection_id, g.hosted_collection_id) AS collection_id,
+            COALESCE(col.local_id, g.hosted_collection_id) AS collection_id,
             g.collection_id AS local_authority_row_id,
             COALESCE(col.display_name, hosted.display_name) AS collection_name,
             g.hosted_collection_id, g.hosted_replica_id, hosted.provider_url,

--- a/services/server/src/canonical-json.ts
+++ b/services/server/src/canonical-json.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Canonical JSON for protocol hashes. Object keys use deterministic UTF-16
+ * ordering and values use the ECMAScript JSON primitive representation required
+ * by RFC 8785.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Canonical JSON cannot contain a non-finite number.");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0);
+    return `{${entries
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+      .join(",")}}`;
+  }
+  throw new TypeError(`Canonical JSON cannot contain ${typeof value}.`);
+}
+
+export function canonicalSha256(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -36,7 +36,8 @@ describe("database migrations", () => {
       "0001_collaboration_foundations",
       "0001a_authentication_foundations",
       "0002_instance_administration",
-      "0003_authorization_request_collection"
+      "0003_authorization_request_collection",
+      "0004_separate_application_keys"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -289,7 +290,8 @@ describe("database migrations", () => {
       "0001_collaboration_foundations",
       "0001a_authentication_foundations",
       "0002_instance_administration",
-      "0003_authorization_request_collection"
+      "0003_authorization_request_collection",
+      "0004_separate_application_keys"
     ]);
   });
 

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -325,7 +325,8 @@ export async function bootstrapLegacyBaseline(db: DatabaseQueryable): Promise<vo
       requested_operations jsonb NOT NULL,
       collection_id uuid,
       relay_protocol integer,
-      application_public_key text,
+      application_agreement_public_key text,
+      application_signing_public_key text,
       device_code_hash text UNIQUE,
       user_code text,
       user_code_hash text UNIQUE,
@@ -777,7 +778,8 @@ export async function bootstrapLegacyBaseline(db: DatabaseQueryable): Promise<vo
   );
   await revokeLegacyHostedBearerGrants(db);
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
-  await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
+  await ensureColumn(db, "authorization_requests", "application_agreement_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_agreement_public_key text");
+  await ensureColumn(db, "authorization_requests", "application_signing_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_signing_public_key text");
   await ensureColumn(db, "authorization_requests", "collection_id", "ALTER TABLE authorization_requests ADD COLUMN collection_id uuid");
   // Retain the unused legacy column until the previous release is outside the
   // production rollback window. Runtime compatibility is not a license for a

--- a/services/server/src/hosted.ts
+++ b/services/server/src/hosted.ts
@@ -372,11 +372,13 @@ function manifestDigest(state: SerializedMemoryAuthority): string {
     ...(state.resources?.documents ?? []).map((resource) => ({
       kind: "resource" as const,
       path: resource.path,
+      identity: "",
       document_hash: digest(resource.document)
     })),
     ...state.records.map((record) => ({
       kind: "record" as const,
       path: record.path,
+      identity: record.record_id,
       document_hash: record.revision
     }))
   ]);

--- a/services/server/src/inventory-authority.test.ts
+++ b/services/server/src/inventory-authority.test.ts
@@ -77,7 +77,7 @@ describe("authoritative connector inventory", () => {
       enabled: boolean;
       authority_state: string;
     }>(
-      "SELECT present, enabled, authority_state FROM collections WHERE id = $1",
+      "SELECT present, enabled, authority_state FROM collections WHERE local_id = $1",
       [omittedServerId]
     );
     expect(retired.rows[0]).toEqual({

--- a/services/server/src/live-authorization.test.ts
+++ b/services/server/src/live-authorization.test.ts
@@ -104,9 +104,30 @@ describe("live connector-mediated authorization", () => {
     });
     const relayMessages: Array<Record<string, unknown>> = [];
     let rejectActivation = false;
+    socket.on("open", () => {
+      socket.send(JSON.stringify({
+        type: "relay_hello",
+        protocol_version: 1,
+        connector_version: "0.1.0-test",
+        capabilities: [
+          "authorization-activation",
+          "encrypted-relay",
+          "policy-ack"
+        ]
+      }));
+    });
     socket.on("message", (raw) => {
       const message = JSON.parse(raw.toString()) as Record<string, unknown>;
       relayMessages.push(message);
+      if (message.type === "policy_snapshot") {
+        socket.send(JSON.stringify({
+          type: "policy_applied",
+          protocol_version: 1,
+          request_id: message.request_id,
+          revision: message.revision,
+          ok: true
+        }));
+      }
       if (message.type === "authorization_offer_request") {
         socket.send(JSON.stringify({
           type: "authorization_offer_response",
@@ -250,6 +271,54 @@ describe("live connector-mediated authorization", () => {
       "SELECT COUNT(*) AS count FROM grants WHERE activated_at IS NULL"
     );
     expect(Number(pendingGrants.rows[0].count)).toBe(0);
+  });
+
+  it("rejects a pre-handshake connector with an actionable upgrade response", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Owner", email: "upgrade@example.test" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    const connector = (await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Outdated computer" }
+    })).json();
+    const address = await app.listen({ host: "127.0.0.1", port: 0 });
+    const socket = new WebSocket(
+      `${address.replace(/^http/, "ws")}/v1/relay`,
+      { headers: { authorization: `Bearer ${connector.token}` } }
+    );
+    await once(socket, "open");
+    const messagePromise = once(socket, "message");
+    const closePromise = once(socket, "close");
+    socket.send(JSON.stringify({
+      type: "policy_applied",
+      protocol_version: 1,
+      request_id: "01911111-1111-7111-8111-111111111111",
+      revision: `sha256:${"0".repeat(64)}`,
+      ok: true
+    }));
+    const [raw] = await messagePromise;
+    expect(JSON.parse(raw.toString())).toMatchObject({
+      type: "relay_incompatible",
+      protocol_version: 1,
+      code: "connector_upgrade_required",
+      update_url: "https://github.com/mdbase-dev/mdbase-connect/releases/latest"
+    });
+    const [code] = await closePromise;
+    expect(code).toBe(4406);
   });
 });
 

--- a/services/server/src/manifest.test.ts
+++ b/services/server/src/manifest.test.ts
@@ -4,6 +4,21 @@ import {
   isNativeRedirectUri,
   registerApplicationManifest
 } from "./manifest.js";
+import { canonicalJson, canonicalSha256 } from "./canonical-json.js";
+
+describe("canonical protocol JSON", () => {
+  it("hashes equivalent objects identically regardless of insertion order", () => {
+    const left = { z: 1, a: { beta: true, alpha: ["x", 2] } };
+    const right = { a: { alpha: ["x", 2], beta: true }, z: 1 };
+    expect(canonicalJson(left)).toBe('{"a":{"alpha":["x",2],"beta":true},"z":1}');
+    expect(canonicalSha256(left)).toBe(canonicalSha256(right));
+  });
+
+  it("rejects values outside the JSON data model", () => {
+    expect(() => canonicalJson(Number.NaN)).toThrow("non-finite");
+    expect(() => canonicalJson(1n)).toThrow("bigint");
+  });
+});
 
 describe("native manifest callbacks", () => {
   it("accepts a reverse-domain private-use application scheme", () => {

--- a/services/server/src/manifest.ts
+++ b/services/server/src/manifest.ts
@@ -6,6 +6,7 @@ import type {
 } from "@mdbase/connect-protocol";
 import { isNativeRedirectUri } from "@mdbase/connect-protocol";
 import { z } from "zod";
+import { canonicalSha256 } from "./canonical-json.js";
 
 export { isNativeRedirectUri };
 
@@ -172,9 +173,7 @@ export function registerApplicationManifest(
     const parsed = manifestSchema.parse(value);
     validateManifestIdentity(parsed, allowInsecure);
     const manifest: AppManifest = parsed;
-    const digest = createHash("sha256")
-      .update(JSON.stringify(manifest))
-      .digest("hex");
+    const digest = canonicalSha256(manifest).slice("sha256:".length);
     return {
       manifest,
       canonicalIdentity: `bundle:${parsed.id}:sha256:${digest}`,

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -10,6 +10,10 @@ import type {
   GrantPolicy,
   GrantScope
 } from "@mdbase/connect-protocol";
+import {
+  CONTROL_PROTOCOL_VERSION,
+  RELAY_CAPABILITIES
+} from "@mdbase/connect-protocol";
 import type { DatabasePool } from "./db.js";
 import {
   LocalRelayBroker,
@@ -19,6 +23,7 @@ import {
   type RelayBrokerCommand,
   type RelayBrokerReply
 } from "./relay-broker.js";
+import { canonicalSha256 } from "./canonical-json.js";
 import type { WebSocket } from "ws";
 
 const OPERATION_TIMEOUT_MS = 30_000;
@@ -26,6 +31,9 @@ const BROKER_OPERATION_TIMEOUT_MS = OPERATION_TIMEOUT_MS + 1_000;
 const OFFER_TIMEOUT_MS = 3_000;
 const BROKER_OFFER_TIMEOUT_MS = OFFER_TIMEOUT_MS + 1_000;
 const POLICY_TIMEOUT_MS = 5_000;
+const HANDSHAKE_TIMEOUT_MS = 5_000;
+const INCOMPATIBLE_CLOSE_CODE = 4406;
+const CONNECTOR_UPDATE_URL = "https://github.com/mdbase-dev/mdbase-connect/releases/latest";
 
 interface PendingRequest {
   resolve(value: unknown): void;
@@ -33,13 +41,24 @@ interface PendingRequest {
   timer: NodeJS.Timeout;
   socket: WebSocket;
   expectedEncrypted?: EncryptedRelayEnvelope;
-  expectedType?: "operation_response" | "authorization_offer_response" | "authorization_activation_response";
+  expectedType?:
+    | "operation_response"
+    | "authorization_offer_response"
+    | "authorization_activation_response"
+    | "policy_applied";
+  expectedPolicyRevision?: string;
 }
 
 interface ConnectorSession {
   generation: string;
   socket: WebSocket;
   binding: RelayBrokerBinding;
+}
+
+interface RelayHello {
+  protocol_version: number;
+  connector_version: string;
+  capabilities: string[];
 }
 
 export class RelayHub {
@@ -51,7 +70,22 @@ export class RelayHub {
     private readonly broker: RelayBroker = new LocalRelayBroker()
   ) {}
 
-  async attach(connectorId: string, socket: WebSocket): Promise<void> {
+  beginHandshake(socket: WebSocket): Promise<RelayHello | null> {
+    return receiveRelayHello(socket);
+  }
+
+  async attach(
+    connectorId: string,
+    socket: WebSocket,
+    handshake: Promise<RelayHello | null> = receiveRelayHello(socket)
+  ): Promise<void> {
+    const hello = await handshake;
+    if (!hello
+        || hello.protocol_version !== CONTROL_PROTOCOL_VERSION
+        || !RELAY_CAPABILITIES.every((capability) => hello.capabilities.includes(capability))) {
+      rejectIncompatibleRelay(socket);
+      return;
+    }
     const updated = await this.db.query<{ relay_generation: string | number }>(
       `UPDATE connectors
        SET last_seen_at = now(), relay_generation = relay_generation + 1
@@ -113,7 +147,12 @@ export class RelayHub {
           paused?: boolean;
           collections?: unknown[];
           contracts?: unknown[];
+          revision?: string;
         };
+        if (message.protocol_version !== CONTROL_PROTOCOL_VERSION) {
+          rejectIncompatibleRelay(socket);
+          return;
+        }
         if (!message.request_id) return;
         const pending = this.pending.get(message.request_id);
         if (!pending || pending.socket !== socket) return;
@@ -182,6 +221,30 @@ export class RelayHub {
           }
           return;
         }
+        if (message.type === "policy_applied") {
+          if (pending.expectedType !== "policy_applied"
+              || message.revision !== pending.expectedPolicyRevision) {
+            this.rejectPending(
+              message.request_id,
+              new ConnectorOperationError(
+                "invalid_policy_acknowledgement",
+                "The connector acknowledged a different policy revision."
+              )
+            );
+            return;
+          }
+          if (message.ok) this.resolvePending(message.request_id, message);
+          else {
+            this.rejectPending(
+              message.request_id,
+              new ConnectorOperationError(
+                message.error?.code ?? "policy_apply_failed",
+                message.error?.message ?? "The connector could not apply its policy."
+              )
+            );
+          }
+          return;
+        }
         if (message.type !== "operation_response") return;
         if (pending.expectedType !== "operation_response") {
           this.rejectPending(
@@ -207,6 +270,13 @@ export class RelayHub {
         socket.close(4002, "Invalid relay message");
       }
     });
+
+    socket.send(JSON.stringify({
+      type: "relay_welcome",
+      protocol_version: CONTROL_PROTOCOL_VERSION,
+      session_id: generation,
+      capabilities: [...RELAY_CAPABILITIES]
+    }));
     socket.once("close", () => {
       const current = this.connectors.get(connectorId);
       if (current?.socket === socket && current.generation === generation) {
@@ -266,30 +336,33 @@ export class RelayHub {
     );
     const generation = await this.currentGeneration(connectorId);
     if (!generation) return;
+    const policyGrants = grants.rows.map((grant) => ({
+      id: grant.id,
+      application_id: grant.application_id,
+      collection_id: grant.local_id,
+      operations: grant.operations,
+      scope: grant.scope,
+      application_name: grant.application_name,
+      application_distribution: grant.application_distribution,
+      application_homepage: grant.application_homepage,
+      ...(grant.application_project_url
+        ? { application_project_url: grant.application_project_url }
+        : {}),
+      application_origin: grant.application_origin === "null"
+        ? "null"
+        : new URL(grant.application_origin).origin,
+      application_icon: grant.application_icon,
+      collection_name: grant.collection_name,
+      notification_criteria: grant.notification_criteria,
+      created_at: grant.created_at,
+      ...(grant.encryption ? { encryption: grant.encryption } : {})
+    }));
     const message = {
       type: "policy_snapshot",
-      protocol_version: 1,
-      grants: grants.rows.map((grant) => ({
-        id: grant.id,
-        application_id: grant.application_id,
-        collection_id: grant.local_id,
-        operations: grant.operations,
-        scope: grant.scope,
-        application_name: grant.application_name,
-        application_distribution: grant.application_distribution,
-        application_homepage: grant.application_homepage,
-        ...(grant.application_project_url
-          ? { application_project_url: grant.application_project_url }
-          : {}),
-        application_origin: grant.application_origin === "null"
-          ? "null"
-          : new URL(grant.application_origin).origin,
-        application_icon: grant.application_icon,
-        collection_name: grant.collection_name,
-        notification_criteria: grant.notification_criteria,
-        created_at: grant.created_at,
-        ...(grant.encryption ? { encryption: grant.encryption } : {})
-      }))
+      protocol_version: CONTROL_PROTOCOL_VERSION,
+      request_id: randomUUID(),
+      revision: canonicalSha256(policyGrants),
+      grants: policyGrants
     };
     try {
       await this.broker.request(
@@ -308,17 +381,17 @@ export class RelayHub {
   async route(input: {
     connectorId: string;
     localCollectionId: string;
+    requestId: string;
     grantId: string;
     applicationId: string;
     operation: string;
     operationInput: unknown;
   }): Promise<unknown> {
     const generation = await this.requireCurrentGeneration(input.connectorId);
-    const requestId = randomUUID();
     return this.deliver(input.connectorId, generation, {
       type: "operation_request",
-      protocol_version: 1,
-      request_id: requestId,
+      protocol_version: CONTROL_PROTOCOL_VERSION,
+      request_id: input.requestId,
       grant_id: input.grantId,
       collection_id: input.localCollectionId,
       application_id: input.applicationId,
@@ -353,7 +426,7 @@ export class RelayHub {
     const requestId = randomUUID();
     const response = await this.deliver(connectorId, generation, {
       type: "authorization_offer_request",
-      protocol_version: 1,
+      protocol_version: CONTROL_PROTOCOL_VERSION,
       request_id: requestId,
       authorization_id: authorizationId
     }, BROKER_OFFER_TIMEOUT_MS);
@@ -374,7 +447,7 @@ export class RelayHub {
     const requestId = randomUUID();
     const response = await this.deliver(connectorId, generation, {
       type: "authorization_activation_request",
-      protocol_version: 1,
+      protocol_version: CONTROL_PROTOCOL_VERSION,
       request_id: requestId,
       authorization_id: input.authorizationId,
       collection_id: input.collectionId,
@@ -437,11 +510,29 @@ export class RelayHub {
       return brokerError("unavailable", "connector_offline", "The computer hosting this collection is offline.");
     }
     if (command.kind === "policy") {
+      const requestId = requestIdFromMessage(command.message);
+      const revision = policyRevisionFromMessage(command.message);
+      if (!requestId || !revision) {
+        return brokerError("internal", "invalid_policy_snapshot", "The policy snapshot was incomplete.");
+      }
       try {
-        session.socket.send(JSON.stringify(command.message));
-        return { version: 1, ok: true };
-      } catch {
-        return brokerError("unavailable", "connector_offline", "The computer hosting this collection is offline.");
+        const value = await this.sendToConnector(
+          session.socket,
+          requestId,
+          command.message,
+          undefined,
+          "policy_applied",
+          revision
+        );
+        return { version: 1, ok: true, value };
+      } catch (error) {
+        if (error instanceof RelayUnavailableError) {
+          return brokerError("unavailable", "connector_offline", error.message);
+        }
+        if (error instanceof ConnectorOperationError) {
+          return brokerError("connector", error.code, error.message);
+        }
+        return brokerError("internal", "policy_delivery_failed", "The connector could not apply its policy.");
       }
     }
     const requestId = requestIdFromMessage(command.message);
@@ -477,7 +568,8 @@ export class RelayHub {
     requestId: string,
     message: unknown,
     expectedEncrypted?: EncryptedRelayEnvelope,
-    expectedType?: PendingRequest["expectedType"]
+    expectedType?: PendingRequest["expectedType"],
+    expectedPolicyRevision?: string
   ): Promise<unknown> {
     if (this.pending.has(requestId)) {
       return Promise.reject(new ConnectorOperationError(
@@ -501,7 +593,8 @@ export class RelayHub {
         timer,
         socket,
         expectedEncrypted,
-        expectedType
+        expectedType,
+        expectedPolicyRevision
       });
       try {
         socket.send(JSON.stringify(message), (error) => {
@@ -556,6 +649,12 @@ function requestIdFromMessage(message: unknown): string | null {
   return typeof requestId === "string" && requestId.length > 0 ? requestId : null;
 }
 
+function policyRevisionFromMessage(message: unknown): string | null {
+  if (typeof message !== "object" || message === null || Array.isArray(message)) return null;
+  const revision = (message as { revision?: unknown }).revision;
+  return typeof revision === "string" && revision.length > 0 ? revision : null;
+}
+
 function encryptedRequestFromMessage(message: unknown): EncryptedRelayEnvelope | undefined {
   if (typeof message !== "object" || message === null || Array.isArray(message)) return undefined;
   return (message as { type?: unknown }).type === "encrypted_operation_request"
@@ -572,10 +671,57 @@ function expectedResponseType(message: unknown): PendingRequest["expectedType"] 
       return "authorization_offer_response";
     case "authorization_activation_request":
       return "authorization_activation_response";
+    case "policy_snapshot":
+      return "policy_applied";
     default:
       return undefined;
   }
 }
+
+async function receiveRelayHello(socket: WebSocket): Promise<RelayHello | null> {
+  return new Promise((resolve) => {
+    const finish = (value: RelayHello | null) => {
+      clearTimeout(timer);
+      socket.off("message", onMessage);
+      socket.off("close", onClose);
+      resolve(value);
+    };
+    const onMessage = (raw: WebSocket.RawData) => {
+      try {
+        const value = JSON.parse(raw.toString()) as Record<string, unknown>;
+        finish(value.type === "relay_hello"
+          && typeof value.protocol_version === "number"
+          && typeof value.connector_version === "string"
+          && Array.isArray(value.capabilities)
+          && value.capabilities.every((capability) => typeof capability === "string")
+          ? {
+              protocol_version: value.protocol_version,
+              connector_version: value.connector_version,
+              capabilities: value.capabilities as string[]
+            }
+          : null);
+      } catch {
+        finish(null);
+      }
+    };
+    const onClose = () => finish(null);
+    const timer = setTimeout(() => finish(null), HANDSHAKE_TIMEOUT_MS);
+    socket.once("message", onMessage);
+    socket.once("close", onClose);
+  });
+}
+
+function rejectIncompatibleRelay(socket: WebSocket): void {
+  if (socket.readyState !== 1) return;
+  socket.send(JSON.stringify({
+    type: "relay_incompatible",
+    protocol_version: CONTROL_PROTOCOL_VERSION,
+    code: "connector_upgrade_required",
+    message: "This mdbase Connect version is no longer compatible. Update the desktop app and reconnect.",
+    update_url: CONNECTOR_UPDATE_URL
+  }), () => socket.close(INCOMPATIBLE_CLOSE_CODE, "Connector upgrade required"));
+}
+
 
 function brokerError(
   kind: "unavailable" | "connector" | "internal",


### PR DESCRIPTION
## What changed

- makes the v1 relay handshake and capability negotiation mandatory, with explicit upgrade errors and acknowledged, revision-bound policy snapshots
- gives public APIs stable logical collection IDs while keeping authority database IDs internal
- wraps operations in versioned, request-ID-bound envelopes and persists SDK mutation intent so uncertain outcomes retry the exact request
- separates P-256 agreement and signing keys and binds hosted request proofs to the signing key
- makes hosted record mutations exactly-once across retries and concurrent provider instances
- makes authority-transfer manifests commit to stable record identity and exact Markdown bytes, and carries those exact bytes in snapshot records
- bumps the coordinated prerelease to `0.1.0-beta.16`

## Why

The unreleased protocol had several implicit assumptions that could strand an older desktop, change collection identity across transports, replay an uncertain mutation incorrectly, or calculate different authority-transfer digests from semantically equivalent Markdown. Since the SDK and consumers are still pre-release, this establishes one strict final v1 shape without compatibility aliases.

## Developer and user impact

Consumers must update to beta.16 before the beta.16 server deploy. In return, stale clients receive a clear upgrade path, collection selection uses stable public identities, retries are safe, and filesystem mirrors preserve authoritative Markdown byte-for-byte.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (server 181, client 72, sync 90, plus all other workspaces)
- `cargo test --workspace`
- `node scripts/e2e.mjs` (real Chromium + Rust daemon)
- `node scripts/relay-e2e.mjs` (Postgres + two server instances + NATS reconnect/outage)
- `node scripts/hosted-provider-e2e.mjs` (Postgres + provider + browser + Rust/TypeScript mirrors + authority transfer + exact-once replay)
- `node scripts/check-release-version.mjs v0.1.0-beta.16`
