### PR TITLE
Freeze the control-plane legacy baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -1297,7 +1297,7 @@ mod tests {
         for message in [
             RelayMessage::RelayHello {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
-                connector_version: "0.1.0-beta.16".to_string(),
+                connector_version: "0.1.0-beta.17".to_string(),
                 capabilities: RELAY_CAPABILITIES
                     .iter()
                     .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.16"
+version = "0.1.0-beta.17"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.16
-git tag -a v0.1.0-beta.16 -m "mdbase connect 0.1.0-beta.16"
-git push origin v0.1.0-beta.16
+pnpm version:check v0.1.0-beta.17
+git tag -a v0.1.0-beta.17 -m "mdbase connect 0.1.0-beta.17"
+git push origin v0.1.0-beta.17
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -360,7 +360,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.16",
+    connector_version: "0.1.0-beta.17",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.16" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.17" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -325,8 +325,7 @@ export async function bootstrapLegacyBaseline(db: DatabaseQueryable): Promise<vo
       requested_operations jsonb NOT NULL,
       collection_id uuid,
       relay_protocol integer,
-      application_agreement_public_key text,
-      application_signing_public_key text,
+      application_public_key text,
       device_code_hash text UNIQUE,
       user_code text,
       user_code_hash text UNIQUE,
@@ -778,8 +777,7 @@ export async function bootstrapLegacyBaseline(db: DatabaseQueryable): Promise<vo
   );
   await revokeLegacyHostedBearerGrants(db);
   await ensureColumn(db, "authorization_requests", "relay_protocol", "ALTER TABLE authorization_requests ADD COLUMN relay_protocol integer");
-  await ensureColumn(db, "authorization_requests", "application_agreement_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_agreement_public_key text");
-  await ensureColumn(db, "authorization_requests", "application_signing_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_signing_public_key text");
+  await ensureColumn(db, "authorization_requests", "application_public_key", "ALTER TABLE authorization_requests ADD COLUMN application_public_key text");
   await ensureColumn(db, "authorization_requests", "collection_id", "ALTER TABLE authorization_requests ADD COLUMN collection_id uuid");
   // Retain the unused legacy column until the previous release is outside the
   // production rollback window. Runtime compatibility is not a license for a


### PR DESCRIPTION
## Summary
- restore the control-plane legacy baseline to its frozen schema
- leave the independent application keys exclusively in numbered migration `0004`
- bump the pre-release consistently to `v0.1.0-beta.17` because beta.16 artifacts are already immutable

## Validation
- `pnpm version:check v0.1.0-beta.17`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `cargo test --workspace`
- `node scripts/e2e.mjs`
- beta.14-to-beta.17 schema diff contains only new numbered migration SQL