### PR TITLE
Release final v1 as beta.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-hosted-provider/migrations/0014_operation_requests.sql
+++ b/crates/connect-hosted-provider/migrations/0014_operation_requests.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS hosted_provider_operation_requests (
+  replica_id uuid NOT NULL REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
+  request_id uuid NOT NULL,
+  operation text NOT NULL,
+  request_hash bytea NOT NULL,
+  prepared_mutation_ciphertext bytea,
+  response_ciphertext bytea,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  PRIMARY KEY (replica_id, request_id)
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_operation_requests_created_idx
+  ON hosted_provider_operation_requests (created_at);

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -252,42 +252,37 @@ impl HostedProvider {
                 .await
             {
                 Ok(pool) => match hosted_migrator().run(&pool).await {
-                    Ok(()) => {
-                        prepare_bridge_operation_requests_schema(&pool).await?;
-                        match verify_database_key(&pool, &crypto).await {
-                            Ok(()) => {
-                                let notifications = notification_config
-                                    .clone()
-                                    .map(|config| {
-                                        HostedNotificationRuntime::new(pool.clone(), config)
-                                    })
-                                    .transpose()?;
-                                return Ok(Self {
-                                    pool,
-                                    crypto,
-                                    limits,
-                                    working_sets: Arc::new(Mutex::new(HashMap::new())),
-                                    notifications,
-                                });
-                            }
-                            Err(DatabaseKeyError::Invalid(error)) => {
-                                pool.close().await;
-                                return Err(error);
-                            }
-                            Err(DatabaseKeyError::Database(error))
-                                if started.elapsed() < DATABASE_STARTUP_TIMEOUT =>
-                            {
-                                tracing::warn!(error = %error, "hosted provider key check unavailable; retrying");
-                                pool.close().await;
-                            }
-                            Err(DatabaseKeyError::Database(error)) => {
-                                tracing::error!(error = %error, "hosted provider key check failed");
-                                return Err(ApiError::internal(
-                                    "The hosted provider could not verify its authoritative store.",
-                                ));
-                            }
+                    Ok(()) => match verify_database_key(&pool, &crypto).await {
+                        Ok(()) => {
+                            let notifications = notification_config
+                                .clone()
+                                .map(|config| HostedNotificationRuntime::new(pool.clone(), config))
+                                .transpose()?;
+                            return Ok(Self {
+                                pool,
+                                crypto,
+                                limits,
+                                working_sets: Arc::new(Mutex::new(HashMap::new())),
+                                notifications,
+                            });
                         }
-                    }
+                        Err(DatabaseKeyError::Invalid(error)) => {
+                            pool.close().await;
+                            return Err(error);
+                        }
+                        Err(DatabaseKeyError::Database(error))
+                            if started.elapsed() < DATABASE_STARTUP_TIMEOUT =>
+                        {
+                            tracing::warn!(error = %error, "hosted provider key check unavailable; retrying");
+                            pool.close().await;
+                        }
+                        Err(DatabaseKeyError::Database(error)) => {
+                            tracing::error!(error = %error, "hosted provider key check failed");
+                            return Err(ApiError::internal(
+                                "The hosted provider could not verify its authoritative store.",
+                            ));
+                        }
+                    },
                     Err(error) if started.elapsed() < DATABASE_STARTUP_TIMEOUT => {
                         tracing::warn!(error = %error, "hosted provider migration unavailable; retrying");
                         pool.close().await;
@@ -5994,30 +5989,6 @@ fn hosted_migrator() -> sqlx::migrate::Migrator {
     let mut migrator = sqlx::migrate!("./migrations");
     migrator.set_ignore_missing(true);
     migrator
-}
-
-async fn prepare_bridge_operation_requests_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
-    sqlx::raw_sql(
-        r#"
-        CREATE TABLE IF NOT EXISTS hosted_provider_operation_requests (
-          replica_id uuid NOT NULL REFERENCES hosted_provider_replicas(id) ON DELETE CASCADE,
-          request_id uuid NOT NULL,
-          operation text NOT NULL,
-          request_hash bytea NOT NULL,
-          prepared_mutation_ciphertext bytea,
-          response_ciphertext bytea,
-          created_at timestamptz NOT NULL DEFAULT now(),
-          completed_at timestamptz,
-          PRIMARY KEY (replica_id, request_id)
-        );
-
-        CREATE INDEX IF NOT EXISTS hosted_provider_operation_requests_created_idx
-          ON hosted_provider_operation_requests (created_at);
-        "#,
-    )
-    .execute(pool)
-    .await?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -1297,7 +1297,7 @@ mod tests {
         for message in [
             RelayMessage::RelayHello {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
-                connector_version: "0.1.0-beta.17".to_string(),
+                connector_version: "0.1.0-beta.18".to_string(),
                 capabilities: RELAY_CAPABILITIES
                     .iter()
                     .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.17"
+version = "0.1.0-beta.18"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.17
-git tag -a v0.1.0-beta.17 -m "mdbase connect 0.1.0-beta.17"
-git push origin v0.1.0-beta.17
+pnpm version:check v0.1.0-beta.18
+git tag -a v0.1.0-beta.18 -m "mdbase connect 0.1.0-beta.18"
+git push origin v0.1.0-beta.18
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -360,7 +360,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.17",
+    connector_version: "0.1.0-beta.18",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.17" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.18" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- restore numbered migration 0014 after the rollback bridge prepared its additive schema
- remove the bridge-only unrecorded schema preparation
- retain permanent SQLx tolerance for later additive migrations so this release is a safe rollback target
- publish the tested final v1 SDK/server set as beta.18

## Validation

- pnpm version:check
- pnpm build
- pnpm typecheck
- pnpm test
- cargo fmt --check
- cargo test --workspace
- node scripts/e2e.mjs
- node scripts/hosted-provider-e2e.mjs against disposable PostgreSQL 18, including browser SDK, authority transfer, concurrent writers, backup/restore, restart recovery, and exactly-once retries
- git diff --check