### PR TITLE
Release provider hardening as beta.19

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,5 +1,5 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.17
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:1f1637d3e30fb5e1d81b068d16af79ab29693008610e9bd6a5c9c510e6606578
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:52ef58d6e90e4e23339b3231b2eee8bf765a5f26e79b67cf3bae23df815bc8db
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.18
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:ff2b77ae4a07eb3561767bd31d38a5bdb855dce0b15fa900e3659f22fc88b3fa
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:7e4a33bf275012094bbf4b6834e00e9c05d185c835b7f6be05ca6495db048f25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -1297,7 +1297,7 @@ mod tests {
         for message in [
             RelayMessage::RelayHello {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
-                connector_version: "0.1.0-beta.18".to_string(),
+                connector_version: "0.1.0-beta.19".to_string(),
                 capabilities: RELAY_CAPABILITIES
                     .iter()
                     .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.18"
+version = "0.1.0-beta.19"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.18
-git tag -a v0.1.0-beta.18 -m "mdbase connect 0.1.0-beta.18"
-git push origin v0.1.0-beta.18
+pnpm version:check v0.1.0-beta.19
+git tag -a v0.1.0-beta.19 -m "mdbase connect 0.1.0-beta.19"
+git push origin v0.1.0-beta.19
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -360,7 +360,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.18",
+    connector_version: "0.1.0-beta.19",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.18" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.19" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- release current Connect `main` as `v0.1.0-beta.19`
- include the hosted-provider startup validation and notification-recovery readiness added after beta.18
- point the exact previous-release upgrade rehearsal at the signed beta.18 server and provider images
- keep the wire protocol at v1

## Validation
- `pnpm version:check v0.1.0-beta.19`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `cargo fmt --check`
- `cargo test --workspace`
- `node scripts/e2e.mjs`
- `cargo build -p mdbase-connect-hosted-provider -p mdbase-cli`
- `node scripts/hosted-provider-e2e.mjs` against disposable PostgreSQL 18

CI additionally rehearses the upgrade from the exact signed beta.18 images.
