### PR TITLE
Migrate legacy notification events before readiness

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,5 +1,5 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.18
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:ff2b77ae4a07eb3561767bd31d38a5bdb855dce0b15fa900e3659f22fc88b3fa
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:7e4a33bf275012094bbf4b6834e00e9c05d185c835b7f6be05ca6495db048f25
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.19
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:2e9a07c8e17f9f470ca102ac4fc6e13bff6e5c0441bed4ca9f8d67e4a86a0f14
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:aeb491bed5dcee1c43c358186bb86615868ea687b81d6eea06fe5a60198d3935

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -277,22 +277,25 @@ jobs:
           );
           SQL
 
-      - name: Reproduce the previous release partial migration
+      - name: Apply the previous release migration
         run: |
           . .github/previous-release.env
-          if docker run --name mdbase-provider-previous-migration \
+          docker run --detach --name mdbase-provider-previous-migration \
             --network host \
             --env DATABASE_URL \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
-            "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE"; then
-            echo "Previous provider unexpectedly accepted the profile-0.1 timer ID." >&2
-            docker rm --force mdbase-provider-previous-migration >/dev/null
-            exit 1
-          fi
-          previous_logs=$(docker logs mdbase-provider-previous-migration 2>&1)
-          echo "$previous_logs"
-          grep --fixed-strings "unsupported_notification_event" <<<"$previous_logs"
+            "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE" >/dev/null
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:8790/ready >/dev/null; then
+              break
+            fi
+            if [ "$attempt" = 30 ]; then
+              docker logs mdbase-provider-previous-migration
+              exit 1
+            fi
+            sleep 2
+          done
           docker rm --force mdbase-provider-previous-migration >/dev/null
 
           previous_contract=$(docker run --rm --network host \

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -266,9 +266,9 @@ jobs:
               "operations":["changes"],
               "scope":{"contracts":[],"access":"full_collection"},
               "notification_criteria":[{
-                "id":"record.created",
-                "event":{"id":"mdbase.record.created","version":1},
-                "presentation":{"title":"Record created"}
+                "id":"task.reminder",
+                "event":{"id":"timer.fired","version":1},
+                "presentation":{"title":"Task reminder"}
               }],
               "created_at":"2026-07-29T00:00:00Z"
             }'::jsonb
@@ -307,17 +307,21 @@ jobs:
             sleep 2
           done
 
-          version=$(docker run --rm --network host \
+          contract=$(docker run --rm --network host \
             --env PGPASSWORD=previous-provider-upgrade \
             postgres:18-alpine \
             psql --host 127.0.0.1 --username mdbase --dbname mdbase_provider_upgrade \
             --set ON_ERROR_STOP=1 \
             --tuples-only --no-align \
-            --command "SELECT grant_json #>> '{notification_criteria,0,event,version}'
+            --command "SELECT concat(
+                         grant_json #>> '{notification_criteria,0,event,id}',
+                         '|',
+                         grant_json #>> '{notification_criteria,0,event,version}'
+                       )
                        FROM hosted_provider_notification_grants
                        WHERE grant_id = '22222222-2222-4222-8222-222222222222'")
-          echo "Migrated notification contract version: $version"
-          [[ "$version" == "1.0.0" ]]
+          echo "Migrated notification contract: $contract"
+          [[ "$contract" == "mdbase.runtime.timer.fired|1.0.0" ]]
 
   hosted-provider:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -242,6 +242,8 @@ jobs:
             postgres:18-alpine \
             psql --host 127.0.0.1 --username mdbase --dbname mdbase_provider_upgrade \
             --set ON_ERROR_STOP=1 <<'SQL'
+          DELETE FROM _sqlx_migrations WHERE version = 15;
+
           INSERT INTO hosted_provider_collections
             (id, template, spec_version, max_records, max_content_bytes,
              max_document_bytes, max_replicas, resource_revision,
@@ -274,6 +276,40 @@ jobs:
             }'::jsonb
           );
           SQL
+
+      - name: Reproduce the previous release partial migration
+        run: |
+          . .github/previous-release.env
+          if docker run --name mdbase-provider-previous-migration \
+            --network host \
+            --env DATABASE_URL \
+            --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
+            --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
+            "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE"; then
+            echo "Previous provider unexpectedly accepted the profile-0.1 timer ID." >&2
+            docker rm --force mdbase-provider-previous-migration >/dev/null
+            exit 1
+          fi
+          previous_logs=$(docker logs mdbase-provider-previous-migration 2>&1)
+          echo "$previous_logs"
+          grep --fixed-strings "unsupported_notification_event" <<<"$previous_logs"
+          docker rm --force mdbase-provider-previous-migration >/dev/null
+
+          previous_contract=$(docker run --rm --network host \
+            --env PGPASSWORD=previous-provider-upgrade \
+            postgres:18-alpine \
+            psql --host 127.0.0.1 --username mdbase --dbname mdbase_provider_upgrade \
+            --set ON_ERROR_STOP=1 \
+            --tuples-only --no-align \
+            --command "SELECT concat(
+                         grant_json #>> '{notification_criteria,0,event,id}',
+                         '|',
+                         grant_json #>> '{notification_criteria,0,event,version}'
+                       )
+                       FROM hosted_provider_notification_grants
+                       WHERE grant_id = '22222222-2222-4222-8222-222222222222'")
+          echo "Previous release partial migration: $previous_contract"
+          [[ "$previous_contract" == "timer.fired|1.0.0" ]]
 
       - name: Require candidate migration and recovery readiness
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-hosted-provider/migrations/0016_notification_event_ids.sql
+++ b/crates/connect-hosted-provider/migrations/0016_notification_event_ids.sql
@@ -1,0 +1,16 @@
+-- Runtime profile 0.2 names runtime events under the stable mdbase.runtime
+-- namespace. Provider grants are a durable copy of the control-plane grant
+-- and must be upgraded before Rust deserializes and validates them.
+UPDATE hosted_provider_notification_grants
+SET grant_json = replace(
+      replace(
+        grant_json::text,
+        '"event": {"id": "timer.fired"',
+        '"event": {"id": "mdbase.runtime.timer.fired"'
+      ),
+      '"event":{"id":"timer.fired"',
+      '"event":{"id":"mdbase.runtime.timer.fired"'
+    )::jsonb,
+    updated_at = now()
+WHERE grant_json::text LIKE '%"event": {"id": "timer.fired"%'
+   OR grant_json::text LIKE '%"event":{"id":"timer.fired"%';

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -1297,7 +1297,7 @@ mod tests {
         for message in [
             RelayMessage::RelayHello {
                 protocol_version: CONTROL_PROTOCOL_VERSION,
-                connector_version: "0.1.0-beta.19".to_string(),
+                connector_version: "0.1.0-beta.20".to_string(),
                 capabilities: RELAY_CAPABILITIES
                     .iter()
                     .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.19"
+version = "0.1.0-beta.20"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -98,9 +98,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.19
-git tag -a v0.1.0-beta.19 -m "mdbase connect 0.1.0-beta.19"
-git push origin v0.1.0-beta.19
+pnpm version:check v0.1.0-beta.20
+git tag -a v0.1.0-beta.20 -m "mdbase connect 0.1.0-beta.20"
+git push origin v0.1.0-beta.20
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -360,7 +360,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.19",
+    connector_version: "0.1.0-beta.20",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -541,12 +541,16 @@ try {
   await postgresQuery(`
     UPDATE hosted_provider_notification_grants
     SET grant_json = jsonb_set(
-      grant_json,
-      '{notification_criteria,0,event,version}',
-      '1'::jsonb
+      jsonb_set(
+        grant_json,
+        '{notification_criteria,0,event,version}',
+        '1'::jsonb
+      ),
+      '{notification_criteria,1,event,id}',
+      '"timer.fired"'::jsonb
     )
     WHERE grant_id = '${notificationGrantId}';
-    DELETE FROM _sqlx_migrations WHERE version = 15;
+    DELETE FROM _sqlx_migrations WHERE version IN (15, 16);
     UPDATE mdbase_runtime_schema SET version = 1 WHERE singleton = TRUE;
   `);
   const upgradedNotificationProvider = await startProvider(databaseUrl, 0, masterKey, {
@@ -566,6 +570,14 @@ try {
       WHERE grant_id = '${notificationGrantId}'
     `),
     "1.0.0"
+  );
+  assert.equal(
+    await postgresQuery(`
+      SELECT grant_json #>> '{notification_criteria,1,event,id}'
+      FROM hosted_provider_notification_grants
+      WHERE grant_id = '${notificationGrantId}'
+    `),
+    "mdbase.runtime.timer.fired"
   );
   assert.equal(
     await postgresQuery("SELECT version FROM mdbase_runtime_schema WHERE singleton = TRUE"),

--- a/scripts/pack-consumer-sdk.mjs
+++ b/scripts/pack-consumer-sdk.mjs
@@ -8,7 +8,9 @@ const packageDirectories = new Map([
   ["connect", "packages/client"],
   ["protocol", "packages/protocol"],
   ["sync", "packages/sync"],
+  ["pickle", "packages/pickle"],
 ]);
+const defaultPackages = ["connect", "protocol", "sync"];
 
 const options = parseArguments(process.argv.slice(2));
 const destination = resolve(options.destination);
@@ -81,14 +83,14 @@ function parseArguments(arguments_) {
   const destinationIndex = arguments_.indexOf("--destination");
   if (destinationIndex === -1 || !arguments_[destinationIndex + 1]) {
     throw new Error(
-      "Usage: node scripts/pack-consumer-sdk.mjs --destination <vendor-directory> [--packages connect,protocol,sync]",
+      "Usage: node scripts/pack-consumer-sdk.mjs --destination <vendor-directory> [--packages connect,protocol,sync,pickle]",
     );
   }
   const packagesIndex = arguments_.indexOf("--packages");
   return {
     destination: arguments_[destinationIndex + 1],
     packages: packagesIndex === -1
-      ? [...packageDirectories.keys()]
+      ? defaultPackages
       : arguments_[packagesIndex + 1]?.split(",").filter(Boolean) ?? [],
   };
 }

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.19" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.20" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/migrations/0006_notification_event_ids.sql
+++ b/services/server/migrations/0006_notification_event_ids.sql
@@ -1,0 +1,29 @@
+-- mdbase:skip-if-missing-table applications
+-- Runtime profile 0.2 names runtime events under the stable mdbase.runtime
+-- namespace. Applications and grants both retain notification criteria, so
+-- migrate both durable copies before the control plane reads them.
+UPDATE applications
+SET notifications = replace(
+  replace(
+    notifications::text,
+    '"event": {"id": "timer.fired"',
+    '"event": {"id": "mdbase.runtime.timer.fired"'
+  ),
+  '"event":{"id":"timer.fired"',
+  '"event":{"id":"mdbase.runtime.timer.fired"'
+)::jsonb
+WHERE notifications::text LIKE '%"event": {"id": "timer.fired"%'
+   OR notifications::text LIKE '%"event":{"id":"timer.fired"%';
+
+UPDATE grants
+SET notification_criteria = replace(
+  replace(
+    notification_criteria::text,
+    '"event": {"id": "timer.fired"',
+    '"event": {"id": "mdbase.runtime.timer.fired"'
+  ),
+  '"event":{"id":"timer.fired"',
+  '"event":{"id":"mdbase.runtime.timer.fired"'
+)::jsonb
+WHERE notification_criteria::text LIKE '%"event": {"id": "timer.fired"%'
+   OR notification_criteria::text LIKE '%"event":{"id":"timer.fired"%';

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.19",
+  "version": "0.1.0-beta.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -38,7 +38,8 @@ describe("database migrations", () => {
       "0002_instance_administration",
       "0003_authorization_request_collection",
       "0004_separate_application_keys",
-      "0005_notification_contract_versions"
+      "0005_notification_contract_versions",
+      "0006_notification_event_ids"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -293,7 +294,8 @@ describe("database migrations", () => {
       "0002_instance_administration",
       "0003_authorization_request_collection",
       "0004_separate_application_keys",
-      "0005_notification_contract_versions"
+      "0005_notification_contract_versions",
+      "0006_notification_event_ids"
     ]);
   });
 
@@ -319,7 +321,7 @@ describe("database migrations", () => {
     await expect(assertControlPlaneMigrationsCurrent(db)).resolves.toBeUndefined();
   });
 
-  it("upgrades persisted notification contract versions before they are read", async () => {
+  it("upgrades persisted notification contracts before they are read", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());
     const userId = randomUUID();
@@ -328,8 +330,8 @@ describe("database migrations", () => {
     const grantId = randomUUID();
     const criterion = {
       id: "task.created",
-      event: { id: "mdbase.record.created", version: 1 },
-      presentation: { title: "Task created" }
+      event: { id: "timer.fired", version: 1 },
+      presentation: { title: "Task reminder" }
     };
     await db.query(
       "INSERT INTO users (id, email, name) VALUES ($1, $2, 'Owner')",
@@ -358,21 +360,33 @@ describe("database migrations", () => {
       [grantId, userId, applicationId, collectionId, JSON.stringify([criterion])]
     );
     await db.query(
-      "DELETE FROM schema_migrations WHERE id = '0005_notification_contract_versions'"
+      `DELETE FROM schema_migrations
+       WHERE id IN (
+         '0005_notification_contract_versions',
+         '0006_notification_event_ids'
+       )`
     );
 
     await runControlPlaneMigrations(db);
 
     const application = await db.query<{
-      notifications: { criteria: Array<{ event: { version: unknown } }> };
+      notifications: {
+        criteria: Array<{ event: { id: string; version: unknown } }>;
+      };
     }>("SELECT notifications FROM applications WHERE id = $1", [applicationId]);
     const grant = await db.query<{
-      notification_criteria: Array<{ event: { version: unknown } }>;
+      notification_criteria: Array<{
+        event: { id: string; version: unknown };
+      }>;
     }>("SELECT notification_criteria FROM grants WHERE id = $1", [grantId]);
     expect(application.rows[0]?.notifications.criteria[0]?.event.version)
       .toBe("1.0.0");
+    expect(application.rows[0]?.notifications.criteria[0]?.event.id)
+      .toBe("mdbase.runtime.timer.fired");
     expect(grant.rows[0]?.notification_criteria[0]?.event.version)
       .toBe("1.0.0");
+    expect(grant.rows[0]?.notification_criteria[0]?.event.id)
+      .toBe("mdbase.runtime.timer.fired");
   });
 
   it("fails closed when an application starts before pre-deploy migration", async () => {


### PR DESCRIPTION
## Summary

- add one-way control-plane and hosted-provider migrations from the pre-release `timer.fired` event ID to the canonical v1 `mdbase.runtime.timer.fired` ID
- extend migration coverage to replay the legacy numeric event version and legacy timer ID together
- make the previous-release provider canary start from the exact signed beta.19 image and require notification recovery readiness plus canonical persisted state
- release the candidate as `0.1.0-beta.20`
- support Pickle in immutable consumer SDK packing while preserving the existing default artifact set

## Why

The beta.19 production promotion correctly failed its provider readiness gate and rolled back after encountering a durable profile-0.1 notification grant. Migration 0015 upgraded the event version but did not migrate the old timer event ID. This change migrates both durable grant copies before application startup and makes that exact beta.19-to-candidate path a required CI gate.

No runtime alias or backwards-compatibility path is added.

## Local verification

- `pnpm version:check v0.1.0-beta.20`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `cargo fmt --check`
- `cargo test --workspace`
- `pnpm e2e`
- `pnpm e2e:provider` (disposable PostgreSQL 18, including notification migration/recovery)
- immutable `connect,protocol,pickle` SDK pack smoke
