### PR TITLE
Release mdbase Connect beta.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-protocol/src/tests.rs
+++ b/crates/connect-protocol/src/tests.rs
@@ -122,7 +122,7 @@ fn rust_relay_messages_match_the_canonical_wire_schema() {
     for message in [
         RelayMessage::RelayHello {
             protocol_version: CONTROL_PROTOCOL_VERSION,
-            connector_version: "0.1.0-beta.20".to_string(),
+            connector_version: "0.1.0-beta.21".to_string(),
             capabilities: RELAY_CAPABILITIES
                 .iter()
                 .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "clap",
  "directories",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "directories",
  "keyring",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "async-trait",
  "axum",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.20"
+version = "0.1.0-beta.21"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -114,9 +114,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.20
-git tag -a v0.1.0-beta.20 -m "mdbase connect 0.1.0-beta.20"
-git push origin v0.1.0-beta.20
+pnpm version:check v0.1.0-beta.21
+git tag -a v0.1.0-beta.21 -m "mdbase connect 0.1.0-beta.21"
+git push origin v0.1.0-beta.21
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-dev",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/pickle",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-protocol",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -364,7 +364,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.20",
+    connector_version: "0.1.0-beta.21",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-sync",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-webhooks",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.20" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.21" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- advance all Rust and Node package versions to `0.1.0-beta.21`
- update protocol version fixtures and release commands
- refresh both checked-in Cargo locks

## Validation

- `pnpm version:check v0.1.0-beta.21`
- `pnpm check:release-readiness`
- `pnpm check:architecture`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`