### PR TITLE
Make Connect onboarding app-led

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -7,6 +7,7 @@ await build({
     "src/main/main.ts",
     "src/main/preload.ts",
     "src/main/agent-startup.ts",
+    "src/main/deep-link.ts",
     "src/main/editor-url.ts",
     "src/main/electron-update-backend.ts",
     "src/main/release-source.ts",

--- a/apps/desktop/scripts/connection-progress-smoke.mjs
+++ b/apps/desktop/scripts/connection-progress-smoke.mjs
@@ -55,7 +55,8 @@ try {
   });
   const pairingWindow = await firstApp.firstWindow({ timeout: 15_000 });
   await pairingWindow.getByRole("heading", { name: "Connect this computer." }).waitFor();
-  await pairingWindow.getByLabel("Server").fill(portalUrl);
+  await pairingWindow.getByText("Use another Connect server", { exact: true }).click();
+  await pairingWindow.getByLabel("Server address").fill(portalUrl);
   await pairingWindow.getByLabel("Computer name").fill("Progress test computer");
   await pairingWindow.getByRole("button", { name: "Continue in browser" }).click();
 

--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -41,7 +41,12 @@ try {
   await pairingWindow
     .getByRole("heading", { name: "Connect this computer." })
     .waitFor();
-  await pairingWindow.getByLabel("Server").fill(environment.serverUrl);
+  await pairingWindow
+    .getByText("Use another Connect server", { exact: true })
+    .click();
+  await pairingWindow
+    .getByLabel("Server address")
+    .fill(environment.serverUrl);
   await pairingWindow
     .getByLabel("Computer name")
     .fill("Docker test computer");

--- a/apps/desktop/src/main/deep-link.ts
+++ b/apps/desktop/src/main/deep-link.ts
@@ -1,0 +1,19 @@
+export function routeForDeepLink(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "mdbase-connect:") return null;
+    if (url.hostname === "authorize") {
+      const requestId = url.searchParams.get("request_id");
+      return requestId ? `access:${requestId}` : "access";
+    }
+    if (url.hostname === "mirror") {
+      const collectionId = url.searchParams.get("collection");
+      return collectionId ? `collections:mirror:${collectionId}` : "collections";
+    }
+    if (url.hostname === "paired") return "overview";
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -18,6 +18,7 @@ import { promisify } from "node:util";
 import { ensureAgentReady, type AgentPing } from "./agent-startup";
 import { contractSetupInput } from "./contract-setup-input";
 import { AgentControlError, requestAgent } from "./control-client";
+import { routeForDeepLink } from "./deep-link";
 import { buildEditorUrl } from "./editor-url";
 import { ElectronUpdateBackend } from "./electron-update-backend";
 import { createTrayImage } from "./tray-image";
@@ -754,20 +755,8 @@ function registerDeepLinks(): void {
 }
 
 function handleDeepLink(value: string | undefined): void {
-  if (!value?.startsWith("mdbase-connect://")) return;
-  try {
-    const url = new URL(value);
-    if (url.hostname === "authorize") {
-      showRoute("access");
-    } else if (url.hostname === "paired") {
-      showRoute("overview");
-    } else if (url.hostname === "mirror") {
-      const collectionId = url.searchParams.get("collection");
-      showRoute(collectionId ? `collections:mirror:${collectionId}` : "collections");
-    }
-  } catch {
-    // Ignore malformed protocol invocations.
-  }
+  const route = routeForDeepLink(value);
+  if (route) showRoute(route);
 }
 
 function showRoute(route: string): void {

--- a/apps/desktop/src/renderer/authorization-components.tsx
+++ b/apps/desktop/src/renderer/authorization-components.tsx
@@ -15,6 +15,9 @@ export function RequestPermissionChoices({ groups, selected, onChange }: {
       count + group.operations.filter((operation) => selectedSet.has(operation.id)).length,
     0
   );
+  const selectedGroups = groups.filter((group) =>
+    group.operations.some((operation) => selectedSet.has(operation.id))
+  );
   function toggle(operation: string, checked: boolean) {
     onChange(checked
       ? [...selected, operation]
@@ -22,7 +25,13 @@ export function RequestPermissionChoices({ groups, selected, onChange }: {
   }
   return (
     <details className="request-permission-review">
-      <summary><span><strong>{selectedTotal} of {total} selected</strong><small>Review or narrow individual actions</small></span><b>Review</b></summary>
+      <summary>
+        <span>
+          <strong>{selectedGroups.map((group) => group.label).join(" · ")}</strong>
+          <small>{selectedTotal} of {total} specific actions selected. Open details to narrow access.</small>
+        </span>
+        <b>Details</b>
+      </summary>
       <div className="request-permission-groups">{groups.map((group) => (
         <fieldset key={group.id}>
           <legend>{group.label}</legend>

--- a/apps/desktop/src/renderer/collections-view.tsx
+++ b/apps/desktop/src/renderer/collections-view.tsx
@@ -42,7 +42,7 @@ export function Collections({
 }) {
   return (
     <section className="collection-section">
-      <SectionHeading title="Collections" note="Authority and local copies are shown separately.">
+      <SectionHeading title="Collections" note="Main copies and synced folders are shown separately.">
         <button className="button secondary" disabled={busy} onClick={onAdd}>Add existing</button>
         <button className="button primary" disabled={busy} onClick={onCreate}>Create collection</button>
       </SectionHeading>
@@ -67,14 +67,14 @@ export function Collections({
         )?.path ?? conflict.display_name;
         return <section className="copy-registration" aria-labelledby={`authority-${conflict.collection_id}`} key={conflict.collection_id}>
           <div>
-            <p className="eyebrow">Collection identity conflict</p>
+            <p className="eyebrow">Same collection in two places</p>
             <h2 id={`authority-${conflict.collection_id}`}>Choose which copy of {conflict.display_name} to use.</h2>
             <p>The selected folder and an existing connected copy share the same collection ID.</p>
             <dl className="identity-conflict-details">
               <div><dt>Selected folder</dt><dd><code title={selectedFolder}>{selectedFolder}</code></dd></div>
               <div><dt>Currently active through</dt><dd>{conflict.active_connector_name}</dd></div>
             </dl>
-            <small>Using the selected folder moves authority here and revokes application access through {conflict.active_connector_name}. Keeping both writes a new ID only to the selected folder’s <code>mdbase.yaml</code>.</small>
+            <small>Using the selected folder makes it the main copy and revokes application access through {conflict.active_connector_name}. Keeping both writes a new ID only to the selected folder’s <code>mdbase.yaml</code>.</small>
           </div>
           <div className="copy-registration-actions">
             <button className="button secondary" disabled={busy} onClick={() => void onAct(async () => {
@@ -82,15 +82,15 @@ export function Collections({
               onNotice(`${independent.display_name} now has an independent collection identity.`);
             })}>Keep both copies</button>
             <button className="button primary" disabled={busy} onClick={() => void onAct(async () => {
-              if (!window.confirm(`Use ${selectedFolder} as the authority for ${conflict.display_name}? Existing application access through ${conflict.active_connector_name} will be revoked.`)) return;
+              if (!window.confirm(`Use ${selectedFolder} as the main copy of ${conflict.display_name}? Existing application access through ${conflict.active_connector_name} will be revoked.`)) return;
               await window.mdbaseConnect.takeCollectionAuthority(conflict.collection_id);
-              onNotice(`${conflict.display_name} now uses ${selectedFolder} as its authoritative folder.`);
+              onNotice(`${conflict.display_name} now uses ${selectedFolder} as its main folder.`);
             })}>Use selected folder</button>
           </div>
         </section>;
       })}
       <div className="collection-authority-group">
-        <SectionHeading title="On this computer" note="These folders are authoritative here." count={collections.length} />
+        <SectionHeading title="On this computer" note="Each folder below is the main copy of its collection." count={collections.length} />
         {collections.length === 0 ? (
           <Empty title="No computer-owned collections" text="Add a folder with an existing mdbase.yaml, or create one here." />
         ) : (
@@ -119,7 +119,7 @@ export function Collections({
           count={hosted.hosted_collections.length}
         />
         {hosted.hosted_collections.length === 0 ? (
-          <Empty title="No hosted collections" text="Create one to keep its authority online, with an optional folder mirror here." />
+          <Empty title="No hosted collections" text="Create one to keep its main copy available without this computer, with an optional synced folder here." />
         ) : (
           <div className="collection-list">
             {hosted.hosted_collections.map((collection) => (
@@ -204,8 +204,8 @@ function CollectionRow({ collection, cloudConfigured, busy, onAct, onNotice }: {
         </form>
         <section className="collection-editor-section">
           <div>
-            <strong>Authority</strong>
-            <small>Move the source of truth online while keeping this folder as a two-way mirror.</small>
+            <strong>Main copy</strong>
+            <small>Keep this collection available without this computer while this folder continues to sync edits both ways.</small>
           </div>
           <div className="collection-config-actions">
             <button
@@ -214,21 +214,18 @@ function CollectionRow({ collection, cloudConfigured, busy, onAct, onNotice }: {
               disabled={busy || !cloudConfigured || !collection.enabled}
               onClick={() => {
                 if (!window.confirm(
-                  `Move ${collection.display_name} authority online? `
-                  + "The collection will be uploaded directly to the provider, existing local app grants will be revoked, "
-                  + "and this folder will become a two-way mirror."
+                  `Make ${collection.display_name} available without this computer? `
+                  + "The main copy will move to mdbase, existing app access for this folder will be revoked, "
+                  + "and this folder will continue to sync edits both ways."
                 )) return;
                 void onAct(async () => {
-                  const result = await window.mdbaseConnect.transferCollectionAuthority(collection.id);
+                  await window.mdbaseConnect.transferCollectionAuthority(collection.id);
                   setEditing(false);
-                  onNotice(
-                    `${collection.display_name} is now online at authority epoch `
-                    + `${result.transfer.authority_epoch}; this folder is its two-way mirror.`
-                  );
+                  onNotice(`${collection.display_name} is now available without this computer. This folder will stay in sync.`);
                 });
               }}
             >
-              Move authority online
+              Make available without this computer
             </button>
             {!cloudConfigured && <small>Connect this computer to an account first.</small>}
           </div>
@@ -299,10 +296,10 @@ function HostedCollectionRow({
           </div>
           <span className="authority-label">
             {collection.authority_state === "transferred"
-              ? "Retired hosted copy · authority moved"
+              ? "Hosted copy retired · main copy moved"
               : collection.authority_state === "transferring"
-                ? "Authority transfer in progress"
-                : `Hosted authority · ${activeReplicas.length} ${plural(activeReplicas.length, "mirror", "mirrors")}`}
+                ? "Main copy is moving"
+                : `Main copy hosted by mdbase · ${activeReplicas.length} synced ${plural(activeReplicas.length, "folder", "folders")}`}
           </span>
         </div>
         <div className="collection-status">
@@ -321,7 +318,7 @@ function HostedCollectionRow({
           >
             Open in editor <span aria-hidden="true">↗</span>
           </button>}
-          <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : mirror ? "Mirror" : "Details"}</button>
+          <button className="quiet-action" disabled={busy} aria-expanded={editing} onClick={() => setEditing((value) => !value)}>{editing ? "Close" : mirror ? "Sync" : "Details"}</button>
         </div>
       </div>
       {editing && <div className="collection-editor hosted-editor">
@@ -333,7 +330,7 @@ function HostedCollectionRow({
           });
         }}>
           <section className="collection-editor-section">
-            <div><strong>Details</strong><small>The name is stored with the hosted authority.</small></div>
+            <div><strong>Details</strong><small>The name is stored with the hosted main copy.</small></div>
             <div className="collection-fields">
               <label><span>Name</span><input value={name} maxLength={200} required onChange={(event) => setName(event.target.value)} /></label>
               <button className="button secondary" disabled={busy || !name.trim() || name.trim() === collection.display_name}>Save name</button>
@@ -342,15 +339,15 @@ function HostedCollectionRow({
         </form>
         {collection.authority_state !== "transferred" && <section className="collection-editor-section mirror-section">
           <div>
-            <strong>Mirror on this computer</strong>
-            <small>A mirror is a local copy. The hosted collection remains authoritative.</small>
+            <strong>Synced folder on this computer</strong>
+            <small>Keep ordinary Markdown here while the main copy remains hosted by mdbase.</small>
           </div>
           {mirror ? (
             <div className="mirror-control">
               <div className="mirror-state-row">
                 <StatusDot state={state.dot} />
                 <div><strong>{state.label}</strong><button className="path" title={mirror.path} onClick={() => void window.mdbaseConnect.openMirror(mirror.replica_id)}>{mirror.path}</button></div>
-                <code>{mirror.mode === "read_write" ? "two-way" : "receive-only"}</code>
+                <code>{mirror.mode === "read_write" ? "edits sync both ways" : "downloads updates only"}</code>
               </div>
               {mirror.progress && <small>{mirror.progress.phase === "uploading" ? "Uploading" : "Applying"} {mirror.progress.completed}{mirror.progress.total === null ? "" : ` of ${mirror.progress.total}`} changes…</small>}
               {mirror.error && <div className="message error-message compact-message">{mirror.error}</div>}
@@ -388,36 +385,36 @@ function HostedCollectionRow({
                 })}>{mirror.syncing ? "Synchronizing…" : "Sync now"}</button>
                 <button className="quiet-action" disabled={busy} onClick={() => void window.mdbaseConnect.openMirror(mirror.replica_id)}>Open folder</button>
                 <button className="quiet-action danger" disabled={busy} onClick={() => {
-                  if (!window.confirm(`Stop mirroring ${collection.display_name} on this computer? The folder and its files will remain.`)) return;
+                  if (!window.confirm(`Stop syncing ${collection.display_name} on this computer? The folder and its files will remain.`)) return;
                   void onAct(async () => {
                     await window.mdbaseConnect.disconnectMirror(mirror.replica_id);
-                    onNotice(`The mirror was disconnected. Files remain at ${mirror.path}.`);
+                    onNotice(`The synced folder was disconnected. Files remain at ${mirror.path}.`);
                   });
-                }}>Stop mirror</button>
+                }}>Stop syncing</button>
               </div>
             </div>
           ) : (
             <div className="mirror-setup">
               <label><span>Folder</span><button type="button" className="folder-picker" onClick={() => void chooseMirrorFolder()}>{path || "Choose a folder…"}</button></label>
-              <label><span>Synchronization</span><select value={mode} onChange={(event) => setMode(event.target.value as "read_only" | "read_write")}><option value="read_write">Two-way</option><option value="read_only">Receive-only</option></select></label>
-              <small>Two-way mirrors upload local edits. Receive-only mirrors replace their local view with hosted changes.</small>
+              <label><span>How should it sync?</span><select value={mode} onChange={(event) => setMode(event.target.value as "read_only" | "read_write")}><option value="read_write">Sync edits both ways</option><option value="read_only">Download updates only</option></select></label>
+              <small>Syncing both ways sends local edits to mdbase. Download-only folders replace their local view with hosted changes.</small>
               <button className="button primary" disabled={busy || !path} onClick={() => void onAct(async () => {
                 await window.mdbaseConnect.connectMirror({ collectionId: collection.id, path, mode });
                 setPath("");
-                onNotice(`${collection.display_name} is now mirrored on this computer.`);
-              })}>Start mirror</button>
+                onNotice(`${collection.display_name} now has a synced folder on this computer.`);
+              })}>Start syncing</button>
             </div>
           )}
         </section>}
         {collection.authority_state === "transferred" ? (
           <section className="collection-editor-section">
             <div>
-              <strong>Authority</strong>
+              <strong>Main copy</strong>
               <small>This hosted copy is retained for recovery but no longer accepts changes.</small>
             </div>
             <div className="authority-transfer-control">
               <div>
-                <strong>Source of truth moved to this computer</strong>
+                <strong>Main copy moved to this computer</strong>
                 <small>The collection now appears under On this computer. Applications need fresh access to the computer-owned collection.</small>
               </div>
             </div>
@@ -425,8 +422,8 @@ function HostedCollectionRow({
         ) : mirror && (
           <section className="collection-editor-section">
             <div>
-              <strong>Authority</strong>
-              <small>Make this synchronized folder the source of truth.</small>
+              <strong>Main copy</strong>
+              <small>Make this synced folder the main copy.</small>
             </div>
             <div className="authority-transfer-control">
               <div>
@@ -441,9 +438,9 @@ function HostedCollectionRow({
                   if (
                     !mirror.promotion_pending
                     && !window.confirm(
-                      `Move ${collection.display_name} authority to this computer? `
-                      + `${mirror.path} will become the source of truth. Hosted writes will stop, `
-                      + "and existing application access and other mirrors will be revoked. "
+                      `Use this folder as the main copy of ${collection.display_name}? `
+                      + `${mirror.path} will become the main copy. Hosted changes will stop, `
+                      + "and existing application access and other synced folders will be revoked. "
                       + "You will confirm this change in your browser."
                     )
                   ) return;
@@ -451,18 +448,15 @@ function HostedCollectionRow({
                   void onAct(async () => {
                     onNotice(
                       mirror.promotion_pending
-                        ? "Resuming the authority transfer. Keep mdbase connect open."
-                        : "Confirm the authority transfer in your browser, then return to mdbase connect."
+                        ? "Resuming the main-copy change. Keep mdbase connect open."
+                        : "Confirm the main-copy change in your browser, then return to mdbase connect."
                     );
                     try {
-                      const result = await window.mdbaseConnect.promoteMirrorAuthority(
+                      await window.mdbaseConnect.promoteMirrorAuthority(
                         mirror.replica_id
                       );
                       setEditing(false);
-                      onNotice(
-                        `${collection.display_name} now uses this computer as its authority at epoch `
-                        + `${result.authority_epoch}. Applications need fresh access.`
-                      );
+                      onNotice(`${collection.display_name} now uses this folder as its main copy. Applications need fresh access.`);
                     } finally {
                       setPromotionStarting(false);
                     }
@@ -476,9 +470,9 @@ function HostedCollectionRow({
         )}
         {activeReplicas.some((replica) => replica.id !== mirror?.replica_id) && (
           <section className="collection-editor-section">
-            <div><strong>Other mirrors</strong><small>Mirrors connected from another installation or through the command line.</small></div>
+            <div><strong>Other synced folders</strong><small>Folders connected from another installation or through the command line.</small></div>
             <div className="replica-list">{activeReplicas.filter((replica) => replica.id !== mirror?.replica_id).map((replica) => (
-              <div key={replica.id}><span>{replica.name}</span><code>{replica.mode === "read_write" ? "two-way" : "receive-only"}</code><small>{replica.sync_status?.last_seen_at ? `Seen ${relativeTime(replica.sync_status.last_seen_at)}` : "Not synchronized yet"}</small><button className="quiet-action danger" disabled={busy} onClick={() => {
+              <div key={replica.id}><span>{replica.name}</span><code>{replica.mode === "read_write" ? "edits sync both ways" : "downloads updates only"}</code><small>{replica.sync_status?.last_seen_at ? `Seen ${relativeTime(replica.sync_status.last_seen_at)}` : "Not synchronized yet"}</small><button className="quiet-action danger" disabled={busy} onClick={() => {
                 if (!window.confirm(`Revoke ${replica.name}? Its local files will remain, but it will no longer synchronize.`)) return;
                 void onAct(async () => {
                   await window.mdbaseConnect.revokeHostedReplica(replica.id);
@@ -489,13 +483,13 @@ function HostedCollectionRow({
           </section>
         )}
         <div className="collection-danger-row">
-          <small>Deleting a hosted collection permanently removes its hosted records. Local mirror files remain.</small>
+          <small>Deleting a hosted collection permanently removes its hosted records. Synced folder files remain.</small>
           <button className="quiet-action danger" disabled={busy} onClick={() => {
             if (!window.confirm(`Permanently delete the hosted collection ${collection.display_name}? This cannot be undone.`)) return;
             void onAct(async () => {
               if (mirror) await window.mdbaseConnect.disconnectMirror(mirror.replica_id);
               await window.mdbaseConnect.deleteHostedCollection(collection.id);
-              onNotice(`${collection.display_name} was deleted. Any local mirror files remain.`);
+              onNotice(`${collection.display_name} was deleted. Any synced folder files remain.`);
             });
           }}>Delete hosted collection</button>
         </div>
@@ -503,5 +497,3 @@ function HostedCollectionRow({
     </article>
   );
 }
-
-

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -27,7 +27,9 @@ import {
   initialContractSetupChoice,
   type ContractSetupChoice
 } from "./contract-setup-editor";
+import { ConnectionProgress, Overview } from "./overview-view";
 import {
+  AccessControl,
   Brand,
   Empty,
   NavButton,
@@ -59,9 +61,9 @@ const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }>
     lede: "Collections, application access, and connection status in one place."
   },
   collections: {
-    eyebrow: "Collection authority",
-    title: "Your collections, in one place.",
-    lede: "Manage folders owned by this computer and collections hosted by mdbase."
+    eyebrow: "Collection storage",
+    title: "Your collections.",
+    lede: "See where each main copy lives and which folders stay in sync."
   },
   access: {
     eyebrow: "Application access",
@@ -74,14 +76,21 @@ const routeCopy: Record<Route, { eyebrow: string; title: string; lede: string }>
     lede: "Successful, failed, and denied remote operations are recorded locally."
   },
   settings: {
-    eyebrow: "Connector settings",
+    eyebrow: "Settings",
     title: "Connection and startup.",
-    lede: "Manage this computer, its portal, and background behavior."
+    lede: "Manage this computer, its account connection, and background behavior."
   }
 };
 
+const RESUME_AUTHORIZATION_KEY = "mdbase:resume-authorization";
+
+function storedAuthorizationTarget(): string | null {
+  return localStorage.getItem(RESUME_AUTHORIZATION_KEY);
+}
+
 function App() {
-  const [route, setRoute] = useState<Route>("overview");
+  const [route, setRoute] = useState<Route>(() => storedAuthorizationTarget() ? "access" : "overview");
+  const [authorizationTarget, setAuthorizationTarget] = useState<string | null>(storedAuthorizationTarget);
   const [status, setStatus] = useState<AgentStatus | null>(null);
   const [updateStatus, setUpdateStatus] = useState<DesktopUpdateStatus | null>(null);
   const [collections, setCollections] = useState<CollectionSummary[]>([]);
@@ -128,6 +137,13 @@ function App() {
     void refresh();
     const timer = window.setInterval(() => void refresh(true), 5_000);
     const removeNavigation = window.mdbaseConnect.onNavigate((next) => {
+      if (next === "access" || next.startsWith("access:")) {
+        const requestId = next.startsWith("access:") ? next.slice("access:".length) : "pending";
+        localStorage.setItem(RESUME_AUTHORIZATION_KEY, requestId);
+        setAuthorizationTarget(requestId);
+        setRoute("access");
+        return;
+      }
       if (next.startsWith("collections:mirror:")) {
         setMirrorTarget(next.slice("collections:mirror:".length));
         setRoute("collections");
@@ -144,6 +160,12 @@ function App() {
       removeUpdateStatus();
     };
   }, [refresh]);
+
+  useEffect(() => {
+    if (cloud?.configured && route === "access" && authorizationTarget) {
+      localStorage.removeItem(RESUME_AUTHORIZATION_KEY);
+    }
+  }, [authorizationTarget, cloud?.configured, route]);
 
   async function act(action: () => Promise<void>) {
     setBusy(true);
@@ -264,6 +286,8 @@ function App() {
             collectionCount={collectionCount}
             busy={busy}
             onNavigate={setRoute}
+            onAdd={() => void addExisting()}
+            onCreate={() => setCreateOpen(true)}
             onPause={(paused) => void act(async () => {
               await window.mdbaseConnect.setAccessPaused(paused);
               setNotice(paused ? "Remote access is paused on this computer." : "Remote access is available again.");
@@ -294,7 +318,17 @@ function App() {
             collections={collections}
             hostedCollections={hosted.hosted_collections}
             canCreateHosted={hosted.hosted_collections_available !== false}
+            focusedRequestId={authorizationTarget === "pending" ? null : authorizationTarget}
+            resumeAuthorization={authorizationTarget !== null}
             busy={busy}
+            onAddCollection={() => void addExisting()}
+            onCreateCollection={() => setCreateOpen(true)}
+            onAuthorizationHandled={(requestId) => {
+              if (authorizationTarget === requestId || authorizationTarget === "pending") {
+                setAuthorizationTarget(null);
+                localStorage.removeItem(RESUME_AUTHORIZATION_KEY);
+              }
+            }}
             onAct={act}
             onNotice={setNotice}
           />
@@ -317,16 +351,16 @@ function App() {
           <section className="modal" role="dialog" aria-modal="true" aria-labelledby="create-title" onMouseDown={(event) => event.stopPropagation()}>
             <p className="eyebrow">New collection</p>
             <h2 id="create-title">Create an mdbase collection</h2>
-            <p>Choose the authority deliberately. You can mirror a hosted collection onto this computer after creating it.</p>
+            <p>Choose where the main copy should live. A collection hosted by mdbase can also keep a synced folder on this computer.</p>
             <fieldset className="authority-choice">
-              <legend>Collection authority</legend>
+              <legend>Where should the main copy live?</legend>
               <label className={newAuthority === "local" ? "selected" : ""}>
                 <input type="radio" name="authority" value="local" checked={newAuthority === "local"} onChange={() => setNewAuthority("local")} />
-                <span><strong>On this computer</strong><small>A folder here is the final authority.</small></span>
+                <span><strong>On this computer</strong><small>The folder you choose is the main copy.</small></span>
               </label>
               <label className={`${newAuthority === "hosted" ? "selected" : ""} ${cloud?.configured && hosted.hosted_collections_available !== false ? "" : "disabled"}`}>
                 <input type="radio" name="authority" value="hosted" checked={newAuthority === "hosted"} disabled={!cloud?.configured || hosted.hosted_collections_available === false} onChange={() => setNewAuthority("hosted")} />
-                <span><strong>Hosted by mdbase</strong><small>{!cloud?.configured ? "Connect this computer to your account first." : hosted.hosted_collections_available !== false ? "Available while this computer is offline; optional local mirror." : "Hosted collections are not enabled for this Connect service."}</small></span>
+                <span><strong>Hosted by mdbase</strong><small>{!cloud?.configured ? "Connect this computer to your account first." : hosted.hosted_collections_available !== false ? "Available while this computer is off; add a synced folder if you want one." : "Hosted collections are not enabled for this Connect service."}</small></span>
               </label>
             </fieldset>
             <label><span>Collection name</span><input autoFocus value={newName} onChange={(event) => setNewName(event.target.value)} placeholder="Workouts" /></label>
@@ -342,75 +376,26 @@ function App() {
   );
 }
 
-function ConnectionProgress() {
-  return <div className="connection-progress" role="status" aria-live="polite">
-    <StatusDot state="connecting" />
-    <div><strong>Checking this computer</strong><small>Starting the local connector and checking its secure connection.</small></div>
-  </div>;
-}
-
-function Overview({ status, cloud, access, collectionCount, busy, onNavigate, onPause }: {
-  status: AgentStatus | null;
-  cloud: CloudSetting;
-  access: AccessSnapshot;
-  collectionCount: number;
-  busy: boolean;
-  onNavigate(route: Route): void;
-  onPause(paused: boolean): void;
-}) {
-  if (!cloud.configured) {
-    return <PairingPanel />;
-  }
-  return (
-    <div className="workspace-stack">
-      {access.pending_authorizations.length > 0 && (
-        <button className="pending-banner" onClick={() => onNavigate("access")}>
-          <span>{access.pending_authorizations.length}</span>
-          <div><strong>{plural(access.pending_authorizations.length, "application is", "applications are")} waiting for a decision</strong><small>Review the requested collection and operations.</small></div>
-          <b>Review requests</b>
-        </button>
-      )}
-      <section className="readiness-panel">
-        <div className="readiness-copy">
-          <p className="eyebrow">Connection state</p>
-          <h2>{status?.paused ? "Access is paused." : access.online ? "This computer is ready." : "Working from the local cache."}</h2>
-          <p>{status?.paused ? "Apps remain connected, but every collection operation is being denied locally." : access.online ? "Approved applications can reach available collections directly or through mdbase while this connector is running." : "Direct access keeps working from cached local policy. Cloud changes resume when the portal reconnects."}</p>
-        </div>
-        <SettingSwitch
-          className="pause-control"
-          label="Application access"
-          description="Pause direct and relayed operations without disconnecting apps"
-          checked={status ? !status.paused : false}
-          disabled={busy || status === null}
-          stateLabel={status ? status.paused ? "Paused" : "Available" : "Checking"}
-          onChange={(checked) => onPause(!checked)}
-        />
-      </section>
-      <section className="overview-list" aria-label="Connector summary">
-        <OverviewRow label="Collections" value={`${collectionCount} managed`} detail="Computer-owned and hosted authorities stay explicit" action="Manage" onClick={() => onNavigate("collections")} />
-        <OverviewRow label="Application access" value={`${access.grants.length} active`} detail="Each grant is limited to one collection" action="Manage" onClick={() => onNavigate("access")} />
-        <OverviewRow label="Portal" value={access.account?.user_email ?? cloud.serverUrl ?? "Configured"} detail={access.account?.connector_name ?? "Cloud identity unavailable while offline"} action="Settings" onClick={() => onNavigate("settings")} />
-      </section>
-    </div>
-  );
-}
-
-function OverviewRow({ label, value, detail, action, onClick }: { label: string; value: string; detail: string; action: string; onClick(): void }) {
-  return <div className="overview-row"><span>{label}</span><div><strong>{value}</strong><small>{detail}</small></div><button className="quiet-action" onClick={onClick}>{action}</button></div>;
-}
-
-function Access({ cloud, access, collections, hostedCollections, canCreateHosted, busy, onAct, onNotice }: {
+function Access({ cloud, access, collections, hostedCollections, canCreateHosted, focusedRequestId, resumeAuthorization, busy, onAddCollection, onCreateCollection, onAuthorizationHandled, onAct, onNotice }: {
   cloud: CloudSetting;
   access: AccessSnapshot;
   collections: CollectionSummary[];
   hostedCollections: HostedCollectionSummary[];
   canCreateHosted: boolean;
+  focusedRequestId: string | null;
+  resumeAuthorization: boolean;
   busy: boolean;
+  onAddCollection(): void;
+  onCreateCollection(): void;
+  onAuthorizationHandled(requestId: string): void;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
 }) {
   const applicationAccess = useMemo(() => groupApplicationAccess(access.grants), [access.grants]);
-  if (!cloud.configured) return <PairingPanel />;
+  const pendingAuthorizations = useMemo(() => [...access.pending_authorizations].sort((left, right) =>
+    left.id === focusedRequestId ? -1 : right.id === focusedRequestId ? 1 : 0
+  ), [access.pending_authorizations, focusedRequestId]);
+  if (!cloud.configured) return <PairingPanel resumeAuthorization={resumeAuthorization} />;
   return (
     <div className="workspace-stack">
       <section>
@@ -419,7 +404,20 @@ function Access({ cloud, access, collections, hostedCollections, canCreateHosted
           <Empty title="No applications are waiting" text="New connection requests from websites and downloaded files will appear here." />
         ) : (
           <div className="request-list">
-            {access.pending_authorizations.map((request) => <AuthorizationRequest key={request.id} request={request} collections={collections} hostedCollections={hostedCollections} canCreateHosted={canCreateHosted} busy={busy} onAct={onAct} onNotice={onNotice} />)}
+            {pendingAuthorizations.map((request) => <AuthorizationRequest
+              key={request.id}
+              request={request}
+              collections={collections}
+              hostedCollections={hostedCollections}
+              canCreateHosted={canCreateHosted}
+              focused={request.id === focusedRequestId}
+              busy={busy}
+              onAddCollection={onAddCollection}
+              onCreateCollection={onCreateCollection}
+              onHandled={onAuthorizationHandled}
+              onAct={onAct}
+              onNotice={onNotice}
+            />)}
           </div>
         )}
       </section>
@@ -427,7 +425,7 @@ function Access({ cloud, access, collections, hostedCollections, canCreateHosted
       <section>
         <SectionHeading title="Connected applications" note="Applications are grouped here; expand one to review its collection access." count={applicationAccess.length} />
         {applicationAccess.length === 0 ? (
-          <Empty title="No applications connected" text="Connect from an mdbase-enabled application to manage its access here." />
+          <Empty title="No applications connected" text="Open the app you want to use and choose its mdbase connection action. The request will appear here for your decision." />
         ) : (
           <div className="application-access-list">{applicationAccess.map((group) => (
             <ApplicationGrantGroup key={group.applicationId} group={group} busy={busy} onAct={onAct} onNotice={onNotice} />
@@ -479,12 +477,16 @@ function ApplicationGrantGroup({ group, busy, onAct, onNotice }: {
   );
 }
 
-function AuthorizationRequest({ request, collections, hostedCollections, canCreateHosted, busy, onAct, onNotice }: {
+function AuthorizationRequest({ request, collections, hostedCollections, canCreateHosted, focused, busy, onAddCollection, onCreateCollection, onHandled, onAct, onNotice }: {
   request: PendingAuthorization;
   collections: CollectionSummary[];
   hostedCollections: HostedCollectionSummary[];
   canCreateHosted: boolean;
+  focused: boolean;
   busy: boolean;
+  onAddCollection(): void;
+  onCreateCollection(): void;
+  onHandled(requestId: string): void;
   onAct(action: () => Promise<void>): Promise<void>;
   onNotice(value: string): void;
 }) {
@@ -647,14 +649,20 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
     onNotice(`${created.display_name} was created and selected. Application access is not allowed yet.`);
   }
   return (
-    <article className="request-panel">
+    <article className={`request-panel ${focused ? "focused-request" : ""}`} id={`authorization-${request.id}`}>
       <div className="request-identity"><p className="eyebrow">Access request</p><h3>{request.application_name}</h3><code>{request.application_distribution === "portable" ? `Downloaded HTML file${request.application_project_url ? ` · ${host(request.application_project_url)}` : ""}` : host(request.application_homepage)}</code>{request.application_distribution === "portable" ? <small className="portable-request-warning">Unverified file origin. Only allow it if you intentionally opened the file{request.user_code ? ` and it shows ${request.user_code}` : ""}.</small> : <small>Only continue if you recognize this exact site. An approved application can use the selected data until you revoke it.</small>}<small>Expires {relativeTime(request.expires_at)}</small>{request.requirements.contracts.length > 0 && <small>{scopeDescription(request.requirements.contracts)}</small>}</div>
       <div className="request-decision">
         <section className="request-section">
           <div><strong>Collection</strong><small>{request.collection_id ? `${request.application_name} requested this specific collection.` : `Choose where ${request.application_name} can work.`}</small></div>
           <div className="request-section-content">
             <label><span>Collection</span><select value={collectionId} disabled={selectable.length === 0 || busy} onChange={(event) => setCollectionId(event.target.value)}>{selectable.length === 0 && <option value="">No compatible collection</option>}{selectable.map((collection) => <option key={collection.id} value={collection.id}>{collection.display_name} · {collection.kind === "hosted" ? "Hosted by mdbase" : "on this computer"}{collection.provisionable ? " · setup required" : ""}</option>)}</select></label>
-            {selectable.length === 0 && <small>{request.collection_id ? "The collection requested by this application is not available." : "No available local or hosted collection supports all requested operations and contracts."}</small>}
+            {selectable.length === 0 && <small>{request.collection_id ? "The collection requested by this application is not available." : "No collection is ready for this application yet. Add a compatible folder or create a collection without restarting the request."}</small>}
+            {selectable.length === 0 && request.requirements.collection_kind !== "hosted" && (
+              <div className="request-prerequisite-actions">
+                <button className="button primary" type="button" disabled={busy} onClick={onAddCollection}>Add a folder</button>
+                <button className="button secondary" type="button" disabled={busy} onClick={onCreateCollection}>Create collection</button>
+              </div>
+            )}
             {canCreateHosted && !request.collection_id && (creatingHosted ? (
               <form
                 className="request-collection-create"
@@ -725,9 +733,10 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
             ? `${request.application_name} will use ${selected.display_name}, ${selected.kind === "hosted" ? "hosted by mdbase" : "on this computer"}, until you revoke access.`
             : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
           <div className="decision-actions">
-            <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
+            <button className="button secondary danger-text" disabled={busy} onClick={() => void onAct(async () => { await window.mdbaseConnect.denyAuthorization(request.id); onHandled(request.id); onNotice(`${request.application_name} was denied.`); })}>Deny</button>
             <button className="button primary" disabled={busy || !selected || selectedPermissionCount === 0 || !setupReady} onClick={() => void onAct(async () => {
-              if (selected?.kind === "hosted") {
+              if (!selected) return;
+              if (selected.kind === "hosted") {
                 await window.mdbaseConnect.approveHostedAuthorization({
                   requestId: request.id,
                   collectionId,
@@ -742,7 +751,8 @@ function AuthorizationRequest({ request, collections, hostedCollections, canCrea
                   contractSetups
                 });
               }
-              onNotice(`${request.application_name} can now use the selected operations.`);
+              onHandled(request.id);
+              onNotice(`${request.application_name} is connected to ${selected.display_name}. Return to the application to continue.`);
             })}>{setup.length > 0 ? `Set up and allow ${request.application_name}` : `Allow ${request.application_name}`}</button>
           </div>
         </footer>
@@ -824,14 +834,14 @@ function Settings({ startup, cloud, access, status, updateStatus, busy, onAct, o
     <div className="workspace-stack settings-stack">
       {!cloud.configured ? <PairingPanel /> : (
         <section>
-          <SectionHeading title="Portal connection" note="Account and routing metadata for this computer." />
+          <SectionHeading title="Account connection" note="The account this computer uses for application requests." />
           <div className="settings-rows">
             <ComputerNameSetting account={access.account} online={access.online} busy={busy} onAct={onAct} onNotice={onNotice} />
-            <SettingRow label="Server" value={cloud.serverUrl ?? "Configured"} detail={access.online ? "Control service reachable" : "Using cached local policy"} mono />
-            <SettingRow label="Connection" value={connection.settingsLabel} detail="The relay connection is always outbound from this computer" />
-            <SettingRow label="Direct access" value={status?.direct_access_available ? "Available" : "Unavailable"} detail="Approved apps on this computer can bypass the relay" />
+            <SettingRow label="Connect service" value={cloud.serverUrl ?? "Configured"} detail={access.online ? "Account changes are up to date" : "Saved app access still works on this computer"} mono />
+            <SettingRow label="Connection" value={connection.settingsLabel} detail="Keeps approved apps on other devices connected to this computer" />
+            <SettingRow label="Apps on this computer" value={status?.direct_access_available ? "Available" : "Unavailable"} detail="Approved apps here can connect without sending records over the internet" />
           </div>
-          <button className="button secondary danger-text disconnect-button" disabled={busy} onClick={() => { if (window.confirm("Disconnect this computer from its portal? Existing local collection files are unaffected.")) void onAct(async () => { await window.mdbaseConnect.clearCloudConfig(); }); }}>Disconnect computer</button>
+          <button className="button secondary danger-text disconnect-button" disabled={busy} onClick={() => { if (window.confirm("Disconnect this computer from your account? Existing local collection files are unaffected.")) void onAct(async () => { await window.mdbaseConnect.clearCloudConfig(); }); }}>Disconnect computer</button>
         </section>
       )}
       <section>
@@ -849,16 +859,12 @@ function Settings({ startup, cloud, access, status, updateStatus, busy, onAct, o
               onNotice(checked ? "mdbase connect will start at login." : "Launch at login is off.");
             })}
           />
-          <SettingSwitch
-            className="setting-toggle"
-            label="Application access"
-            description="Pause direct and relayed operations while keeping grants connected"
-            checked={status ? !status.paused : false}
+          <AccessControl
+            paused={status?.paused ?? false}
             disabled={busy || status === null}
-            stateLabel={status ? status.paused ? "Paused" : "Available" : "Checking"}
-            onChange={(checked) => void onAct(async () => {
-              await window.mdbaseConnect.setAccessPaused(!checked);
-              onNotice(checked ? "Application access is available." : "Application access is paused.");
+            onChange={(paused) => void onAct(async () => {
+              await window.mdbaseConnect.setAccessPaused(paused);
+              onNotice(paused ? "App access is paused." : "App access is available again.");
             })}
           />
         </div>
@@ -915,7 +921,7 @@ function Settings({ startup, cloud, access, status, updateStatus, busy, onAct, o
           </div>
         </div>
       </section>
-      <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Folder locations are never synchronized.</strong><p>Computer-owned collection content stays on this computer. Hosted Markdown is stored by the encrypted hosted provider and optional mirrors synchronize directly with it; the account portal receives only collection and access metadata.</p></div></section>
+      <section className="privacy-block"><span className="privacy-lock">⌁</span><div><strong>Folder locations are never uploaded.</strong><p>Collections kept on this computer stay here. Hosted Markdown is stored by mdbase, and synced folders exchange changes directly with it. Your account only receives collection and app-access details.</p></div></section>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/overview-view.tsx
+++ b/apps/desktop/src/renderer/overview-view.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { AccessControl, PairingPanel, StatusDot } from "./ui-components";
+import { plural, type Route } from "./view-model";
+
+export function ConnectionProgress() {
+  return <div className="connection-progress" role="status" aria-live="polite">
+    <StatusDot state="connecting" />
+    <div><strong>Checking this computer</strong><small>Starting the local connector and checking its secure connection.</small></div>
+  </div>;
+}
+
+export function Overview({ status, cloud, access, collectionCount, busy, onNavigate, onAdd, onCreate, onPause }: {
+  status: AgentStatus | null;
+  cloud: CloudSetting;
+  access: AccessSnapshot;
+  collectionCount: number;
+  busy: boolean;
+  onNavigate(route: Route): void;
+  onAdd(): void;
+  onCreate(): void;
+  onPause(paused: boolean): void;
+}) {
+  if (!cloud.configured) return <PairingPanel />;
+  return (
+    <div className="workspace-stack">
+      {access.pending_authorizations.length > 0 && (
+        <button className="pending-banner" onClick={() => onNavigate("access")}>
+          <span>{access.pending_authorizations.length}</span>
+          <div><strong>{plural(access.pending_authorizations.length, "application is", "applications are")} waiting for a decision</strong><small>Review the requested collection and operations.</small></div>
+          <b>Review requests</b>
+        </button>
+      )}
+      {collectionCount === 0 && (
+        <section className="first-collection">
+          <div>
+            <p className="eyebrow">First step</p>
+            <h2>Add a collection for your apps.</h2>
+            <p>Choose an existing mdbase folder or create a new collection. Adding a folder does not move or upload its files.</p>
+          </div>
+          <div>
+            <button className="button primary" disabled={busy} onClick={onAdd}>Add existing folder</button>
+            <button className="button secondary" disabled={busy} onClick={onCreate}>Create collection</button>
+          </div>
+        </section>
+      )}
+      <section className="readiness-panel">
+        <div className="readiness-copy">
+          <p className="eyebrow">Connection state</p>
+          <h2>{status?.paused ? "Access is paused." : access.online ? "This computer is ready." : "Working from the local cache."}</h2>
+          <p>{status?.paused ? "Connected apps remain listed, but this computer is denying their requests." : access.online ? "Approved apps can use the collections you made available while mdbase connect is running." : "Apps on this computer can keep using saved access. Access from elsewhere resumes when the connection returns."}</p>
+        </div>
+        <AccessControl
+          paused={status?.paused ?? false}
+          disabled={busy || status === null}
+          onChange={onPause}
+        />
+      </section>
+      <section className="overview-list" aria-label="Connector summary">
+        <OverviewRow label="Collections" value={`${collectionCount} managed`} detail="Each collection shows where its main copy lives" action="Manage" onClick={() => onNavigate("collections")} />
+        <OverviewRow label="App access" value={`${access.grants.length} active`} detail="Start in an mdbase-enabled app; its request will appear here" action="Review" onClick={() => onNavigate("access")} />
+        <OverviewRow label="Account" value={access.account?.user_email ?? cloud.serverUrl ?? "Configured"} detail={access.account?.connector_name ?? "Account details unavailable while offline"} action="Settings" onClick={() => onNavigate("settings")} />
+      </section>
+    </div>
+  );
+}
+
+function OverviewRow({ label, value, detail, action, onClick }: { label: string; value: string; detail: string; action: string; onClick(): void }) {
+  return <div className="overview-row"><span>{label}</span><div><strong>{value}</strong><small>{detail}</small></div><button className="quiet-action" onClick={onClick}>{action}</button></div>;
+}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -53,6 +53,10 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .pending-banner strong { font-size: var(--type-row-title); }
 .pending-banner small, .pending-banner b { color: var(--muted); font-size: var(--type-supporting); }
 .pending-banner b { color: var(--ink); }
+.first-collection { display: flex; align-items: flex-end; justify-content: space-between; gap: 32px; padding: 22px 0 26px; border-top: 1px solid var(--line); }
+.first-collection h2 { margin: 0; font-size: 20px; letter-spacing: -0.025em; }
+.first-collection p:last-child { max-width: 58ch; margin: 7px 0 0; color: var(--muted); font-size: var(--type-body); line-height: 1.5; }
+.first-collection > div:last-child { display: flex; flex: 0 0 auto; gap: 8px; }
 .readiness-panel { display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(230px, 0.7fr); align-items: center; gap: 48px; padding: 26px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: var(--paper); }
 .readiness-copy h2 { margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.025em; }
 .readiness-copy > p:last-child { max-width: 62ch; margin: 8px 0 0; color: var(--muted); font-size: var(--type-body); line-height: 1.55; }
@@ -60,6 +64,11 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .pause-control .toggle-copy, .setting-toggle .toggle-copy { display: grid; gap: 3px; }
 .pause-control strong, .setting-toggle strong { font-size: var(--type-body); font-weight: 700; }
 .pause-control small, .setting-toggle small { color: var(--muted); font-size: var(--type-supporting); font-weight: 400; }
+.access-control { display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+.access-control > div { display: grid; gap: 3px; }
+.access-control strong { font-size: var(--type-body); }
+.access-control small { max-width: 44ch; color: var(--muted); font-size: var(--type-supporting); line-height: 1.45; }
+.access-control .button { flex: 0 0 auto; }
 .toggle-action { display: flex; align-items: center; justify-content: flex-end; gap: 10px; min-width: 112px; flex: 0 0 auto; }
 .toggle-state { color: var(--muted); font-family: var(--mono); font-size: var(--type-metadata); font-weight: 500; text-align: right; }
 .pause-control input, .setting-toggle input { appearance: none; width: 38px; min-width: 38px; height: 22px; min-height: 0; flex: 0 0 auto; margin: 0; padding: 2px; border: 1px solid var(--line-strong); border-radius: 12px; background: var(--paper); cursor: pointer; transition: border-color 160ms var(--ease), background 160ms var(--ease); }
@@ -170,6 +179,7 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 .request-list { display: grid; margin-top: 10px; }
 .request-panel { display: grid; grid-template-columns: minmax(150px, 0.38fr) minmax(0, 1fr); align-items: start; gap: 32px; padding: 22px 0; border-bottom: 1px solid var(--line); background: var(--paper); }
 .request-panel:first-child { border-top: 1px solid var(--line); }
+.request-panel.focused-request { scroll-margin-top: 28px; outline: 1px solid var(--line-strong); outline-offset: 10px; }
 .identity-mark { display: none; }
 .request-identity, .grant-identity { display: grid; gap: 3px; }
 .request-identity h3 { margin: 0; font-size: 16px; font-weight: 700; }
@@ -215,6 +225,7 @@ h1 { margin: 0; font-size: 26px; font-weight: 700; line-height: 1.15; letter-spa
 label > span, fieldset > legend { color: var(--muted); font-size: var(--type-supporting); font-weight: 700; }
 input, select { width: 100%; min-height: 36px; padding: 0 10px; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--ink); background: var(--paper); font-size: var(--type-body); }
 .request-section-content > label, .manual-app label, .manual-grant > label, .pairing-form label { display: grid; gap: 5px; }
+.request-prerequisite-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
 .request-permission-review, .notification-request { min-width: 0; }
 .request-permission-review > summary, .notification-request > summary { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 36px; cursor: pointer; list-style: none; }
 .request-permission-review > summary::-webkit-details-marker, .notification-request > summary::-webkit-details-marker { display: none; }
@@ -255,7 +266,7 @@ fieldset legend { margin-bottom: 6px; }
 .activity-row time { color: var(--muted); font-size: var(--type-action); text-align: right; }
 
 .settings-rows { border-top: 1px solid var(--line); }
-.setting-row, .setting-toggle { min-height: 64px; padding: 10px 0; border-bottom: 1px solid var(--line); }
+.setting-row, .setting-toggle, .settings-rows > .access-control { min-height: 64px; padding: 10px 0; border-bottom: 1px solid var(--line); }
 .setting-row { display: grid; grid-template-columns: 140px minmax(0, 1fr) auto; align-items: center; gap: 20px; }
 .setting-row > span { color: var(--muted); font-size: var(--type-supporting); }
 .setting-row div { display: grid; gap: 3px; }
@@ -277,8 +288,11 @@ fieldset legend { margin-bottom: 6px; }
 .pairing-intro .eyebrow { display: none; }
 .pairing-intro h2 { margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.025em; }
 .pairing-intro > p:last-child { max-width: 56ch; margin: 9px 0 0; color: var(--muted); font-size: var(--type-body); line-height: 1.55; }
-.pairing-form { display: grid; grid-template-columns: 1fr 0.8fr; align-items: end; gap: 11px; }
-.pairing-form .button { grid-column: 1 / -1; justify-self: end; margin-top: 3px; }
+.pairing-form { display: grid; grid-template-columns: 1fr; align-items: end; gap: 12px; }
+.pairing-form .button { justify-self: end; margin-top: 3px; }
+.pairing-server { padding-top: 3px; border-top: 1px solid var(--line); }
+.pairing-server > summary { padding: 9px 0 4px; color: var(--muted); font-size: var(--type-action); font-weight: 700; cursor: pointer; }
+.pairing-server > label { display: grid; gap: 5px; padding-top: 6px; }
 .pairing-wait { display: grid; grid-template-columns: 7px 1fr auto; align-items: center; gap: 12px; padding: 15px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .pairing-wait div { display: grid; gap: 4px; min-width: 0; }
 .pairing-wait strong { font-size: var(--type-body); font-weight: 700; }
@@ -325,6 +339,7 @@ fieldset legend { margin-bottom: 6px; }
   .replica-list small { grid-column: 1 / -1; }
   .request-footer { align-items: flex-start; flex-direction: column; }
   .readiness-panel, .pairing-panel { grid-template-columns: 1fr; gap: 24px; }
+  .first-collection { align-items: flex-start; flex-direction: column; }
   .application-grant-group > summary { grid-template-columns: minmax(0, 1fr) auto; gap: 8px 16px; padding: 10px 0; }
   .application-grant-group > summary > span { grid-column: 1; }
   .application-grant-group > summary > b { grid-column: 2; grid-row: 1; }
@@ -334,6 +349,7 @@ fieldset legend { margin-bottom: 6px; }
   .overview-row { grid-template-columns: 95px minmax(0, 1fr) auto; }
   .pairing-form { grid-template-columns: 1fr; }
   .pairing-form .button { grid-column: 1; }
+  .access-control { align-items: flex-start; flex-direction: column; }
   .copy-registration { grid-template-columns: 1fr; gap: 16px; }
   .copy-registration-actions { justify-content: flex-end; }
   .identity-conflict-details > div { grid-template-columns: 120px minmax(0, 1fr); }

--- a/apps/desktop/src/renderer/ui-components.tsx
+++ b/apps/desktop/src/renderer/ui-components.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from "react";
 import type { ConnectionDotState } from "./connection-state.mjs";
 import { message, type Route } from "./view-model";
 
-export function PairingPanel() {
+export function PairingPanel({ resumeAuthorization = false }: { resumeAuthorization?: boolean }) {
   const [serverUrl, setServerUrl] = useState("https://connect.mdbase.dev");
   const [connectorName, setConnectorName] = useState("This computer");
   const [pairing, setPairing] = useState<{ pairingId: string; verificationUri: string } | null>(null);
@@ -48,7 +48,15 @@ export function PairingPanel() {
 
   return (
     <section className="pairing-panel">
-      <div className="pairing-intro"><p className="eyebrow">Portal connection</p><h2>{pairing ? "Finish in your browser." : "Connect this computer."}</h2><p>{pairing ? "Sign in and approve the computer. This window will update automatically, and no token needs to be copied." : "A portal supplies identity and routing so authorized websites can find this connector. Collection paths remain local."}</p></div>
+      <div className="pairing-intro">
+        <p className="eyebrow">Account connection</p>
+        <h2>{pairing ? "Finish in your browser." : resumeAuthorization ? "Connect this computer to continue." : "Connect this computer."}</h2>
+        <p>{pairing
+          ? "Sign in and approve this computer. This window updates automatically, and there is no code to copy."
+          : resumeAuthorization
+            ? "Your application request will keep waiting. Sign in so you can choose a folder on this computer, then continue the same request."
+            : "Sign in so approved applications can find collections on this computer. Folder locations remain private."}</p>
+      </div>
       {pairError && <div className="message error-message">{pairError}</div>}
       {pairing ? (
         <div className="pairing-wait" role="status" aria-live="polite">
@@ -61,8 +69,11 @@ export function PairingPanel() {
         </div>
       ) : (
         <form className="pairing-form" onSubmit={(event) => void begin(event)}>
-          <label><span>Server</span><input type="url" value={serverUrl} onChange={(event) => setServerUrl(event.target.value)} /></label>
           <label><span>Computer name</span><input value={connectorName} onChange={(event) => setConnectorName(event.target.value)} /></label>
+          <details className="pairing-server">
+            <summary>Use another Connect server</summary>
+            <label><span>Server address</span><input type="url" value={serverUrl} onChange={(event) => setServerUrl(event.target.value)} /></label>
+          </details>
           <button className="button primary" disabled={starting || !serverUrl.trim() || !connectorName.trim()}>{starting ? "Opening browser…" : "Continue in browser"}</button>
         </form>
       )}
@@ -126,4 +137,27 @@ export function SettingSwitch({ className, label, description, checked, disabled
   );
 }
 
+export function AccessControl({ paused, disabled, onChange }: {
+  paused: boolean;
+  disabled: boolean;
+  onChange(paused: boolean): void;
+}) {
+  return (
+    <div className="access-control">
+      <div>
+        <strong>{paused ? "App access is paused" : "App access is available"}</strong>
+        <small>{paused
+          ? "Connected apps remain listed, but this computer is denying their requests."
+          : "Approved apps can use the collections you made available."}</small>
+      </div>
+      <button
+        className={`button ${paused ? "primary" : "secondary"}`}
+        disabled={disabled}
+        onClick={() => onChange(!paused)}
+      >
+        {paused ? "Resume app access" : "Pause app access"}
+      </button>
+    </div>
+  );
+}
 

--- a/apps/desktop/src/renderer/view-model.ts
+++ b/apps/desktop/src/renderer/view-model.ts
@@ -57,7 +57,7 @@ export function mirrorState(mirror: DesktopMirrorSummary | undefined): {
   dot: ConnectionDotState;
   label: string;
 } {
-  if (!mirror) return { dot: "idle", label: "Not mirrored" };
+  if (!mirror) return { dot: "idle", label: "No synced folder" };
   if (mirror.promotion) {
     return {
       dot: "connecting",
@@ -65,7 +65,7 @@ export function mirrorState(mirror: DesktopMirrorSummary | undefined): {
     };
   }
   if (mirror.syncing) return { dot: "connecting", label: "Synchronizing" };
-  if (mirror.error || mirror.state === "offline") return { dot: "danger", label: "Mirror needs attention" };
+  if (mirror.error || mirror.state === "offline") return { dot: "danger", label: "Synced folder needs attention" };
   if (mirror.conflicts.length > 0) return { dot: "paused", label: "Conflicts need a decision" };
   if (mirror.local_issues.length > 0 || mirror.state === "attention") return { dot: "paused", label: "Local files need attention" };
   if (mirror.state === "changes_waiting" || mirror.pending > 0) return { dot: "connecting", label: "Changes waiting" };
@@ -81,17 +81,17 @@ export function authorityPromotionState(
   if (!mirror) {
     return {
       enabled: false,
-      title: "A two-way mirror is required",
-      detail: "Create and synchronize a two-way mirror on this computer first.",
-      button: "Move authority to this computer"
+      title: "A folder that syncs edits both ways is required",
+      detail: "Add a synced folder on this computer and let it finish updating first.",
+      button: "Use this folder as the main copy"
     };
   }
   if (starting && !mirror.promotion) {
     return {
       enabled: false,
-      title: "Preparing authority transfer",
+      title: "Preparing the main-copy change",
       detail: "Checking the folder before opening browser confirmation.",
-      button: "Preparing transfer…"
+      button: "Preparing change…"
     };
   }
   if (mirror.promotion) {
@@ -108,33 +108,33 @@ export function authorityPromotionState(
   if (mirror.promotion_pending) {
     return {
       enabled: true,
-      title: "Authority transfer ready to resume",
-      detail: "The folder was already verified. Finish activating it as the source of truth.",
-      button: "Resume authority move"
+      title: "Main-copy change ready to resume",
+      detail: "The folder was already verified. Finish making it the main copy.",
+      button: "Resume main-copy change"
     };
   }
   if (mirror.mode !== "read_write") {
     return {
       enabled: false,
-      title: "A two-way mirror is required",
-      detail: "Receive-only folders cannot become authoritative. Recreate this mirror as two-way.",
-      button: "Move authority to this computer"
+      title: "This folder only downloads updates",
+      detail: "A folder must sync edits both ways before it can become the main copy.",
+      button: "Use this folder as the main copy"
     };
   }
   if (collection.authority_state !== "active") {
     return {
       enabled: false,
-      title: "Authority transfer already in progress",
+      title: "The main copy is already moving",
       detail: "Return to the browser confirmation or wait for the current request to expire.",
-      button: "Move authority to this computer"
+      button: "Use this folder as the main copy"
     };
   }
   if (mirror.syncing) {
     return {
       enabled: false,
       title: "Mirror is synchronizing",
-      detail: "Authority can move after the current synchronization finishes.",
-      button: "Move authority to this computer"
+      detail: "The main copy can move after the current synchronization finishes.",
+      button: "Use this folder as the main copy"
     };
   }
   if (
@@ -146,37 +146,37 @@ export function authorityPromotionState(
   ) {
     return {
       enabled: false,
-      title: "Mirror needs attention",
-      detail: "Resolve mirror errors and file conflicts before moving authority.",
-      button: "Move authority to this computer"
+      title: "Synced folder needs attention",
+      detail: "Resolve its errors and file conflicts before making it the main copy.",
+      button: "Use this folder as the main copy"
     };
   }
   if (mirror.state !== "up_to_date" || mirror.pending > 0) {
     return {
       enabled: false,
-      title: "Synchronize this mirror first",
-      detail: "The folder must match the hosted collection before it can become authoritative.",
-      button: "Move authority to this computer"
+      title: "Let this folder finish syncing first",
+      detail: "The folder must match the hosted collection before it can become the main copy.",
+      button: "Use this folder as the main copy"
     };
   }
   return {
     enabled: true,
-    title: "Move authority to this computer",
-    detail: "Browser confirmation will pause hosted writes, verify this folder, and revoke existing application access.",
-    button: "Move authority to this computer"
+    title: "Use this folder as the main copy",
+    detail: "Browser confirmation will briefly pause hosted changes, verify this folder, and revoke existing application access.",
+    button: "Use this folder as the main copy"
   };
 }
 
 function authorityPromotionPhaseLabel(
   phase: NonNullable<DesktopMirrorSummary["promotion"]>["phase"]
 ): string {
-  if (phase === "synchronizing") return "Synchronizing mirror";
+  if (phase === "synchronizing") return "Updating synced folder";
   if (phase === "awaiting_approval") return "Waiting for browser approval";
   if (phase === "verifying") return "Verifying exact folder contents";
-  if (phase === "registering") return "Registering local authority";
-  if (phase === "registered" || phase === "activating") return "Activating local authority";
-  if (phase === "resuming") return "Resuming authority transfer";
-  return "Finishing authority transfer";
+  if (phase === "registering") return "Registering the folder";
+  if (phase === "registered" || phase === "activating") return "Making the folder the main copy";
+  if (phase === "resuming") return "Resuming the main-copy change";
+  return "Finishing the main-copy change";
 }
 
 export function hasContract(contracts: ContractRequirement[], required: ContractRequirement) { return contracts.some((contract) => sameContract(contract, required)); }
@@ -193,7 +193,19 @@ export function scopeDescription(contracts: ContractRequirement[]): string {
 }
 
 export function host(value: string) { try { return new URL(value).host; } catch { return value; } }
-export function message(error: unknown): string { return error instanceof Error ? error.message : String(error); }
+export function message(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (/failed to fetch|networkerror|network request failed/i.test(detail)) {
+    return "mdbase connect could not reach the service. Check your connection and try again.";
+  }
+  if (/pairing.+(?:expired|not found)|pairing request.+(?:expired|not found)/i.test(detail)) {
+    return "This computer setup request expired. Start again to create a new one.";
+  }
+  if (/unsupported.+protocol|up-to-date connector|no longer compatible/i.test(detail)) {
+    return "This version of mdbase connect needs to be updated before it can continue.";
+  }
+  return detail;
+}
 export function plural(count: number, singular: string, pluralValue: string) { return count === 1 ? singular : pluralValue; }
 export function relativeTime(value: string) {
   const date = new Date(value.includes("T") ? value : `${value.replace(" ", "T")}Z`);
@@ -206,4 +218,3 @@ export function relativeTime(value: string) {
   if (Math.abs(hours) < 24) return formatter.format(hours, "hour");
   return formatter.format(Math.round(hours / 24), "day");
 }
-

--- a/apps/desktop/test/deep-link.test.mjs
+++ b/apps/desktop/test/deep-link.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { routeForDeepLink } = require("../dist/main/deep-link.js");
+
+test("authorization links preserve the exact request route", () => {
+  assert.equal(
+    routeForDeepLink("mdbase-connect://authorize?request_id=request%2Fwith%20spaces"),
+    "access:request/with spaces"
+  );
+  assert.equal(routeForDeepLink("mdbase-connect://authorize"), "access");
+});
+
+test("other supported links retain their existing routes", () => {
+  assert.equal(routeForDeepLink("mdbase-connect://paired"), "overview");
+  assert.equal(
+    routeForDeepLink("mdbase-connect://mirror?collection=collection-1"),
+    "collections:mirror:collection-1"
+  );
+  assert.equal(routeForDeepLink("mdbase-connect://mirror"), "collections");
+});
+
+test("malformed and unrelated links are ignored", () => {
+  assert.equal(routeForDeepLink(undefined), null);
+  assert.equal(routeForDeepLink("not a url"), null);
+  assert.equal(routeForDeepLink("https://connect.mdbase.dev/authorize"), null);
+  assert.equal(routeForDeepLink("mdbase-connect://unknown"), null);
+});

--- a/apps/portal/src/authority-workflows.tsx
+++ b/apps/portal/src/authority-workflows.tsx
@@ -202,38 +202,38 @@ export function AuthorityAdoption({ adoptionId }: { adoptionId: string }) {
   const inactive = adoption.state === "cancelled" || adoption.state === "expired";
   return (
     <main className="center-page">
-      <PageBrand label="Collection adoption" />
+      <PageBrand label="Move collection online" />
       <section className="decision-panel authority-decision">
         {adoption.state === "completed" ? <>
-          <p className="eyebrow outcome-label">Adoption complete</p>
+          <p className="eyebrow outcome-label">Move complete</p>
           <h1>{adoption.display_name} is now hosted.</h1>
           <p>
-            mdbase is the authoritative home for this collection.
+            mdbase now keeps the main copy of this collection.
             {adoption.retain_mirror
-              ? ` ${adoption.mirror_name ?? adoption.source_name} will continue as a two-way local mirror.`
-              : " The original local files are no longer authoritative."}
+              ? ` ${adoption.mirror_name ?? adoption.source_name} will continue as a synced folder, with edits syncing both ways.`
+              : " The original local files are no longer the main copy."}
           </p>
           <div className="transfer-status" role="status">
             <span className="status-dot connected" aria-hidden="true" />
-            <span>Hosted authority, epoch {adoption.authority_epoch}</span>
+            <span>Main copy hosted by mdbase</span>
           </div>
           <a className="button primary link-button" href="/">Return to your account</a>
         </> : inactive ? <>
-          <p className="eyebrow">Adoption ended</p>
+          <p className="eyebrow">Move ended</p>
           <h1>Your local collection was kept.</h1>
-          <p>No hosted authority was activated.</p>
+          <p>The main copy was not moved to mdbase.</p>
           {error && <div className="message error" role="alert">{error}</div>}
           <a className="button primary link-button" href="/">Return to your account</a>
         </> : adoption.state !== "requested" ? <>
-          <p className="eyebrow outcome-label">Adoption approved</p>
+          <p className="eyebrow outcome-label">Move approved</p>
           <h1>Return to {adoption.source_name}.</h1>
           <p>
-            The app is uploading and validating a final, fenced collection snapshot.
-            Hosted authority will activate only after that exact snapshot is complete.
+            The app is uploading and checking a final collection snapshot.
+            The main copy will move only after that exact snapshot is complete.
           </p>
           <div className="transfer-status" role="status">
             <span className="status-dot paused" aria-hidden="true" />
-            <span>{adoption.state === "activating" ? "Activating hosted authority" : "Waiting for the app"}</span>
+            <span>{adoption.state === "activating" ? "Finishing the move" : "Waiting for the app"}</span>
           </div>
           {error && <div className="message error" role="alert">{error}</div>}
         </> : <>
@@ -241,18 +241,18 @@ export function AuthorityAdoption({ adoptionId }: { adoptionId: string }) {
           <h1>{adoption.display_name}</h1>
           <p>
             Approving uploads the complete collection from {adoption.source_name}, validates it
-            as one snapshot, and then makes the hosted copy authoritative.
+            as one snapshot, and then makes the hosted version the main copy.
           </p>
           <div className="message">
             {adoption.retain_mirror
-              ? `After activation, ${adoption.mirror_name ?? adoption.source_name} becomes a two-way mirror—not a second authority.`
-              : "After activation, the original local files are no longer authoritative."}
+              ? `After the move, ${adoption.mirror_name ?? adoption.source_name} stays as a synced folder. It will not be a second main copy.`
+              : "After the move, the original local files are no longer the main copy."}
           </div>
           {error && <div className="message error" role="alert">{error}</div>}
           <div className="decision-actions">
             <a className="button secondary link-button" href="/">Cancel</a>
             <button className="button primary" disabled={busy} onClick={() => void approve()}>
-              {busy ? "Approving…" : "Adopt this collection"}
+              {busy ? "Approving…" : "Move this collection"}
             </button>
           </div>
         </>}
@@ -323,25 +323,25 @@ export function AuthorityTransfer({ transferId }: { transferId: string }) {
   const inactive = transfer.state === "cancelled" || transfer.state === "expired";
   return (
     <main className="center-page">
-      <PageBrand label="Authority transfer" />
+      <PageBrand label="Move main copy" />
       <section className="decision-panel authority-decision">
         {transfer.state === "completed" ? <>
           <p className="eyebrow outcome-label">Transfer complete</p>
           <h1>{collectionName} now lives on your computer.</h1>
           <p>
-            The folder on {mirrorName} is the source of truth. Hosted access has stopped
+            The folder on {mirrorName} is now the main copy. Hosted access has stopped
             and previous application connections were revoked.
           </p>
           <div className="transfer-status" role="status">
             <span className="status-dot connected" aria-hidden="true" />
-            <span>Local authority, epoch {transfer.authority_epoch}</span>
+            <span>Main copy on {mirrorName}</span>
           </div>
           <a className="button primary link-button" href="/">Return to your account</a>
         </> : inactive ? <>
           <p className="eyebrow">Transfer ended</p>
-          <h1>Hosted authority was kept.</h1>
+          <h1>The main copy stayed hosted.</h1>
           <p>
-            {collectionName} remains hosted. No source-of-truth change was completed.
+            {collectionName} remains hosted. Its main copy did not move.
           </p>
           {error && <div className="message error" role="alert">{error}</div>}
           <a className="button primary link-button" href="/">Return to your account</a>
@@ -349,8 +349,8 @@ export function AuthorityTransfer({ transferId }: { transferId: string }) {
           <p className="eyebrow outcome-label">Transfer approved</p>
           <h1>Return to {mirrorName}.</h1>
           <p>
-            The command is checking the final hosted sequence, registering the folder
-            with mdbase connect, and activating local authority.
+            mdbase connect is checking the latest hosted changes, registering the folder,
+            and making it the main copy.
           </p>
           <div className="transfer-status" role="status">
             <span className="status-dot paused" aria-hidden="true" />
@@ -363,14 +363,14 @@ export function AuthorityTransfer({ transferId }: { transferId: string }) {
             </button>
           </div>
         </> : <>
-          <p className="eyebrow">Move source of truth</p>
-          <h1>Make {mirrorName} authoritative?</h1>
+          <p className="eyebrow">Move the main copy</p>
+          <h1>Use the folder on {mirrorName} as the main copy?</h1>
           <p>
             {collectionName} will stop being hosted and become a computer-owned collection.
             This changes where every future edit is accepted.
           </p>
           <dl className="transfer-consequences">
-            <div><dt>Folder</dt><dd>The synchronized Markdown folder becomes the source of truth.</dd></div>
+            <div><dt>Folder</dt><dd>The synced Markdown folder becomes the main copy.</dd></div>
             <div><dt>Hosted service</dt><dd>Writes pause during verification, then hosted access is retired.</dd></div>
             <div><dt>Applications</dt><dd>Existing access is revoked. Connect applications again to use the local collection.</dd></div>
             <div><dt>Recovery</dt><dd>If verification fails or this request expires, hosted writes resume.</dd></div>
@@ -381,7 +381,7 @@ export function AuthorityTransfer({ transferId }: { transferId: string }) {
               Keep it hosted
             </button>
             <button className="button primary" disabled={busy} onClick={() => void approve()}>
-              {busy ? "Approving…" : "Move authority"}
+              {busy ? "Approving…" : "Move main copy"}
             </button>
           </div>
         </>}
@@ -389,5 +389,4 @@ export function AuthorityTransfer({ transferId }: { transferId: string }) {
     </main>
   );
 }
-
 

--- a/apps/portal/src/authorization-view.tsx
+++ b/apps/portal/src/authorization-view.tsx
@@ -112,6 +112,9 @@ export function Authorization({ requestId }: { requestId: string }) {
     unavailable_connectors: UnavailableConnector[];
   } | null>(null);
   const [status, setStatus] = useState<"pending" | "setting_up" | "approved" | "denied">("pending");
+  const [continuingInDesktop, setContinuingInDesktop] = useState(
+    () => new URLSearchParams(location.search).get("continue_in_desktop") === "1"
+  );
   const [error, setError] = useState("");
   const returning = useRef(false);
   useSystemTheme();
@@ -171,12 +174,24 @@ export function Authorization({ requestId }: { requestId: string }) {
 
   if (!request) return <Loading error={error} />;
   const authorization = request.authorization;
+  function continueInDesktop(value: boolean) {
+    const url = new URL(location.href);
+    if (value) url.searchParams.set("continue_in_desktop", "1");
+    else url.searchParams.delete("continue_in_desktop");
+    history.replaceState(history.state, "", url);
+    setContinuingInDesktop(value);
+  }
   return (
     <main className="center-page">
       <PageBrand label="Application request" themePicker={false} />
       <section className="decision-panel authorization-panel">
         <RequestIdentity request={authorization} large />
-        {status === "pending" ? <>
+        {status === "pending" && continuingInDesktop ? (
+          <DesktopContinuation
+            request={authorization}
+            onReviewHere={() => continueInDesktop(false)}
+          />
+        ) : status === "pending" ? <>
           <p>{authorization.application_name} is asking to use one collection. Choose where it can work and review what it can do.</p>
           {error && <div className="message error">{error}</div>}
           <ApprovalForm
@@ -184,6 +199,7 @@ export function Authorization({ requestId }: { requestId: string }) {
             canCreateHosted={request.hosted_collections_available !== false}
             collections={request.collections}
             unavailableConnectors={request.unavailable_connectors}
+            onContinueInDesktop={() => continueInDesktop(true)}
             onDecision={(decision) => setStatus(decision)}
             onCollectionCreated={(collection) => setRequest((current) => current ? {
               ...current,
@@ -192,7 +208,7 @@ export function Authorization({ requestId }: { requestId: string }) {
                 : [...current.collections, collection]
             } : current)}
           />
-        </> : status === "setting_up" ? <><p className="eyebrow outcome-label">Approval recorded</p><h2>Finishing collection setup…</h2><p>Your choices are being validated by the collection’s live authority. The application does not have access yet.</p></> : status === "approved" ? <><p className="eyebrow outcome-label">Access approved</p><h2>{authorization.distribution === "portable" ? "Return to the downloaded application." : "Returning to the application…"}</h2><p>{authorization.distribution === "portable" ? "The file will finish connecting with its one-time device code. You can close this window." : "Your approved collection and permissions will follow you back."}</p></> : <><p className="eyebrow outcome-label">Access denied</p><h2>{authorization.distribution === "portable" ? "Return to the downloaded application." : "Returning to the application…"}</h2><p>{authorization.distribution === "portable" ? "The file will learn that access was not granted. You can close this window." : "The application will show that access was not granted."}</p></>}
+        </> : status === "setting_up" ? <><p className="eyebrow outcome-label">Approval recorded</p><h2>Finishing collection setup…</h2><p>Your choices are being checked with the collection’s main copy. The application does not have access yet.</p></> : status === "approved" ? <><p className="eyebrow outcome-label">Access approved</p><h2>{authorization.distribution === "portable" ? "Return to the downloaded application." : "Returning to the application…"}</h2><p>{authorization.distribution === "portable" ? "The file will finish connecting with its one-time device code. You can close this window." : "Your approved collection and permissions will follow you back."}</p></> : <><p className="eyebrow outcome-label">Access denied</p><h2>{authorization.distribution === "portable" ? "Return to the downloaded application." : "Returning to the application…"}</h2><p>{authorization.distribution === "portable" ? "The file will learn that access was not granted. You can close this window." : "The application will show that access was not granted."}</p></>}
       </section>
     </main>
   );
@@ -221,6 +237,29 @@ export function RequestIdentity({ request, large = false }: { request: PendingAu
         )}
       </div>
     </div>
+  );
+}
+
+function DesktopContinuation({ request, onReviewHere }: {
+  request: PendingAuthorization;
+  onReviewHere(): void;
+}) {
+  const desktopUrl = `mdbase-connect://authorize?request_id=${encodeURIComponent(request.id)}`;
+  return (
+    <section className="desktop-continuation" aria-live="polite">
+      <p className="eyebrow">Continue on this computer</p>
+      <h2>Choose the folder in mdbase connect.</h2>
+      <p>This request remains open while you connect the computer or add a collection. Approve it in the desktop app, then return here to continue to {request.application_name}.</p>
+      <div className="desktop-continuation-status">
+        <span className="status-dot connecting" aria-hidden="true" />
+        <div><strong>Waiting for mdbase connect</strong><small>The page will notice when the request is approved.</small></div>
+      </div>
+      <div className="desktop-continuation-actions">
+        <a className="button primary link-button" href={desktopUrl}>Open mdbase connect</a>
+        <button className="button secondary" type="button" onClick={onReviewHere}>Review in this browser</button>
+      </div>
+      <p className="field-note">If the desktop app does not open, <a href="https://github.com/mdbase-dev/mdbase-connect/releases/latest" target="_blank" rel="noreferrer">install the latest release</a>, then return to this page. The request expires {relativeTime(request.expires_at)}.</p>
+    </section>
   );
 }
 
@@ -370,6 +409,7 @@ export function ApprovalForm({
   collections,
   canCreateHosted,
   unavailableConnectors = [],
+  onContinueInDesktop,
   onDecision,
   onCollectionCreated
 }: {
@@ -377,6 +417,7 @@ export function ApprovalForm({
   collections: AvailableCollection[];
   canCreateHosted: boolean;
   unavailableConnectors?: UnavailableConnector[];
+  onContinueInDesktop?(): void;
   onDecision(decision: "approved" | "denied"): void | Promise<void>;
   onCollectionCreated(collection: AvailableCollection): void;
 }) {
@@ -626,6 +667,19 @@ export function ApprovalForm({
               ? `${connector.connector_name} has remote access paused.`
               : `${connector.connector_name} is offline.`).join(" ")} Those local collections cannot be selected until their computer is available.
           </div>}
+          {request.requirements.collection_kind !== "hosted"
+            && (compatible.length === 0 || unavailableConnectors.length > 0)
+            && <div className="desktop-collection-option">
+              <div>
+                <strong>Use a folder on this computer</strong>
+                <p>Open the desktop app to connect this computer, add a folder, and continue this same request.</p>
+              </div>
+              <a
+                className="button secondary link-button"
+                href={`mdbase-connect://authorize?request_id=${encodeURIComponent(request.id)}`}
+                onClick={onContinueInDesktop}
+              >Use a local folder</a>
+            </div>}
           {canCreateHosted && !request.collection_id && (creatingHosted ? (
             <form
               className="authorization-collection-create"
@@ -797,11 +851,14 @@ function PermissionChoices({
       count + group.operations.filter((operation) => selected.has(operation.id)).length,
     0
   );
+  const selectedGroups = groups.filter((group) =>
+    group.operations.some((operation) => selected.has(operation.id))
+  );
   return (
     <details className="permission-review">
       <summary>
-        <span><strong>{selectedTotal} of {total} selected</strong><small>Review or narrow individual actions</small></span>
-        <b>Review</b>
+        <span><strong>{selectedGroups.map((group) => group.label).join(" · ")}</strong><small>{selectedTotal} of {total} specific actions selected. Open details to narrow access.</small></span>
+        <b>Details</b>
       </summary>
       <div className="permission-groups">{groups.map((group) => (
         <fieldset className="permission-group" key={group.id}>

--- a/apps/portal/src/dashboard-view.tsx
+++ b/apps/portal/src/dashboard-view.tsx
@@ -189,14 +189,14 @@ function HostedCollections({ collections, canCreate, onChanged, onError }: {
   return <>
     <SectionHeading
       title="Hosted collections"
-      note="Keep the authoritative Markdown on mdbase, with optional local mirrors."
+      note="Keep the main copy on mdbase, with optional synced folders."
       count={collections.length}
     />
     {collections.length === 0 && !creating
       ? <Empty
           title="No hosted collections"
           text={canCreate
-            ? "Create an mdbase collection whose source of truth stays available without a connected computer."
+            ? "Create an mdbase collection that stays available without a connected computer."
             : "Hosted collections are not enabled for this Connect service."}
         />
       : <div className="hosted-list">{collections.map((collection) => (
@@ -204,7 +204,7 @@ function HostedCollections({ collections, canCreate, onChanged, onError }: {
         ))}</div>}
     {canCreate && (creating ? <form className="inline-create" onSubmit={(event) => void create(event)}>
       <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
-      <p>Starts as a clean mdbase 0.3 collection. Add Markdown through compatible apps, with an optional exact local mirror.</p>
+      <p>Starts as a clean mdbase collection. Add Markdown through compatible apps and optionally keep a folder in sync.</p>
       <div><button type="button" className="quiet-action" disabled={busy} onClick={() => setCreating(false)}>Cancel</button><button className="button primary" disabled={busy || !name.trim()}>{busy ? "Creating…" : "Create collection"}</button></div>
     </form> : <button className="button secondary" onClick={() => setCreating(true)}>Create hosted collection</button>)}
   </>;
@@ -265,10 +265,10 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
     <div className="hosted-summary">
       <div><strong>{collection.display_name}</strong><small>
         {collection.authority_state === "transferred"
-          ? `mdbase · moved to a computer · authority epoch ${collection.authority_epoch}`
+          ? "Main copy moved to a computer"
           : collection.authority_state === "transferring"
-            ? "mdbase · authority transfer in progress"
-            : `mdbase · authoritative on mdbase · created ${relativeTime(collection.created_at)}`}
+            ? "Main copy is moving to a computer"
+            : `Main copy hosted by mdbase · created ${relativeTime(collection.created_at)}`}
       </small></div>
       <span className={`availability ${isActive ? "online" : "idle"}`}><i />
         {collection.authority_state === "transferred"
@@ -277,7 +277,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
             ? "Moving"
             : "Hosted"}
       </span>
-      <span className="replica-count">{activeReplicas.length} {activeReplicas.length === 1 ? "mirror" : "mirrors"}</span>
+      <span className="replica-count">{activeReplicas.length} synced {activeReplicas.length === 1 ? "folder" : "folders"}</span>
       <div className="computer-actions">
         {editorCollectionId && <a
           className="quiet-action"
@@ -287,7 +287,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
         >
           Open in editor <span aria-hidden="true">↗</span>
         </a>}
-        {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Mirror</button>}
+        {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "mirror" ? null : "mirror")}>Sync a folder</button>}
         {isActive && <button className="quiet-action" disabled={busy} onClick={() => setPanel(panel === "rename" ? null : "rename")}>Rename</button>}
         <button className="quiet-danger" disabled={busy} onClick={() => void remove()}>Delete</button>
       </div>
@@ -300,7 +300,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
       <MirrorSetup collectionId={collection.id} />
     </div>}
     {activeReplicas.length > 0 && <details className="replica-detail">
-      <summary>Manage mirrors</summary>
+      <summary>Manage synced folders</summary>
       <div>{activeReplicas.map((replica) => <div className="replica-row" key={replica.id}>
         <div><strong>{replica.name}</strong><small>{mirrorStatus(replica)}</small></div>
         <div><button className="quiet-danger" disabled={busy} onClick={() => void revoke(replica.id, replica.name)}>Revoke</button></div>
@@ -310,7 +310,7 @@ function HostedCollectionRow({ collection, onChanged, onError }: {
 }
 
 function mirrorStatus(replica: HostedCollection["replicas"][number]): string {
-  const mode = replica.mode === "read_only" ? "Receive-only" : "Two-way";
+  const mode = replica.mode === "read_only" ? "Downloads updates only" : "Edits sync both ways";
   if (!replica.sync_status) return `${mode} · status unavailable`;
   if (!replica.sync_status.last_seen_at) return `${mode} · waiting for first sync`;
   const lag = Math.max(
@@ -324,9 +324,9 @@ function mirrorStatus(replica: HostedCollection["replicas"][number]): string {
 function MirrorSetup({ collectionId }: { collectionId: string }) {
   const desktopUrl = `mdbase-connect://mirror?collection=${encodeURIComponent(collectionId)}`;
   return <div className="mirror-setup" aria-live="polite">
-    <p><strong>Choose the folder in mdbase connect.</strong> The desktop app controls synchronization and keeps mirror credentials in private application storage.</p>
+    <p><strong>Choose the folder in mdbase connect.</strong> The desktop app keeps the folder location and connection details on your computer.</p>
     <div className="mirror-setup-actions"><a className="button primary" href={desktopUrl}>Open mdbase connect</a></div>
-    <p>Existing Markdown is reviewed before upload. Path collisions stop for an explicit decision, and the hosted collection remains authoritative.</p>
+    <p>Existing Markdown is checked before upload. If files overlap, mdbase connect asks you which version to keep. The main copy remains hosted.</p>
   </div>;
 }
 
@@ -500,4 +500,3 @@ function PortalGrant({ grant, connectorName, disabled, onChanged, onError }: {
     </div>
   </details>;
 }
-

--- a/apps/portal/src/portal-model.ts
+++ b/apps/portal/src/portal-model.ts
@@ -17,7 +17,19 @@ export function editorUrl(collectionId?: string): string {
 }
 
 export function initials(value: string) { return value.split(/\s+/).map((part) => part[0]).join("").slice(0, 2).toUpperCase(); }
-export function message(value: unknown) { return value instanceof Error ? value.message : String(value); }
+export function message(value: unknown) {
+  const detail = value instanceof Error ? value.message : String(value);
+  if (/failed to fetch|networkerror|network request failed/i.test(detail)) {
+    return "mdbase connect could not reach the service. Check your connection and try again.";
+  }
+  if (/authorization.+(?:expired|not found)|request.+(?:expired|not found)/i.test(detail)) {
+    return "This application request has expired. Return to the application and start again.";
+  }
+  if (/unsupported.+protocol|up-to-date connector|no longer compatible/i.test(detail)) {
+    return "The mdbase connect app on this computer needs to be updated before you can continue.";
+  }
+  return detail;
+}
 export function host(value: string) { try { return new URL(value).host; } catch { return value; } }
 export function formatDeviceCode(value: string) {
   const canonical = value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 8);
@@ -97,4 +109,3 @@ export function relativeTime(value: string) {
   if (Math.abs(hours) < 24) return format.format(hours, "hour");
   return format.format(Math.round(hours / 24), "day");
 }
-

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -812,6 +812,73 @@ h1 {
   gap: 1rem;
 }
 
+.desktop-collection-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.desktop-collection-option > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.desktop-collection-option strong {
+  font-size: 0.76rem;
+}
+
+.desktop-collection-option p {
+  max-width: 52ch;
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.desktop-continuation {
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--line);
+}
+
+.desktop-continuation h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.desktop-continuation > p:not(.eyebrow, .field-note) {
+  max-width: 62ch;
+  margin: 0.55rem 0 0;
+  color: var(--ink-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.desktop-continuation-status {
+  display: grid;
+  grid-template-columns: 0.45rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 1rem;
+  padding: 0.9rem 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.desktop-continuation-status > div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.desktop-continuation-status strong { font-size: 0.76rem; }
+.desktop-continuation-status small { color: var(--ink-muted); font-size: 0.7rem; }
+.desktop-continuation-actions { display: flex; flex-wrap: wrap; gap: 0.55rem; margin-top: 1rem; }
+.desktop-continuation .field-note { margin-top: 0.85rem; }
+.desktop-continuation .field-note a { color: var(--ink); }
+
 .authorization-collection-create {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -1186,6 +1253,10 @@ select {
 .permission-review summary strong,
 .notification-access summary strong {
   font-size: 0.76rem;
+}
+
+.permission-review summary strong {
+  line-height: 1.4;
 }
 
 .permission-review summary b,
@@ -1823,6 +1894,11 @@ select {
   .approval-section {
     grid-template-columns: 1fr;
     gap: 0.65rem;
+  }
+
+  .desktop-collection-option {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .contract-setup-mode {

--- a/packages/ui/access.test.ts
+++ b/packages/ui/access.test.ts
@@ -65,12 +65,15 @@ test("groups requested operations into plain-language permission categories", ()
       },
       {
         id: "change",
-        label: "Change records",
-        description: "Create, edit, rename, move, or delete records.",
-        operations: [
-          { id: "create", label: "Create records" },
-          { id: "delete", label: "Delete records" }
-        ]
+        label: "Create and edit records",
+        description: "Create, edit, rename, or move records.",
+        operations: [{ id: "create", label: "Create records" }]
+      },
+      {
+        id: "delete",
+        label: "Delete records",
+        description: "Permanently remove records from this collection.",
+        operations: [{ id: "delete", label: "Delete records" }]
       },
       {
         id: "manage",

--- a/packages/ui/access.ts
+++ b/packages/ui/access.ts
@@ -43,9 +43,15 @@ const authorizationOperationGroups = [
   },
   {
     id: "change",
-    label: "Change records",
-    description: "Create, edit, rename, move, or delete records.",
-    operations: ["create", "update", "rename", "delete"]
+    label: "Create and edit records",
+    description: "Create, edit, rename, or move records.",
+    operations: ["create", "update", "rename"]
+  },
+  {
+    id: "delete",
+    label: "Delete records",
+    description: "Permanently remove records from this collection.",
+    operations: ["delete"]
   },
   {
     id: "manage",

--- a/scripts/browser-accessibility.test.mjs
+++ b/scripts/browser-accessibility.test.mjs
@@ -16,7 +16,9 @@ const browser = await chromium.launch({ headless: true });
 try {
   await auditPortalLogin();
   await auditPortalDashboard();
+  await auditPortalColdStartAuthorization();
   await auditPortalDeviceAuthorization();
+  await auditDesktopResumedAuthorization();
   await auditDesktopRoutes();
   console.log(
     "Browser accessibility passed: landmarks, names, headings, keyboard reachability, and reduced motion."
@@ -113,10 +115,124 @@ async function auditPortalDeviceAuthorization() {
   await page.close();
 }
 
+async function auditPortalColdStartAuthorization() {
+  const page = await browser.newPage();
+  const errors = watchPageErrors(page);
+  const requestId = "22222222-2222-4222-8222-222222222222";
+  const authorization = portalAuthorizationFixture(requestId);
+  await page.route("**/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === `/v1/authorization-requests/${requestId}`) {
+      await route.fulfill({
+        json: {
+          authorization,
+          collections: [],
+          hosted_collections_available: true,
+          unavailable_connectors: []
+        }
+      });
+      return;
+    }
+    if (pathname === `/v1/authorization-requests/${requestId}/status`) {
+      await route.fulfill({ json: { status: "pending" } });
+      return;
+    }
+    await route.fulfill({ status: 404, json: { error: "not_found" } });
+  });
+  await page.goto(`${servers[0].origin}/authorize/${requestId}`);
+  await page.getByRole("heading", { name: "Workout journal" }).waitFor();
+  const localFolder = page.getByRole("link", { name: "Use a local folder" });
+  assert.equal(
+    await localFolder.getAttribute("href"),
+    `mdbase-connect://authorize?request_id=${requestId}`,
+    "portal authorization: desktop link preserves request ID"
+  );
+  await expectText(page, "View and find records · Create and edit records · Delete records");
+  await localFolder.evaluate((element) => {
+    element.addEventListener("click", (event) => event.preventDefault(), { once: true });
+  });
+  await localFolder.click();
+  await page.getByRole("heading", { name: "Choose the folder in mdbase connect." }).waitFor();
+  assert.equal(
+    new URL(page.url()).searchParams.get("continue_in_desktop"),
+    "1",
+    "portal authorization: browser records desktop continuation"
+  );
+  await auditPage(page, "portal desktop continuation", { keyboard: true });
+  await page.getByRole("button", { name: "Review in this browser" }).click();
+  await localFolder.waitFor();
+  assert.equal(
+    new URL(page.url()).searchParams.has("continue_in_desktop"),
+    false,
+    "portal authorization: browser review remains available"
+  );
+  assert.deepEqual(errors, []);
+  await page.close();
+}
+
+async function auditDesktopResumedAuthorization() {
+  const page = await browser.newPage();
+  const errors = watchPageErrors(page);
+  const requestId = "33333333-3333-4333-8333-333333333333";
+  await page.addInitScript((authorizationId) => {
+    localStorage.setItem("mdbase:resume-authorization", authorizationId);
+    const status = {
+      protocol_version: 1,
+      state: "connected",
+      registered_collections: 0,
+      paused: false,
+      direct_access_available: true
+    };
+    const updateStatus = {
+      phase: "idle",
+      current_version: "0.1.0",
+      channel: "beta",
+      message: "Up to date",
+      can_check: true,
+      can_install: false
+    };
+    window.mdbaseConnect = {
+      status: async () => status,
+      updateStatus: async () => updateStatus,
+      listCollections: async () => [],
+      getLaunchAtLogin: async () => ({ enabled: false, available: true }),
+      getCloudConfig: async () => ({ configured: false, serverUrl: null }),
+      accessSnapshot: async () => ({
+        configured: false,
+        online: false,
+        grants: [],
+        pending_authorizations: [],
+        authority_conflicts: []
+      }),
+      listActivity: async () => [],
+      hostedSnapshot: async () => ({
+        online: false,
+        hosted_collections_available: false,
+        hosted_collections: [],
+        grants: [],
+        pending_authorizations: []
+      }),
+      listMirrors: async () => [],
+      onNavigate: () => () => undefined,
+      onUpdateStatus: () => () => undefined
+    };
+  }, requestId);
+  await page.goto(servers[1].origin);
+  await page.getByRole("heading", { name: "Decide what apps can do." }).waitFor();
+  await page.getByRole("heading", { name: "Connect this computer to continue." }).waitFor();
+  const serverAddress = page.getByLabel("Server address");
+  assert.equal(await serverAddress.isVisible(), false, "desktop pairing: server address starts hidden");
+  await page.getByText("Use another Connect server", { exact: true }).click();
+  await serverAddress.waitFor({ state: "visible" });
+  await auditPage(page, "desktop resumed authorization", { keyboard: true });
+  assert.deepEqual(errors, []);
+  await page.close();
+}
+
 async function auditDesktopRoutes() {
   const page = await browser.newPage();
   const errors = watchPageErrors(page);
-  await page.addInitScript(() => {
+  await page.addInitScript((pendingAuthorization) => {
     const status = {
       protocol_version: 1,
       state: "connected",
@@ -142,7 +258,7 @@ async function auditDesktopRoutes() {
         user_email: "user@example.com"
       },
       grants: [],
-      pending_authorizations: [],
+      pending_authorizations: [pendingAuthorization],
       authority_conflicts: []
     };
     window.mdbaseConnect = {
@@ -171,23 +287,75 @@ async function auditDesktopRoutes() {
       checkForUpdates: async () => updateStatus,
       installUpdate: async () => updateStatus
     };
-  });
+  }, desktopAuthorizationFixture("44444444-4444-4444-8444-444444444444"));
   await page.goto(servers[1].origin);
   await page.getByRole("heading", { name: "Your local connection." }).waitFor();
+  await page.getByRole("button", { name: "Add existing folder" }).waitFor();
+  await page.getByRole("button", { name: "Create collection" }).waitFor();
+  await page.getByRole("button", { name: "Pause app access" }).waitFor();
   await auditPage(page, "desktop overview", { keyboard: true });
 
   for (const route of [
-    ["Collections", "Your collections, in one place."],
+    ["Collections", "Your collections."],
     ["App access", "Decide what apps can do."],
     ["Activity", "What reached this computer."],
     ["Settings", "Connection and startup."]
   ]) {
     await page.getByRole("button", { name: route[0] }).click();
     await page.getByRole("heading", { name: route[1] }).waitFor();
+    if (route[0] === "App access") {
+      await page.getByRole("button", { name: "Add a folder" }).waitFor();
+      await page.getByRole("button", { name: "Create collection" }).waitFor();
+      await expectText(page, "View and find records · Create and edit records · Delete records");
+    }
     await auditPage(page, `desktop ${route[0].toLowerCase()}`);
   }
   assert.deepEqual(errors, []);
   await page.close();
+}
+
+function portalAuthorizationFixture(id) {
+  return {
+    id,
+    flow: "authorization_code",
+    requested_operations: ["read", "create", "delete"],
+    collection_id: null,
+    expires_at: "2099-08-01T00:00:00.000Z",
+    application_id: "app-workout-journal",
+    application_name: "Workout journal",
+    distribution: "web",
+    homepage: "https://journal.example",
+    project_url: null,
+    icon: null,
+    requirements: { contracts: [], access: "full_collection" },
+    provisions: { type_packs: [] },
+    notifications: { criteria: [] },
+    available_collections: [],
+    unavailable_connectors: []
+  };
+}
+
+function desktopAuthorizationFixture(id) {
+  return {
+    id,
+    application_id: "app-workout-journal",
+    application_name: "Workout journal",
+    application_distribution: "web",
+    application_homepage: "https://journal.example",
+    flow: "authorization_code",
+    requested_operations: ["read", "create", "delete"],
+    requirements: { contracts: [], access: "full_collection" },
+    provisions: { type_packs: [] },
+    notifications: { criteria: [] },
+    compatible_collection_ids: [],
+    provisionable_collection_ids: [],
+    collection_types: [],
+    expires_at: "2099-08-01T00:00:00.000Z"
+  };
+}
+
+async function expectText(page, value) {
+  await page.getByText(value, { exact: true }).waitFor();
 }
 
 async function auditPage(page, label, options = {}) {

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -48,6 +48,9 @@ const cliBinary = join(repoRoot, "target", "debug", `mdbase${extension}`);
 let agent;
 let manifestServer;
 let browserManifestServer;
+let onboardingBrowser;
+let onboardingContext;
+let onboardingPage;
 let directOrigin;
 const applicationKeyStore = new MemoryGrantKeyStore();
 let relayContext;
@@ -69,11 +72,70 @@ try {
   });
   const cookie = session.response.headers.get("set-cookie")?.split(";")[0];
   if (!cookie) throw new Error("Development session did not set a cookie");
-  const connector = await request("/v1/connectors", {
+
+  const manifest = await openManifestServer();
+  manifestServer = manifest.server;
+  browserManifestServer = manifest.browserServer;
+  directOrigin = manifest.origin;
+  const application = await request("/v1/apps/register", {
     method: "POST",
-    cookie,
-    body: { name: "MVP computer" }
+    body: { manifest: manifest.applicationManifest }
   });
+  const appId = application.body.application.id;
+  const applicationKey = await applicationKeyStore.create("e2e-grant");
+  const verifier = "end-to-end-pkce-verifier-with-forty-three-characters";
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const authorize = await fetch(
+    `${serverUrl}/oauth/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(manifest.redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256&state=e2e&operations=describe,changes,read,query,create,update&relay_protocol=1&application_agreement_public_key=${encodeURIComponent(applicationKey.agreementPublicKey)}&application_signing_public_key=${encodeURIComponent(applicationKey.signingPublicKey)}`,
+    { headers: { cookie }, redirect: "manual" }
+  );
+  if (authorize.status !== 302) throw new Error(`Authorization start returned HTTP ${authorize.status}`);
+  const authorizationId = authorize.headers.get("location")?.split("/").at(-1);
+  if (!authorizationId) throw new Error("Authorization request ID missing");
+
+  onboardingBrowser = await chromium.launch({ headless: true });
+  onboardingContext = await onboardingBrowser.newContext();
+  const cookieSeparator = cookie.indexOf("=");
+  await onboardingContext.addCookies([{
+    name: cookie.slice(0, cookieSeparator),
+    value: cookie.slice(cookieSeparator + 1),
+    url: serverUrl
+  }]);
+  onboardingPage = await onboardingContext.newPage();
+  await onboardingPage.goto(`${serverUrl}/authorize/${authorizationId}`);
+  const localFolder = onboardingPage.getByRole("link", { name: "Use a local folder" });
+  await localFolder.waitFor({ state: "visible" });
+  const expectedDeepLink = `mdbase-connect://authorize?request_id=${authorizationId}`;
+  if (await localFolder.getAttribute("href") !== expectedDeepLink) {
+    throw new Error("The onboarding handoff did not preserve the authorization request ID");
+  }
+  await localFolder.evaluate((element) => {
+    element.addEventListener("click", (event) => event.preventDefault(), { once: true });
+  });
+  await localFolder.click();
+  await onboardingPage.getByRole("heading", {
+    name: "Choose the folder in mdbase connect."
+  }).waitFor();
+  if (new URL(onboardingPage.url()).searchParams.get("continue_in_desktop") !== "1") {
+    throw new Error("The browser did not retain the desktop continuation state");
+  }
+
+  const pairing = await request("/v1/pairing-requests", {
+    method: "POST",
+    body: { connector_name: "MVP computer" }
+  });
+  await request(`/v1/pairing-requests/${pairing.body.pairing_id}/approve`, {
+    method: "POST",
+    cookie
+  });
+  const paired = await request(`/v1/pairing-requests/${pairing.body.pairing_id}/exchange`, {
+    method: "POST",
+    authorization: `Bearer ${pairing.body.pairing_secret}`
+  });
+  if (paired.body.status !== "paired" || !paired.body.token) {
+    throw new Error(`Connector pairing did not complete: ${JSON.stringify(paired.body)}`);
+  }
+  const connectorToken = paired.body.token;
 
   agent = startAgent([]);
   await waitForAgent();
@@ -172,7 +234,7 @@ secret: connector scope test
     `---\ntype: workout\ntitle: Bulk ${index}\nstatus: open\n---\n`
   )));
   await stopAgent(agent);
-  agent = startAgent(["--server-url", serverUrl], connector.body.token);
+  agent = startAgent(["--server-url", serverUrl], connectorToken);
 
   const dashboard = await poll(async () => {
     const current = await request("/v1/me", { cookie });
@@ -180,25 +242,6 @@ secret: connector scope test
   }, "collection metadata did not reach the portal");
   const collection = dashboard.collections[0];
 
-  const manifest = await openManifestServer();
-  manifestServer = manifest.server;
-  browserManifestServer = manifest.browserServer;
-  directOrigin = manifest.origin;
-  const application = await request("/v1/apps/register", {
-    method: "POST",
-    body: { manifest: manifest.applicationManifest }
-  });
-  const appId = application.body.application.id;
-  const applicationKey = await applicationKeyStore.create("e2e-grant");
-  const verifier = "end-to-end-pkce-verifier-with-forty-three-characters";
-  const challenge = createHash("sha256").update(verifier).digest("base64url");
-  const authorize = await fetch(
-    `${serverUrl}/oauth/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(manifest.redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256&state=e2e&operations=describe,changes,read,query,create,update&relay_protocol=1&application_agreement_public_key=${encodeURIComponent(applicationKey.agreementPublicKey)}&application_signing_public_key=${encodeURIComponent(applicationKey.signingPublicKey)}`,
-    { headers: { cookie }, redirect: "manual" }
-  );
-  if (authorize.status !== 302) throw new Error(`Authorization start returned HTTP ${authorize.status}`);
-  const authorizationId = authorize.headers.get("location")?.split("/").at(-1);
-  if (!authorizationId) throw new Error("Authorization request ID missing");
   await poll(async () => {
     const snapshot = await cliJson(["access", "snapshot"]);
     return snapshot.result?.pending_authorizations?.some((pending) => pending.id === authorizationId)
@@ -214,6 +257,20 @@ secret: connector scope test
     return current.body.redirect_uri ? current : null;
   }, "approved authorization did not return to the browser");
   const callback = new URL(completed.body.redirect_uri);
+  await onboardingPage.waitForURL(
+    (url) => url.href.startsWith(manifest.redirectUri),
+    { timeout: 10_000 }
+  );
+  const continuedCallback = new URL(onboardingPage.url());
+  if (!continuedCallback.searchParams.get("code")
+      || continuedCallback.searchParams.get("state") !== "e2e") {
+    throw new Error("The waiting browser page did not continue with the approved request");
+  }
+  await onboardingContext.close();
+  await onboardingBrowser.close();
+  onboardingContext = undefined;
+  onboardingBrowser = undefined;
+  onboardingPage = undefined;
   const token = await request("/oauth/token", {
     method: "POST",
     form: {
@@ -253,7 +310,7 @@ secret: connector scope test
     await readFile(join(collectionPath, "_types", "workout.md"))
   );
   await stopAgent(agent);
-  agent = startAgent(["--server-url", serverUrl], connector.body.token);
+  agent = startAgent(["--server-url", serverUrl], connectorToken);
   await poll(async () => {
     const current = await request("/v1/me", { cookie });
     return current.body.collections.filter(
@@ -1085,6 +1142,8 @@ implements:
   }
   process.stdout.write("mdbase connect end-to-end MVP path passed\n");
 } finally {
+  await onboardingContext?.close().catch(() => {});
+  await onboardingBrowser?.close().catch(() => {});
   if (agent) await stopAgent(agent);
   if (browserManifestServer) {
     await new Promise((resolveClose) => browserManifestServer.close(resolveClose));
@@ -1158,6 +1217,7 @@ async function request(path, options = {}) {
   const headers = {};
   let body;
   if (options.cookie) headers.cookie = options.cookie;
+  if (options.authorization) headers.authorization = options.authorization;
   if (options.body) {
     headers["content-type"] = "application/json";
     body = JSON.stringify(options.body);

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2305,13 +2305,13 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     await expect(page.getByRole("heading", { name: "Your connections." })).toBeVisible();
 
     await page.getByRole("button", { name: "Create hosted collection" }).click();
-    await expect(page.getByText(/Starts as a clean mdbase 0\.3 collection/)).toBeVisible();
+    await expect(page.getByText(/Starts as a clean mdbase collection/)).toBeVisible();
     await expect(page.getByText(/application-specific template/i)).toHaveCount(0);
     await page.getByLabel("Collection name").fill("Browser E2E collection");
     await page.getByRole("button", { name: "Create collection" }).click();
     const row = page.locator("article.hosted-row").filter({ hasText: "Browser E2E collection" });
     await expect(row).toBeVisible();
-    await expect(row).toContainText("mdbase · authoritative on mdbase");
+    await expect(row).toContainText("Main copy hosted by mdbase");
 
     const dashboard = await page.evaluate(async () => {
       const response = await fetch("/v1/me");
@@ -2325,7 +2325,7 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
         "href",
         `https://editor.mdbase.dev/?collection=${collectionId}`
       );
-    await row.getByRole("button", { name: "Mirror" }).click();
+    await row.getByRole("button", { name: "Sync a folder" }).click();
     await expect(row.getByRole("link", { name: "Open mdbase connect" }))
       .toHaveAttribute("href", `mdbase-connect://mirror?collection=${collectionId}`);
     await expect(row).toContainText("Choose the folder in mdbase connect");
@@ -2382,9 +2382,9 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     const connectedRow = page.locator("article.hosted-row").filter({
       hasText: "Browser E2E collection"
     });
-    await connectedRow.getByText("Manage mirrors").click();
+    await connectedRow.getByText("Manage synced folders").click();
     await expect(connectedRow).toContainText("Browser writable mirror");
-    await expect(connectedRow).toContainText("Two-way · up to date");
+    await expect(connectedRow).toContainText("Edits sync both ways · up to date");
     page.once("dialog", (dialog) => dialog.accept());
     await connectedRow.getByRole("button", { name: "Revoke" }).click();
     await expect(connectedRow).not.toContainText(
@@ -2499,12 +2499,12 @@ async function authorityPromotionCliE2E(
     const page = await context.newPage();
     await page.goto(transferUri);
     await expect(page.getByRole("heading", {
-      name: /authoritative\?/
+      name: "Use the folder on Promotion mirror as the main copy?"
     })).toBeVisible();
     await expect(page.getByText(
       "Existing access is revoked. Connect applications again to use the local collection."
     )).toBeVisible();
-    await page.getByRole("button", { name: "Move authority" }).click();
+    await page.getByRole("button", { name: "Move main copy" }).click();
     const promotionExit = await waitForExit(promotion, 30_000);
     assert.equal(
       promotionExit,


### PR DESCRIPTION
## What changed

- preserve an application authorization request across the portal-to-desktop handoff, pairing restart, and first-collection setup
- let users add or create a collection directly from the pending desktop request
- replace protocol-facing language with main-copy, synced-folder, and consequence-based permission language
- make pause/resume explicit, hide alternate server configuration behind an advanced disclosure, and improve common error messages
- add focused deep-link, browser accessibility, live onboarding, and real cold-start E2E coverage

## Why

The existing pieces supported application authorization, computer pairing, and collection setup, but a new user had to navigate those stages separately and could lose the context of the request that brought them to Connect.

## User impact

Users can now start in an app and follow one continuous request through sign-in, pairing, folder selection, approval, and return to the app. Existing infrastructure controls remain available with clearer language.

## Validation

- `cargo fmt --all`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:accessibility`
- `pnpm check:architecture`
- `pnpm e2e`
- live Electron connection-progress smoke
- Docker-backed Electron E2E
