### PR TITLE
Remove security audit release gate

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Security policy
 
 mdbase connect is prerelease software. Its security boundaries are actively
-tested, but beta builds are not a substitute for an independently reviewed,
-signed stable release. The open stable-release gates are recorded in
-[`config/release-readiness.json`](config/release-readiness.json).
+tested, but beta builds are not a substitute for a signed stable release. The
+open stable-release gates are recorded in
+[`config/release-readiness.json`](config/release-readiness.json). An independent
+security audit is planned separately and is not a stable-release gate.
 
 ## Reporting a vulnerability
 

--- a/config/release-readiness.json
+++ b/config/release-readiness.json
@@ -2,14 +2,6 @@
   "schemaVersion": 1,
   "gates": [
     {
-      "id": "independent-cryptography-review",
-      "title": "Independent cryptography review",
-      "owner": "Security owner",
-      "status": "required",
-      "evidence": [],
-      "notes": "Review the browser-to-connector protocol, key continuity, counter persistence, envelope construction, and hosted key hierarchy."
-    },
-    {
       "id": "first-contact-trust-decision",
       "title": "First-contact connector trust decision",
       "owner": "Product and security owners",

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -197,8 +197,9 @@ Protocol 1 fixes the interoperable profile to P-256 ECDH, HKDF-SHA-256, and
 AES-256-GCM. A 96-bit nonce contains a zero 32-bit prefix and the grant's
 monotonic unsigned 64-bit counter. Canonical context strings and envelope
 schemas are shared across Rust and TypeScript and covered by cross-runtime
-tests. An external cryptographic review is still required before a public
-security claim.
+tests. An independent security audit, including external cryptographic review,
+remains planned but is not a stable-release gate. Public security claims must
+state whether that audit has occurred.
 
 ### Downgrade behavior
 
@@ -405,7 +406,7 @@ and decrypted recovery material never enter audit events.
 - keyed record-path lookup without plaintext record paths in PostgreSQL; and
 - ciphertext tamper, wrong-key, two-provider race, sync, and operation tests.
 
-### Next: release security and key operations
+### Next: security review and key operations
 
 - native application key storage for a future non-browser SDK;
 - first-contact connector identity verification or key transparency;

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -49,7 +49,7 @@ Beta builds may proceed with the external risks recorded as `required` in
 `config/release-readiness.json`. They remain visible in every CI run. A stable
 release is different: the Desktop Release workflow automatically invokes
 `pnpm check:release-readiness -- --stable`, which fails until every gate is
-`complete` and includes a durable evidence reference. The required review,
+`complete` and includes a durable evidence reference. The required decision,
 operational drill, or publisher control must actually have happened; changing
 the status without evidence is itself rejected.
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -158,10 +158,10 @@ allowlist of fields instead of serializing request or database objects.
 
 ## Residual risks before stable
 
-The beta deliberately accepts several risks that require people, production
-infrastructure, or publisher accounts rather than another local refactor:
+The beta deliberately accepts several risks that require production
+infrastructure, publisher accounts, or an explicit product decision rather
+than another local refactor. The following remain stable-release gates:
 
-- independent review of the custom cryptographic protocol and implementation;
 - an explicit first-contact connector trust or transparency decision;
 - a managed key service plus rehearsed key rotation;
 - verified encrypted backup, restoration, and deletion behavior; and
@@ -172,6 +172,10 @@ These are machine-readable gates in
 `pnpm check:release-readiness` validates and reports them during beta;
 `pnpm check:release-readiness -- --stable` fails until every gate is marked
 complete with durable evidence.
+
+An independent security audit, including the custom cryptographic protocol and
+implementation, remains planned separately. It is not a stable-release gate;
+release notes and security claims must state whether that audit has occurred.
 
 ## Verification map
 

--- a/scripts/lib/release-readiness.test.mjs
+++ b/scripts/lib/release-readiness.test.mjs
@@ -8,12 +8,12 @@ function manifest(gates) {
 
 function gate(overrides = {}) {
   return {
-    id: "independent-review",
-    title: "Independent review",
+    id: "rotation-drill",
+    title: "Key rotation drill",
     owner: "Security owner",
     status: "required",
     evidence: [],
-    notes: "Review the security boundary.",
+    notes: "Exercise the key rotation procedure.",
     ...overrides
   };
 }
@@ -22,14 +22,14 @@ test("accepts a documented open gate for a beta release", () => {
   const result = evaluateReleaseReadiness(manifest([gate()]));
 
   assert.deepEqual(result.failures, []);
-  assert.deepEqual(result.incomplete.map((item) => item.id), ["independent-review"]);
+  assert.deepEqual(result.incomplete.map((item) => item.id), ["rotation-drill"]);
 });
 
 test("blocks a stable release while any gate is open", () => {
   const result = evaluateReleaseReadiness(manifest([gate()]), { stable: true });
 
   assert.deepEqual(result.failures, [
-    "Stable release is blocked by 1 incomplete readiness gate(s): independent-review"
+    "Stable release is blocked by 1 incomplete readiness gate(s): rotation-drill"
   ]);
 });
 


### PR DESCRIPTION
## What changed

- remove the independent cryptography review from the machine-readable stable-release gates
- keep an independent security audit documented as planned, but explicitly non-blocking
- align the security policy, threat model, encryption guidance, release documentation, and focused test fixture

## Why

The independent security audit will be commissioned separately and should not block a stable release. The release-readiness manifest and documentation previously treated that review as a mandatory release prerequisite.

## Impact

Stable readiness now reports four remaining gates instead of five. Security documentation continues to disclose whether the independent audit has occurred.

## Validation

- `node --test scripts/lib/release-readiness.test.mjs`
- `pnpm check:release-readiness`
- `pnpm check:release-readiness -- --stable` (expected to remain blocked by the four unrelated open gates)
- `git diff --check`
