### PR TITLE
Add beta access requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ MDBASE_CONNECT_REGISTRATION=closed
 # own. This stable HMAC secret protects privacy-safe shared rate-limit keys.
 # Configure both legal document URLs before enabling invited signup.
 # MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET=replace-with-at-least-32-random-characters
+# Optional public beta-access form origin. Requests are accepted only from this
+# exact browser origin and use the shared database-backed rate limiter.
+# MDBASE_CONNECT_BETA_ACCESS_ORIGIN=https://mdbase.dev
 # MDBASE_CONNECT_TERMS_URL=https://example.com/terms/
 # MDBASE_CONNECT_PRIVACY_URL=https://example.com/privacy/
 # Invitation delivery and runtime password recovery:

--- a/services/server/migrations/0007_beta_access_requests.sql
+++ b/services/server/migrations/0007_beta_access_requests.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS beta_access_requests (
+  id uuid PRIMARY KEY,
+  email text NOT NULL,
+  normalized_email text NOT NULL UNIQUE,
+  email_normalization_version integer NOT NULL DEFAULT 1,
+  invitation_id uuid REFERENCES invitations(id) ON DELETE SET NULL,
+  invited_at timestamptz,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (email_normalization_version = 1),
+  CHECK (invitation_id IS NULL OR invited_at IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS beta_access_requests_requested_idx
+  ON beta_access_requests(requested_at DESC, id DESC);

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -34,6 +34,7 @@ import { registerAuthorityAdoptionRoutes } from "./features/authority-adoption/r
 import { registerHostedToLocalTransferRoutes } from "./features/authority-transfer/hosted-to-local-routes.js";
 import { registerLocalToHostedTransferRoutes } from "./features/authority-transfer/local-to-hosted-routes.js";
 import { registerAuthorityConflictRoutes } from "./features/connectors/authority-conflict-routes.js";
+import { registerBetaAccessRoutes } from "./features/beta-access/routes.js";
 import { registerConnectorControlRoutes } from "./features/connectors/control-routes.js";
 import { registerConnectorInventoryRoutes } from "./features/connectors/inventory-routes.js";
 import { registerConnectorManagementRoutes } from "./features/connectors/management-routes.js";
@@ -61,6 +62,7 @@ interface BuildOptions {
   googleAuth?: GoogleAuthConfig;
   registration?: RegistrationMode;
   authRateLimitSecret?: string;
+  betaAccessOrigin?: string;
   authenticationLegalDocuments?: AuthenticationLegalDocuments;
   emailTransport?: EmailTransport;
   hostedCollections?: boolean;
@@ -208,6 +210,16 @@ export async function buildApp(options: BuildOptions) {
     hostedProvider: options.hostedProvider,
     revision: options.revision
   });
+  if (options.betaAccessOrigin) {
+    if (!options.authRateLimitSecret) {
+      throw new Error("Beta access requests require a rate-limit secret.");
+    }
+    registerBetaAccessRoutes(app, {
+      db: options.db,
+      allowedOrigin: options.betaAccessOrigin,
+      rateLimitSecret: options.authRateLimitSecret
+    });
+  }
   registerPasswordAuthRoutes(app, {
     db: options.db,
     publicUrl,

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -109,6 +109,63 @@ describe("authentication operator command", () => {
     expect(JSON.stringify(stored.rows)).not.toContain(result.invitation.token);
   });
 
+  it("lists beta requests and marks a matching request when invited", async () => {
+    const context = await fixture();
+    await context.db.query(
+      `INSERT INTO beta_access_requests
+         (id, email, normalized_email, email_normalization_version)
+       VALUES ('10000000-0000-4000-8000-000000000071',
+         'Person@Example.com', 'person@example.com', 1)`
+    );
+    expect(await runAuthAdminCommand([
+      "beta",
+      "list",
+      "--status",
+      "pending"
+    ], context)).toEqual({
+      requests: [expect.objectContaining({
+        email: "Person@Example.com",
+        status: "pending"
+      })],
+      next_cursor: null
+    });
+
+    await configurePolicy(context);
+    const created = await runAuthAdminCommand([
+      "invite",
+      "create",
+      "--email",
+      "person@example.com",
+      "--actor",
+      "operator:test",
+      "--reason",
+      "Invite the next beta participant"
+    ], context) as { invitation: { id: string } };
+    expect(await runAuthAdminCommand([
+      "beta",
+      "list",
+      "--status",
+      "pending"
+    ], context)).toEqual({ requests: [], next_cursor: null });
+    const invited = await runAuthAdminCommand([
+      "beta",
+      "list",
+      "--status",
+      "invited"
+    ], context) as {
+      requests: Array<{
+        status: string;
+        invitation_id: string;
+        invited_at: string;
+      }>;
+    };
+    expect(invited.requests[0]).toMatchObject({
+      status: "invited",
+      invitation_id: created.invitation.id,
+      invited_at: expect.any(String)
+    });
+  });
+
   it("rejects ambiguous or unsafe command input", async () => {
     const context = await fixture();
     await expect(runAuthAdminCommand([

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -4,6 +4,7 @@ import {
   type AuthenticationSettings
 } from "./authentication-policy.js";
 import { PasswordAccountService } from "./password-auth.js";
+import { normalizeEmailAddress } from "./email-identity.js";
 import type { RegistrationMode } from "./runtime-config.js";
 import {
   EmailDeliveryError,
@@ -70,6 +71,9 @@ async function runCommand(
   }
   if (area === "invite" && action === "resend") {
     return resendInvitation(rest, context);
+  }
+  if (area === "beta" && action === "list") {
+    return listBetaAccessRequests(rest, context);
   }
   if (area === "users" && action === "list") {
     return listUsers(rest, context);
@@ -277,6 +281,12 @@ async function createAndDeliverInvitation(
         }
       : {})
   });
+  await context.db.query(
+    `UPDATE beta_access_requests
+     SET invitation_id = $2, invited_at = now()
+     WHERE normalized_email = $1`,
+    [normalizeEmailAddress(invitation.email), invitation.id]
+  );
   const invitationPath =
     `/signup#invitation=${encodeURIComponent(invitation.token)}`;
   const showToken = !flags.has("token-output")
@@ -375,6 +385,22 @@ async function listInvitations(
       : {}),
     ...(flags.has("status")
       ? { status: invitationStatus(requiredFlag(flags, "status")) }
+      : {})
+  });
+}
+
+async function listBetaAccessRequests(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<unknown> {
+  const flags = parseFlags(argv, new Set(["limit", "cursor", "status"]));
+  return instanceAdmin(context).listBetaAccessRequests({
+    limit: pageLimit(flags),
+    ...(flags.has("cursor")
+      ? { cursor: requiredFlag(flags, "cursor") }
+      : {}),
+    ...(flags.has("status")
+      ? { status: betaAccessStatus(requiredFlag(flags, "status")) }
       : {})
   });
 }
@@ -639,6 +665,13 @@ function invitationStatus(
   );
 }
 
+function betaAccessStatus(value: string): "pending" | "invited" {
+  if (value === "pending" || value === "invited") return value;
+  throw new AuthAdminUsageError(
+    "--status must be pending or invited."
+  );
+}
+
 function userStatus(value: string): "active" | "suspended" {
   if (value === "active" || value === "suspended") return value;
   throw new AuthAdminUsageError(
@@ -721,6 +754,7 @@ export function usage(): string {
     "  auth-admin invite show --id <uuid>",
     "  auth-admin invite revoke --id <uuid> --operation-id <uuid> --actor <id> --reason <text>",
     "  auth-admin invite resend --id <uuid> --actor <id> --reason <text> [--expires-in <seconds>]",
+    "  auth-admin beta list [--status pending|invited] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin users list [--status active|suspended] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin users show --user <uuid|email>",
     "  auth-admin users suspend --user <uuid|email> --operation-id <uuid> --actor <id> --reason <text>",

--- a/services/server/src/beta-access.ts
+++ b/services/server/src/beta-access.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from "node:crypto";
+import type { DatabasePool } from "./database-types.js";
+import {
+  EMAIL_NORMALIZATION_VERSION,
+  normalizeEmailAddress
+} from "./email-identity.js";
+
+export class BetaAccessRequestService {
+  constructor(private readonly db: DatabasePool) {}
+
+  async request(emailInput: string): Promise<void> {
+    const email = emailInput.trim().normalize("NFC");
+    const normalizedEmail = normalizeEmailAddress(email);
+    await this.db.query(
+      `INSERT INTO beta_access_requests
+         (id, email, normalized_email, email_normalization_version)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT(normalized_email) DO NOTHING`,
+      [randomUUID(), email, normalizedEmail, EMAIL_NORMALIZATION_VERSION]
+    );
+  }
+}

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -39,7 +39,8 @@ describe("database migrations", () => {
       "0003_authorization_request_collection",
       "0004_separate_application_keys",
       "0005_notification_contract_versions",
-      "0006_notification_event_ids"
+      "0006_notification_event_ids",
+      "0007_beta_access_requests"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -295,7 +296,8 @@ describe("database migrations", () => {
       "0003_authorization_request_collection",
       "0004_separate_application_keys",
       "0005_notification_contract_versions",
-      "0006_notification_event_ids"
+      "0006_notification_event_ids",
+      "0007_beta_access_requests"
     ]);
   });
 

--- a/services/server/src/features/beta-access/routes.test.ts
+++ b/services/server/src/features/beta-access/routes.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "../../app.js";
+import { createDatabase } from "../../db.js";
+
+const resources: Array<() => Promise<void>> = [];
+const allowedOrigin = "https://mdbase.dev";
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("beta access requests", () => {
+  it("stores one normalized request and returns the same response for repeats", async () => {
+    const { app, db } = await fixture();
+    for (const email of ["Person@Example.com", " person@example.com "]) {
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/beta-access-requests",
+        headers: { origin: allowedOrigin },
+        payload: { email }
+      });
+      expect(response.statusCode).toBe(202);
+      expect(response.json()).toEqual({ accepted: true });
+      expect(response.headers["cache-control"]).toBe("no-store");
+    }
+    const stored = await db.query<{
+      email: string;
+      normalized_email: string;
+      email_normalization_version: number;
+    }>(
+      `SELECT email, normalized_email, email_normalization_version
+       FROM beta_access_requests`
+    );
+    expect(stored.rows).toEqual([{
+      email: "Person@Example.com",
+      normalized_email: "person@example.com",
+      email_normalization_version: 1
+    }]);
+  });
+
+  it("ignores the honeypot and rejects untrusted origins and invalid addresses", async () => {
+    const { app, db } = await fixture();
+    const honeypot = await app.inject({
+      method: "POST",
+      url: "/v1/beta-access-requests",
+      headers: { origin: allowedOrigin },
+      payload: { email: "bot@example.com", website: "https://spam.example" }
+    });
+    expect(honeypot.statusCode).toBe(202);
+    const stored = await db.query("SELECT id FROM beta_access_requests");
+    expect(stored.rows).toHaveLength(0);
+
+    const denied = await app.inject({
+      method: "POST",
+      url: "/v1/beta-access-requests",
+      headers: { origin: "https://other.example" },
+      payload: { email: "person@example.com" }
+    });
+    expect(denied.statusCode).toBe(403);
+    expect(denied.json().error.code).toBe("origin_denied");
+
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/v1/beta-access-requests",
+      headers: { origin: allowedOrigin },
+      payload: { email: "not-an-address" }
+    });
+    expect(invalid.statusCode).toBe(400);
+    expect(invalid.json().error.code).toBe("invalid_request");
+  });
+
+  it("applies a shared email rate limit", async () => {
+    const { app } = await fixture();
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const accepted = await app.inject({
+        method: "POST",
+        url: "/v1/beta-access-requests",
+        headers: { origin: allowedOrigin },
+        payload: { email: "limited@example.com" }
+      });
+      expect(accepted.statusCode).toBe(202);
+    }
+    const denied = await app.inject({
+      method: "POST",
+      url: "/v1/beta-access-requests",
+      headers: { origin: allowedOrigin },
+      payload: { email: "limited@example.com" }
+    });
+    expect(denied.statusCode).toBe(429);
+    expect(denied.json().error.code).toBe("rate_limited");
+    expect(Number(denied.headers["retry-after"])).toBeGreaterThan(0);
+  });
+});
+
+async function fixture() {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  const result = await buildApp({
+    db,
+    devAuth: true,
+    publicUrl: "http://connect.test",
+    betaAccessOrigin: allowedOrigin,
+    authRateLimitSecret: "test-rate-limit-secret".repeat(2)
+  });
+  resources.push(() => result.app.close());
+  return { ...result, db };
+}

--- a/services/server/src/features/beta-access/routes.ts
+++ b/services/server/src/features/beta-access/routes.ts
@@ -1,0 +1,112 @@
+import type { FastifyInstance, FastifyReply } from "fastify";
+import { z } from "zod";
+import {
+  AuthRateLimiter,
+  type AuthRateLimitRule
+} from "../../auth-rate-limit.js";
+import { BetaAccessRequestService } from "../../beta-access.js";
+import type { DatabasePool } from "../../database-types.js";
+import { normalizeEmailAddress } from "../../email-identity.js";
+import { apiError, OriginDeniedError } from "../../platform/http-errors.js";
+
+const EMAIL_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 5,
+  windowSeconds: 24 * 60 * 60,
+  baseBlockSeconds: 60 * 60,
+  maxBlockSeconds: 24 * 60 * 60
+};
+const IP_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 20,
+  windowSeconds: 60 * 60,
+  baseBlockSeconds: 60 * 60,
+  maxBlockSeconds: 24 * 60 * 60
+};
+const GLOBAL_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 300,
+  windowSeconds: 60 * 60,
+  baseBlockSeconds: 15 * 60,
+  maxBlockSeconds: 60 * 60
+};
+
+interface BetaAccessRoutesOptions {
+  db: DatabasePool;
+  allowedOrigin: string;
+  rateLimitSecret: string;
+}
+
+export function registerBetaAccessRoutes(
+  app: FastifyInstance,
+  options: BetaAccessRoutesOptions
+): void {
+  const requests = new BetaAccessRequestService(options.db);
+  const limiter = new AuthRateLimiter(options.db, options.rateLimitSecret);
+
+  app.post("/v1/beta-access-requests", {
+    config: { rateLimit: { max: 30, timeWindow: "1 minute" } }
+  }, async (request, reply) => {
+    reply.header("cache-control", "no-store");
+    if (request.headers.origin !== options.allowedOrigin) {
+      throw new OriginDeniedError();
+    }
+    const input = z.object({
+      email: z.string().trim().pipe(z.email().max(320)),
+      website: z.string().max(500).optional()
+    }).strict().parse(request.body);
+    if (input.website?.trim()) {
+      return reply.code(202).send({ accepted: true });
+    }
+    const normalizedEmail = normalizeEmailAddress(input.email);
+    const allowed = await consumeLimits(limiter, [
+      {
+        scope: "beta_access.email",
+        key: normalizedEmail,
+        rule: EMAIL_LIMIT
+      },
+      {
+        scope: "beta_access.ip",
+        key: request.ip,
+        rule: IP_LIMIT
+      },
+      {
+        scope: "beta_access.global",
+        key: "global",
+        rule: GLOBAL_LIMIT
+      }
+    ], reply);
+    if (!allowed) return;
+    await requests.request(input.email);
+    return reply.code(202).send({ accepted: true });
+  });
+}
+
+async function consumeLimits(
+  limiter: AuthRateLimiter,
+  attempts: Array<{
+    scope: string;
+    key: string;
+    rule: AuthRateLimitRule;
+  }>,
+  reply: FastifyReply
+): Promise<boolean> {
+  let retryAfterSeconds = 0;
+  for (const attempt of attempts) {
+    const decision = await limiter.consume(
+      attempt.scope,
+      attempt.key,
+      attempt.rule
+    );
+    if (!decision.allowed) {
+      retryAfterSeconds = Math.max(
+        retryAfterSeconds,
+        decision.retryAfterSeconds
+      );
+    }
+  }
+  if (retryAfterSeconds === 0) return true;
+  reply.header("retry-after", String(retryAfterSeconds));
+  reply.code(429).send(apiError(
+    "rate_limited",
+    "Too many access requests. Please try again later."
+  ));
+  return false;
+}

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -31,6 +31,7 @@ const { app } = await buildApp({
   googleAuth: runtime.googleAuth ?? undefined,
   registration: runtime.registration,
   authRateLimitSecret: runtime.authRateLimitSecret ?? undefined,
+  betaAccessOrigin: runtime.betaAccessOrigin ?? undefined,
   authenticationLegalDocuments:
     runtime.authenticationLegalDocuments ?? undefined,
   emailTransport: runtime.transactionalEmail

--- a/services/server/src/instance-admin.ts
+++ b/services/server/src/instance-admin.ts
@@ -34,6 +34,12 @@ export interface InvitationPageInput {
   status?: "active" | "accepted" | "revoked" | "expired";
 }
 
+export interface BetaAccessRequestPageInput {
+  limit?: number;
+  cursor?: string;
+  status?: "pending" | "invited";
+}
+
 export interface AuditPageInput {
   limit?: number;
   cursor?: string;
@@ -61,6 +67,14 @@ interface InvitationRow {
   send_count: number | string;
   last_sent_at: Date | string | null;
   created_at: Date | string;
+}
+
+interface BetaAccessRequestRow {
+  id: string;
+  email: string;
+  invitation_id: string | null;
+  invited_at: Date | string | null;
+  requested_at: Date | string;
 }
 
 interface AuditRow {
@@ -319,6 +333,48 @@ export class InstanceAdminService {
       throw new InstanceAdminNotFoundError("Invitation was not found.");
     }
     return { invitation: invitationSummary(result.rows[0]) };
+  }
+
+  async listBetaAccessRequests(input: BetaAccessRequestPageInput = {}) {
+    const limit = pageSize(input.limit);
+    const cursor = input.cursor ? decodeCursor(input.cursor) : null;
+    const values: unknown[] = [];
+    const conditions: string[] = [];
+    if (input.status === "pending") conditions.push("invited_at IS NULL");
+    if (input.status === "invited") conditions.push("invited_at IS NOT NULL");
+    if (cursor) {
+      values.push(cursor.createdAt, cursor.id);
+      conditions.push(
+        `(requested_at < $${values.length - 1}
+          OR (requested_at = $${values.length - 1} AND id < $${values.length}))`
+      );
+    }
+    values.push(limit + 1);
+    const result = await this.db.query<BetaAccessRequestRow>(
+      `SELECT id, email, invitation_id, invited_at, requested_at
+       FROM beta_access_requests
+       ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
+       ORDER BY requested_at DESC, id DESC
+       LIMIT $${values.length}`,
+      values
+    );
+    const rows = result.rows.slice(0, limit);
+    return {
+      requests: rows.map((row) => ({
+        id: row.id,
+        email: row.email,
+        status: row.invited_at ? "invited" as const : "pending" as const,
+        requested_at: iso(row.requested_at),
+        invited_at: nullableIso(row.invited_at),
+        invitation_id: row.invitation_id
+      })),
+      next_cursor: result.rows.length > limit && rows.length
+        ? encodeCursor(
+            rows[rows.length - 1]!.requested_at,
+            rows[rows.length - 1]!.id
+          )
+        : null
+    };
   }
 
   async revokeInvitation(invitationId: string, mutation: OperatorMutation) {

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -16,6 +16,7 @@ function config(overrides: Partial<Parameters<typeof validateRuntimeConfig>[0]> 
     googleAuth: null,
     registration: "closed" as const,
     authRateLimitSecret: null,
+    betaAccessOrigin: null,
     authenticationLegalDocuments: null,
     transactionalEmail: null,
     hostedCollections: false,
@@ -153,6 +154,25 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_DEV_AUTH: "1",
       MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "too-short"
     })).toThrow(/at least 32 bytes/);
+  });
+
+  it("enables beta requests only for a canonical origin with shared rate limiting", () => {
+    const value = runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "x".repeat(32),
+      MDBASE_CONNECT_BETA_ACCESS_ORIGIN: "https://mdbase.dev/"
+    });
+    expect(value.betaAccessOrigin).toBe("https://mdbase.dev");
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_BETA_ACCESS_ORIGIN: "https://mdbase.dev"
+    })).toThrow(/RATE_LIMIT_SECRET/);
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "https://connect.example",
+      MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET: "x".repeat(32),
+      MDBASE_CONNECT_BETA_ACCESS_ORIGIN: "https://mdbase.dev/beta/"
+    })).toThrow(/origin/);
   });
 
   it("supports password-only authentication infrastructure and validates legal document URLs", () => {

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -26,6 +26,7 @@ export interface RuntimeConfig {
   googleAuth: GoogleAuthConfig | null;
   registration: RegistrationMode;
   authRateLimitSecret: string | null;
+  betaAccessOrigin: string | null;
   authenticationLegalDocuments: AuthenticationLegalDocuments | null;
   transactionalEmail: TransactionalEmailConfig | null;
   hostedCollections: boolean;
@@ -92,6 +93,17 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
   ) {
     throw new Error(
       "Authentication rate-limit digest secret must contain at least 32 bytes."
+    );
+  }
+  const betaAccessOrigin = config.betaAccessOrigin
+    ? validatePublicOrigin(
+        config.betaAccessOrigin,
+        "MDBASE_CONNECT_BETA_ACCESS_ORIGIN"
+      )
+    : null;
+  if (betaAccessOrigin && config.authRateLimitSecret === null) {
+    throw new Error(
+      "Beta access requests require MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET."
     );
   }
   if (config.authenticationLegalDocuments) {
@@ -174,7 +186,12 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
       keyIds.add(key.kid);
     }
   }
-  return { ...config, publicUrl: publicUrl.origin, hostedProvider };
+  return {
+    ...config,
+    publicUrl: publicUrl.origin,
+    betaAccessOrigin,
+    hostedProvider
+  };
 }
 
 export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
@@ -193,6 +210,8 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   const registration = registrationMode(env.MDBASE_CONNECT_REGISTRATION);
   const authRateLimitSecret =
     env.MDBASE_CONNECT_AUTH_RATE_LIMIT_SECRET?.trim() || null;
+  const betaAccessOrigin =
+    env.MDBASE_CONNECT_BETA_ACCESS_ORIGIN?.trim() || null;
   const termsUrl = env.MDBASE_CONNECT_TERMS_URL?.trim() ?? "";
   const privacyUrl = env.MDBASE_CONNECT_PRIVACY_URL?.trim() ?? "";
   if (Boolean(termsUrl) !== Boolean(privacyUrl)) {
@@ -267,6 +286,7 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
       : null,
     registration,
     authRateLimitSecret,
+    betaAccessOrigin,
     authenticationLegalDocuments,
     transactionalEmail,
     hostedCollections: env.MDBASE_CONNECT_HOSTED_COLLECTIONS === "1",
@@ -448,6 +468,29 @@ function validatePublicDocumentUrl(value: string, name: string): void {
   ) {
     throw new Error(`${name} must use HTTPS outside loopback development.`);
   }
+}
+
+function validatePublicOrigin(value: string, name: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an absolute origin.`);
+  }
+  if (
+    url.username
+    || url.password
+    || url.pathname !== "/"
+    || url.search
+    || url.hash
+    || (
+      url.protocol !== "https:"
+      && !(url.protocol === "http:" && isLoopback(url.hostname))
+    )
+  ) {
+    throw new Error(`${name} must be an HTTPS origin outside loopback development.`);
+  }
+  return url.origin;
 }
 
 function validateRelayBrokerServer(server: string): void {


### PR DESCRIPTION
## Summary

- add an email-only beta-access intake endpoint backed by a deduplicated database table
- restrict the endpoint to a configured public origin and protect it with a honeypot plus distributed email, IP, and global rate limits
- expose pending and invited requests through operator tooling, and mark matching requests when an invitation is created

## Why

mdbase.dev needs a low-friction way to collect beta interest without opening registration or requiring people to justify access. Account creation remains invitation-only.

## Impact

Deployments can set MDBASE_CONNECT_BETA_ACCESS_ORIGIN=https://mdbase.dev. The endpoint returns a generic accepted response, stores only email and request metadata, and keeps the existing invitation commands as the approval boundary.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- pnpm typecheck
- pnpm test
- pnpm e2e