### PR TITLE
Redesign Connect management surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,11 +6,10 @@ mdbase connect is a desktop utility used at a personal computer while the user
 is making a consequential access decision. The theme is minimal and precise in
 both ordinary daylight and a dim room. Light mode is paper-like; dark mode uses
 deep blue-black surfaces without turning the product into terminal cosplay.
-Portal and desktop share a compact product header, visual tokens, and core
-controls. Desktop views sit in a quiet horizontal tab row below that header;
-the compact portal overview needs no section navigation. Content remains an
-uninterrupted canvas. Hierarchy comes from typography, spacing, and alignment
-rather than tinted boxes or decoration.
+Portal and desktop share a single compact left sidebar, visual tokens, and core
+controls. Each navigation item opens one focused page in an uninterrupted
+canvas. Hierarchy comes from typography, spacing, and alignment rather than
+tinted boxes or decoration.
 
 ## Color
 
@@ -83,13 +82,13 @@ and interaction guidance in
 
 ## Layout
 
-- Portal and desktop share a full-width product header with identity or
-  connection state aligned opposite the wordmark.
-- Desktop primary navigation uses a single horizontal tab row. Counts appear
-  only when they clarify local collection state or pending action.
-- The portal keeps requests, active application grants, computers, and service
-  details in one centered overview. It does not add navigation when the complete
-  page is already visible.
+- Portal and desktop use the same fixed left-sidebar shell, with identity or
+  connection state in its footer and a focused page canvas beside it.
+- Counts appear only when they clarify collection state, connected resources,
+  or pending action. The current destination uses ordinary page navigation.
+- The portal gives requests, hosted collections, application access, computers,
+  and account management stable routes. Its overview summarizes those pages
+  without duplicating their management controls.
 - Collection metadata editing expands inline beneath the collection row. Name
   and description remain visibly tied to `mdbase.yaml`; availability is a
   separate immediate control.

--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -247,6 +247,13 @@ try {
   await portalPage
     .getByRole("heading", { name: "Your connections." })
     .waitFor();
+  await portalPage
+    .getByRole("navigation", { name: "mdbase connect navigation" })
+    .getByRole("link", { name: /^App access/ })
+    .click();
+  await portalPage
+    .getByRole("heading", { name: "Decide what apps can do." })
+    .waitFor();
   const portalApplication = portalPage
     .locator("details.portal-application-access")
     .filter({ hasText: "Docker fixture consumer" });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -349,6 +349,18 @@ function registerIpc(): void {
       serverUrl: configuration.server_url
     };
   });
+  ipcMain.handle("connect:account:open", async (event) => {
+    trustedIpc(event);
+    const configuration = await requestReadyAgent<{
+      configured: boolean;
+      server_url: string | null;
+    }>("account.configuration");
+    if (!configuration.configured || !configuration.server_url) {
+      throw new Error("Connect this computer to a portal first.");
+    }
+    const accountUrl = new URL("/account", validateServerUrl(configuration.server_url));
+    await shell.openExternal(accountUrl.href);
+  });
   ipcMain.handle("connect:cloud:set", async (event, input: unknown) => {
     trustedIpc(event);
     if (!input || typeof input !== "object") throw new Error("Invalid cloud connection input.");

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -46,6 +46,7 @@ contextBridge.exposeInMainWorld("mdbaseConnect", {
   getLaunchAtLogin: () => ipcRenderer.invoke("connect:startup:get"),
   setLaunchAtLogin: (enabled: boolean) => ipcRenderer.invoke("connect:startup:set", enabled),
   getCloudConfig: () => ipcRenderer.invoke("connect:cloud:get"),
+  openAccount: () => ipcRenderer.invoke("connect:account:open"),
   setCloudConfig: (input: { serverUrl: string; connectorToken: string }) =>
     ipcRenderer.invoke("connect:cloud:set", input),
   clearCloudConfig: () => ipcRenderer.invoke("connect:cloud:clear"),

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -326,6 +326,7 @@ interface Window {
     getLaunchAtLogin(): Promise<StartupSetting>;
     setLaunchAtLogin(enabled: boolean): Promise<StartupSetting>;
     getCloudConfig(): Promise<CloudSetting>;
+    openAccount(): Promise<void>;
     setCloudConfig(input: { serverUrl: string; connectorToken: string }): Promise<CloudSetting>;
     clearCloudConfig(): Promise<CloudSetting>;
     beginPairing(input: { serverUrl: string; connectorName: string }): Promise<{

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -15,7 +15,6 @@ import {
   typeFields,
   type SetupType
 } from "@mdbase/connect-ui/contract-setup";
-import { applyThemePreference, loadThemePreference, saveThemePreference, type ThemePreference } from "@mdbase/connect-ui/theme";
 import "@mdbase/connect-ui/styles.css";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -30,13 +29,14 @@ import {
 import { ConnectionProgress, Overview } from "./overview-view";
 import {
   AccessControl,
-  Brand,
   Empty,
-  NavButton,
+  MobileProductBar,
   PairingPanel,
+  ProductSidebar,
   SectionHeading,
   SettingSwitch,
-  StatusDot
+  StatusDot,
+  ThemeMenu
 } from "./ui-components";
 import {
   allOperations,
@@ -109,6 +109,7 @@ function App() {
   const [newPath, setNewPath] = useState("");
   const [newAuthority, setNewAuthority] = useState<"local" | "hosted">("local");
   const [mirrorTarget, setMirrorTarget] = useState<string | null>(null);
+  const [navigationOpen, setNavigationOpen] = useState(false);
 
   const refresh = useCallback(async (quiet = false) => {
     try {
@@ -166,6 +167,15 @@ function App() {
       localStorage.removeItem(RESUME_AUTHORIZATION_KEY);
     }
   }, [authorizationTarget, cloud?.configured, route]);
+
+  useEffect(() => {
+    if (!navigationOpen) return;
+    const close = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setNavigationOpen(false);
+    };
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [navigationOpen]);
 
   async function act(action: () => Promise<void>) {
     setBusy(true);
@@ -245,30 +255,25 @@ function App() {
     };
   }, [access, hosted]);
   const collectionCount = collections.length + hosted.hosted_collections.length;
+  const selectRoute = (next: Route) => {
+    setRoute(next);
+    setNavigationOpen(false);
+  };
 
   return (
-    <div className="shell">
-      <header className="product-header desktop-header">
-        <div className="product-header-inner">
-          <Brand />
-          <div className="product-header-meta" role="status" aria-live="polite">
-            <StatusDot state={connection.dot} />
-            <div className="product-header-meta-copy"><strong>{connection.label}</strong><small>{access.account?.connector_name ?? "This computer"} · {collectionCount} {plural(collectionCount, "collection", "collections")}</small></div>
-          </div>
-        </div>
-      </header>
-
-      <nav className="view-tabs" aria-label="mdbase connect views">
-        <div className="view-tabs-inner">
-          <NavButton route="overview" current={route} label="Overview" onSelect={setRoute} />
-          <NavButton route="collections" current={route} label="Collections" count={collectionCount} onSelect={setRoute} />
-          <NavButton route="access" current={route} label="App access" attention={combinedAccess.pending_authorizations.length} onSelect={setRoute} />
-          <NavButton route="activity" current={route} label="Activity" onSelect={setRoute} />
-          <NavButton route="settings" current={route} label="Settings" onSelect={setRoute} />
-        </div>
-      </nav>
-
-      <main className="content">
+    <div className={`shell product-shell ${navigationOpen ? "navigation-open" : ""}`}>
+      <ProductSidebar
+        route={route}
+        collectionCount={collectionCount}
+        pendingCount={combinedAccess.pending_authorizations.length}
+        connection={connection}
+        computerName={`${access.account?.connector_name ?? "This computer"} · ${collectionCount} ${plural(collectionCount, "collection", "collections")}`}
+        onSelect={selectRoute}
+      />
+      <button className="product-sidebar-backdrop" aria-label="Close navigation" onClick={() => setNavigationOpen(false)} />
+      <div className="product-canvas desktop-canvas">
+        <MobileProductBar open={navigationOpen} onOpen={() => setNavigationOpen(true)} />
+        <main className="content">
         <header className="topbar">
           <div><p className="eyebrow">{copy.eyebrow}</p><h1>{copy.title}</h1><p className="lede">{copy.lede}</p></div>
         </header>
@@ -344,11 +349,11 @@ function App() {
             onNotice={setNotice}
           />
         )}
-      </main>
+        </main>
 
-      {createOpen && (
-        <div className="modal-backdrop" role="presentation" onMouseDown={() => !busy && setCreateOpen(false)}>
-          <section className="modal" role="dialog" aria-modal="true" aria-labelledby="create-title" onMouseDown={(event) => event.stopPropagation()}>
+        {createOpen && (
+          <div className="modal-backdrop" role="presentation" onMouseDown={() => !busy && setCreateOpen(false)}>
+            <section className="modal" role="dialog" aria-modal="true" aria-labelledby="create-title" onMouseDown={(event) => event.stopPropagation()}>
             <p className="eyebrow">New collection</p>
             <h2 id="create-title">Create an mdbase collection</h2>
             <p>Choose where the main copy should live. A collection hosted by mdbase can also keep a synced folder on this computer.</p>
@@ -369,9 +374,10 @@ function App() {
               <button className="button secondary" disabled={busy} onClick={() => setCreateOpen(false)}>Cancel</button>
               <button className="button primary" disabled={busy || !newName.trim() || (newAuthority === "local" && !newPath)} onClick={() => void createCollection()}>Create collection</button>
             </div>
-          </section>
-        </div>
-      )}
+            </section>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -841,7 +847,10 @@ function Settings({ startup, cloud, access, status, updateStatus, busy, onAct, o
             <SettingRow label="Connection" value={connection.settingsLabel} detail="Keeps approved apps on other devices connected to this computer" />
             <SettingRow label="Apps on this computer" value={status?.direct_access_available ? "Available" : "Unavailable"} detail="Approved apps here can connect without sending records over the internet" />
           </div>
-          <button className="button secondary danger-text disconnect-button" disabled={busy} onClick={() => { if (window.confirm("Disconnect this computer from your account? Existing local collection files are unaffected.")) void onAct(async () => { await window.mdbaseConnect.clearCloudConfig(); }); }}>Disconnect computer</button>
+          <div className="portal-connection-actions">
+            <button className="button secondary" disabled={busy} onClick={() => void onAct(() => window.mdbaseConnect.openAccount())}>Manage account in portal</button>
+            <button className="button secondary danger-text disconnect-button" disabled={busy} onClick={() => { if (window.confirm("Disconnect this computer from your account? Existing local collection files are unaffected.")) void onAct(async () => { await window.mdbaseConnect.clearCloudConfig(); }); }}>Disconnect computer</button>
+          </div>
         </section>
       )}
       <section>
@@ -917,7 +926,7 @@ function Settings({ startup, cloud, access, status, updateStatus, busy, onAct, o
           <div className="setting-row">
             <span>Theme</span>
             <div><strong>Color theme</strong><small>System follows your operating system appearance</small></div>
-            <ThemeSelect />
+            <ThemeMenu placement="up" />
           </div>
         </div>
       </section>
@@ -948,23 +957,6 @@ function ComputerNameSetting({ account, online, busy, onAct, onNotice }: {
 
 function SettingRow({ label, value, detail, mono = false }: { label: string; value: string; detail: string; mono?: boolean }) {
   return <div className="setting-row"><span>{label}</span><div><strong className={mono ? "mono" : ""}>{value}</strong><small>{detail}</small></div></div>;
-}
-
-function ThemeSelect() {
-  const [preference, setPreference] = useState<ThemePreference>(loadThemePreference);
-  useEffect(() => {
-    applyThemePreference(preference);
-    if (preference !== "system") return;
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    const update = () => applyThemePreference("system");
-    media.addEventListener("change", update);
-    return () => media.removeEventListener("change", update);
-  }, [preference]);
-  return <select className="theme-select" aria-label="Color theme" value={preference} onChange={(event) => {
-    const next = event.target.value as ThemePreference;
-    setPreference(next);
-    saveThemePreference(next);
-  }}><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>;
 }
 
 createRoot(document.getElementById("root")!).render(<React.StrictMode><App /></React.StrictMode>);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1,13 +1,8 @@
 html, body, #root { width: 100%; min-width: 100%; height: 100%; min-height: 100%; margin: 0; }
 body { overflow: hidden; }
 button { color: inherit; }
-.shell { --type-metadata: 10px; --type-action: 11px; --type-supporting: 12px; --type-body: 13px; --type-row-title: 14px; display: flex; flex-direction: column; height: 100vh; background: var(--paper); }
-.desktop-header .product-header-inner, .view-tabs-inner { width: min(70rem, 100%); }
-.desktop-header .product-brand-label { font-size: var(--type-supporting); }
-.desktop-header .product-header-meta-copy strong { font-size: var(--type-body); }
-.desktop-header .product-header-meta-copy small { font-size: var(--type-supporting); }
-.desktop-header .product-avatar, .view-tab-count { font-size: var(--type-metadata); }
-.view-tab { font-size: var(--type-body); }
+.shell { --type-metadata: 10px; --type-action: 11px; --type-supporting: 12px; --type-body: 13px; --type-row-title: 14px; height: 100vh; overflow: hidden; background: var(--paper); }
+.desktop-canvas { height: 100vh; min-height: 0; display: flex; flex-direction: column; }
 .content { min-width: 0; flex: 1 1 auto; padding: 42px clamp(38px, 6vw, 80px) 64px; overflow: auto; background: var(--paper); }
 .content > * { width: min(960px, 100%); margin-inline: auto; }
 .topbar { display: block; min-height: 76px; }
@@ -277,7 +272,8 @@ fieldset legend { margin-bottom: 6px; }
 .setting-editor label > span { font-size: var(--type-action); }
 .setting-toggle.disabled .toggle-copy strong { color: var(--muted); }
 .setting-toggle.disabled .toggle-copy small { color: var(--faint); }
-.disconnect-button { margin-top: 14px; }
+.portal-connection-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.disconnect-button { margin: 0; }
 .privacy-block { display: block; padding: 18px 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .privacy-block div { display: grid; gap: 4px; }
 .privacy-block strong { font-size: var(--type-body); font-weight: 700; }
@@ -353,6 +349,10 @@ fieldset legend { margin-bottom: 6px; }
   .copy-registration { grid-template-columns: 1fr; gap: 16px; }
   .copy-registration-actions { justify-content: flex-end; }
   .identity-conflict-details > div { grid-template-columns: 120px minmax(0, 1fr); }
+}
+@media (max-width: 760px) {
+  .content { padding-top: 30px; }
+  .topbar { min-height: 70px; }
 }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.001ms !important; animation-duration: 0.001ms !important; }

--- a/apps/desktop/src/renderer/ui-components.tsx
+++ b/apps/desktop/src/renderer/ui-components.tsx
@@ -3,7 +3,13 @@ import {
   mdbaseMarkAccentRect,
   mdbaseMarkInkRects
 } from "@mdbase/connect-ui/brand";
-import React, { useEffect, useState } from "react";
+import {
+  applyThemePreference,
+  loadThemePreference,
+  saveThemePreference,
+  type ThemePreference
+} from "@mdbase/connect-ui/theme";
+import React, { useEffect, useRef, useState } from "react";
 import type { ConnectionDotState } from "./connection-state.mjs";
 import { message, type Route } from "./view-model";
 
@@ -81,8 +87,53 @@ export function PairingPanel({ resumeAuthorization = false }: { resumeAuthorizat
   );
 }
 
+export function ProductSidebar({
+  route,
+  collectionCount,
+  pendingCount,
+  connection,
+  computerName,
+  onSelect
+}: {
+  route: Route;
+  collectionCount: number;
+  pendingCount: number;
+  connection: { dot: ConnectionDotState; label: string };
+  computerName: string;
+  onSelect(route: Route): void;
+}) {
+  return <aside id="product-navigation" className="product-sidebar">
+    <div className="product-sidebar-brand"><Brand /></div>
+    <nav className="product-sidebar-nav" aria-label="mdbase connect navigation">
+      <NavButton route="overview" current={route} label="Overview" onSelect={onSelect} />
+      <NavButton route="collections" current={route} label="Collections" count={collectionCount} onSelect={onSelect} />
+      <NavButton route="access" current={route} label="App access" attention={pendingCount} onSelect={onSelect} />
+      <NavButton route="activity" current={route} label="Activity" onSelect={onSelect} />
+    </nav>
+    <footer className="product-sidebar-footer">
+      <div className="product-sidebar-footer-nav">
+        <NavButton route="settings" current={route} label="Settings" onSelect={onSelect} />
+      </div>
+      <div className="product-sidebar-status" role="status" aria-live="polite">
+        <StatusDot state={connection.dot} />
+        <span className="product-sidebar-status-copy">
+          <strong>{connection.label}</strong>
+          <small>{computerName}</small>
+        </span>
+      </div>
+    </footer>
+  </aside>;
+}
+
+export function MobileProductBar({ open, onOpen }: { open: boolean; onOpen(): void }) {
+  return <header className="mobile-product-bar">
+    <Brand />
+    <button className="mobile-navigation-button" aria-label="Open navigation" aria-controls="product-navigation" aria-expanded={open} onClick={onOpen}><span /></button>
+  </header>;
+}
+
 export function NavButton({ route, current, label, count, attention, onSelect }: { route: Route; current: Route; label: string; count?: number; attention?: number; onSelect(route: Route): void }) {
-  return <button className={`view-tab ${current === route ? "active" : ""}`} aria-current={current === route ? "page" : undefined} onClick={() => onSelect(route)}><span>{label}</span>{attention ? <b className="view-tab-count attention">{attention}</b> : count !== undefined ? <b className="view-tab-count">{count}</b> : null}</button>;
+  return <button className={`product-sidebar-link ${current === route ? "active" : ""}`} aria-current={current === route ? "page" : undefined} onClick={() => onSelect(route)}><span>{label}</span>{attention ? <b className="product-sidebar-count attention">{attention}</b> : count !== undefined ? <b className="product-sidebar-count">{count}</b> : null}</button>;
 }
 
 export function SectionHeading({ title, note, count, children }: { title: string; note: string; count?: number; children?: React.ReactNode }) {
@@ -161,3 +212,101 @@ export function AccessControl({ paused, disabled, onChange }: {
   );
 }
 
+const themeChoices: Array<{ value: ThemePreference; label: string }> = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" }
+];
+
+export function ThemeMenu({ placement = "down" }: { placement?: "up" | "down" }) {
+  const [preference, setPreference] = useState<ThemePreference>(loadThemePreference);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  useEffect(() => {
+    applyThemePreference(preference);
+    if (preference !== "system") return;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const update = () => applyThemePreference("system");
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, [preference]);
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: Event) => {
+      if (event.target instanceof Node && !containerRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    document.addEventListener("focusin", closeOutside);
+    const frame = requestAnimationFrame(() => {
+      optionRefs.current[themeChoices.findIndex(({ value }) => value === preference)]?.focus();
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("pointerdown", closeOutside);
+      document.removeEventListener("focusin", closeOutside);
+    };
+  }, [open, preference]);
+
+  function choose(next: ThemePreference) {
+    setPreference(next);
+    saveThemePreference(next);
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function moveFocus(event: React.KeyboardEvent<HTMLDivElement>) {
+    const current = optionRefs.current.findIndex((option) => option === document.activeElement);
+    let next = current;
+    if (event.key === "ArrowDown") next = (current + 1) % themeChoices.length;
+    else if (event.key === "ArrowUp") next = (current - 1 + themeChoices.length) % themeChoices.length;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = themeChoices.length - 1;
+    else if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+      return;
+    } else return;
+    event.preventDefault();
+    optionRefs.current[next]?.focus();
+  }
+
+  const label = themeChoices.find(({ value }) => value === preference)?.label ?? "System";
+  return <div className={`theme-menu theme-menu-${placement}`} ref={containerRef}>
+    <button
+      ref={triggerRef}
+      type="button"
+      className="theme-menu-trigger"
+      aria-label={`Color theme: ${label}`}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      title={`Color theme: ${label}`}
+      onClick={() => setOpen((value) => !value)}
+    ><ThemeGlyph preference={preference} /></button>
+    {open && <div className="theme-menu-popover" role="menu" aria-label="Color theme" onKeyDown={moveFocus}>
+      {themeChoices.map((choice, index) => <button
+        key={choice.value}
+        ref={(element) => { optionRefs.current[index] = element; }}
+        type="button"
+        className="theme-menu-option"
+        role="menuitemradio"
+        aria-checked={preference === choice.value}
+        onClick={() => choose(choice.value)}
+      >
+        <ThemeGlyph preference={choice.value} />
+        <span>{choice.label}</span>
+        <svg className="theme-menu-check" viewBox="0 0 16 16" aria-hidden="true"><path d="m3.5 8.2 2.8 2.8 6.2-6.3" /></svg>
+      </button>)}
+    </div>}
+  </div>;
+}
+
+function ThemeGlyph({ preference }: { preference: ThemePreference }) {
+  if (preference === "light") return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="3" /><path d="M10 2.4v1.2M10 16.4v1.2M2.4 10h1.2M16.4 10h1.2M4.6 4.6l.9.9M14.5 14.5l.9.9M15.4 4.6l-.9.9M5.5 14.5l-.9.9" /></svg>;
+  if (preference === "dark") return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><path d="M16.3 12.6A6.8 6.8 0 0 1 7.4 3.7 6.8 6.8 0 1 0 16.3 12.6Z" /></svg>;
+  return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><rect x="2.8" y="3.5" width="14.4" height="10.2" rx="1.5" /><path d="M7.2 16.5h5.6M10 13.7v2.8" /></svg>;
+}

--- a/apps/portal/src/account-view.tsx
+++ b/apps/portal/src/account-view.tsx
@@ -1,0 +1,277 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  api,
+  ApiError,
+  type AccountData,
+  type DashboardData
+} from "./api";
+import { GoogleIdentityButton } from "./auth-view";
+import {
+  authenticationLabel,
+  message,
+  pluralLabel,
+  registrationLabel,
+  tokenFromFragment
+} from "./portal-model";
+import { Empty, PageBrand, SectionHeading } from "./portal-ui";
+import { SessionManager } from "./session-manager";
+
+export function AccountView({ dashboard }: { dashboard: DashboardData }) {
+  const [account, setAccount] = useState<AccountData | null>(null);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [busy, setBusy] = useState("");
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [deletionOpen, setDeletionOpen] = useState(false);
+  const [deletionConfirmation, setDeletionConfirmation] = useState("");
+  const [deletionPassword, setDeletionPassword] = useState("");
+  const [reauthToken] = useState(() => tokenFromFragment("delete_token"));
+  const [googleAction, setGoogleAction] = useState<"link" | "delete" | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setAccount(await api<AccountData>("/v1/account"));
+      setError("");
+    } catch (reason) {
+      if (reason instanceof ApiError && reason.status === 401) {
+        location.href = `/login?return_to=${encodeURIComponent(location.href)}`;
+      } else setError(message(reason));
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+  useEffect(() => {
+    const linked = new URLSearchParams(location.search).get("linked");
+    if (linked === "github" || linked === "google") {
+      setNotice(`${providerLabel(linked)} is now connected.`);
+      history.replaceState(history.state, "", location.pathname);
+    }
+  }, []);
+
+  const googleCompleted = useCallback((redirectTo: string) => {
+    location.href = redirectTo;
+  }, []);
+  const googleFailed = useCallback((reason: string) => {
+    setError(reason);
+    setGoogleAction(null);
+  }, []);
+
+  async function disconnect(provider: "github" | "google") {
+    setBusy(`disconnect-${provider}`);
+    setError("");
+    setNotice("");
+    try {
+      await api(`/v1/account/identities/${provider}`, { method: "DELETE" });
+      setNotice(`${providerLabel(provider)} disconnected.`);
+      await refresh();
+    } catch (reason) {
+      setError(message(reason));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function changePassword(event: React.FormEvent) {
+    event.preventDefault();
+    if (newPassword !== passwordConfirmation) {
+      setError("New passwords do not match.");
+      return;
+    }
+    setBusy("password");
+    setError("");
+    setNotice("");
+    try {
+      await api("/v1/account/password", {
+        method: "PATCH",
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword
+        })
+      });
+      setCurrentPassword("");
+      setNewPassword("");
+      setPasswordConfirmation("");
+      setPasswordOpen(false);
+      setNotice("Password changed. Other browser sessions were signed out.");
+    } catch (reason) {
+      setError(message(reason));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function deleteAccount(event: React.FormEvent) {
+    event.preventDefault();
+    setBusy("delete");
+    setError("");
+    try {
+      await api("/v1/account", {
+        method: "DELETE",
+        body: JSON.stringify({
+          confirmation: deletionConfirmation,
+          ...(deletionPassword ? { current_password: deletionPassword } : {}),
+          ...(reauthToken ? { reauth_token: reauthToken } : {})
+        })
+      });
+      location.href = "/account-deleted";
+    } catch (reason) {
+      setError(message(reason));
+      setBusy("");
+    }
+  }
+
+  if (!account) {
+    return <main className="account-main account-management-main">
+      <header><p className="eyebrow">Account</p><h1>Account and storage.</h1></header>
+      <p className="account-loading" role="status">{error || "Loading account details…"}</p>
+    </main>;
+  }
+
+  const linkedByProvider = new Map(
+    account.authentication.identities.map((identity) => [identity.provider, identity])
+  );
+  const providers = (["github", "google"] as const).filter((provider) =>
+    account.authentication.available_providers[provider] || linkedByProvider.has(provider)
+  );
+  const canPasswordDelete = account.authentication.password.configured;
+  const canExternalDelete = account.authentication.identities.length > 0;
+  const deletionAuthorized = account.deletion.development_confirmation
+    || Boolean(reauthToken)
+    || Boolean(deletionPassword);
+
+  return <main className="account-main account-management-main">
+    <header><p className="eyebrow">Account</p><h1>Account and storage.</h1><p>Manage hosted data, sign-in methods, and browser sessions.</p></header>
+    {error && <div className="message error" role="alert">{error}</div>}
+    {notice && <div className="message success" role="status">{notice}</div>}
+
+    <section id="storage">
+      <SectionHeading title="Hosted storage" note="Local collection files stay on your computers and are not measured here." />
+      <div className="account-setting-list">
+        <div className="account-setting-row storage-total-row">
+          <div><strong>Used by hosted collections</strong><small>{storageDetail(account)}</small></div>
+          <span className="account-setting-value">{account.storage.total_content_bytes === null ? "Unavailable" : formatBytes(account.storage.total_content_bytes)}</span>
+        </div>
+        {account.storage.collections.map((collection) => <StorageRow key={collection.id} collection={collection} />)}
+      </div>
+    </section>
+
+    <section id="sign-in-methods">
+      <SectionHeading title="Sign-in methods" note="Connect more than one method so you always have a way back into your account." />
+      {!account.authentication.managed ? (
+        <Empty title="Managed by your tailnet" text="Sign-in methods for this account are controlled by Tailscale." />
+      ) : <div className="account-setting-list">
+        {providers.map((provider) => {
+          const identity = linkedByProvider.get(provider);
+          return <div className="account-setting-row" key={provider}>
+            <div><strong>{providerLabel(provider)}</strong><small>{identity ? identityDescription(identity) : "Not connected"}{identity?.current ? " · current session" : ""}</small></div>
+            <div className="account-setting-actions">
+              {!identity && provider === "github" && <a className="button secondary compact" href="/v1/account/identities/github/link?return_to=%2Faccount">Connect</a>}
+              {!identity && provider === "google" && googleAction !== "link" && <button className="button secondary compact" onClick={() => setGoogleAction("link")}>Connect</button>}
+              {!identity && provider === "google" && googleAction === "link" && <GoogleIdentityButton startUrl="/v1/account/identities/google/link?return_to=%2Faccount" onComplete={googleCompleted} onError={googleFailed} />}
+              {identity && <button className="button quiet compact" disabled={!identity.removable || busy === `disconnect-${provider}`} title={!identity.removable ? identity.current ? "This method is used by the current session." : "This is your only sign-in method." : undefined} onClick={() => void disconnect(provider)}>{busy === `disconnect-${provider}` ? "Disconnecting…" : "Disconnect"}</button>}
+            </div>
+          </div>;
+        })}
+        {(account.authentication.available_providers.password || account.authentication.password.configured) && <div className="account-setting-row account-setting-row-stack">
+          <div className="account-setting-row-main"><div><strong>Email and password</strong><small>{account.authentication.password.configured ? account.authentication.password.email ?? "Configured" : "Not configured"}{account.authentication.password.current ? " · current session" : ""}</small></div>
+            {account.authentication.password.change_available && <button className="button secondary compact" onClick={() => setPasswordOpen((open) => !open)}>{passwordOpen ? "Cancel" : "Change password"}</button>}
+          </div>
+          {passwordOpen && <form className="inline-account-form" onSubmit={(event) => void changePassword(event)}>
+            <label><span>Current password</span><input type="password" autoComplete="current-password" required value={currentPassword} onChange={(event) => setCurrentPassword(event.target.value)} /></label>
+            <label><span>New password</span><input type="password" autoComplete="new-password" minLength={15} required aria-describedby="account-password-guidance" value={newPassword} onChange={(event) => setNewPassword(event.target.value)} /></label>
+            <p className="field-note" id="account-password-guidance">Use at least 15 characters. Spaces are welcome.</p>
+            <label><span>Confirm new password</span><input type="password" autoComplete="new-password" minLength={15} required value={passwordConfirmation} onChange={(event) => setPasswordConfirmation(event.target.value)} /></label>
+            <button className="button primary" disabled={busy === "password"}>{busy === "password" ? "Changing password…" : "Change password"}</button>
+          </form>}
+        </div>}
+      </div>}
+    </section>
+
+    {account.authentication.managed && <section id="sessions"><SessionManager onError={setError} /></section>}
+
+    <section id="account-details">
+      <SectionHeading title="Account details" note="Identity and service configuration." />
+      <div className="account-setting-list">
+        <div className="account-setting-row"><div><strong>Authentication</strong><small>Current browser</small></div><span className="account-setting-value">{authenticationLabel(dashboard.authentication.provider)}</span></div>
+        <div className="account-setting-row"><div><strong>Registration</strong><small>Service policy</small></div><span className="account-setting-value">{registrationLabel(dashboard.authentication.registration)}</span></div>
+      </div>
+      {account.authentication.managed && <button className="button secondary account-sign-out" onClick={() => void api("/v1/logout", { method: "POST" }).then(() => { location.href = "/login"; })}>Sign out</button>}
+    </section>
+
+    <section id="delete-account" className="danger-section">
+      <SectionHeading title="Delete account" note="Permanent for hosted data. Local files are never removed from your computers." />
+      {!account.deletion.available ? <p>This account is managed by your tailnet and cannot be deleted here.</p> : !deletionOpen ? (
+        <button className="button danger" onClick={() => setDeletionOpen(true)}>Delete account…</button>
+      ) : <form className="account-deletion-form" onSubmit={(event) => void deleteAccount(event)}>
+        <div className="deletion-effects">
+          <p><strong>This permanently deletes:</strong></p>
+          <ul>
+            <li>{pluralLabel(account.deletion.hosted_collections, "hosted collection", "hosted collections")} and their stored data</li>
+            <li>Application access and {pluralLabel(account.deletion.computers, "connected computer", "connected computers")}</li>
+            <li>Every browser session and sign-in method</li>
+          </ul>
+          <p><strong>Local collection and mirror files remain on your computers.</strong></p>
+        </div>
+        {!account.deletion.development_confirmation && !reauthToken && <div className="account-reauthentication">
+          <strong>Confirm your identity</strong>
+          {canPasswordDelete && <label><span>Current password</span><input type="password" autoComplete="current-password" value={deletionPassword} onChange={(event) => setDeletionPassword(event.target.value)} /></label>}
+          {canExternalDelete && <div className="account-setting-actions">
+            {account.authentication.identities.some(({ provider }) => provider === "github") && <a className="button secondary compact" href="/v1/account/reauth/github?return_to=%2Faccount">Verify with GitHub</a>}
+            {account.authentication.identities.some(({ provider }) => provider === "google") && googleAction !== "delete" && <button type="button" className="button secondary compact" onClick={() => setGoogleAction("delete")}>Verify with Google</button>}
+          </div>}
+          {googleAction === "delete" && <GoogleIdentityButton startUrl="/v1/account/reauth/google?return_to=%2Faccount" onComplete={googleCompleted} onError={googleFailed} />}
+          {!canPasswordDelete && !canExternalDelete && <p className="field-note">No supported reauthentication method is connected.</p>}
+        </div>}
+        {reauthToken && <p className="quiet-status" role="status"><span className="status-dot connected" aria-hidden="true" /><span>Identity confirmed for this deletion.</span></p>}
+        <label><span>Type DELETE to confirm</span><input autoComplete="off" spellCheck={false} value={deletionConfirmation} onChange={(event) => setDeletionConfirmation(event.target.value)} /></label>
+        <div className="inline-actions"><button type="button" className="button secondary" disabled={busy === "delete"} onClick={() => { setDeletionOpen(false); setDeletionConfirmation(""); setDeletionPassword(""); }}>Cancel</button><button className="button danger" disabled={busy === "delete" || deletionConfirmation !== "DELETE" || !deletionAuthorized}>{busy === "delete" ? "Deleting account…" : "Delete account permanently"}</button></div>
+      </form>}
+    </section>
+  </main>;
+}
+
+export function DeletedAccount() {
+  return <main className="center-page"><PageBrand label="connect" /><section className="auth-panel"><p className="eyebrow">Account deleted</p><h1>Your account has been deleted.</h1><p>Hosted data and access credentials were removed. Any local collection and mirror files remain on your computers.</p><a className="button secondary auth-complete-action" href="/login">Return to sign in</a></section></main>;
+}
+
+function StorageRow({ collection }: { collection: AccountData["storage"]["collections"][number] }) {
+  const usage = collection.usage;
+  const percentage = usage && usage.max_content_bytes > 0
+    ? Math.min(100, usage.content_bytes / usage.max_content_bytes * 100)
+    : 0;
+  return <div className="account-setting-row storage-collection-row">
+    <div><strong>{collection.display_name}</strong><small>{usage ? `${pluralLabel(usage.record_count, "record", "records")} · ${formatBytes(usage.content_bytes)} of ${formatBytes(usage.max_content_bytes)}` : "Usage temporarily unavailable"}</small></div>
+    {usage && <div className="storage-progress" role="progressbar" aria-label={`${collection.display_name} storage`} aria-valuemin={0} aria-valuemax={usage.max_content_bytes} aria-valuenow={usage.content_bytes}><span style={{ width: `${percentage}%` }} /></div>}
+  </div>;
+}
+
+function storageDetail(account: AccountData): string {
+  const collections = pluralLabel(account.storage.collections.length, "hosted collection", "hosted collections");
+  if (account.storage.status === "unavailable") return `${collections} · usage temporarily unavailable`;
+  const records = pluralLabel(account.storage.total_records ?? 0, "record", "records");
+  return `${collections} · ${records}${account.storage.status === "partial" ? " · partial usage" : ""}`;
+}
+
+function providerLabel(provider: "github" | "google") {
+  return provider === "github" ? "GitHub" : "Google";
+}
+
+function identityDescription(identity: AccountData["authentication"]["identities"][number]) {
+  if (identity.provider === "github" && identity.login) return `@${identity.login}`;
+  return identity.email ?? "Connected";
+}
+
+function formatBytes(value: number): string {
+  if (value < 1_024) return `${value} ${value === 1 ? "byte" : "bytes"}`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let amount = value;
+  let index = -1;
+  do {
+    amount /= 1_024;
+    index += 1;
+  } while (amount >= 1_024 && index < units.length - 1);
+  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: amount < 10 ? 1 : 0 }).format(amount)} ${units[index]}`;
+}

--- a/apps/portal/src/api.ts
+++ b/apps/portal/src/api.ts
@@ -29,6 +29,59 @@ export interface AccountSession {
   current: boolean;
 }
 
+export interface AccountData {
+  user: { id: string; name: string; email: string | null; login: string | null };
+  authentication: {
+    managed: boolean;
+    current_provider: "google" | "github" | "password" | "tailscale" | "session";
+    available_providers: {
+      github: boolean;
+      google: boolean;
+      password: boolean;
+    };
+    identities: Array<{
+      provider: "github" | "google";
+      subject: string;
+      login: string | null;
+      email: string | null;
+      email_verified: boolean;
+      linked_at: string;
+      current: boolean;
+      removable: boolean;
+    }>;
+    password: {
+      configured: boolean;
+      email: string | null;
+      current: boolean;
+      change_available: boolean;
+    };
+  };
+  storage: {
+    status: "available" | "partial" | "unavailable";
+    total_content_bytes: number | null;
+    total_records: number | null;
+    collections: Array<{
+      id: string;
+      display_name: string;
+      usage: null | {
+        collection_id: string;
+        record_count: number;
+        content_bytes: number;
+        max_records: number;
+        max_content_bytes: number;
+        max_document_bytes: number;
+      };
+    }>;
+  };
+  deletion: {
+    available: boolean;
+    hosted_collections: number;
+    local_collections: number;
+    computers: number;
+    development_confirmation: boolean;
+  };
+}
+
 export interface DashboardData {
   user: { id: string; name: string; email: string | null; login: string | null };
   hosted_collections_available?: boolean;

--- a/apps/portal/src/auth-view.tsx
+++ b/apps/portal/src/auth-view.tsx
@@ -579,6 +579,18 @@ interface GoogleAccountsApi {
 let googleLibrary: Promise<GoogleAccountsApi> | null = null;
 
 function GoogleSignIn({ returnTo, onError }: { returnTo: string; onError(value: string): void }) {
+  return <GoogleIdentityButton
+    startUrl={`/auth/google?return_to=${encodeURIComponent(returnTo)}`}
+    onComplete={(redirectTo) => { location.href = redirectTo; }}
+    onError={onError}
+  />;
+}
+
+export function GoogleIdentityButton({ startUrl, onComplete, onError }: {
+  startUrl: string;
+  onComplete(redirectTo: string): void;
+  onError(value: string): void;
+}) {
   const button = useRef<HTMLDivElement>(null);
   const [attempt, setAttempt] = useState(0);
   const [busy, setBusy] = useState(false);
@@ -589,9 +601,7 @@ function GoogleSignIn({ returnTo, onError }: { returnTo: string; onError(value: 
     async function prepare() {
       try {
         setReady(false);
-        const start = await api<{ client_id: string; nonce: string }>(
-          `/auth/google?return_to=${encodeURIComponent(returnTo)}`
-        );
+        const start = await api<{ client_id: string; nonce: string }>(startUrl);
         const google = await loadGoogleIdentityServices();
         if (!active || !button.current) return;
         button.current.replaceChildren();
@@ -608,7 +618,7 @@ function GoogleSignIn({ returnTo, onError }: { returnTo: string; onError(value: 
               headers: { "x-mdbase-auth": "google" },
               body: JSON.stringify({ credential: response.credential })
             }).then((result) => {
-              location.href = result.redirect_to;
+              onComplete(result.redirect_to);
             }).catch((reason) => {
               onError(message(reason));
               setBusy(false);
@@ -633,7 +643,7 @@ function GoogleSignIn({ returnTo, onError }: { returnTo: string; onError(value: 
     }
     void prepare();
     return () => { active = false; };
-  }, [attempt, onError, returnTo]);
+  }, [attempt, onComplete, onError, startUrl]);
 
   return <div className={`google-provider ${busy ? "busy" : ""}`} aria-busy={busy}>
     <div ref={button} className="google-button" />
@@ -659,4 +669,3 @@ function loadGoogleIdentityServices(): Promise<GoogleAccountsApi> {
   });
   return googleLibrary;
 }
-

--- a/apps/portal/src/dashboard-view.tsx
+++ b/apps/portal/src/dashboard-view.tsx
@@ -4,6 +4,7 @@ import {
   type ApplicationAccessGroup
 } from "@mdbase/connect-ui/access";
 import React, { useEffect, useState } from "react";
+import { AccountView } from "./account-view";
 import {
   api,
   ApiError,
@@ -13,30 +14,59 @@ import {
 import { ApprovalForm, RequestIdentity } from "./authorization-view";
 import {
   allOperations,
-  authenticationLabel,
   editorUrl,
   host,
   identityLabel,
-  initials,
   message,
   pluralLabel,
-  registrationLabel,
   relativeTime,
   scopeDescription
 } from "./portal-model";
 import {
-  AccountRow,
-  Brand,
   Empty,
   Loading,
-  SectionHeading,
-  ThemeSelect
+  MobileProductBar,
+  ProductSidebar,
+  SectionHeading
 } from "./portal-ui";
-import { SessionManager } from "./session-manager";
 
-export function Dashboard() {
+export type PortalView = "overview" | "requests" | "hosted" | "permissions" | "computers" | "account";
+
+const routeCopy: Record<Exclude<PortalView, "account">, { eyebrow: string; title: string; lede: string }> = {
+  overview: {
+    eyebrow: "Your account",
+    title: "Your connections.",
+    lede: "Hosted data, application access, and connected computers in one place."
+  },
+  requests: {
+    eyebrow: "Application requests",
+    title: "Review access requests.",
+    lede: "Approve the collection and exact actions an application can use."
+  },
+  hosted: {
+    eyebrow: "Hosted authority",
+    title: "Collections hosted by mdbase.",
+    lede: "Manage always-available Markdown collections and their local mirrors."
+  },
+  permissions: {
+    eyebrow: "Application access",
+    title: "Decide what apps can do.",
+    lede: "Review, narrow, or revoke access without changing the underlying collection."
+  },
+  computers: {
+    eyebrow: "Remote connection",
+    title: "Your connected computers.",
+    lede: "See which computers are available and revoke connections you no longer use."
+  }
+};
+
+export function Dashboard({ view = "overview", onNavigate }: {
+  view?: PortalView;
+  onNavigate(path: string): void;
+}) {
   const [data, setData] = useState<DashboardData | null>(null);
   const [error, setError] = useState("");
+  const [navigationOpen, setNavigationOpen] = useState(false);
 
   async function refresh() {
     try {
@@ -54,107 +84,148 @@ export function Dashboard() {
     const timer = window.setInterval(() => void refresh(), 5_000);
     return () => window.clearInterval(timer);
   }, []);
+
+  useEffect(() => {
+    if (!navigationOpen) return;
+    const close = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setNavigationOpen(false);
+    };
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [navigationOpen]);
+
+  useEffect(() => {
+    const label = view === "account" ? "Account" : routeCopy[view].title.replace(/\.$/, "");
+    document.title = `${label} · mdbase connect`;
+  }, [view]);
+
   if (!data) return <Loading error={error} />;
   const activeGrants = data.grants.filter((grant) => !grant.revoked_at);
   const applicationAccess = groupApplicationAccess(activeGrants);
+  const sidebarItems = [
+    { id: "overview", label: "Overview", href: "/" },
+    { id: "requests", label: "Requests", href: "/requests", count: data.pending_authorizations.length, attention: data.pending_authorizations.length > 0 },
+    { id: "hosted", label: "Hosted collections", href: "/hosted-collections", count: data.hosted_collections.length },
+    { id: "permissions", label: "App access", href: "/app-access", count: applicationAccess.length },
+    { id: "computers", label: "Computers", href: "/computers", count: data.connectors.length }
+  ];
+  const navigate = (_id: string, href: string) => {
+    setNavigationOpen(false);
+    onNavigate(href);
+  };
+  const copy = view === "account" ? null : routeCopy[view];
 
   return (
-    <div className="account-shell">
-      <header className="product-header account-header">
-        <div className="product-header-inner">
-          <Brand productLabel />
-          <div className="product-header-meta">
-            <a
-              className="portal-editor-link"
-              href={editorUrl()}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Open mdbase editor in a new tab"
-            >
-              <span className="portal-editor-link-label">Editor</span>
-              <span aria-hidden="true">↗</span>
-            </a>
-            <ThemeSelect />
-            <div className="product-header-meta-copy"><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></div>
-            <span className="product-avatar" aria-hidden="true">{initials(data.user.name)}</span>
-          </div>
-        </div>
-      </header>
-      <main className="account-main">
-        <header><p className="eyebrow">Your account</p><h1>Your connections.</h1><p>Approve application requests and manage the computers connected to your account.</p></header>
-        {error && <div className="message error">{error}</div>}
-        <section id="requests" aria-label="Access requests" className={data.pending_authorizations.length ? "attention-section" : "requests-clear"}>
-          {data.pending_authorizations.length === 0 ? <div className="quiet-status" role="status"><span className="status-dot connected" aria-hidden="true" /><span>No access requests waiting</span></div> : <>
-          <SectionHeading title="Access requests" note="A request expires automatically if you do nothing." count={data.pending_authorizations.length} />
-            <div className="request-list">{data.pending_authorizations.map((request) => (
-              <article className="request-row" key={request.id}>
-                <RequestIdentity request={request} />
-                <ApprovalForm
-                  request={request}
-                  canCreateHosted={data.hosted_collections_available !== false}
-                  collections={[
-                    ...(request.available_collections ?? []),
-                    ...data.hosted_collections
-                      .filter((collection) => collection.authority_state === "active")
-                      .map((collection) => ({
-                      ...collection,
-                      kind: "hosted" as const,
-                      connector_name: "Hosted by mdbase"
-                    }))
-                  ]}
-                  unavailableConnectors={request.unavailable_connectors}
-                  onDecision={refresh}
-                  onCollectionCreated={() => void refresh()}
-                />
-              </article>
-            ))}</div></>}
-        </section>
-        <section id="hosted">
-          <HostedCollections
-            collections={data.hosted_collections}
-            canCreate={data.hosted_collections_available !== false}
-            onChanged={refresh}
-            onError={setError}
-          />
-        </section>
-        <section id="permissions">
-          <SectionHeading title="Application access" note="Applications are grouped here; expand one to review its collection access." count={applicationAccess.length} />
-          {applicationAccess.length === 0 ? (
-            <Empty title="No applications connected" text="Approved website and downloaded application connections will appear here." />
-          ) : (
-            <div className="portal-application-list">{applicationAccess.map((group) => (
-              <PortalApplicationAccess
-                key={group.applicationId}
-                group={group}
-                collections={data.collections}
-                onChanged={refresh}
-                onError={setError}
-              />
-            ))}</div>
-          )}
-        </section>
-        <section id="computers">
-          <SectionHeading title="Connected computers" note="Revoking a computer immediately invalidates all of its application access." count={data.connectors.length} />
-          {data.connectors.length === 0 ? <Empty title="No computers connected" text="Open mdbase connect on a computer and choose Connect this computer." /> : (
-            <div className="computer-list">{data.connectors.map((connector) => {
-              const collections = data.collections.filter((collection) => collection.connector_id === connector.id);
-              const online = connector.last_seen_at !== null
-                && Date.now() - new Date(connector.last_seen_at).getTime() < 45_000;
-              return <ComputerRow key={connector.id} connector={connector} collectionCount={collections.length} availableCount={online ? collections.filter((collection) => collection.enabled).length : 0} onChanged={refresh} onError={setError} />;
-            })}</div>
-          )}
-        </section>
-        <section id="account">
-          <SectionHeading title="Account" note="Authentication and service details." />
-          <div className="account-rows"><AccountRow label="Authentication" value={authenticationLabel(data.authentication.provider)} detail={data.authentication.provider === "tailscale" ? "Controlled by your tailnet" : undefined} /><AccountRow label="Registration" value={registrationLabel(data.authentication.registration)} detail={data.authentication.registration === "open" ? "New identities may create an account" : data.authentication.registration === "invite" ? "New accounts require an invitation" : "New account creation is paused"} /></div>
-          {data.authentication.provider !== "tailscale" && <>
-            <SessionManager onError={setError} />
-            <button className="button secondary" onClick={() => void api("/v1/logout", { method: "POST" }).then(() => { location.href = "/login"; })}>Sign out</button>
-          </>}
-        </section>
-      </main>
+    <div className={`account-shell product-shell ${navigationOpen ? "navigation-open" : ""}`}>
+      <ProductSidebar
+        items={sidebarItems}
+        active={view}
+        account={data.user.name}
+        identity={identityLabel(data.user)}
+        editorHref={editorUrl()}
+        onNavigate={navigate}
+      />
+      <button className="product-sidebar-backdrop" aria-label="Close navigation" onClick={() => setNavigationOpen(false)} />
+      <div className="product-canvas portal-canvas">
+        <MobileProductBar open={navigationOpen} onOpen={() => setNavigationOpen(true)} />
+        {view === "account" ? <AccountView dashboard={data} /> : <main className="account-main portal-route-main">
+          <header><p className="eyebrow">{copy!.eyebrow}</p><h1>{copy!.title}</h1><p>{copy!.lede}</p></header>
+          {error && <div className="message error" role="alert">{error}</div>}
+          {view === "overview" && <OverviewPage data={data} applicationCount={applicationAccess.length} onNavigate={onNavigate} />}
+          {view === "requests" && <RequestsPage data={data} onChanged={refresh} />}
+          {view === "hosted" && <section><HostedCollections collections={data.hosted_collections} canCreate={data.hosted_collections_available !== false} onChanged={refresh} onError={setError} /></section>}
+          {view === "permissions" && <ApplicationAccessPage data={data} groups={applicationAccess} onChanged={refresh} onError={setError} />}
+          {view === "computers" && <ComputersPage data={data} onChanged={refresh} onError={setError} />}
+        </main>}
+      </div>
     </div>
   );
+}
+
+function OverviewPage({ data, applicationCount, onNavigate }: {
+  data: DashboardData;
+  applicationCount: number;
+  onNavigate(path: string): void;
+}) {
+  const onlineComputers = data.connectors.filter((connector) => connector.last_seen_at !== null
+    && Date.now() - new Date(connector.last_seen_at).getTime() < 45_000).length;
+  return <section>
+    <SectionHeading title="At a glance" note="Open a page to manage its details." />
+    <div className="portal-overview-list">
+      <OverviewRow href="/requests" label="Requests" value={String(data.pending_authorizations.length)} detail={data.pending_authorizations.length ? pluralLabel(data.pending_authorizations.length, "request waiting", "requests waiting") : "No requests waiting"} attention={data.pending_authorizations.length > 0} onNavigate={onNavigate} />
+      <OverviewRow href="/hosted-collections" label="Hosted collections" value={String(data.hosted_collections.length)} detail={data.hosted_collections.length ? "Authoritative on mdbase" : "No hosted collections"} onNavigate={onNavigate} />
+      <OverviewRow href="/app-access" label="App access" value={String(applicationCount)} detail={pluralLabel(applicationCount, "connected application", "connected applications")} onNavigate={onNavigate} />
+      <OverviewRow href="/computers" label="Computers" value={String(data.connectors.length)} detail={`${onlineComputers} online`} onNavigate={onNavigate} />
+    </div>
+  </section>;
+}
+
+function OverviewRow({ href, label, value, detail, attention = false, onNavigate }: {
+  href: string;
+  label: string;
+  value: string;
+  detail: string;
+  attention?: boolean;
+  onNavigate(path: string): void;
+}) {
+  return <a className="portal-overview-row" href={href} onClick={(event) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    onNavigate(href);
+  }}><div><strong>{label}</strong><small>{detail}</small></div><span className={attention ? "attention" : ""}>{value}</span><b>Open</b></a>;
+}
+
+function RequestsPage({ data, onChanged }: { data: DashboardData; onChanged(): Promise<void> }) {
+  return <section aria-label="Access requests" className={data.pending_authorizations.length ? "attention-section" : ""}>
+    <SectionHeading title="Waiting for approval" note="Requests expire automatically if you do nothing." count={data.pending_authorizations.length} />
+    {data.pending_authorizations.length === 0 ? <Empty title="No access requests" text="New application requests will appear here for an explicit decision." /> : <div className="request-list">{data.pending_authorizations.map((request) => (
+      <article className="request-row" key={request.id}>
+        <RequestIdentity request={request} />
+        <ApprovalForm
+          request={request}
+          canCreateHosted={data.hosted_collections_available !== false}
+          collections={[
+            ...(request.available_collections ?? []),
+            ...data.hosted_collections
+              .filter((collection) => collection.authority_state === "active")
+              .map((collection) => ({ ...collection, kind: "hosted" as const, connector_name: "Hosted by mdbase" }))
+          ]}
+          unavailableConnectors={request.unavailable_connectors}
+          onDecision={onChanged}
+          onCollectionCreated={() => void onChanged()}
+        />
+      </article>
+    ))}</div>}
+  </section>;
+}
+
+function ApplicationAccessPage({ data, groups, onChanged, onError }: {
+  data: DashboardData;
+  groups: ApplicationAccessGroup<DashboardData["grants"][number]>[];
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  return <section>
+    <SectionHeading title="Connected applications" note="Expand an application to review its collection access." count={groups.length} />
+    {groups.length === 0 ? <Empty title="No applications connected" text="Approved website and downloaded application connections will appear here." /> : <div className="portal-application-list">{groups.map((group) => (
+      <PortalApplicationAccess key={group.applicationId} group={group} collections={data.collections} onChanged={onChanged} onError={onError} />
+    ))}</div>}
+  </section>;
+}
+
+function ComputersPage({ data, onChanged, onError }: {
+  data: DashboardData;
+  onChanged(): Promise<void>;
+  onError(value: string): void;
+}) {
+  return <section>
+    <SectionHeading title="Computers" note="Revoking a computer immediately invalidates all of its application access." count={data.connectors.length} />
+    {data.connectors.length === 0 ? <Empty title="No computers connected" text="Open mdbase connect on a computer and choose Connect this computer." /> : <div className="computer-list">{data.connectors.map((connector) => {
+      const collections = data.collections.filter((collection) => collection.connector_id === connector.id);
+      const online = connector.last_seen_at !== null && Date.now() - new Date(connector.last_seen_at).getTime() < 45_000;
+      return <ComputerRow key={connector.id} connector={connector} collectionCount={collections.length} availableCount={online ? collections.filter((collection) => collection.enabled).length : 0} onChanged={onChanged} onError={onError} />;
+    })}</div>}
+  </section>;
 }
 
 function HostedCollections({ collections, canCreate, onChanged, onError }: {

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -4,7 +4,7 @@ import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
 import "@mdbase/connect-ui/styles.css";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   ForgotPassword,
@@ -12,6 +12,7 @@ import {
   ResetPassword,
   Signup
 } from "./auth-view";
+import { DeletedAccount } from "./account-view";
 import {
   AuthorityAdoption,
   AuthorityTransfer,
@@ -19,26 +20,47 @@ import {
   Pairing
 } from "./authority-workflows";
 import { Authorization, DeviceAuthorization } from "./authorization-view";
-import { Dashboard } from "./dashboard-view";
+import { Dashboard, type PortalView } from "./dashboard-view";
 import "./styles.css";
 
+const dashboardViews: Record<string, PortalView> = {
+  "/": "overview",
+  "/requests": "requests",
+  "/hosted-collections": "hosted",
+  "/app-access": "permissions",
+  "/computers": "computers",
+  "/account": "account"
+};
+
 function Portal() {
-  const pairingId = location.pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
-  const mirrorPairingId = location.pathname.match(/^\/mirror\/([0-9a-f-]+)$/i)?.[1];
-  const authorityAdoptionId = location.pathname.match(/^\/adopt\/([0-9a-f-]+)$/i)?.[1];
-  const authorityTransferId = location.pathname.match(/^\/transfer\/([0-9a-f-]+)$/i)?.[1];
-  const authorizationId = location.pathname.match(/^\/authorize\/([0-9a-f-]+)$/i)?.[1];
-  if (location.pathname === "/login") return <Login />;
-  if (location.pathname === "/signup") return <Signup />;
-  if (location.pathname === "/forgot-password") return <ForgotPassword />;
-  if (location.pathname === "/reset-password") return <ResetPassword />;
-  if (location.pathname === "/device") return <DeviceAuthorization />;
+  const [pathname, setPathname] = useState(location.pathname);
+  useEffect(() => {
+    const update = () => setPathname(location.pathname);
+    window.addEventListener("popstate", update);
+    return () => window.removeEventListener("popstate", update);
+  }, []);
+
+  const pairingId = pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
+  const mirrorPairingId = pathname.match(/^\/mirror\/([0-9a-f-]+)$/i)?.[1];
+  const authorityAdoptionId = pathname.match(/^\/adopt\/([0-9a-f-]+)$/i)?.[1];
+  const authorityTransferId = pathname.match(/^\/transfer\/([0-9a-f-]+)$/i)?.[1];
+  const authorizationId = pathname.match(/^\/authorize\/([0-9a-f-]+)$/i)?.[1];
+  if (pathname === "/login") return <Login />;
+  if (pathname === "/signup") return <Signup />;
+  if (pathname === "/forgot-password") return <ForgotPassword />;
+  if (pathname === "/reset-password") return <ResetPassword />;
+  if (pathname === "/device") return <DeviceAuthorization />;
   if (pairingId) return <Pairing pairingId={pairingId} />;
   if (mirrorPairingId) return <MirrorPairing pairingId={mirrorPairingId} />;
   if (authorityAdoptionId) return <AuthorityAdoption adoptionId={authorityAdoptionId} />;
   if (authorityTransferId) return <AuthorityTransfer transferId={authorityTransferId} />;
   if (authorizationId) return <Authorization requestId={authorizationId} />;
-  return <Dashboard />;
+  if (pathname === "/account-deleted") return <DeletedAccount />;
+  return <Dashboard view={dashboardViews[pathname] ?? "overview"} onNavigate={(nextPath) => {
+    if (location.pathname !== nextPath) history.pushState({}, "", nextPath);
+    setPathname(nextPath);
+    window.scrollTo(0, 0);
+  }} />;
 }
 
 createRoot(document.getElementById("root")!).render(<React.StrictMode><Portal /></React.StrictMode>);

--- a/apps/portal/src/portal-ui.tsx
+++ b/apps/portal/src/portal-ui.tsx
@@ -9,11 +9,84 @@ import {
   saveThemePreference,
   type ThemePreference
 } from "@mdbase/connect-ui/theme";
-import { useEffect, useState } from "react";
+import { type MouseEvent, useEffect, useRef, useState } from "react";
+
+const themeChoices: Array<{ value: ThemePreference; label: string }> = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" }
+];
+
+export interface ProductSidebarItem {
+  id: string;
+  label: string;
+  href?: string;
+  count?: number;
+  attention?: boolean;
+}
+
+export function ProductSidebar({ items, active, account, identity, editorHref, accountHref = "/account", onNavigate }: {
+  items: ProductSidebarItem[];
+  active: string;
+  account: string;
+  identity: string;
+  editorHref: string;
+  accountHref?: string;
+  onNavigate(id: string, href: string): void;
+}) {
+  const follow = (event: MouseEvent<HTMLAnchorElement>, id: string, href: string) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    onNavigate(id, href);
+  };
+  return <aside id="product-navigation" className="product-sidebar">
+    <div className="product-sidebar-brand"><Brand productLabel /></div>
+    <nav className="product-sidebar-nav" aria-label="mdbase connect navigation">
+      {items.map((item) => <a
+        key={item.id}
+        className={`product-sidebar-link ${active === item.id ? "active" : ""}`}
+        href={item.href ?? `/${item.id}`}
+        aria-current={active === item.id ? "page" : undefined}
+        onClick={(event) => follow(event, item.id, item.href ?? `/${item.id}`)}
+      >
+        <span>{item.label}</span>
+        {item.count !== undefined && <b className={`product-sidebar-count ${item.attention ? "attention" : ""}`}>{item.count}</b>}
+      </a>)}
+    </nav>
+    <footer className="product-sidebar-footer">
+      <div className="product-sidebar-footer-nav">
+        <a
+          className={`product-sidebar-link ${active === "account" ? "active" : ""}`}
+          href={accountHref}
+          aria-current={active === "account" ? "page" : undefined}
+          onClick={(event) => follow(event, "account", accountHref)}
+        >Account</a>
+      </div>
+      <div className="product-sidebar-account">
+        <span className="product-sidebar-account-copy"><strong>{account}</strong><small>{identity}</small></span>
+        <ThemeMenu placement="up" />
+      </div>
+      <div className="product-sidebar-utilities">
+        <a className="product-sidebar-utility" href={editorHref} target="_blank" rel="noreferrer">Open editor <span aria-hidden="true">↗</span></a>
+      </div>
+    </footer>
+  </aside>;
+}
+
+export function MobileProductBar({ open, onOpen }: { open: boolean; onOpen(): void }) {
+  return <header className="mobile-product-bar">
+    <Brand productLabel />
+    <button className="mobile-navigation-button" aria-label="Open navigation" aria-controls="product-navigation" aria-expanded={open} onClick={onOpen}><span /></button>
+  </header>;
+}
 
 export function AccountRow({ label, value, detail, mono = false }: { label: string; value: string; detail?: string; mono?: boolean }) { return <div className="account-row"><span>{label}</span><div><strong className={mono ? "mono" : ""}>{value}</strong>{detail && <small>{detail}</small>}</div></div>; }
-export function ThemeSelect() {
+export function ThemeMenu({ placement = "down" }: { placement?: "up" | "down" }) {
   const [preference, setPreference] = useState<ThemePreference>(loadThemePreference);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   useEffect(() => {
     applyThemePreference(preference);
     if (preference !== "system") return;
@@ -22,11 +95,77 @@ export function ThemeSelect() {
     media.addEventListener("change", update);
     return () => media.removeEventListener("change", update);
   }, [preference]);
-  return <select className="theme-select" aria-label="Color theme" value={preference} onChange={(event) => {
-    const next = event.target.value as ThemePreference;
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: Event) => {
+      if (event.target instanceof Node && !containerRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    document.addEventListener("focusin", closeOutside);
+    const frame = requestAnimationFrame(() => {
+      optionRefs.current[themeChoices.findIndex(({ value }) => value === preference)]?.focus();
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("pointerdown", closeOutside);
+      document.removeEventListener("focusin", closeOutside);
+    };
+  }, [open, preference]);
+
+  function choose(next: ThemePreference) {
     setPreference(next);
     saveThemePreference(next);
-  }}><option value="system">System</option><option value="light">Light</option><option value="dark">Dark</option></select>;
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function moveFocus(event: React.KeyboardEvent<HTMLDivElement>) {
+    const current = optionRefs.current.findIndex((option) => option === document.activeElement);
+    let next = current;
+    if (event.key === "ArrowDown") next = (current + 1) % themeChoices.length;
+    else if (event.key === "ArrowUp") next = (current - 1 + themeChoices.length) % themeChoices.length;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = themeChoices.length - 1;
+    else if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+      return;
+    } else return;
+    event.preventDefault();
+    optionRefs.current[next]?.focus();
+  }
+
+  const label = themeChoices.find(({ value }) => value === preference)?.label ?? "System";
+  return <div className={`theme-menu theme-menu-${placement}`} ref={containerRef}>
+    <button
+      ref={triggerRef}
+      type="button"
+      className="theme-menu-trigger"
+      aria-label={`Color theme: ${label}`}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      title={`Color theme: ${label}`}
+      onClick={() => setOpen((value) => !value)}
+    ><ThemeGlyph preference={preference} /></button>
+    {open && <div className="theme-menu-popover" role="menu" aria-label="Color theme" onKeyDown={moveFocus}>
+      {themeChoices.map((choice, index) => <button
+        key={choice.value}
+        ref={(element) => { optionRefs.current[index] = element; }}
+        type="button"
+        className="theme-menu-option"
+        role="menuitemradio"
+        aria-checked={preference === choice.value}
+        onClick={() => choose(choice.value)}
+      >
+        <ThemeGlyph preference={choice.value} />
+        <span>{choice.label}</span>
+        <svg className="theme-menu-check" viewBox="0 0 16 16" aria-hidden="true"><path d="m3.5 8.2 2.8 2.8 6.2-6.3" /></svg>
+      </button>)}
+    </div>}
+  </div>;
 }
 export function useSystemTheme() {
   useEffect(() => {
@@ -37,10 +176,15 @@ export function useSystemTheme() {
     return () => media.removeEventListener("change", update);
   }, []);
 }
-export function PageBrand({ label, themePicker = true }: { label: string; themePicker?: boolean }) { return <div className="page-brand-row"><div className="page-brand"><Brand /><span>{label}</span></div>{themePicker && <ThemeSelect />}</div>; }
+export function PageBrand({ label, themePicker = true }: { label: string; themePicker?: boolean }) { return <div className="page-brand-row"><div className="page-brand"><Brand /><span>{label}</span></div>{themePicker && <ThemeMenu />}</div>; }
 export function Brand({ productLabel = false }: { productLabel?: boolean }) { return <div className="product-brand"><MdbaseMark /><strong>mdbase</strong>{productLabel && <span className="product-brand-label">connect</span>}</div>; }
 function MdbaseMark() { return <svg className="product-brand-mark" viewBox={MDBASE_MARK_VIEW_BOX} aria-hidden="true" focusable="false"><g className="product-brand-mark-ink">{mdbaseMarkInkRects.map((rect) => <rect key={`${rect.x}-${rect.y}`} {...rect} />)}</g><rect className="product-brand-mark-accent" {...mdbaseMarkAccentRect} /></svg>; }
 export function SectionHeading({ title, note, count }: { title: string; note: string; count?: number }) { return <div className="section-heading"><div><h2>{title}</h2><p>{note}</p></div>{count !== undefined && <span>{count}</span>}</div>; }
 export function Empty({ title, text }: { title: string; text: string }) { return <div className="empty"><span className="empty-folder" /><strong>{title}</strong><p>{text}</p></div>; }
 export function Loading({ error = "" }: { error?: string }) { return <main className="loading"><Brand /><p>{error || "Opening mdbase connect…"}</p></main>; }
 
+function ThemeGlyph({ preference }: { preference: ThemePreference }) {
+  if (preference === "light") return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="3" /><path d="M10 2.4v1.2M10 16.4v1.2M2.4 10h1.2M16.4 10h1.2M4.6 4.6l.9.9M14.5 14.5l.9.9M15.4 4.6l-.9.9M5.5 14.5l-.9.9" /></svg>;
+  if (preference === "dark") return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><path d="M16.3 12.6A6.8 6.8 0 0 1 7.4 3.7 6.8 6.8 0 1 0 16.3 12.6Z" /></svg>;
+  return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><rect x="2.8" y="3.5" width="14.4" height="10.2" rx="1.5" /><path d="M7.2 16.5h5.6M10 13.7v2.8" /></svg>;
+}

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -39,28 +39,8 @@ body,
   min-height: 100vh;
 }
 
-.account-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.portal-editor-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  min-height: 2rem;
-  padding: 0 0.45rem;
-  border-radius: 3px;
-  color: var(--ink-soft);
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.portal-editor-link:hover {
-  color: var(--ink);
-  background: var(--paper-hover);
+.portal-canvas {
+  min-height: 100vh;
 }
 
 .account-main {
@@ -110,6 +90,10 @@ h1 {
   scroll-margin-top: 1.5rem;
 }
 
+.account-main > header {
+  scroll-margin-top: 1.5rem;
+}
+
 .account-main .requests-clear {
   margin-top: 1.8rem;
 }
@@ -150,6 +134,63 @@ h1 {
   color: var(--ink-muted);
   font-family: var(--mono);
   font-size: 0.66rem;
+}
+
+.portal-overview-list {
+  border-top: 1px solid var(--line);
+}
+
+.portal-overview-row {
+  min-height: 4.35rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 3.5rem;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.65rem 0.7rem;
+  border-bottom: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.portal-overview-row:hover {
+  background: var(--paper-hover);
+}
+
+.portal-overview-row > div {
+  min-width: 0;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.portal-overview-row strong {
+  font-size: 0.82rem;
+}
+
+.portal-overview-row small {
+  overflow: hidden;
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.portal-overview-row > span,
+.portal-overview-row > b {
+  color: var(--ink-muted);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  font-weight: 500;
+  text-align: right;
+}
+
+.portal-overview-row > span.attention {
+  color: var(--action);
+  font-weight: 700;
+}
+
+.portal-overview-row > b {
+  color: var(--ink-soft);
 }
 
 .computer-list,
@@ -689,6 +730,179 @@ h1 {
 .session-loading {
   padding: 1rem 0;
   border-bottom: 1px solid var(--line);
+}
+
+.account-management-main {
+  max-width: 62rem;
+}
+
+.account-loading {
+  margin-top: 2rem;
+  color: var(--ink-muted);
+  font-size: 0.78rem;
+}
+
+.account-setting-list {
+  border-top: 1px solid var(--line);
+}
+
+.account-setting-row {
+  min-height: 4.35rem;
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.account-setting-row > div:first-child,
+.account-setting-row-main > div:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.account-setting-row strong {
+  font-size: 0.82rem;
+}
+
+.account-setting-row small {
+  color: var(--ink-muted);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.account-setting-value {
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  text-align: right;
+}
+
+.account-setting-actions,
+.inline-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.account-setting-row-stack {
+  display: block;
+  padding: 0;
+}
+
+.account-setting-row-main {
+  min-height: 4.35rem;
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.65rem 0;
+}
+
+.inline-account-form,
+.account-deletion-form {
+  max-width: 36rem;
+  display: grid;
+  gap: 0.9rem;
+  padding: 0.4rem 0 1.25rem;
+}
+
+.inline-account-form label,
+.account-deletion-form label,
+.account-reauthentication label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.inline-account-form label > span,
+.account-deletion-form label > span,
+.account-reauthentication label > span {
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.storage-collection-row {
+  grid-template-columns: minmax(12rem, 1fr) minmax(7rem, 12rem);
+}
+
+.storage-progress {
+  height: 3px;
+  overflow: hidden;
+  background: var(--line);
+}
+
+.storage-progress span {
+  height: 100%;
+  display: block;
+  min-width: 1px;
+  background: var(--accent);
+}
+
+.account-sign-out {
+  margin-top: 1rem;
+}
+
+.danger-section {
+  padding-top: 0.25rem;
+}
+
+.danger-section .section-heading {
+  border-bottom-color: color-mix(in oklch, var(--danger) 35%, var(--line));
+}
+
+.button.danger {
+  border-color: color-mix(in oklch, var(--danger) 42%, var(--line));
+  color: var(--danger);
+}
+
+.button.quiet {
+  min-height: 2rem;
+  padding-inline: 0.55rem;
+  border-color: transparent;
+  color: var(--ink-muted);
+}
+
+.button.compact {
+  min-height: 2rem;
+  padding-inline: 0.65rem;
+}
+
+.deletion-effects {
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.deletion-effects p,
+.deletion-effects li,
+.account-reauthentication > p {
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.deletion-effects p {
+  margin-bottom: 0.55rem;
+}
+
+.deletion-effects ul {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0 0 0.75rem;
+  padding-left: 1.1rem;
+}
+
+.account-reauthentication {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0.85rem 0;
+}
+
+.account-reauthentication > strong {
+  font-size: 0.78rem;
 }
 
 .attention-section .section-heading {
@@ -1463,6 +1677,11 @@ select {
   border-color: color-mix(in oklch, var(--danger) 35%, var(--line));
 }
 
+.message.success {
+  color: var(--connected);
+  border-color: color-mix(in oklch, var(--connected) 35%, var(--line));
+}
+
 .center-page {
   display: grid;
   align-content: center;
@@ -1774,16 +1993,21 @@ select {
 }
 
 @media (max-width: 760px) {
-  .portal-editor-link-label {
-    display: none;
-  }
-
-  .account-header .product-header-meta-copy {
-    display: none;
-  }
-
   .account-main {
     padding: 2.5rem 1.5rem 4rem;
+  }
+
+  .account-main section,
+  .account-main > header {
+    scroll-margin-top: 4.5rem;
+  }
+
+  .portal-overview-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .portal-overview-row > b {
+    display: none;
   }
 
   h1,
@@ -1809,6 +2033,23 @@ select {
   .session-row > div:last-child {
     grid-column: 2;
     grid-row: 1 / span 2;
+  }
+
+  .account-setting-row,
+  .account-setting-row-main,
+  .storage-collection-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.65rem;
+    padding: 0.85rem 0;
+  }
+
+  .account-setting-actions,
+  .inline-actions {
+    justify-content: flex-start;
+  }
+
+  .account-setting-value {
+    text-align: left;
   }
 
   .hosted-summary {
@@ -1932,13 +2173,6 @@ select {
 
   .page-brand-row {
     margin-bottom: 2.3rem;
-  }
-}
-
-@media (max-width: 420px) {
-  .page-brand-row {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }
 

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -161,6 +161,10 @@ pub fn app(state: AppState) -> Router {
             patch(rename_collection).delete(delete_collection),
         )
         .route(
+            "/internal/v1/collections/{collection_id}/usage",
+            get(collection_usage),
+        )
+        .route(
             "/internal/v1/collections/{collection_id}/replicas",
             get(list_replicas).post(register_replica),
         )
@@ -341,6 +345,16 @@ async fn rename_collection(
         .rename_collection(collection_id, &input.display_name)
         .await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+async fn collection_usage(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let usage = state.provider.collection_usage(collection_id).await?;
+    Ok(Json(json!({ "usage": usage })))
 }
 
 async fn upsert_notification_grant(

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -172,6 +172,16 @@ pub struct ProviderCollection {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct ProviderCollectionUsage {
+    pub collection_id: Uuid,
+    pub record_count: u64,
+    pub content_bytes: u64,
+    pub max_records: u64,
+    pub max_content_bytes: u64,
+    pub max_document_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct ProviderReplicaStatus {
     pub id: Uuid,
     pub head: u64,

--- a/crates/connect-hosted-provider/src/provider/collections.rs
+++ b/crates/connect-hosted-provider/src/provider/collections.rs
@@ -1,6 +1,35 @@
 use super::*;
 
 impl HostedProvider {
+    pub async fn collection_usage(
+        &self,
+        collection_id: Uuid,
+    ) -> ApiResult<ProviderCollectionUsage> {
+        let row = sqlx::query(
+            r#"SELECT record_count, content_bytes, max_records,
+                      max_content_bytes, max_document_bytes
+               FROM hosted_provider_collections
+               WHERE id = $1 AND state <> 'deleting'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        Ok(ProviderCollectionUsage {
+            collection_id,
+            record_count: number(row.get::<i64, _>("record_count"), "record count")?,
+            content_bytes: number(row.get::<i64, _>("content_bytes"), "content size")?,
+            max_records: number(row.get::<i64, _>("max_records"), "record quota")?,
+            max_content_bytes: number(row.get::<i64, _>("max_content_bytes"), "content quota")?,
+            max_document_bytes: number(row.get::<i64, _>("max_document_bytes"), "document quota")?,
+        })
+    }
+
     pub async fn create_collection(
         &self,
         collection_id: Uuid,

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -7,6 +7,7 @@
   --color-canvas: oklch(99.5% 0.002 255);
   --color-surface: oklch(99.5% 0.002 255);
   --color-surface-subtle: oklch(97.5% 0.004 255);
+  --color-selected: oklch(96.4% 0.016 238);
   --color-text: oklch(21% 0.018 255);
   --color-text-soft: oklch(39% 0.016 255);
   --color-text-muted: oklch(54% 0.014 255);
@@ -21,6 +22,7 @@
   --color-scrim: oklch(20% 0.006 250 / 0.22);
   --paper: var(--color-surface);
   --hover: var(--color-surface-subtle);
+  --selected: var(--color-selected);
   --ink: var(--color-text);
   --ink-soft: var(--color-text-soft);
   --muted: var(--color-text-muted);
@@ -42,6 +44,7 @@
   --color-canvas: oklch(17.5% 0.012 255);
   --color-surface: oklch(19.5% 0.012 255);
   --color-surface-subtle: oklch(23.5% 0.014 255);
+  --color-selected: oklch(27% 0.035 238);
   --color-text: oklch(92% 0.008 255);
   --color-text-soft: oklch(80% 0.01 255);
   --color-text-muted: oklch(68% 0.012 255);
@@ -62,6 +65,7 @@
     --color-canvas: oklch(17.5% 0.012 255);
     --color-surface: oklch(19.5% 0.012 255);
     --color-surface-subtle: oklch(23.5% 0.014 255);
+    --color-selected: oklch(27% 0.035 238);
     --color-text: oklch(92% 0.008 255);
     --color-text-soft: oklch(80% 0.01 255);
     --color-text-muted: oklch(68% 0.012 255);
@@ -102,22 +106,105 @@ select {
   font: inherit;
 }
 
-.theme-select {
-  width: auto;
-  min-height: 2rem;
-  padding: 0 1.65rem 0 0.55rem;
-  border: 1px solid var(--line);
+.theme-menu {
+  position: relative;
+  display: inline-flex;
+  justify-self: end;
+}
+
+.theme-menu-trigger {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+  transition: color 160ms var(--ease), background-color 160ms var(--ease), border-color 160ms var(--ease);
+}
+
+.theme-menu-trigger:hover,
+.theme-menu-trigger[aria-expanded="true"] {
+  border-color: var(--line);
+  color: var(--ink);
+  background: var(--hover);
+}
+
+.theme-glyph {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.45;
+}
+
+.theme-menu-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  width: 138px;
+  display: grid;
+  gap: 1px;
+  padding: 4px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  background: var(--paper);
+  box-shadow: 0 10px 24px color-mix(in oklch, var(--ink) 10%, transparent);
+}
+
+.theme-menu-up .theme-menu-popover {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+
+.theme-menu-option {
+  width: 100%;
+  min-height: 32px;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) 14px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border: 0;
   border-radius: 3px;
   color: var(--ink-soft);
-  background: var(--paper);
-  font-family: var(--mono);
-  font-size: 0.66rem;
+  background: transparent;
+  font-size: 12px;
+  text-align: left;
   cursor: pointer;
 }
 
-.theme-select:hover {
-  border-color: var(--line-strong);
+.theme-menu-option:hover,
+.theme-menu-option:focus-visible {
   color: var(--ink);
+  background: var(--hover);
+}
+
+.theme-menu-option[aria-checked="true"] {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.theme-menu-check {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  opacity: 0;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+}
+
+.theme-menu-option[aria-checked="true"] .theme-menu-check {
+  opacity: 1;
 }
 
 button:focus-visible,
@@ -313,6 +400,268 @@ code,
 }
 
 .view-tab-count.attention { color: var(--action); }
+
+.product-shell {
+  width: 100%;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 208px minmax(0, 1fr);
+  background: var(--paper);
+}
+
+.product-sidebar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  min-width: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 22px 10px 14px;
+  border-right: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.product-sidebar-brand {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  padding: 0 9px;
+}
+
+.product-sidebar-nav {
+  display: grid;
+  gap: 2px;
+  margin-top: 35px;
+}
+
+.product-sidebar-link {
+  width: 100%;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: 4px;
+  color: var(--muted);
+  background: transparent;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.25;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 160ms var(--ease), background-color 160ms var(--ease);
+}
+
+.product-sidebar-link:hover {
+  color: var(--ink);
+  background: var(--hover);
+}
+
+.product-sidebar-link.active,
+.product-sidebar-link[aria-current="page"],
+.product-sidebar-link[aria-current="location"] {
+  color: var(--ink);
+  background: var(--selected);
+  font-weight: 700;
+}
+
+.product-sidebar-count {
+  flex: 0 0 auto;
+  color: var(--faint);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.product-sidebar-count.attention {
+  color: var(--action);
+}
+
+.product-sidebar-footer {
+  display: grid;
+  gap: 9px;
+  margin-top: auto;
+}
+
+.product-sidebar-footer-nav {
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.product-sidebar-status,
+.product-sidebar-account {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 7px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 6px 9px;
+}
+
+.product-sidebar-account {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+}
+
+.product-sidebar-status-copy,
+.product-sidebar-account-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.product-sidebar-status-copy strong,
+.product-sidebar-account-copy strong {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.product-sidebar-status-copy small,
+.product-sidebar-account-copy small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.product-sidebar-utilities {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 3px;
+}
+
+.product-sidebar-utility {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 4px;
+  color: var(--muted);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.product-sidebar-utility:hover {
+  color: var(--ink);
+  background: var(--hover);
+}
+
+.product-canvas {
+  min-width: 0;
+  background: var(--paper);
+}
+
+.mobile-product-bar,
+.product-sidebar-backdrop {
+  display: none;
+}
+
+.mobile-navigation-button {
+  width: 34px;
+  height: 34px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.mobile-navigation-button:hover {
+  color: var(--ink);
+  background: var(--hover);
+}
+
+.mobile-navigation-button span,
+.mobile-navigation-button::before,
+.mobile-navigation-button::after {
+  width: 15px;
+  height: 1px;
+  display: block;
+  background: currentColor;
+  content: "";
+}
+
+.mobile-navigation-button span {
+  margin-block: 4px;
+}
+
+@media (max-width: 760px) {
+  .product-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .product-sidebar {
+    position: fixed;
+    left: 0;
+    width: min(248px, calc(100vw - 48px));
+    box-shadow: 16px 0 40px oklch(20% 0.012 255 / 0.12);
+    transform: translateX(-102%);
+    visibility: hidden;
+    transition: transform 180ms var(--ease), visibility 0s linear 180ms;
+  }
+
+  .navigation-open .product-sidebar {
+    transform: translateX(0);
+    visibility: visible;
+    transition: transform 180ms var(--ease), visibility 0s;
+  }
+
+  .product-sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 20;
+    display: block;
+    border: 0;
+    background: var(--color-scrim);
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+    transition: opacity 180ms var(--ease), visibility 0s linear 180ms;
+  }
+
+  .navigation-open .product-sidebar-backdrop {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+    transition: opacity 180ms var(--ease), visibility 0s;
+  }
+
+  .mobile-product-bar {
+    position: sticky;
+    top: 0;
+    z-index: 15;
+    min-height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 0 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--paper);
+  }
+
+  .mobile-product-bar .product-brand-label {
+    display: inline;
+  }
+}
 
 @media (max-width: 600px) {
   .product-header-inner {

--- a/scripts/browser-accessibility.test.mjs
+++ b/scripts/browser-accessibility.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
-import { readFile, stat } from "node:fs/promises";
+import { mkdir, readFile, stat } from "node:fs/promises";
 import { extname, resolve, sep } from "node:path";
 import { chromium } from "@playwright/test";
 
@@ -8,6 +8,8 @@ const roots = {
   portal: resolve("apps/portal/dist"),
   desktop: resolve("apps/desktop/dist/renderer")
 };
+const screenshotDirectory = process.env.MDBASE_CONNECT_A11Y_SCREENSHOT_DIR;
+if (screenshotDirectory) await mkdir(screenshotDirectory, { recursive: true });
 const servers = await Promise.all(
   Object.values(roots).map((root) => serveStaticApplication(root))
 );
@@ -16,6 +18,8 @@ const browser = await chromium.launch({ headless: true });
 try {
   await auditPortalLogin();
   await auditPortalDashboard();
+  await auditPortalAccount();
+  await auditPortalAccountDeleted();
   await auditPortalColdStartAuthorization();
   await auditPortalDeviceAuthorization();
   await auditDesktopResumedAuthorization();
@@ -100,7 +104,185 @@ async function auditPortalDashboard() {
   });
   await page.goto(servers[0].origin);
   await page.getByRole("heading", { name: "Your connections." }).waitFor();
+  const portalNavigation = page.getByRole("navigation", { name: "mdbase connect navigation" });
+  await portalNavigation.waitFor();
+  await assertThemeMenu(page, "portal dashboard");
   await auditPage(page, "portal dashboard", { keyboard: true });
+
+  await portalNavigation.getByRole("link", { name: /^Requests/ }).click();
+  await page.getByRole("heading", { name: "Review access requests." }).waitFor();
+  assert.equal(new URL(page.url()).pathname, "/requests", "portal requests: stable route");
+  assert.equal(await portalNavigation.getByRole("link", { name: /^Requests/ }).getAttribute("aria-current"), "page");
+  await page.goBack();
+  await page.getByRole("heading", { name: "Your connections." }).waitFor();
+
+  for (const route of [
+    ["Requests", "/requests", "Review access requests."],
+    ["Hosted collections", "/hosted-collections", "Collections hosted by mdbase."],
+    ["App access", "/app-access", "Decide what apps can do."],
+    ["Computers", "/computers", "Your connected computers."]
+  ]) {
+    await portalNavigation.getByRole("link", { name: new RegExp(`^${route[0]}`) }).click();
+    await page.getByRole("heading", { name: route[2] }).waitFor();
+    assert.equal(new URL(page.url()).pathname, route[1], `portal ${route[0]}: stable route`);
+    assert.equal(
+      await portalNavigation.getByRole("link", { name: new RegExp(`^${route[0]}`) }).getAttribute("aria-current"),
+      "page",
+      `portal ${route[0]}: current page exposed`
+    );
+    await auditPage(page, `portal ${route[0].toLowerCase()}`);
+    if (screenshotDirectory) {
+      await page.screenshot({
+        path: resolve(screenshotDirectory, `portal-${route[0].toLowerCase().replaceAll(" ", "-")}.png`),
+        fullPage: true
+      });
+    }
+  }
+  await page.reload();
+  await page.getByRole("heading", { name: "Your connected computers." }).waitFor();
+  assert.equal(new URL(page.url()).pathname, "/computers", "portal route survives reload");
+  await portalNavigation.getByRole("link", { name: /^Overview/ }).click();
+  await page.getByRole("heading", { name: "Your connections." }).waitFor();
+  await assertResponsiveSidebar(page, "portal dashboard");
+  assert.deepEqual(errors, []);
+  await page.close();
+}
+
+async function auditPortalAccount() {
+  const page = await browser.newPage();
+  const errors = watchPageErrors(page);
+  await page.route("**/v1/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === "/v1/me") {
+      await route.fulfill({
+        json: {
+          user: {
+            id: "11111111-1111-4111-8111-111111111111",
+            name: "Example User",
+            email: "user@example.com",
+            login: "example"
+          },
+          hosted_collections_available: true,
+          authentication: { provider: "password", registration: "open" },
+          connectors: [],
+          collections: [],
+          hosted_collections: [],
+          grants: [],
+          pending_authorizations: []
+        }
+      });
+      return;
+    }
+    if (pathname === "/v1/account") {
+      await route.fulfill({
+        json: {
+          user: {
+            id: "11111111-1111-4111-8111-111111111111",
+            name: "Example User",
+            email: "user@example.com",
+            login: "example"
+          },
+          authentication: {
+            managed: true,
+            current_provider: "password",
+            available_providers: {
+              github: true,
+              google: true,
+              password: true
+            },
+            identities: [{
+              provider: "github",
+              subject: "12345",
+              login: "example",
+              email: null,
+              email_verified: false,
+              linked_at: "2026-07-31T01:02:03.000Z",
+              current: false,
+              removable: true
+            }],
+            password: {
+              configured: true,
+              email: "user@example.com",
+              current: true,
+              change_available: true
+            }
+          },
+          storage: {
+            status: "available",
+            total_content_bytes: 12_345,
+            total_records: 42,
+            collections: [{
+              id: "22222222-2222-4222-8222-222222222222",
+              display_name: "Research notes",
+              usage: {
+                collection_id: "22222222-2222-4222-8222-222222222222",
+                record_count: 42,
+                content_bytes: 12_345,
+                max_records: 100_000,
+                max_content_bytes: 1_073_741_824,
+                max_document_bytes: 2_097_152
+              }
+            }]
+          },
+          deletion: {
+            available: true,
+            hosted_collections: 1,
+            local_collections: 2,
+            computers: 1,
+            development_confirmation: false
+          }
+        }
+      });
+      return;
+    }
+    if (pathname === "/v1/account/sessions") {
+      await route.fulfill({ json: { sessions: [] } });
+      return;
+    }
+    await route.fulfill({ status: 404, json: { error: "not_found" } });
+  });
+  await page.goto(`${servers[0].origin}/account`);
+  await page.getByRole("heading", { name: "Account and storage." }).waitFor();
+  await expectText(page, "42 records");
+  assert.equal(
+    await page.getByRole("progressbar", { name: "Research notes storage" })
+      .getAttribute("aria-valuenow"),
+    "12345"
+  );
+  await auditPage(page, "portal account", { keyboard: true });
+  if (screenshotDirectory) {
+    await page.evaluate(() => scrollTo(0, 0));
+    await page.screenshot({
+      path: resolve(screenshotDirectory, "portal-account.png"),
+      fullPage: true
+    });
+  }
+  await page.getByRole("button", { name: "Change password" }).click();
+  await page.getByLabel("Current password").waitFor();
+  assert.equal(
+    await page.getByLabel("New password", { exact: true }).getAttribute("minlength"),
+    "15"
+  );
+  assert.equal(await page.getByLabel("Confirm new password").getAttribute("minlength"), "15");
+  await auditPage(page, "portal password change", { keyboard: true });
+  await page.getByRole("button", { name: "Cancel", exact: true }).click();
+  await page.getByLabel("Current password").waitFor({ state: "detached" });
+  await assertResponsiveSidebar(page, "portal account");
+  await page.getByRole("button", { name: "Delete account…" }).click();
+  await expectText(page, "Local files are never removed from your computers.");
+  await expectText(page, "Local collection and mirror files remain on your computers.");
+  assert.equal(
+    await page.getByRole("button", { name: "Delete account permanently" }).isDisabled(),
+    true
+  );
+  await auditPage(page, "portal account deletion", { keyboard: true });
+  if (screenshotDirectory) {
+    await page.evaluate(() => scrollTo(0, 0));
+    await page.screenshot({
+      path: resolve(screenshotDirectory, "portal-account-deletion.png"),
+      fullPage: true
+    });
+  }
   assert.deepEqual(errors, []);
   await page.close();
 }
@@ -229,6 +411,17 @@ async function auditDesktopResumedAuthorization() {
   await page.close();
 }
 
+async function auditPortalAccountDeleted() {
+  const page = await browser.newPage();
+  const errors = watchPageErrors(page);
+  await page.goto(`${servers[0].origin}/account-deleted`);
+  await page.getByRole("heading", { name: "Your account has been deleted." }).waitFor();
+  await expectText(page, "Any local collection and mirror files remain on your computers.");
+  await auditPage(page, "portal account deleted", { keyboard: true });
+  assert.deepEqual(errors, []);
+  await page.close();
+}
+
 async function auditDesktopRoutes() {
   const page = await browser.newPage();
   const errors = watchPageErrors(page);
@@ -270,6 +463,7 @@ async function auditDesktopRoutes() {
         configured: true,
         serverUrl: "https://connect.mdbase.dev"
       }),
+      openAccount: async () => undefined,
       accessSnapshot: async () => access,
       listActivity: async () => [],
       hostedSnapshot: async () => ({
@@ -293,7 +487,15 @@ async function auditDesktopRoutes() {
   await page.getByRole("button", { name: "Add existing folder" }).waitFor();
   await page.getByRole("button", { name: "Create collection" }).waitFor();
   await page.getByRole("button", { name: "Pause app access" }).waitFor();
+  await page.getByRole("navigation", { name: "mdbase connect navigation" }).waitFor();
   await auditPage(page, "desktop overview", { keyboard: true });
+  if (screenshotDirectory) {
+    await page.evaluate(() => scrollTo(0, 0));
+    await page.screenshot({
+      path: resolve(screenshotDirectory, "desktop-overview.png"),
+      fullPage: true
+    });
+  }
 
   for (const route of [
     ["Collections", "Your collections."],
@@ -308,8 +510,21 @@ async function auditDesktopRoutes() {
       await page.getByRole("button", { name: "Create collection" }).waitFor();
       await expectText(page, "View and find records · Create and edit records · Delete records");
     }
-    await auditPage(page, `desktop ${route[0].toLowerCase()}`);
+    if (route[0] === "Settings") {
+      await assertThemeMenu(page, "desktop settings");
+    }
+    await auditPage(page, `desktop ${route[0].toLowerCase()}`, {
+      keyboard: route[0] === "Settings"
+    });
+    if (screenshotDirectory && route[0] === "Settings") {
+      await page.evaluate(() => scrollTo(0, 0));
+      await page.screenshot({
+        path: resolve(screenshotDirectory, "desktop-settings.png"),
+        fullPage: true
+      });
+    }
   }
+  await assertResponsiveSidebar(page, "desktop application");
   assert.deepEqual(errors, []);
   await page.close();
 }
@@ -354,8 +569,82 @@ function desktopAuthorizationFixture(id) {
   };
 }
 
-async function expectText(page, value) {
-  await page.getByText(value, { exact: true }).waitFor();
+async function assertThemeMenu(page, label) {
+  const trigger = page.getByRole("button", { name: /^Color theme:/ }).first();
+  await trigger.waitFor();
+  assert.equal((await trigger.textContent())?.trim(), "", `${label}: trigger is icon only`);
+  assert.equal(await trigger.getAttribute("aria-expanded"), "false", `${label}: menu starts closed`);
+
+  await trigger.click();
+  assert.equal(await trigger.getAttribute("aria-expanded"), "true", `${label}: menu exposes open state`);
+  const menu = page.getByRole("menu", { name: "Color theme" });
+  await menu.waitFor();
+  assert.equal(await page.getByRole("menuitemradio").count(), 3, `${label}: every theme is available`);
+  await page.waitForFunction(() => document.activeElement?.getAttribute("role") === "menuitemradio");
+  if (screenshotDirectory) {
+    await page.screenshot({
+      path: resolve(screenshotDirectory, `${label.replaceAll(" ", "-")}-theme-menu.png`)
+    });
+  }
+
+  await page.keyboard.press("End");
+  const dark = page.getByRole("menuitemradio", { name: "Dark" });
+  assert.equal(await dark.evaluate((element) => element === document.activeElement), true, `${label}: keyboard focus reaches dark`);
+  await page.keyboard.press("Enter");
+  assert.equal(await page.locator("html").getAttribute("data-theme"), "dark", `${label}: dark theme applies`);
+  assert.equal(await trigger.getAttribute("aria-label"), "Color theme: Dark", `${label}: current theme is named`);
+  assert.equal(await trigger.getAttribute("aria-expanded"), "false", `${label}: selecting closes menu`);
+
+  await trigger.click();
+  await page.waitForFunction(() => document.activeElement?.getAttribute("role") === "menuitemradio");
+  if (screenshotDirectory) {
+    await page.screenshot({
+      path: resolve(screenshotDirectory, `${label.replaceAll(" ", "-")}-dark-theme-menu.png`)
+    });
+  }
+  await page.keyboard.press("Home");
+  await page.keyboard.press("Enter");
+  assert.equal(await page.locator("html").getAttribute("data-theme"), null, `${label}: system theme applies`);
+
+  await trigger.click();
+  await page.waitForFunction(() => document.activeElement?.getAttribute("role") === "menuitemradio");
+  await page.keyboard.press("Escape");
+  assert.equal(await trigger.getAttribute("aria-expanded"), "false", `${label}: Escape closes menu`);
+  assert.equal(await trigger.evaluate((element) => element === document.activeElement), true, `${label}: Escape restores trigger focus`);
+}
+
+async function assertResponsiveSidebar(page, label) {
+  const navigation = page.getByRole("navigation", { name: "mdbase connect navigation" });
+  await navigation.waitFor({ state: "visible" });
+  assert.equal(await navigation.isVisible(), true, `${label}: desktop sidebar visible`);
+  await page.setViewportSize({ width: 720, height: 820 });
+  await navigation.waitFor({ state: "hidden" });
+  assert.equal(await navigation.isVisible(), false, `${label}: mobile sidebar starts closed`);
+  const toggle = page.getByRole("button", { name: "Open navigation" });
+  await toggle.click();
+  assert.equal(await toggle.getAttribute("aria-expanded"), "true", `${label}: mobile navigation state exposed`);
+  await navigation.waitFor({ state: "visible" });
+  await page.waitForTimeout(220);
+  assert.equal(await navigation.isVisible(), true, `${label}: mobile sidebar opens`);
+  const navigationBounds = await navigation.boundingBox();
+  assert(
+    navigationBounds
+      && navigationBounds.x >= 0
+      && navigationBounds.x + navigationBounds.width <= 250,
+    `${label}: mobile sidebar finishes on screen (${JSON.stringify(navigationBounds)})`
+  );
+  if (screenshotDirectory) {
+    await page.screenshot({
+      path: resolve(
+        screenshotDirectory,
+        `${label.replaceAll(" ", "-")}-mobile-navigation.png`
+      )
+    });
+  }
+  await page.getByRole("button", { name: "Close navigation" }).click();
+  await navigation.waitFor({ state: "hidden" });
+  assert.equal(await navigation.isVisible(), false, `${label}: mobile sidebar closes`);
+  await page.setViewportSize({ width: 1280, height: 720 });
 }
 
 async function auditPage(page, label, options = {}) {
@@ -508,6 +797,10 @@ function watchPageErrors(page) {
     if (entry.type() === "error") errors.push(entry.text());
   });
   return errors;
+}
+
+async function expectText(page, value) {
+  await page.getByText(value, { exact: false }).first().waitFor();
 }
 
 async function serveStaticApplication(root) {

--- a/scripts/container-e2e.mjs
+++ b/scripts/container-e2e.mjs
@@ -41,6 +41,11 @@ try {
   const portal = await fetch(`${environment.serverUrl}/`);
   assert.equal(portal.status, 200);
   assert.match(await portal.text(), /mdbase/i);
+  const portalRoute = await fetch(`${environment.serverUrl}/app-access`, {
+    headers: { accept: "text/html" }
+  });
+  assert.equal(portalRoute.status, 200);
+  assert.match(await portalRoute.text(), /mdbase/i);
 
   phase("creating an isolated identity and completing real connector pairing");
   const session = await request("/v1/dev/session", {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -879,7 +879,7 @@ try {
   await stopConnectDaemon(desktopProfile, desktopDaemon);
 
   phase("exercising hosted lifecycle and writable enrollment in a real browser");
-  await portalLifecycleE2E(controlUrl, browserMirrorRoot);
+  await portalLifecycleE2E(controlUrl, provider.url, browserMirrorRoot);
 
   phase("moving hosted authority through the CLI and browser confirmation flow");
   await authorityPromotionCliE2E(
@@ -1256,6 +1256,15 @@ schema:
   await writerClient.sync();
   await readerClient.pull();
   assert.equal(findRecord(await readerClient.records(), recordId).frontmatter.title, "Created offline");
+  const storageUsage = await internalRequest(
+    provider.url,
+    `/internal/v1/collections/${collectionId}/usage`
+  );
+  assert.equal(storageUsage.usage.collection_id, collectionId);
+  assert.ok(storageUsage.usage.record_count >= 1);
+  assert.ok(storageUsage.usage.content_bytes > 0);
+  assert.equal(storageUsage.usage.max_records, 100_000);
+  assert.equal(storageUsage.usage.max_content_bytes, 1024 * 1024 * 1024);
   const forbiddenPlaintextColumns = await postgresQuery(
     `SELECT table_name || '.' || column_name
      FROM information_schema.columns
@@ -2295,7 +2304,7 @@ async function portableHostedFileE2E(controlUrl, cookie, collectionId, directory
   }
 }
 
-async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
+async function portalLifecycleE2E(controlUrl, providerUrl, browserMirrorDirectory) {
   const browser = await chromium.launch({ headless: true });
   let connector;
   try {
@@ -2303,6 +2312,11 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     await page.goto(`${controlUrl}/login`);
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByRole("heading", { name: "Your connections." })).toBeVisible();
+    await page
+      .getByRole("navigation", { name: "mdbase connect navigation" })
+      .getByRole("link", { name: /^Hosted collections/ })
+      .click();
+    await expect(page.getByRole("heading", { name: "Collections hosted by mdbase." })).toBeVisible();
 
     await page.getByRole("button", { name: "Create hosted collection" }).click();
     await expect(page.getByText(/Starts as a clean mdbase collection/)).toBeVisible();
@@ -2378,7 +2392,7 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     );
     assert.equal(browserStatus.state, "up_to_date");
 
-    await page.goto(controlUrl);
+    await page.goto(`${controlUrl}/hosted-collections`);
     const connectedRow = page.locator("article.hosted-row").filter({
       hasText: "Browser E2E collection"
     });
@@ -2400,6 +2414,60 @@ async function portalLifecycleE2E(controlUrl, browserMirrorDirectory) {
     page.once("dialog", (dialog) => dialog.accept());
     await renamedRow.getByRole("button", { name: "Delete" }).click();
     await expect(page.getByText("Browser renamed collection", { exact: true })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Create hosted collection" }).click();
+    await page.getByLabel("Collection name").fill("Account deletion collection");
+    await page.getByRole("button", { name: "Create collection" }).click();
+    const deletionCollection = page.locator("article.hosted-row").filter({
+      hasText: "Account deletion collection"
+    });
+    await expect(deletionCollection).toBeVisible();
+    const deletionDashboard = await page.evaluate(async () => {
+      const response = await fetch("/v1/me");
+      return response.json();
+    });
+    const deletionCollectionId = deletionDashboard.hosted_collections.find(
+      (collection) => collection.display_name === "Account deletion collection"
+    ).id;
+
+    await page.goto(`${controlUrl}/account`);
+    await expect(page.getByRole("heading", { name: "Account and storage." })).toBeVisible();
+    await expect(page.getByText("Account deletion collection", { exact: true })).toBeVisible();
+    const account = await page.evaluate(async () => {
+      const response = await fetch("/v1/account");
+      return response.json();
+    });
+    const accountCollection = account.storage.collections.find(
+      (collection) => collection.id === deletionCollectionId
+    );
+    assert.equal(account.storage.status, "available");
+    assert.equal(accountCollection.usage.collection_id, deletionCollectionId);
+    assert.equal(accountCollection.usage.max_content_bytes, 1024 * 1024 * 1024);
+    await page.getByRole("button", { name: "Delete account…" }).click();
+    await expect(page.getByText(/Local files are never removed/)).toBeVisible();
+    await expect(page.getByText(
+      "Local collection and mirror files remain on your computers.",
+      { exact: true }
+    )).toBeVisible();
+    await page.getByLabel("Type DELETE to confirm").fill("DELETE");
+    await page.getByRole("button", { name: "Delete account permanently" }).click();
+    await expect(page).toHaveURL(`${controlUrl}/account-deleted`);
+    await expect(page.getByRole("heading", { name: "Your account has been deleted." }))
+      .toBeVisible();
+    assert.equal(
+      (
+        await rawRequest(
+          providerUrl,
+          `/internal/v1/collections/${deletionCollectionId}/usage`,
+          { token: internalToken }
+        )
+      ).status,
+      404
+    );
+    assert.match(
+      await readFile(join(browserMirrorDirectory, "mdbase.yaml"), "utf8"),
+      /spec_version: 0\.3\.0/
+    );
   } finally {
     if (connector?.exitCode === null && connector.signalCode === null) connector.kill("SIGTERM");
     await browser.close();

--- a/services/server/migrations/0007_oauth_login_state_foundation.sql
+++ b/services/server/migrations/0007_oauth_login_state_foundation.sql
@@ -1,0 +1,14 @@
+-- mdbase:skip-if-table oauth_login_states
+-- Compatibility foundation for installations upgrading directly from beta.8,
+-- before OAuth login state was part of the frozen legacy baseline.
+
+CREATE TABLE oauth_login_states (
+  id uuid PRIMARY KEY,
+  provider text NOT NULL,
+  state_hash text NOT NULL UNIQUE,
+  return_to text NOT NULL,
+  code_verifier text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/server/migrations/0008_account_management.sql
+++ b/services/server/migrations/0008_account_management.sql
@@ -1,0 +1,33 @@
+ALTER TABLE oauth_login_states
+  ADD COLUMN IF NOT EXISTS purpose text NOT NULL DEFAULT 'login';
+
+ALTER TABLE oauth_login_states
+  ADD COLUMN IF NOT EXISTS account_user_id uuid REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE oauth_login_states
+  ADD COLUMN IF NOT EXISTS account_session_id uuid REFERENCES sessions(id) ON DELETE CASCADE;
+
+ALTER TABLE oauth_login_states
+  DROP CONSTRAINT IF EXISTS oauth_login_states_account_flow_check;
+
+ALTER TABLE oauth_login_states
+  ADD CONSTRAINT oauth_login_states_account_flow_check CHECK (
+    (purpose = 'login' AND account_user_id IS NULL AND account_session_id IS NULL)
+    OR
+    (purpose IN ('link', 'reauth_delete') AND account_user_id IS NOT NULL AND account_session_id IS NOT NULL)
+  );
+
+CREATE TABLE IF NOT EXISTS account_action_tokens (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  session_id uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  purpose text NOT NULL CHECK (purpose IN ('delete_account')),
+  token_hash text NOT NULL UNIQUE,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS account_action_tokens_active_idx
+  ON account_action_tokens(user_id, session_id, purpose, expires_at)
+  WHERE consumed_at IS NULL;

--- a/services/server/src/account-management.test.ts
+++ b/services/server/src/account-management.test.ts
@@ -1,0 +1,494 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+import { hashPassword } from "./password.js";
+import { tokenHash } from "./security.js";
+import type { HostedProviderClient } from "./hosted-provider.js";
+
+const resources: Array<() => Promise<void>> = [];
+const origin = "https://connect.example";
+const oldPassword = "a correct old password";
+const newPassword = "a much better new password";
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("account management", () => {
+  it("reports hosted-only usage, quotas, sign-in methods, and deletion impact", async () => {
+    const usage = vi.fn(async (collectionId: string) => ({
+      collection_id: collectionId,
+      record_count: 12,
+      content_bytes: 4_096,
+      max_records: 100_000,
+      max_content_bytes: 1_073_741_824,
+      max_document_bytes: 2_097_152
+    }));
+    const { app, db } = await fixture({
+      hostedCollections: true,
+      hostedProvider: fakeProvider({ collectionUsage: usage })
+    });
+    const account = await seedSession(db);
+    await seedPassword(db, account.userId, account.email, oldPassword);
+    await db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, contracts)
+       VALUES ($1, $2, 'Research', 'mdbase', '[]'::jsonb)`,
+      [randomUUID(), account.userId]
+    );
+    await db.query(
+      `INSERT INTO external_identities
+         (provider, subject, user_id, login, email, email_verified)
+       VALUES ('github', '12345', $1, 'person', NULL, false)`,
+      [account.userId]
+    );
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/account",
+      headers: { cookie: account.cookie }
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["cache-control"]).toBe("no-store");
+    expect(response.json()).toEqual(expect.objectContaining({
+      authentication: expect.objectContaining({
+        current_provider: "session",
+        identities: [expect.objectContaining({
+          provider: "github",
+          login: "person",
+          current: false,
+          removable: true
+        })],
+        password: expect.objectContaining({
+          configured: true,
+          email: account.email,
+          change_available: true
+        })
+      }),
+      storage: {
+        status: "available",
+        total_content_bytes: 4_096,
+        total_records: 12,
+        collections: [expect.objectContaining({
+          display_name: "Research",
+          usage: expect.objectContaining({ max_content_bytes: 1_073_741_824 })
+        })]
+      },
+      deletion: expect.objectContaining({ hosted_collections: 1 })
+    }));
+    expect(usage).toHaveBeenCalledTimes(1);
+  });
+
+  it("changes a password, preserves only the current session, and accepts only the new password", async () => {
+    const { app, db } = await fixture();
+    const first = await seedSession(db);
+    const current = await seedSession(db, {
+      userId: first.userId,
+      email: first.email,
+      clientName: "Current browser"
+    });
+    await seedPassword(db, first.userId, first.email, oldPassword);
+
+    const wrong = await app.inject({
+      method: "PATCH",
+      url: "/v1/account/password",
+      headers: { cookie: current.cookie, origin },
+      payload: { current_password: "not the password", new_password: newPassword }
+    });
+    expect(wrong.statusCode).toBe(401);
+
+    const changed = await app.inject({
+      method: "PATCH",
+      url: "/v1/account/password",
+      headers: { cookie: current.cookie, origin },
+      payload: { current_password: oldPassword, new_password: newPassword }
+    });
+    expect(changed.statusCode).toBe(200);
+    expect(changed.json()).toEqual({ ok: true, other_sessions_signed_out: true });
+    expect((await app.inject({
+      method: "GET", url: "/v1/me", headers: { cookie: first.cookie }
+    })).statusCode).toBe(401);
+    expect((await app.inject({
+      method: "GET", url: "/v1/me", headers: { cookie: current.cookie }
+    })).statusCode).toBe(200);
+    expect((await passwordLogin(app, first.email, oldPassword)).statusCode).toBe(401);
+    expect((await passwordLogin(app, first.email, newPassword)).statusCode).toBe(200);
+  });
+
+  it("links an explicitly authenticated GitHub identity without creating or merging accounts", async () => {
+    const { app, db } = await fixture({
+      githubAuth: {
+        ...githubConfig({ id: "12558714", login: "callumalpass" }),
+        allowedUserIds: new Set<string>()
+      }
+    });
+    await db.query(
+      "UPDATE authentication_settings SET registration_mode = 'closed' WHERE singleton = true"
+    );
+    const account = await seedSession(db);
+    const started = await app.inject({
+      method: "GET",
+      url: "/v1/account/identities/github/link?return_to=%2Faccount",
+      headers: { cookie: account.cookie }
+    });
+    expect(started.statusCode).toBe(302);
+    const authorization = new URL(started.headers.location!);
+    expect(authorization.searchParams.get("allow_signup")).toBe("false");
+    const completed = await completeGitHubFlow(app, started, account.cookie);
+    expect(completed.statusCode).toBe(302);
+    expect(completed.headers.location).toBe("/account?linked=github");
+    const users = await db.query<{ count: string }>("SELECT count(*)::text AS count FROM users");
+    expect(users.rows[0]?.count).toBe("1");
+    const identity = await db.query<{ user_id: string; login: string }>(
+      "SELECT user_id, login FROM external_identities WHERE provider = 'github'"
+    );
+    expect(identity.rows[0]).toEqual({ user_id: account.userId, login: "callumalpass" });
+  });
+
+  it("links a Google identity to the initiating account in closed registration mode", async () => {
+    const verifyCredential = vi.fn(async () => ({
+      id: "google-subject-1",
+      name: "Person Example",
+      email: "person@gmail.com",
+      emailVerified: true,
+      avatarUrl: null
+    }));
+    const { app, db } = await fixture({
+      googleAuth: {
+        clientId: "google-client-id.apps.googleusercontent.com",
+        allowedSubjects: new Set<string>(),
+        verifyCredential
+      }
+    });
+    await db.query(
+      "UPDATE authentication_settings SET registration_mode = 'closed' WHERE singleton = true"
+    );
+    const account = await seedSession(db);
+    await seedSession(db, { email: "person@gmail.com" });
+    const started = await app.inject({
+      method: "GET",
+      url: "/v1/account/identities/google/link?return_to=%2Faccount",
+      headers: { cookie: account.cookie }
+    });
+    expect(started.statusCode).toBe(200);
+    expect(started.json()).toEqual({
+      client_id: "google-client-id.apps.googleusercontent.com",
+      nonce: expect.stringMatching(/^nonce_/)
+    });
+    const oauthCookie = responseCookies(started)
+      .find((value) => value.includes("mdbase_oauth_google="))!;
+    const completed = await app.inject({
+      method: "POST",
+      url: "/auth/google/callback",
+      headers: {
+        cookie: `${account.cookie}; ${cookiePair(oauthCookie)}`,
+        origin,
+        "x-mdbase-auth": "google"
+      },
+      payload: { credential: "credential".repeat(20) }
+    });
+    expect(completed.statusCode).toBe(200);
+    expect(completed.json()).toEqual({ redirect_to: "/account?linked=google" });
+    expect(verifyCredential).toHaveBeenCalledWith(expect.objectContaining({
+      credential: "credential".repeat(20),
+      nonce: started.json().nonce
+    }));
+    const identity = await db.query<{ user_id: string; normalized_email: string }>(
+      "SELECT user_id, normalized_email FROM external_identities WHERE provider = 'google'"
+    );
+    expect(identity.rows[0]).toEqual({
+      user_id: account.userId,
+      normalized_email: "person@gmail.com"
+    });
+    const users = await db.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM users"
+    );
+    expect(users.rows[0]?.count).toBe("2");
+  });
+
+  it("binds an identity-link callback to the exact browser session that started it", async () => {
+    const { app, db } = await fixture({
+      githubAuth: githubConfig({ id: "12558714", login: "callumalpass" })
+    });
+    const first = await seedSession(db);
+    const second = await seedSession(db, {
+      userId: first.userId,
+      email: first.email,
+      clientName: "Other browser"
+    });
+    const started = await app.inject({
+      method: "GET",
+      url: "/v1/account/identities/github/link?return_to=%2Faccount",
+      headers: { cookie: first.cookie }
+    });
+    const rejected = await completeGitHubFlow(app, started, second.cookie);
+    expect(rejected.statusCode).toBe(403);
+    expect(rejected.json().error.code).toBe("account_reauthentication_required");
+    const identities = await db.query("SELECT subject FROM external_identities");
+    expect(identities.rows).toEqual([]);
+  });
+
+  it("refuses identity takeover, current-method removal, and removal of the final method", async () => {
+    const { app, db } = await fixture({
+      githubAuth: githubConfig({ id: "999", login: "claimed" })
+    });
+    const owner = await seedSession(db, { email: "owner@example.com" });
+    const other = await seedSession(db, { email: "other@example.com" });
+    await db.query(
+      `INSERT INTO external_identities
+         (provider, subject, user_id, login, email, email_verified)
+       VALUES ('github', '999', $1, 'claimed', NULL, false)`,
+      [owner.userId]
+    );
+    const started = await app.inject({
+      method: "GET",
+      url: "/v1/account/identities/github/link?return_to=%2Faccount",
+      headers: { cookie: other.cookie }
+    });
+    const conflict = await completeGitHubFlow(app, started, other.cookie);
+    expect(conflict.statusCode).toBe(409);
+    expect(conflict.json().error.code).toBe("identity_already_connected");
+
+    const finalMethod = await app.inject({
+      method: "DELETE",
+      url: "/v1/account/identities/github",
+      headers: { cookie: owner.cookie, origin }
+    });
+    expect(finalMethod.statusCode).toBe(409);
+    expect(finalMethod.json().error.code).toBe("last_identity");
+
+    await seedPassword(db, owner.userId, owner.email, oldPassword);
+    const githubSession = await seedSession(db, {
+      userId: owner.userId,
+      email: owner.email,
+      provider: "github"
+    });
+    const currentMethod = await app.inject({
+      method: "DELETE",
+      url: "/v1/account/identities/github",
+      headers: { cookie: githubSession.cookie, origin }
+    });
+    expect(currentMethod.statusCode).toBe(409);
+    expect(currentMethod.json().error.code).toBe("current_identity");
+  });
+
+  it("requires fresh external reauthentication, deletes hosted data first, and preserves local files semantically", async () => {
+    const deleteCollection = vi.fn(async () => undefined);
+    const { app, db } = await fixture({
+      githubAuth: githubConfig({ id: "12558714", login: "callumalpass" }),
+      hostedCollections: true,
+      hostedProvider: fakeProvider({ deleteCollection })
+    });
+    const account = await seedSession(db);
+    await db.query(
+      `INSERT INTO external_identities
+         (provider, subject, user_id, login, email, email_verified)
+       VALUES ('github', '12558714', $1, 'callumalpass', NULL, false)`,
+      [account.userId]
+    );
+    const hostedId = randomUUID();
+    await db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, contracts)
+       VALUES ($1, $2, 'Only hosted copy', 'mdbase', '[]'::jsonb)`,
+      [hostedId, account.userId]
+    );
+
+    const unconfirmed = await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin },
+      payload: { confirmation: "DELETE" }
+    });
+    expect(unconfirmed.statusCode).toBe(403);
+    expect(deleteCollection).not.toHaveBeenCalled();
+
+    const started = await app.inject({
+      method: "GET",
+      url: "/v1/account/reauth/github?return_to=%2Faccount",
+      headers: { cookie: account.cookie }
+    });
+    const reauthenticated = await completeGitHubFlow(app, started, account.cookie);
+    const redirect = new URL(reauthenticated.headers.location!, origin);
+    const token = new URLSearchParams(redirect.hash.slice(1)).get("delete_token")!;
+    expect(token).toMatch(/^act_/);
+
+    const deleted = await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin },
+      payload: { confirmation: "DELETE", reauth_token: token }
+    });
+    expect(deleted.statusCode).toBe(200);
+    expect(deleteCollection).toHaveBeenCalledWith(hostedId);
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows).toEqual([]);
+    const event = await db.query<{ user_id: string | null; metadata: Record<string, number> }>(
+      "SELECT user_id, metadata FROM audit_events WHERE event_type = 'account.deleted'"
+    );
+    expect(event.rows[0]).toEqual({
+      user_id: null,
+      metadata: { hosted_collections_deleted: 1, local_collections_preserved: 0 }
+    });
+    expect(responseCookies(deleted).join("\n")).toContain("Max-Age=0");
+  });
+
+  it("keeps the account intact when hosted-provider deletion fails", async () => {
+    const { app, db } = await fixture({
+      hostedCollections: true,
+      hostedProvider: fakeProvider({
+        deleteCollection: vi.fn(async () => { throw new Error("provider offline"); })
+      })
+    });
+    const account = await seedSession(db);
+    await seedPassword(db, account.userId, account.email, oldPassword);
+    await db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, contracts)
+       VALUES ($1, $2, 'Important', 'mdbase', '[]'::jsonb)`,
+      [randomUUID(), account.userId]
+    );
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin },
+      payload: { confirmation: "DELETE", current_password: oldPassword }
+    });
+    expect(response.statusCode).toBe(500);
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
+      .toHaveLength(1);
+  });
+});
+
+async function fixture(options: Partial<Parameters<typeof buildApp>[0]> = {}) {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  await db.query(
+    `INSERT INTO authentication_settings
+       (singleton, registration_mode, password_auth_enabled,
+        email_delivery_enabled, revision, updated_by, update_reason)
+     VALUES (true, 'open', true, false, 1, 'test', 'account tests')`
+  );
+  const { app } = await buildApp({
+    db,
+    publicUrl: origin,
+    registration: "open",
+    authRateLimitSecret: "account-test-rate-limit-secret-with-32-bytes",
+    ...options
+  });
+  resources.push(() => app.close());
+  return { app, db };
+}
+
+async function seedSession(
+  db: Awaited<ReturnType<typeof createDatabase>>,
+  options: {
+    userId?: string;
+    email?: string;
+    provider?: string;
+    clientName?: string;
+  } = {}
+) {
+  const userId = options.userId ?? randomUUID();
+  const email = options.email ?? "person@example.com";
+  if (!options.userId) {
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, $2, 'Person Example')",
+      [userId, email]
+    );
+  }
+  const token = `ses_${randomUUID()}_${randomUUID()}`;
+  await db.query(
+    `INSERT INTO sessions
+       (id, user_id, token_hash, provider, account_session_epoch,
+        expires_at, client_name)
+     SELECT $1, id, $3, $4, session_epoch,
+            now() + interval '30 days', $5
+     FROM users WHERE id = $2`,
+    [randomUUID(), userId, tokenHash(token), options.provider ?? "session", options.clientName ?? "Test browser"]
+  );
+  return { userId, email, cookie: `__Host-mdbase_session=${token}` };
+}
+
+async function seedPassword(
+  db: Awaited<ReturnType<typeof createDatabase>>,
+  userId: string,
+  email: string,
+  password: string
+) {
+  await db.query(
+    `INSERT INTO email_identities
+       (id, user_id, email, normalized_email, verified_at, is_primary)
+     VALUES ($1, $2, $3, $3, now(), true)`,
+    [randomUUID(), userId, email]
+  );
+  await db.query(
+    "INSERT INTO password_credentials (user_id, password_hash) VALUES ($1, $2)",
+    [userId, await hashPassword(password)]
+  );
+}
+
+function githubConfig(identity: { id: string; login: string }) {
+  return {
+    clientId: "github-client-id",
+    clientSecret: "github-client-secret",
+    allowedUserIds: new Set([identity.id]),
+    exchangeCode: async () => ({ ...identity, name: "Linked Person", email: null })
+  };
+}
+
+function fakeProvider(overrides: Record<string, unknown> = {}): HostedProviderClient {
+  return {
+    url: "https://provider.example",
+    collectionUsage: async (collectionId: string) => ({
+      collection_id: collectionId,
+      record_count: 0,
+      content_bytes: 0,
+      max_records: 100_000,
+      max_content_bytes: 1_073_741_824,
+      max_document_bytes: 2_097_152
+    }),
+    deleteCollection: async () => undefined,
+    revokeReplica: async () => undefined,
+    ...overrides
+  } as unknown as HostedProviderClient;
+}
+
+async function completeGitHubFlow(
+  app: Awaited<ReturnType<typeof buildApp>>["app"],
+  started: Awaited<ReturnType<Awaited<ReturnType<typeof buildApp>>["app"]["inject"]>>,
+  sessionCookie: string
+) {
+  const authorization = new URL(started.headers.location!);
+  const state = authorization.searchParams.get("state")!;
+  const oauthCookie = responseCookies(started)
+    .find((value) => value.includes("mdbase_oauth_github="))!;
+  return app.inject({
+    method: "GET",
+    url: `/auth/github/callback?code=code-1&state=${encodeURIComponent(state)}`,
+    headers: { cookie: `${sessionCookie}; ${cookiePair(oauthCookie)}` }
+  });
+}
+
+async function passwordLogin(
+  app: Awaited<ReturnType<typeof buildApp>>["app"],
+  email: string,
+  password: string
+) {
+  return app.inject({
+    method: "POST",
+    url: "/v1/auth/password/login",
+    headers: { origin },
+    payload: { email, password }
+  });
+}
+
+function responseCookies(response: { headers: Record<string, string | string[] | undefined> }): string[] {
+  const value = response.headers["set-cookie"];
+  return value ? (Array.isArray(value) ? value : [value]) : [];
+}
+
+function cookiePair(value: string): string {
+  return value.split(";", 1)[0];
+}

--- a/services/server/src/account-management.ts
+++ b/services/server/src/account-management.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from "node:crypto";
+import type {
+  DatabasePool,
+  DatabaseQueryable
+} from "./database-types.js";
+import type {
+  ExternalProvider,
+  VerifiedExternalIdentity
+} from "./external-auth.js";
+import {
+  EMAIL_NORMALIZATION_VERSION,
+  normalizeEmailAddress
+} from "./email-identity.js";
+import { audit } from "./platform/audit-events.js";
+import { randomToken, tokenHash } from "./security.js";
+
+export class ExternalIdentityConflictError extends Error {
+  constructor() {
+    super("That sign-in identity is already attached to another account.");
+    this.name = "ExternalIdentityConflictError";
+  }
+}
+
+export class IdentityRemovalForbiddenError extends Error {
+  constructor(public readonly code: "current_identity" | "last_identity") {
+    super(code === "current_identity"
+      ? "Sign in with another method before disconnecting the one used by this session."
+      : "Connect another sign-in method before disconnecting this one.");
+    this.name = "IdentityRemovalForbiddenError";
+  }
+}
+
+export class AccountDeletionAuthorizationError extends Error {
+  constructor() {
+    super("Confirm your identity again before deleting this account.");
+    this.name = "AccountDeletionAuthorizationError";
+  }
+}
+
+export interface AccountSignInMethodCounts {
+  external: number;
+  password: boolean;
+}
+
+export async function accountSignInMethodCounts(
+  db: DatabaseQueryable,
+  userId: string
+): Promise<AccountSignInMethodCounts> {
+  const result = await db.query<{
+    external_count: string | number;
+    password_configured: boolean;
+  }>(
+    `SELECT
+       (SELECT count(*) FROM external_identities WHERE user_id = $1) AS external_count,
+       EXISTS(SELECT 1 FROM password_credentials WHERE user_id = $1) AS password_configured`,
+    [userId]
+  );
+  return {
+    external: Number(result.rows[0]?.external_count ?? 0),
+    password: result.rows[0]?.password_configured === true
+  };
+}
+
+export async function linkExternalIdentity(
+  db: DatabasePool,
+  userId: string,
+  identity: VerifiedExternalIdentity
+): Promise<void> {
+  const normalizedEmail = identity.emailVerified && identity.email
+    ? safeNormalizedEmail(identity.email)
+    : null;
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const user = await connection.query(
+      "SELECT id FROM users WHERE id = $1 AND suspended_at IS NULL FOR UPDATE",
+      [userId]
+    );
+    if (!user.rows[0]) throw new ExternalIdentityConflictError();
+    const subject = await connection.query<{ user_id: string }>(
+      `SELECT user_id FROM external_identities
+       WHERE provider = $1 AND subject = $2
+       FOR UPDATE`,
+      [identity.provider, identity.subject]
+    );
+    if (subject.rows[0] && subject.rows[0].user_id !== userId) {
+      throw new ExternalIdentityConflictError();
+    }
+    const provider = await connection.query<{ subject: string }>(
+      `SELECT subject FROM external_identities
+       WHERE provider = $1 AND user_id = $2
+       FOR UPDATE`,
+      [identity.provider, userId]
+    );
+    if (provider.rows[0] && provider.rows[0].subject !== identity.subject) {
+      throw new ExternalIdentityConflictError();
+    }
+    await connection.query(
+      `INSERT INTO external_identities
+         (provider, subject, user_id, login, email, email_verified,
+          normalized_email, email_normalization_version, avatar_url, last_login_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+       ON CONFLICT(provider, subject) DO UPDATE SET
+         login = excluded.login,
+         email = excluded.email,
+         email_verified = excluded.email_verified,
+         normalized_email = excluded.normalized_email,
+         email_normalization_version = excluded.email_normalization_version,
+         avatar_url = excluded.avatar_url,
+         updated_at = now()`,
+      [
+        identity.provider,
+        identity.subject,
+        userId,
+        identity.login,
+        identity.email,
+        identity.emailVerified,
+        normalizedEmail,
+        normalizedEmail ? EMAIL_NORMALIZATION_VERSION : null,
+        identity.avatarUrl
+      ]
+    );
+    await audit(connection, userId, "identity.linked", identity.subject, {
+      provider: identity.provider
+    });
+    await connection.query("COMMIT");
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+function safeNormalizedEmail(value: string): string | null {
+  try {
+    return normalizeEmailAddress(value);
+  } catch {
+    return null;
+  }
+}
+
+export async function removeExternalIdentity(
+  db: DatabasePool,
+  userId: string,
+  provider: ExternalProvider,
+  currentProvider: string | undefined
+): Promise<boolean> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    await connection.query(
+      "SELECT id FROM users WHERE id = $1 FOR UPDATE",
+      [userId]
+    );
+    const identity = await connection.query<{ subject: string }>(
+      `SELECT subject FROM external_identities
+       WHERE user_id = $1 AND provider = $2
+       FOR UPDATE`,
+      [userId, provider]
+    );
+    if (!identity.rows[0]) {
+      await connection.query("ROLLBACK");
+      return false;
+    }
+    if (currentProvider === provider) {
+      throw new IdentityRemovalForbiddenError("current_identity");
+    }
+    const methods = await accountSignInMethodCounts(connection, userId);
+    if (methods.external + Number(methods.password) <= 1) {
+      throw new IdentityRemovalForbiddenError("last_identity");
+    }
+    await connection.query(
+      "DELETE FROM external_identities WHERE user_id = $1 AND provider = $2",
+      [userId, provider]
+    );
+    await connection.query(
+      `UPDATE sessions SET revoked_at = COALESCE(revoked_at, now())
+       WHERE user_id = $1 AND provider = $2`,
+      [userId, provider]
+    );
+    await audit(connection, userId, "identity.disconnected", identity.rows[0].subject, {
+      provider
+    });
+    await connection.query("COMMIT");
+    return true;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+export async function issueAccountActionToken(
+  db: DatabasePool,
+  userId: string,
+  sessionId: string,
+  purpose: "delete_account"
+): Promise<string> {
+  const token = randomToken("act");
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    await connection.query(
+      `UPDATE account_action_tokens SET consumed_at = now()
+       WHERE user_id = $1 AND session_id = $2 AND purpose = $3
+         AND consumed_at IS NULL`,
+      [userId, sessionId, purpose]
+    );
+    await connection.query(
+      `INSERT INTO account_action_tokens
+         (id, user_id, session_id, purpose, token_hash, expires_at)
+       VALUES ($1, $2, $3, $4, $5, now() + interval '10 minutes')`,
+      [randomUUID(), userId, sessionId, purpose, tokenHash(token)]
+    );
+    await audit(connection, userId, "account.reauthenticated", userId, {
+      purpose
+    });
+    await connection.query("COMMIT");
+    return token;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+export async function consumeAccountActionToken(
+  db: DatabaseQueryable,
+  userId: string,
+  sessionId: string,
+  purpose: "delete_account",
+  token: string
+): Promise<boolean> {
+  if (!token || token.length > 200) return false;
+  const consumed = await db.query(
+    `UPDATE account_action_tokens SET consumed_at = now()
+     WHERE user_id = $1 AND session_id = $2 AND purpose = $3
+       AND token_hash = $4 AND consumed_at IS NULL AND expires_at > now()
+     RETURNING id`,
+    [userId, sessionId, purpose, tokenHash(token)]
+  );
+  return Boolean(consumed.rows[0]);
+}

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -24,6 +24,7 @@ import type {
   RegistrationMode
 } from "./runtime-config.js";
 import { registerAccountOverviewRoute } from "./features/account/me-routes.js";
+import { registerAccountManagementRoutes } from "./features/account/management-routes.js";
 import { registerAccountSessionRoutes } from "./features/account/session-routes.js";
 import { registerApplicationRoutes } from "./features/applications/routes.js";
 import { registerExternalAuthRoutes } from "./features/auth/external-routes.js";
@@ -250,6 +251,18 @@ export async function buildApp(options: BuildOptions) {
     db: options.db,
     publicUrl,
     developmentAuth: options.devAuth
+  });
+  registerAccountManagementRoutes(app, {
+    db: options.db,
+    publicUrl,
+    authenticationPolicy,
+    tailscaleAuth: options.tailscaleAuth,
+    developmentAuth: options.devAuth,
+    passwordAuthenticationAvailable: Boolean(options.authRateLimitSecret),
+    githubAvailable: options.githubAuth !== undefined,
+    googleAvailable: options.googleAuth !== undefined,
+    hostedProvider: options.hostedProvider,
+    hostedReference
   });
   registerMirrorPairingRoutes(app, {
     db: options.db,

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -40,7 +40,9 @@ describe("database migrations", () => {
       "0004_separate_application_keys",
       "0005_notification_contract_versions",
       "0006_notification_event_ids",
-      "0007_beta_access_requests"
+      "0007_beta_access_requests",
+      "0007_oauth_login_state_foundation",
+      "0008_account_management"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -267,6 +269,8 @@ describe("database migrations", () => {
          'auth_rate_limit_buckets',
          'authentication_settings',
          'authentication_settings_history',
+         'oauth_login_states',
+         'account_action_tokens',
          'authority_adoption_requests',
          'operator_operations'
        )`
@@ -281,6 +285,8 @@ describe("database migrations", () => {
         "auth_rate_limit_buckets",
         "authentication_settings",
         "authentication_settings_history",
+        "oauth_login_states",
+        "account_action_tokens",
         "authority_adoption_requests",
         "operator_operations"
       ])
@@ -297,7 +303,9 @@ describe("database migrations", () => {
       "0004_separate_application_keys",
       "0005_notification_contract_versions",
       "0006_notification_event_ids",
-      "0007_beta_access_requests"
+      "0007_beta_access_requests",
+      "0007_oauth_login_state_foundation",
+      "0008_account_management"
     ]);
   });
 

--- a/services/server/src/features/account/management-routes.ts
+++ b/services/server/src/features/account/management-routes.ts
@@ -1,0 +1,334 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import {
+  AccountDeletionAuthorizationError,
+  accountSignInMethodCounts,
+  consumeAccountActionToken,
+  removeExternalIdentity
+} from "../../account-management.js";
+import type { AuthenticationPolicyStore } from "../../authentication-policy.js";
+import type { DatabasePool } from "../../database-types.js";
+import type { HostedAuthorityRegistry } from "../../hosted.js";
+import type {
+  HostedCollectionUsage,
+  HostedProviderClient
+} from "../../hosted-provider.js";
+import {
+  PasswordAccountService,
+  PasswordAuthenticationUnavailableError
+} from "../../password-auth.js";
+import { PASSWORD_MAX_UTF8_BYTES } from "../../password.js";
+import { audit } from "../../platform/audit-events.js";
+import { apiError } from "../../platform/http-errors.js";
+import {
+  requireSessionContext,
+  requireUser
+} from "../../platform/request-authentication.js";
+import { requireSameOrigin } from "../../platform/request-security.js";
+import { clearSessionCookies } from "../../platform/session-cookies.js";
+
+interface AccountManagementRoutesOptions {
+  db: DatabasePool;
+  publicUrl: string;
+  authenticationPolicy: AuthenticationPolicyStore;
+  tailscaleAuth?: boolean;
+  developmentAuth?: boolean;
+  passwordAuthenticationAvailable?: boolean;
+  githubAvailable?: boolean;
+  googleAvailable?: boolean;
+  hostedProvider?: HostedProviderClient;
+  hostedReference?: HostedAuthorityRegistry;
+}
+
+interface ExternalIdentityRow {
+  provider: "github" | "google";
+  subject: string;
+  login: string | null;
+  email: string | null;
+  email_verified: boolean;
+  created_at: Date | string;
+}
+
+interface HostedCollectionRow {
+  id: string;
+  display_name: string;
+}
+
+export function registerAccountManagementRoutes(
+  app: FastifyInstance,
+  options: AccountManagementRoutesOptions
+): void {
+  const passwordAccounts = new PasswordAccountService(
+    options.db,
+    options.authenticationPolicy
+  );
+
+  app.get("/v1/account", async (request, reply) => {
+    reply.header("cache-control", "no-store");
+    const user = await requireUser(
+      request,
+      reply,
+      options.db,
+      options.tailscaleAuth
+    );
+    if (!user) return;
+    const [identities, methods, passwordEmail, hostedCollections, counts, settings] =
+      await Promise.all([
+        options.db.query<ExternalIdentityRow>(
+          `SELECT provider, subject, login, email, email_verified, created_at
+           FROM external_identities
+           WHERE user_id = $1
+           ORDER BY provider`,
+          [user.id]
+        ),
+        accountSignInMethodCounts(options.db, user.id),
+        options.db.query<{ email: string }>(
+          `SELECT e.email FROM email_identities e
+           JOIN password_credentials p ON p.user_id = e.user_id
+           WHERE e.user_id = $1 AND e.is_primary = true
+             AND e.retired_at IS NULL`,
+          [user.id]
+        ),
+        options.db.query<HostedCollectionRow>(
+          `SELECT id, display_name FROM hosted_collections
+           WHERE user_id = $1 AND authority_state <> 'transferred'
+           ORDER BY display_name`,
+          [user.id]
+        ),
+        options.db.query<{
+          connectors: string | number;
+          local_collections: string | number;
+        }>(
+          `SELECT
+             (SELECT count(*) FROM connectors WHERE user_id = $1 AND revoked_at IS NULL) AS connectors,
+             (SELECT count(*) FROM collections WHERE user_id = $1 AND present = true) AS local_collections`,
+          [user.id]
+        ),
+        options.authenticationPolicy.current()
+      ]);
+    const storage = await storageSnapshot(
+      hostedCollections.rows,
+      options.hostedProvider,
+      request.log
+    );
+    const authenticationProvider = user.authentication_provider ?? (
+      options.tailscaleAuth ? "tailscale" : "session"
+    );
+    const methodCount = methods.external + Number(methods.password);
+    return {
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        login: user.login
+      },
+      authentication: {
+        managed: authenticationProvider !== "tailscale",
+        current_provider: authenticationProvider,
+        available_providers: {
+          github: options.githubAvailable === true,
+          google: options.googleAvailable === true,
+          password: settings.passwordAuthEnabled
+            && options.passwordAuthenticationAvailable === true
+        },
+        identities: identities.rows.map((identity) => ({
+          provider: identity.provider,
+          subject: identity.subject,
+          login: identity.login,
+          email: identity.email,
+          email_verified: identity.email_verified,
+          linked_at: new Date(identity.created_at).toISOString(),
+          current: authenticationProvider === identity.provider,
+          removable: authenticationProvider !== identity.provider && methodCount > 1
+        })),
+        password: {
+          configured: methods.password,
+          email: passwordEmail.rows[0]?.email ?? null,
+          current: authenticationProvider === "password",
+          change_available: methods.password
+            && settings.passwordAuthEnabled
+            && options.passwordAuthenticationAvailable === true
+        }
+      },
+      storage,
+      deletion: {
+        available: authenticationProvider !== "tailscale",
+        hosted_collections: hostedCollections.rows.length,
+        local_collections: Number(counts.rows[0]?.local_collections ?? 0),
+        computers: Number(counts.rows[0]?.connectors ?? 0),
+        development_confirmation: options.developmentAuth === true
+      }
+    };
+  });
+
+  app.patch("/v1/account/password", {
+    config: { rateLimit: { max: 5, timeWindow: "15 minutes" } }
+  }, async (request, reply) => {
+    requireSameOrigin(request, options.publicUrl);
+    const authenticated = await requireSessionContext(request, reply, options.db);
+    if (!authenticated) return;
+    const settings = await options.authenticationPolicy.current();
+    if (
+      !settings.passwordAuthEnabled
+      || options.passwordAuthenticationAvailable !== true
+    ) {
+      throw new PasswordAuthenticationUnavailableError();
+    }
+    const input = z.object({
+      current_password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES),
+      new_password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES)
+    }).strict().parse(request.body);
+    await passwordAccounts.changePassword({
+      userId: authenticated.user.id,
+      sessionId: authenticated.sessionId,
+      currentPassword: input.current_password,
+      newPassword: input.new_password
+    });
+    return { ok: true, other_sessions_signed_out: true };
+  });
+
+  app.delete("/v1/account/identities/:provider", async (request, reply) => {
+    requireSameOrigin(request, options.publicUrl);
+    const authenticated = await requireSessionContext(request, reply, options.db);
+    if (!authenticated) return;
+    const { provider } = z.object({
+      provider: z.enum(["github", "google"])
+    }).parse(request.params);
+    const removed = await removeExternalIdentity(
+      options.db,
+      authenticated.user.id,
+      provider,
+      authenticated.user.authentication_provider
+    );
+    if (!removed) {
+      return reply.code(404).send(apiError(
+        "identity_not_found",
+        "That sign-in method is no longer connected."
+      ));
+    }
+    return { ok: true };
+  });
+
+  app.delete("/v1/account", {
+    config: { rateLimit: { max: 5, timeWindow: "15 minutes" } }
+  }, async (request, reply) => {
+    requireSameOrigin(request, options.publicUrl);
+    const authenticated = await requireSessionContext(request, reply, options.db);
+    if (!authenticated) return;
+    const input = z.object({
+      confirmation: z.literal("DELETE"),
+      current_password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES).optional(),
+      reauth_token: z.string().min(1).max(200).optional()
+    }).strict().parse(request.body);
+    let authorized = options.developmentAuth === true;
+    if (!authorized && input.current_password) {
+      authorized = await passwordAccounts.verifyAccountPassword(
+        authenticated.user.id,
+        input.current_password
+      );
+    }
+    if (!authorized && input.reauth_token) {
+      authorized = await consumeAccountActionToken(
+        options.db,
+        authenticated.user.id,
+        authenticated.sessionId,
+        "delete_account",
+        input.reauth_token
+      );
+    }
+    if (!authorized) throw new AccountDeletionAuthorizationError();
+
+    const hosted = await options.db.query<HostedCollectionRow>(
+      "SELECT id, display_name FROM hosted_collections WHERE user_id = $1",
+      [authenticated.user.id]
+    );
+    await deleteHostedAuthorities(hosted.rows, options);
+    const localCount = await options.db.query<{ count: string | number }>(
+      "SELECT count(*) AS count FROM collections WHERE user_id = $1 AND present = true",
+      [authenticated.user.id]
+    );
+    await audit(
+      options.db,
+      authenticated.user.id,
+      "account.deleted",
+      authenticated.user.id,
+      {
+        hosted_collections_deleted: hosted.rows.length,
+        local_collections_preserved: Number(localCount.rows[0]?.count ?? 0)
+      }
+    );
+    await options.db.query("DELETE FROM users WHERE id = $1", [authenticated.user.id]);
+    clearSessionCookies(reply);
+    return { ok: true };
+  });
+}
+
+async function storageSnapshot(
+  collections: HostedCollectionRow[],
+  provider: HostedProviderClient | undefined,
+  log: { warn(value: unknown, message: string): void }
+) {
+  if (collections.length === 0) {
+    return {
+      status: "available" as const,
+      total_content_bytes: 0,
+      total_records: 0,
+      collections: []
+    };
+  }
+  if (!provider) {
+    return {
+      status: "unavailable" as const,
+      total_content_bytes: null,
+      total_records: null,
+      collections: collections.map((collection) => ({
+        ...collection,
+        usage: null
+      }))
+    };
+  }
+  const usage = await Promise.all(collections.map(async (collection) => {
+    try {
+      return await provider.collectionUsage(collection.id);
+    } catch (error) {
+      log.warn(
+        { error, collection_id: collection.id },
+        "Hosted storage usage is unavailable"
+      );
+      return null;
+    }
+  }));
+  const available = usage.filter(
+    (value): value is HostedCollectionUsage => value !== null
+  );
+  return {
+    status: available.length === collections.length
+      ? "available" as const
+      : available.length > 0
+        ? "partial" as const
+        : "unavailable" as const,
+    total_content_bytes: available.length > 0
+      ? available.reduce((total, value) => total + value.content_bytes, 0)
+      : null,
+    total_records: available.length > 0
+      ? available.reduce((total, value) => total + value.record_count, 0)
+      : null,
+    collections: collections.map((collection, index) => ({
+      ...collection,
+      usage: usage[index]
+    }))
+  };
+}
+
+async function deleteHostedAuthorities(
+  collections: HostedCollectionRow[],
+  options: AccountManagementRoutesOptions
+): Promise<void> {
+  await Promise.all(collections.map(async (collection) => {
+    if (options.hostedProvider) {
+      await options.hostedProvider.deleteCollection(collection.id);
+    } else if (options.hostedReference) {
+      await options.hostedReference.delete(collection.id);
+    }
+  }));
+}

--- a/services/server/src/features/auth/external-routes.ts
+++ b/services/server/src/features/auth/external-routes.ts
@@ -1,6 +1,15 @@
 import { randomUUID } from "node:crypto";
-import type { FastifyInstance } from "fastify";
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest
+} from "fastify";
 import { z } from "zod";
+import {
+  AccountDeletionAuthorizationError,
+  issueAccountActionToken,
+  linkExternalIdentity
+} from "../../account-management.js";
 import { sessionClientName } from "../../account-sessions.js";
 import type { AuthenticationPolicyStore } from "../../authentication-policy.js";
 import type { DatabasePool } from "../../database-types.js";
@@ -24,6 +33,10 @@ import {
 } from "../../security.js";
 import { apiError } from "../../platform/http-errors.js";
 import {
+  requireSessionContext,
+  sessionContext
+} from "../../platform/request-authentication.js";
+import {
   oauthStateCookieName,
   setSessionCookie
 } from "../../platform/session-cookies.js";
@@ -40,6 +53,42 @@ export function registerExternalAuthRoutes(
   app: FastifyInstance,
   options: ExternalAuthRoutesOptions
 ): void {
+  app.get("/v1/account/identities/github/link", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } }
+  }, async (request, reply) => startGitHubAccountFlow(
+    request,
+    reply,
+    options,
+    "link"
+  ));
+
+  app.get("/v1/account/reauth/github", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } }
+  }, async (request, reply) => startGitHubAccountFlow(
+    request,
+    reply,
+    options,
+    "reauth_delete"
+  ));
+
+  app.get("/v1/account/identities/google/link", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } }
+  }, async (request, reply) => startGoogleAccountFlow(
+    request,
+    reply,
+    options,
+    "link"
+  ));
+
+  app.get("/v1/account/reauth/google", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } }
+  }, async (request, reply) => startGoogleAccountFlow(
+    request,
+    reply,
+    options,
+    "reauth_delete"
+  ));
+
   app.get("/auth/github", {
     config: { rateLimit: { max: 20, timeWindow: "1 minute" } }
   }, async (request, reply) => {
@@ -118,14 +167,12 @@ export function registerExternalAuthRoutes(
         "The GitHub sign-in request is invalid or expired."
       ));
     }
-    const state = await options.db.query<{
-      code_verifier: string;
-      return_to: string;
-    }>(
+    const state = await options.db.query<OAuthStateRow>(
       `UPDATE oauth_login_states SET consumed_at = now()
        WHERE provider = 'github' AND state_hash = $1
          AND consumed_at IS NULL AND expires_at > now()
-       RETURNING code_verifier, return_to`,
+       RETURNING code_verifier, return_to, purpose,
+                 account_user_id, account_session_id`,
       [tokenHash(query.state)]
     );
     if (!state.rows[0]) {
@@ -147,11 +194,14 @@ export function registerExternalAuthRoutes(
       throw new GitHubIdentityError("GitHub returned an invalid user identity.");
     }
     const authenticationSettings = await options.authenticationPolicy.current();
-    if (!identityAllowed(
-      authenticationSettings.registrationMode,
-      options.githubAuth.allowedUserIds,
-      identity.id
-    )) {
+    if (
+      state.rows[0].purpose === "login"
+      && !identityAllowed(
+        authenticationSettings.registrationMode,
+        options.githubAuth.allowedUserIds,
+        identity.id
+      )
+    ) {
       request.log.warn(
         { github_user_id: identity.id },
         "GitHub user is not on the login allowlist"
@@ -163,7 +213,7 @@ export function registerExternalAuthRoutes(
     }
     const name = (identity.name?.trim() || identity.login).slice(0, 100);
     const email = identity.email?.trim().toLowerCase() || null;
-    const session = await createExternalSession(options.db, {
+    const verified = {
       provider: "github",
       subject: identity.id,
       name,
@@ -171,7 +221,17 @@ export function registerExternalAuthRoutes(
       email,
       emailVerified: false,
       avatarUrl: null
-    }, {
+    } as const;
+    if (state.rows[0].purpose !== "login") {
+      const completed = await completeAccountFlow(
+        request,
+        options,
+        state.rows[0],
+        verified
+      );
+      return reply.redirect(completed);
+    }
+    const session = await createExternalSession(options.db, verified, {
       clientName: sessionClientName(request.headers["user-agent"])
     });
     setSessionCookie(reply, session.token, options.publicUrl);
@@ -247,14 +307,12 @@ export function registerExternalAuthRoutes(
         "The Google sign-in request is invalid or expired."
       ));
     }
-    const state = await options.db.query<{
-      code_verifier: string;
-      return_to: string;
-    }>(
+    const state = await options.db.query<OAuthStateRow>(
       `UPDATE oauth_login_states SET consumed_at = now()
        WHERE provider = 'google' AND state_hash = $1
          AND consumed_at IS NULL AND expires_at > now()
-       RETURNING code_verifier, return_to`,
+       RETURNING code_verifier, return_to, purpose,
+                 account_user_id, account_session_id`,
       [tokenHash(cookieState)]
     );
     if (!state.rows[0]) {
@@ -271,11 +329,14 @@ export function registerExternalAuthRoutes(
       throw new GoogleIdentityError("Google returned an invalid account subject.");
     }
     const authenticationSettings = await options.authenticationPolicy.current();
-    if (!identityAllowed(
-      authenticationSettings.registrationMode,
-      options.googleAuth.allowedSubjects,
-      identity.id
-    )) {
+    if (
+      state.rows[0].purpose === "login"
+      && !identityAllowed(
+        authenticationSettings.registrationMode,
+        options.googleAuth.allowedSubjects,
+        identity.id
+      )
+    ) {
       request.log.warn(
         { google_subject: identity.id },
         "Google user is not on the login allowlist"
@@ -292,7 +353,7 @@ export function registerExternalAuthRoutes(
     const email = identity.emailVerified
       ? identity.email?.trim().toLowerCase().slice(0, 320) || null
       : null;
-    const session = await createExternalSession(options.db, {
+    const verified = {
       provider: "google",
       subject: identity.id,
       name,
@@ -300,12 +361,194 @@ export function registerExternalAuthRoutes(
       email,
       emailVerified: identity.emailVerified,
       avatarUrl: identity.avatarUrl
-    }, {
+    } as const;
+    if (state.rows[0].purpose !== "login") {
+      return {
+        redirect_to: await completeAccountFlow(
+          request,
+          options,
+          state.rows[0],
+          verified
+        )
+      };
+    }
+    const session = await createExternalSession(options.db, verified, {
       clientName: sessionClientName(request.headers["user-agent"])
     });
     setSessionCookie(reply, session.token, options.publicUrl);
     return { redirect_to: state.rows[0].return_to };
   });
+}
+
+type AccountOAuthPurpose = "link" | "reauth_delete";
+
+interface OAuthStateRow {
+  code_verifier: string;
+  return_to: string;
+  purpose: "login" | AccountOAuthPurpose;
+  account_user_id: string | null;
+  account_session_id: string | null;
+}
+
+async function startGitHubAccountFlow(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  options: ExternalAuthRoutesOptions,
+  purpose: AccountOAuthPurpose
+) {
+  if (!options.githubAuth) {
+    return reply.code(404).send(apiError("not_found", "Not found."));
+  }
+  const authenticated = await requireSessionContext(request, reply, options.db);
+  if (!authenticated) return;
+  const query = z.object({
+    return_to: z.string().max(2_048).optional()
+  }).parse(request.query);
+  const state = randomToken("oauth");
+  const codeVerifier = randomToken("pkce");
+  await storeAccountOAuthState(
+    options,
+    "github",
+    purpose,
+    state,
+    codeVerifier,
+    safeReturnTarget(query.return_to, options.publicUrl),
+    authenticated.user.id,
+    authenticated.sessionId
+  );
+  reply.setCookie(oauthStateCookieName(options.publicUrl, "github"), state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: options.publicUrl.startsWith("https:"),
+    path: "/",
+    maxAge: 10 * 60
+  });
+  const authorize = new URL("https://github.com/login/oauth/authorize");
+  authorize.searchParams.set("client_id", options.githubAuth.clientId);
+  authorize.searchParams.set("redirect_uri", `${options.publicUrl}/auth/github/callback`);
+  authorize.searchParams.set("state", state);
+  authorize.searchParams.set("code_challenge", pkceChallenge(codeVerifier));
+  authorize.searchParams.set("code_challenge_method", "S256");
+  authorize.searchParams.set("allow_signup", "false");
+  return reply.redirect(authorize.href);
+}
+
+async function startGoogleAccountFlow(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  options: ExternalAuthRoutesOptions,
+  purpose: AccountOAuthPurpose
+) {
+  if (!options.googleAuth) {
+    return reply.code(404).send(apiError("not_found", "Not found."));
+  }
+  const authenticated = await requireSessionContext(request, reply, options.db);
+  if (!authenticated) return;
+  const query = z.object({
+    return_to: z.string().max(2_048).optional()
+  }).parse(request.query);
+  const state = randomToken("oauth");
+  const nonce = randomToken("nonce");
+  await storeAccountOAuthState(
+    options,
+    "google",
+    purpose,
+    state,
+    nonce,
+    safeReturnTarget(query.return_to, options.publicUrl),
+    authenticated.user.id,
+    authenticated.sessionId
+  );
+  reply.setCookie(oauthStateCookieName(options.publicUrl, "google"), state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: options.publicUrl.startsWith("https:"),
+    path: "/",
+    maxAge: 10 * 60
+  });
+  reply.header("cache-control", "no-store");
+  return { client_id: options.googleAuth.clientId, nonce };
+}
+
+async function storeAccountOAuthState(
+  options: ExternalAuthRoutesOptions,
+  provider: "github" | "google",
+  purpose: AccountOAuthPurpose,
+  state: string,
+  verifier: string,
+  returnTo: string,
+  userId: string,
+  sessionId: string
+): Promise<void> {
+  await options.db.query(
+    "DELETE FROM oauth_login_states WHERE expires_at <= now() OR consumed_at IS NOT NULL"
+  );
+  await options.db.query(
+    `INSERT INTO oauth_login_states
+       (id, provider, state_hash, return_to, code_verifier, expires_at,
+        purpose, account_user_id, account_session_id)
+     VALUES ($1, $2, $3, $4, $5, now() + interval '10 minutes', $6, $7, $8)`,
+    [
+      randomUUID(),
+      provider,
+      tokenHash(state),
+      returnTo,
+      verifier,
+      purpose,
+      userId,
+      sessionId
+    ]
+  );
+}
+
+async function completeAccountFlow(
+  request: FastifyRequest,
+  options: ExternalAuthRoutesOptions,
+  state: OAuthStateRow,
+  identity: Parameters<typeof linkExternalIdentity>[2]
+): Promise<string> {
+  const authenticated = await sessionContext(request, options.db);
+  if (
+    !authenticated
+    || authenticated.user.id !== state.account_user_id
+    || authenticated.sessionId !== state.account_session_id
+  ) {
+    throw new AccountDeletionAuthorizationError();
+  }
+  if (state.purpose === "link") {
+    await linkExternalIdentity(options.db, authenticated.user.id, identity);
+    return appendQuery(state.return_to, "linked", identity.provider);
+  }
+  const linked = await options.db.query(
+    `SELECT subject FROM external_identities
+     WHERE user_id = $1 AND provider = $2 AND subject = $3`,
+    [authenticated.user.id, identity.provider, identity.subject]
+  );
+  if (!linked.rows[0]) throw new AccountDeletionAuthorizationError();
+  const token = await issueAccountActionToken(
+    options.db,
+    authenticated.user.id,
+    authenticated.sessionId,
+    "delete_account"
+  );
+  return withFragment(state.return_to, "delete_token", token, options.publicUrl);
+}
+
+function appendQuery(target: string, name: string, value: string): string {
+  const url = new URL(target, "http://localhost");
+  url.searchParams.set(name, value);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function withFragment(
+  target: string,
+  name: string,
+  value: string,
+  publicUrl: string
+): string {
+  const url = new URL(target, publicUrl);
+  url.hash = `${name}=${encodeURIComponent(value)}`;
+  return `${url.pathname}${url.search}${url.hash}`;
 }
 
 function identityAllowed(

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -77,6 +77,55 @@ describe("hosted provider control client", () => {
     );
   });
 
+  it("reads authoritative collection storage usage from the provider", async () => {
+    const usage = {
+      collection_id: "collection",
+      record_count: 42,
+      content_bytes: 12_345,
+      max_records: 100_000,
+      max_content_bytes: 1_073_741_824,
+      max_document_bytes: 2_097_152
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ usage }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    await expect(provider.collectionUsage("collection")).resolves.toEqual(usage);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://provider.example/internal/v1/collections/collection/usage",
+      expect.objectContaining({
+        method: "GET",
+        headers: { authorization: "Bearer internal-secret" }
+      })
+    );
+  });
+
+  it("rejects a successful provider response that omits storage usage", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+    await expect(provider.collectionUsage("collection")).rejects.toEqual(
+      new HostedProviderResponseError(
+        502,
+        "invalid_provider_response",
+        "Hosted storage usage was missing from the provider response."
+      )
+    );
+  });
+
   it("preserves safe provider errors and normalizes network failures", async () => {
     const provider = new HostedProviderClient({
       url: "https://provider.example",

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -38,6 +38,15 @@ export interface HostedReplicaStatus {
   token_expires_at: string;
 }
 
+export interface HostedCollectionUsage {
+  collection_id: string;
+  record_count: number;
+  content_bytes: number;
+  max_records: number;
+  max_content_bytes: number;
+  max_document_bytes: number;
+}
+
 export interface HostedAuthorityTransfer {
   id: string;
   collection_id: string;
@@ -170,6 +179,21 @@ export class HostedProviderClient {
       `/internal/v1/collections/${encodeURIComponent(collectionId)}/replicas`
     ) as { replicas?: HostedReplicaStatus[] } | undefined;
     return result?.replicas ?? [];
+  }
+
+  async collectionUsage(collectionId: string): Promise<HostedCollectionUsage> {
+    const result = await this.request(
+      "GET",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/usage`
+    ) as { usage?: HostedCollectionUsage } | undefined;
+    if (!result?.usage) {
+      throw new HostedProviderResponseError(
+        502,
+        "invalid_provider_response",
+        "Hosted storage usage was missing from the provider response."
+      );
+    }
+    return result.usage;
   }
 
   async rotateReplicaToken(replicaId: string, token: string, tokenTtlSeconds?: number): Promise<void> {

--- a/services/server/src/password-auth.ts
+++ b/services/server/src/password-auth.ts
@@ -56,6 +56,13 @@ export interface PasswordLoginInput {
   clientName?: string;
 }
 
+export interface ChangePasswordInput {
+  userId: string;
+  sessionId: string;
+  currentPassword: string;
+  newPassword: string;
+}
+
 export type InvitationDeliveryOutcome =
   | {
       status: "sent";
@@ -135,6 +142,13 @@ export class PasswordLoginRejectedError extends Error {
   constructor() {
     super("Email or password is incorrect.");
     this.name = "PasswordLoginRejectedError";
+  }
+}
+
+export class PasswordCredentialUnavailableError extends Error {
+  constructor() {
+    super("This account does not have a password sign-in method.");
+    this.name = "PasswordCredentialUnavailableError";
   }
 }
 
@@ -483,6 +497,80 @@ export class PasswordAccountService {
           name: active.name
         }
       };
+    } catch (error) {
+      await connection.query("ROLLBACK");
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async verifyAccountPassword(userId: string, candidate: string): Promise<boolean> {
+    const credential = await this.db.query<{ password_hash: string }>(
+      "SELECT password_hash FROM password_credentials WHERE user_id = $1",
+      [userId]
+    );
+    return verifyPassword(
+      credential.rows[0]?.password_hash ?? await DUMMY_PASSWORD_HASH,
+      candidate
+    );
+  }
+
+  async changePassword(input: ChangePasswordInput): Promise<void> {
+    const preliminary = await this.db.query<{ password_hash: string }>(
+      "SELECT password_hash FROM password_credentials WHERE user_id = $1",
+      [input.userId]
+    );
+    const currentHash = preliminary.rows[0]?.password_hash;
+    const matches = await verifyPassword(
+      currentHash ?? await DUMMY_PASSWORD_HASH,
+      input.currentPassword
+    );
+    if (!currentHash) throw new PasswordCredentialUnavailableError();
+    if (!matches) throw new PasswordLoginRejectedError();
+    const newHash = await hashPassword(input.newPassword);
+    const connection = await this.db.connect();
+    try {
+      await connection.query("BEGIN");
+      const credential = await connection.query<{ password_hash: string }>(
+        `SELECT password_hash FROM password_credentials
+         WHERE user_id = $1 FOR UPDATE`,
+        [input.userId]
+      );
+      if (credential.rows[0]?.password_hash !== currentHash) {
+        throw new PasswordLoginRejectedError();
+      }
+      await connection.query(
+        `UPDATE password_credentials SET
+           password_hash = $2,
+           credential_version = credential_version + 1,
+           updated_at = now()
+         WHERE user_id = $1`,
+        [input.userId, newHash]
+      );
+      const epoch = await connection.query<{ session_epoch: string | number }>(
+        `UPDATE users SET session_epoch = session_epoch + 1
+         WHERE id = $1 AND suspended_at IS NULL
+         RETURNING session_epoch`,
+        [input.userId]
+      );
+      if (!epoch.rows[0]) throw new PasswordLoginRejectedError();
+      await connection.query(
+        `UPDATE sessions SET revoked_at = COALESCE(revoked_at, now())
+         WHERE user_id = $1 AND id <> $2`,
+        [input.userId, input.sessionId]
+      );
+      const preserved = await connection.query(
+        `UPDATE sessions SET account_session_epoch = $3
+         WHERE id = $2 AND user_id = $1 AND revoked_at IS NULL
+         RETURNING id`,
+        [input.userId, input.sessionId, epoch.rows[0].session_epoch]
+      );
+      if (!preserved.rows[0]) throw new PasswordLoginRejectedError();
+      await audit(connection, input.userId, "password.changed", input.userId, {
+        other_sessions_signed_out: true
+      });
+      await connection.query("COMMIT");
     } catch (error) {
       await connection.query("ROLLBACK");
       throw error;

--- a/services/server/src/platform/error-handler.ts
+++ b/services/server/src/platform/error-handler.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance } from "fastify";
 import { SyncError } from "@mdbase/connect-sync";
 import { ZodError } from "zod";
+import {
+  AccountDeletionAuthorizationError,
+  ExternalIdentityConflictError,
+  IdentityRemovalForbiddenError
+} from "../account-management.js";
 import { AccountUnavailableError } from "../external-auth.js";
 import { GitHubIdentityError } from "../github-auth.js";
 import { GoogleIdentityError } from "../google-auth.js";
@@ -14,6 +19,7 @@ import {
   InvalidInvitationError,
   InvitationTargetConflictError,
   PasswordAuthenticationUnavailableError,
+  PasswordCredentialUnavailableError,
   PasswordLoginRejectedError
 } from "../password-auth.js";
 import {
@@ -114,10 +120,31 @@ export function registerErrorHandler(app: FastifyInstance): void {
         "This account does not have access."
       ));
     }
+    if (error instanceof ExternalIdentityConflictError) {
+      return reply.code(409).send(apiError(
+        "identity_already_connected",
+        error.message
+      ));
+    }
+    if (error instanceof IdentityRemovalForbiddenError) {
+      return reply.code(409).send(apiError(error.code, error.message));
+    }
+    if (error instanceof AccountDeletionAuthorizationError) {
+      return reply.code(403).send(apiError(
+        "account_reauthentication_required",
+        error.message
+      ));
+    }
     if (error instanceof PasswordLoginRejectedError) {
       return reply.code(401).send(apiError(
         "invalid_credentials",
         "Email or password is incorrect."
+      ));
+    }
+    if (error instanceof PasswordCredentialUnavailableError) {
+      return reply.code(409).send(apiError(
+        "password_not_configured",
+        error.message
       ));
     }
     if (


### PR DESCRIPTION
## What changed

- Give Portal and Electron a shared editor-like single-sidebar shell.
- Split Portal management into stable pages for overview, requests, hosted collections, app access, computers, and account.
- Add account and storage controls for usage visibility, linked GitHub/Google identities, password changes, session revocation, and account deletion.
- Replace the prominent theme selector with an accessible icon menu.
- Add authoritative hosted-usage reporting and harden OAuth linking/reauthentication behavior.
- Preserve the current app-led authorization and contract-setup flows.

## Why

The Portal sidebar looked like navigation but moved around one long page, and Connect's management surfaces felt less coherent than the editor. These changes make the hierarchy predictable while keeping all existing controls available and shaping each page around its data.

## Impact

This adds two additive database migrations and new authenticated account-management endpoints. Account deletion explicitly leaves local collection and mirror files untouched. Portal routes remain SPA-backed and support direct reloads.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm test:accessibility`
- `pnpm e2e:provider`
- `xvfb-run -a fnm exec --using=24.13.0 pnpm e2e:desktop:container`
- `pnpm e2e:container`
- `pnpm check:architecture`
- `git diff --check origin/main...HEAD`
