### PR TITLE
Prepare durable Beta entitlements and scheduled welcome email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "clap",
  "directories",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "chrono",
  "directories",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "async-trait",
  "axum",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-hosted-provider/migrations/0021_account_storage_quotas.sql
+++ b/crates/connect-hosted-provider/migrations/0021_account_storage_quotas.sql
@@ -1,0 +1,123 @@
+CREATE TABLE IF NOT EXISTS hosted_provider_accounts (
+  id uuid PRIMARY KEY,
+  entitlement_revision bigint NOT NULL CHECK (entitlement_revision > 0),
+  max_live_storage_bytes bigint NOT NULL CHECK (max_live_storage_bytes > 0),
+  max_retained_file_bytes bigint NOT NULL CHECK (max_retained_file_bytes >= max_live_storage_bytes),
+  max_document_bytes bigint NOT NULL CHECK (max_document_bytes > 0),
+  max_single_file_bytes bigint NOT NULL CHECK (max_single_file_bytes > 0),
+  max_replicas_per_collection bigint NOT NULL CHECK (max_replicas_per_collection > 0),
+  max_collections bigint NOT NULL CHECK (max_collections > 0),
+  max_files_per_collection bigint NOT NULL CHECK (max_files_per_collection > 0),
+  collection_count bigint NOT NULL DEFAULT 0 CHECK (collection_count >= 0),
+  live_content_bytes bigint NOT NULL DEFAULT 0 CHECK (live_content_bytes >= 0),
+  live_file_bytes bigint NOT NULL DEFAULT 0 CHECK (live_file_bytes >= 0),
+  retained_file_bytes bigint NOT NULL DEFAULT 0 CHECK (retained_file_bytes >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE hosted_provider_collections
+  ADD COLUMN IF NOT EXISTS account_id uuid
+    REFERENCES hosted_provider_accounts(id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS hosted_provider_collections_account_idx
+  ON hosted_provider_collections(account_id)
+  WHERE account_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION hosted_provider_apply_account_usage()
+RETURNS trigger AS $$
+DECLARE
+  target_account uuid;
+  collection_delta bigint := 0;
+  content_delta bigint := 0;
+  file_delta bigint := 0;
+  retained_delta bigint := 0;
+  account_row hosted_provider_accounts%ROWTYPE;
+  reconciliation boolean :=
+    COALESCE(current_setting('mdbase.quota_reconciliation', true), '') = 'on';
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    target_account := NEW.account_id;
+    collection_delta := 1;
+    content_delta := NEW.content_bytes;
+    file_delta := NEW.file_bytes;
+    retained_delta := NEW.stored_file_bytes;
+  ELSIF TG_OP = 'DELETE' THEN
+    target_account := OLD.account_id;
+    collection_delta := -1;
+    content_delta := -OLD.content_bytes;
+    file_delta := -OLD.file_bytes;
+    retained_delta := -OLD.stored_file_bytes;
+  ELSIF OLD.account_id IS DISTINCT FROM NEW.account_id THEN
+    IF OLD.account_id IS NOT NULL THEN
+      UPDATE hosted_provider_accounts SET
+        collection_count = collection_count - 1,
+        live_content_bytes = live_content_bytes - OLD.content_bytes,
+        live_file_bytes = live_file_bytes - OLD.file_bytes,
+        retained_file_bytes = retained_file_bytes - OLD.stored_file_bytes,
+        updated_at = now()
+      WHERE id = OLD.account_id;
+    END IF;
+    target_account := NEW.account_id;
+    collection_delta := 1;
+    content_delta := NEW.content_bytes;
+    file_delta := NEW.file_bytes;
+    retained_delta := NEW.stored_file_bytes;
+  ELSE
+    target_account := NEW.account_id;
+    content_delta := NEW.content_bytes - OLD.content_bytes;
+    file_delta := NEW.file_bytes - OLD.file_bytes;
+    retained_delta := NEW.stored_file_bytes - OLD.stored_file_bytes;
+  END IF;
+
+  IF target_account IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT * INTO account_row
+  FROM hosted_provider_accounts
+  WHERE id = target_account
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '23503',
+      MESSAGE = 'hosted_provider_account_missing';
+  END IF;
+
+  IF NOT reconciliation
+     AND collection_delta > 0
+     AND account_row.collection_count + collection_delta > account_row.max_collections THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0001',
+      MESSAGE = 'account_collection_quota_exceeded';
+  END IF;
+  IF NOT reconciliation
+     AND content_delta + file_delta > 0
+     AND account_row.live_content_bytes + account_row.live_file_bytes
+           + content_delta + file_delta > account_row.max_live_storage_bytes THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0001',
+      MESSAGE = 'account_storage_quota_exceeded';
+  END IF;
+  IF NOT reconciliation
+     AND retained_delta > 0
+     AND account_row.retained_file_bytes + retained_delta
+           > account_row.max_retained_file_bytes THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0001',
+      MESSAGE = 'account_retained_storage_quota_exceeded';
+  END IF;
+
+  UPDATE hosted_provider_accounts SET
+    collection_count = collection_count + collection_delta,
+    live_content_bytes = live_content_bytes + content_delta,
+    live_file_bytes = live_file_bytes + file_delta,
+    retained_file_bytes = retained_file_bytes + retained_delta,
+    updated_at = now()
+  WHERE id = target_account;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS hosted_provider_collection_account_usage
+  ON hosted_provider_collections;
+CREATE TRIGGER hosted_provider_collection_account_usage
+AFTER INSERT OR DELETE OR UPDATE OF account_id, content_bytes, file_bytes, stored_file_bytes
+ON hosted_provider_collections
+FOR EACH ROW EXECUTE FUNCTION hosted_provider_apply_account_usage();

--- a/crates/connect-hosted-provider/src/error.rs
+++ b/crates/connect-hosted-provider/src/error.rs
@@ -80,6 +80,26 @@ impl IntoResponse for ApiError {
 
 impl From<sqlx::Error> for ApiError {
     fn from(error: sqlx::Error) -> Self {
+        if let Some(database) = error.as_database_error() {
+            let quota = match database.message() {
+                "account_collection_quota_exceeded" => Some((
+                    "account_collection_quota_exceeded",
+                    "The account has reached its hosted collection limit.",
+                )),
+                "account_storage_quota_exceeded" => Some((
+                    "account_storage_quota_exceeded",
+                    "The change would exceed the account's hosted storage limit.",
+                )),
+                "account_retained_storage_quota_exceeded" => Some((
+                    "account_retained_storage_quota_exceeded",
+                    "The change would exceed the account's retained file storage limit.",
+                )),
+                _ => None,
+            };
+            if let Some((code, message)) = quota {
+                return Self::quota(code, message);
+            }
+        }
         tracing::error!(error = %error, "hosted provider database error");
         Self::internal("The hosted provider could not access its authoritative store.")
     }

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -1027,12 +1027,14 @@ mod tests {
     fn collection_creation_requires_a_display_name() {
         assert!(
             serde_json::from_value::<CreateCollectionRequest>(serde_json::json!({
+                "account_id": Uuid::new_v4(),
                 "collection_id": Uuid::new_v4(),
                 "template": "tasknotes"
             }))
             .is_err()
         );
         let input: CreateCollectionRequest = serde_json::from_value(serde_json::json!({
+            "account_id": Uuid::new_v4(),
             "collection_id": Uuid::new_v4(),
             "template": "mdbase",
             "display_name": "Worklog"

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -37,13 +37,15 @@ use crate::{
     error::{ApiError, ApiResult},
     provider::{
         validate_limit, AuthorityRequestProof, HostedProvider, PrepareAuthorityImport,
-        PrepareAuthorityTransfer, ProviderAccountLimits, RegisterReplica, UpdateApplicationReplica,
+        PrepareAuthorityTransfer, RegisterReplica, UpdateApplicationReplica,
     },
 };
 
+mod accounts;
 mod authority_import_files;
 mod files;
 
+use accounts::account_routes;
 use authority_import_files::{
     commit_authority_import_file_upload, open_authority_import_file_upload,
     prepare_authority_import_file_part,
@@ -88,21 +90,6 @@ impl AppState {
             ))
         }
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct CreateCollectionRequest {
-    account_id: Uuid,
-    collection_id: Uuid,
-    template: String,
-    display_name: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct UpsertAccountRequest {
-    entitlement_revision: u64,
-    #[serde(flatten)]
-    limits: ProviderAccountLimits,
 }
 
 #[derive(Debug, Deserialize)]
@@ -188,15 +175,7 @@ pub fn app(state: AppState) -> Router {
         .allow_methods([Method::GET, Method::POST, Method::DELETE])
         .max_age(std::time::Duration::from_secs(600));
     let internal = Router::new()
-        .route(
-            "/internal/v1/accounts/{account_id}",
-            put(upsert_account).get(account_usage),
-        )
-        .route(
-            "/internal/v1/accounts/{account_id}/collections/{collection_id}",
-            put(reconcile_collection_account),
-        )
-        .route("/internal/v1/collections", post(create_collection))
+        .merge(account_routes())
         .route(
             "/internal/v1/collections/{collection_id}",
             patch(rename_collection).delete(delete_collection),
@@ -374,58 +353,6 @@ async fn ready(State(state): State<AppState>) -> ApiResult<Json<Value>> {
         "status": "ready",
         "notifications": notifications
     })))
-}
-
-async fn create_collection(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Json(input): Json<CreateCollectionRequest>,
-) -> ApiResult<(StatusCode, Json<Value>)> {
-    state.authorize_internal(&headers)?;
-    let collection = state
-        .provider
-        .create_collection(
-            input.account_id,
-            input.collection_id,
-            &input.template,
-            &input.display_name,
-        )
-        .await?;
-    Ok((
-        StatusCode::CREATED,
-        Json(json!({ "collection": collection })),
-    ))
-}
-
-async fn upsert_account(
-    State(state): State<AppState>,
-    Path(account_id): Path<Uuid>,
-    Json(input): Json<UpsertAccountRequest>,
-) -> ApiResult<Json<Value>> {
-    let usage = state
-        .provider
-        .upsert_account(account_id, input.entitlement_revision, input.limits)
-        .await?;
-    Ok(Json(json!({ "account": usage })))
-}
-
-async fn account_usage(
-    State(state): State<AppState>,
-    Path(account_id): Path<Uuid>,
-) -> ApiResult<Json<Value>> {
-    let usage = state.provider.account_usage(account_id).await?;
-    Ok(Json(json!({ "account": usage })))
-}
-
-async fn reconcile_collection_account(
-    State(state): State<AppState>,
-    Path((account_id, collection_id)): Path<(Uuid, Uuid)>,
-) -> ApiResult<StatusCode> {
-    state
-        .provider
-        .reconcile_collection_account(account_id, collection_id)
-        .await?;
-    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn rename_collection(
@@ -1021,25 +948,5 @@ mod tests {
         assert!(bool::from(hash.ct_eq(&hash)));
         let other: [u8; 32] = Sha256::digest(b"another-long-test-token-that-is-different").into();
         assert!(!bool::from(hash.ct_eq(&other)));
-    }
-
-    #[test]
-    fn collection_creation_requires_a_display_name() {
-        assert!(
-            serde_json::from_value::<CreateCollectionRequest>(serde_json::json!({
-                "account_id": Uuid::new_v4(),
-                "collection_id": Uuid::new_v4(),
-                "template": "tasknotes"
-            }))
-            .is_err()
-        );
-        let input: CreateCollectionRequest = serde_json::from_value(serde_json::json!({
-            "account_id": Uuid::new_v4(),
-            "collection_id": Uuid::new_v4(),
-            "template": "mdbase",
-            "display_name": "Worklog"
-        }))
-        .unwrap();
-        assert_eq!(input.display_name, "Worklog");
     }
 }

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -37,7 +37,7 @@ use crate::{
     error::{ApiError, ApiResult},
     provider::{
         validate_limit, AuthorityRequestProof, HostedProvider, PrepareAuthorityImport,
-        PrepareAuthorityTransfer, RegisterReplica, UpdateApplicationReplica,
+        PrepareAuthorityTransfer, ProviderAccountLimits, RegisterReplica, UpdateApplicationReplica,
     },
 };
 
@@ -92,9 +92,17 @@ impl AppState {
 
 #[derive(Debug, Deserialize)]
 struct CreateCollectionRequest {
+    account_id: Uuid,
     collection_id: Uuid,
     template: String,
     display_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpsertAccountRequest {
+    entitlement_revision: u64,
+    #[serde(flatten)]
+    limits: ProviderAccountLimits,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,6 +188,14 @@ pub fn app(state: AppState) -> Router {
         .allow_methods([Method::GET, Method::POST, Method::DELETE])
         .max_age(std::time::Duration::from_secs(600));
     let internal = Router::new()
+        .route(
+            "/internal/v1/accounts/{account_id}",
+            put(upsert_account).get(account_usage),
+        )
+        .route(
+            "/internal/v1/accounts/{account_id}/collections/{collection_id}",
+            put(reconcile_collection_account),
+        )
         .route("/internal/v1/collections", post(create_collection))
         .route(
             "/internal/v1/collections/{collection_id}",
@@ -368,12 +384,48 @@ async fn create_collection(
     state.authorize_internal(&headers)?;
     let collection = state
         .provider
-        .create_collection(input.collection_id, &input.template, &input.display_name)
+        .create_collection(
+            input.account_id,
+            input.collection_id,
+            &input.template,
+            &input.display_name,
+        )
         .await?;
     Ok((
         StatusCode::CREATED,
         Json(json!({ "collection": collection })),
     ))
+}
+
+async fn upsert_account(
+    State(state): State<AppState>,
+    Path(account_id): Path<Uuid>,
+    Json(input): Json<UpsertAccountRequest>,
+) -> ApiResult<Json<Value>> {
+    let usage = state
+        .provider
+        .upsert_account(account_id, input.entitlement_revision, input.limits)
+        .await?;
+    Ok(Json(json!({ "account": usage })))
+}
+
+async fn account_usage(
+    State(state): State<AppState>,
+    Path(account_id): Path<Uuid>,
+) -> ApiResult<Json<Value>> {
+    let usage = state.provider.account_usage(account_id).await?;
+    Ok(Json(json!({ "account": usage })))
+}
+
+async fn reconcile_collection_account(
+    State(state): State<AppState>,
+    Path((account_id, collection_id)): Path<(Uuid, Uuid)>,
+) -> ApiResult<StatusCode> {
+    state
+        .provider
+        .reconcile_collection_account(account_id, collection_id)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn rename_collection(

--- a/crates/connect-hosted-provider/src/http/accounts.rs
+++ b/crates/connect-hosted-provider/src/http/accounts.rs
@@ -1,0 +1,118 @@
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    routing::{post, put},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::{error::ApiResult, provider::ProviderAccountLimits};
+
+use super::AppState;
+
+#[derive(Debug, Deserialize)]
+struct UpsertAccountRequest {
+    entitlement_revision: u64,
+    #[serde(flatten)]
+    limits: ProviderAccountLimits,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateCollectionRequest {
+    account_id: Uuid,
+    collection_id: Uuid,
+    template: String,
+    display_name: String,
+}
+
+pub(super) fn account_routes() -> Router<AppState> {
+    Router::new()
+        .route("/internal/v1/collections", post(create_collection))
+        .route(
+            "/internal/v1/accounts/{account_id}",
+            put(upsert_account).get(account_usage),
+        )
+        .route(
+            "/internal/v1/accounts/{account_id}/collections/{collection_id}",
+            put(reconcile_collection_account),
+        )
+}
+
+async fn create_collection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(input): Json<CreateCollectionRequest>,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    state.authorize_internal(&headers)?;
+    let collection = state
+        .provider
+        .create_collection(
+            input.account_id,
+            input.collection_id,
+            &input.template,
+            &input.display_name,
+        )
+        .await?;
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({ "collection": collection })),
+    ))
+}
+
+async fn upsert_account(
+    State(state): State<AppState>,
+    Path(account_id): Path<Uuid>,
+    Json(input): Json<UpsertAccountRequest>,
+) -> ApiResult<Json<Value>> {
+    let usage = state
+        .provider
+        .upsert_account(account_id, input.entitlement_revision, input.limits)
+        .await?;
+    Ok(Json(json!({ "account": usage })))
+}
+
+async fn account_usage(
+    State(state): State<AppState>,
+    Path(account_id): Path<Uuid>,
+) -> ApiResult<Json<Value>> {
+    let usage = state.provider.account_usage(account_id).await?;
+    Ok(Json(json!({ "account": usage })))
+}
+
+async fn reconcile_collection_account(
+    State(state): State<AppState>,
+    Path((account_id, collection_id)): Path<(Uuid, Uuid)>,
+) -> ApiResult<StatusCode> {
+    state
+        .provider
+        .reconcile_collection_account(account_id, collection_id)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_creation_requires_a_display_name() {
+        assert!(
+            serde_json::from_value::<CreateCollectionRequest>(serde_json::json!({
+                "account_id": Uuid::new_v4(),
+                "collection_id": Uuid::new_v4(),
+                "template": "tasknotes"
+            }))
+            .is_err()
+        );
+        let input: CreateCollectionRequest = serde_json::from_value(serde_json::json!({
+            "account_id": Uuid::new_v4(),
+            "collection_id": Uuid::new_v4(),
+            "template": "mdbase",
+            "display_name": "Worklog"
+        }))
+        .unwrap();
+        assert_eq!(input.display_name, "Worklog");
+    }
+}

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -16,6 +16,7 @@ pub use http::{app, AppState};
 pub use notifications::{HostedNotificationConfig, HostedNotificationRuntime};
 pub use provider::{
     HostedProvider, NotificationRecoveryStatus, PrepareAuthorityImport, PrepareAuthorityTransfer,
-    ProviderAuthorityImport, ProviderAuthorityImportState, ProviderAuthorityTransfer,
-    ProviderAuthorityTransferState, ProviderLimits, RegisterReplica, ReplicaPurpose,
+    ProviderAccountLimits, ProviderAccountUsage, ProviderAuthorityImport,
+    ProviderAuthorityImportState, ProviderAuthorityTransfer, ProviderAuthorityTransferState,
+    ProviderLimits, RegisterReplica, ReplicaPurpose,
 };

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -42,6 +42,7 @@ use crate::{
     workspace::{StoredDocument, WorkingSet},
 };
 
+mod account_quotas;
 mod authority_import_cleanup;
 mod authority_import_files;
 mod authority_imports;
@@ -68,6 +69,7 @@ mod provider_state;
 mod replicas;
 mod sync_reads;
 
+use account_quotas::*;
 use authority_snapshots::*;
 use capabilities::*;
 use crypto_state::*;
@@ -96,6 +98,29 @@ pub struct ProviderLimits {
     pub max_file_bytes_per_collection: u64,
     pub max_stored_file_bytes_per_collection: u64,
     pub max_bytes_per_file: u64,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ProviderAccountLimits {
+    pub hosted_storage_bytes: u64,
+    pub retained_file_bytes: u64,
+    pub max_document_bytes: u64,
+    pub max_single_file_bytes: u64,
+    pub max_replicas_per_collection: u64,
+    pub max_hosted_collections: u64,
+    pub max_files_per_collection: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderAccountUsage {
+    pub account_id: Uuid,
+    pub entitlement_revision: u64,
+    pub collection_count: u64,
+    pub live_content_bytes: u64,
+    pub live_file_bytes: u64,
+    pub retained_file_bytes: u64,
+    #[serde(flatten)]
+    pub limits: ProviderAccountLimits,
 }
 
 impl Default for ProviderLimits {
@@ -200,6 +225,13 @@ pub struct ProviderCollectionUsage {
     pub max_records: u64,
     pub max_content_bytes: u64,
     pub max_document_bytes: u64,
+    pub file_count: u64,
+    pub file_bytes: u64,
+    pub stored_file_bytes: u64,
+    pub max_files: u64,
+    pub max_file_bytes: u64,
+    pub max_stored_file_bytes: u64,
+    pub max_single_file_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -235,6 +267,7 @@ pub struct ProviderAuthorityTransfer {
 pub struct PrepareAuthorityImport {
     pub transfer_id: Uuid,
     pub collection_id: Uuid,
+    pub account_id: Uuid,
     pub display_name: String,
     pub token: String,
     pub authority_epoch: u64,

--- a/crates/connect-hosted-provider/src/provider/account_quotas.rs
+++ b/crates/connect-hosted-provider/src/provider/account_quotas.rs
@@ -1,0 +1,290 @@
+use super::*;
+
+#[derive(Debug, Clone)]
+pub(super) struct StoredAccountLimits {
+    pub entitlement_revision: u64,
+    pub limits: ProviderAccountLimits,
+}
+
+impl HostedProvider {
+    pub async fn upsert_account(
+        &self,
+        account_id: Uuid,
+        entitlement_revision: u64,
+        limits: ProviderAccountLimits,
+    ) -> ApiResult<ProviderAccountUsage> {
+        if account_id.is_nil() || entitlement_revision == 0 {
+            return Err(ApiError::bad_request(
+                "invalid_provider_account",
+                "Hosted account identity and entitlement revision must be valid.",
+            ));
+        }
+        self.validate_account_limits(&limits)?;
+        let mut transaction = self.pool.begin().await?;
+        let existing = sqlx::query(
+            r#"SELECT entitlement_revision, max_live_storage_bytes,
+                      max_retained_file_bytes, max_document_bytes,
+                      max_single_file_bytes, max_replicas_per_collection,
+                      max_collections, max_files_per_collection
+               FROM hosted_provider_accounts WHERE id = $1 FOR UPDATE"#,
+        )
+        .bind(account_id)
+        .fetch_optional(&mut *transaction)
+        .await?;
+        if let Some(row) = existing {
+            let stored = stored_account_limits(&row)?;
+            if entitlement_revision < stored.entitlement_revision {
+                return Err(ApiError::conflict(
+                    "stale_entitlement_revision",
+                    "The hosted provider already has a newer account entitlement revision.",
+                ));
+            }
+            if entitlement_revision == stored.entitlement_revision && stored.limits != limits {
+                return Err(ApiError::conflict(
+                    "entitlement_revision_conflict",
+                    "The entitlement revision already exists with different limits.",
+                ));
+            }
+            if entitlement_revision > stored.entitlement_revision {
+                sqlx::query(
+                    r#"UPDATE hosted_provider_accounts SET
+                         entitlement_revision = $2,
+                         max_live_storage_bytes = $3,
+                         max_retained_file_bytes = $4,
+                         max_document_bytes = $5,
+                         max_single_file_bytes = $6,
+                         max_replicas_per_collection = $7,
+                         max_collections = $8,
+                         max_files_per_collection = $9,
+                         updated_at = now()
+                       WHERE id = $1"#,
+                )
+                .bind(account_id)
+                .bind(to_i64(entitlement_revision, "entitlement revision")?)
+                .bind(to_i64(
+                    limits.hosted_storage_bytes,
+                    "account live storage limit",
+                )?)
+                .bind(to_i64(
+                    limits.retained_file_bytes,
+                    "account retained storage limit",
+                )?)
+                .bind(to_i64(limits.max_document_bytes, "document limit")?)
+                .bind(to_i64(limits.max_single_file_bytes, "file limit")?)
+                .bind(to_i64(limits.max_replicas_per_collection, "replica limit")?)
+                .bind(to_i64(limits.max_hosted_collections, "collection limit")?)
+                .bind(to_i64(limits.max_files_per_collection, "file count limit")?)
+                .execute(&mut *transaction)
+                .await?;
+            }
+        } else {
+            sqlx::query(
+                r#"INSERT INTO hosted_provider_accounts
+                     (id, entitlement_revision, max_live_storage_bytes,
+                      max_retained_file_bytes, max_document_bytes,
+                      max_single_file_bytes, max_replicas_per_collection,
+                      max_collections, max_files_per_collection)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"#,
+            )
+            .bind(account_id)
+            .bind(to_i64(entitlement_revision, "entitlement revision")?)
+            .bind(to_i64(
+                limits.hosted_storage_bytes,
+                "account live storage limit",
+            )?)
+            .bind(to_i64(
+                limits.retained_file_bytes,
+                "account retained storage limit",
+            )?)
+            .bind(to_i64(limits.max_document_bytes, "document limit")?)
+            .bind(to_i64(limits.max_single_file_bytes, "file limit")?)
+            .bind(to_i64(limits.max_replicas_per_collection, "replica limit")?)
+            .bind(to_i64(limits.max_hosted_collections, "collection limit")?)
+            .bind(to_i64(limits.max_files_per_collection, "file count limit")?)
+            .execute(&mut *transaction)
+            .await?;
+        }
+        let usage = account_usage(&mut transaction, account_id).await?;
+        transaction.commit().await?;
+        Ok(usage)
+    }
+
+    pub async fn account_usage(&self, account_id: Uuid) -> ApiResult<ProviderAccountUsage> {
+        let mut transaction = self.pool.begin().await?;
+        let usage = account_usage(&mut transaction, account_id).await?;
+        transaction.commit().await?;
+        Ok(usage)
+    }
+
+    pub async fn reconcile_collection_account(
+        &self,
+        account_id: Uuid,
+        collection_id: Uuid,
+    ) -> ApiResult<()> {
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query("SET LOCAL mdbase.quota_reconciliation = 'on'")
+            .execute(&mut *transaction)
+            .await?;
+        let account = load_account_limits(&mut transaction, account_id, false).await?;
+        let result = sqlx::query(
+            r#"UPDATE hosted_provider_collections SET
+                 account_id = $2,
+                 max_content_bytes = $3,
+                 max_document_bytes = $4,
+                 max_replicas = $5,
+                 max_files = $6,
+                 max_file_bytes = $3,
+                 max_stored_file_bytes = $7,
+                 max_single_file_bytes = $8,
+                 updated_at = now()
+               WHERE id = $1 AND state <> 'deleting'
+                 AND (account_id IS NULL OR account_id = $2)"#,
+        )
+        .bind(collection_id)
+        .bind(account_id)
+        .bind(to_i64(
+            account.limits.hosted_storage_bytes,
+            "live storage limit",
+        )?)
+        .bind(to_i64(account.limits.max_document_bytes, "document limit")?)
+        .bind(to_i64(
+            account.limits.max_replicas_per_collection,
+            "replica limit",
+        )?)
+        .bind(to_i64(
+            account.limits.max_files_per_collection,
+            "file count limit",
+        )?)
+        .bind(to_i64(
+            account.limits.retained_file_bytes,
+            "retained file limit",
+        )?)
+        .bind(to_i64(
+            account.limits.max_single_file_bytes,
+            "single file limit",
+        )?)
+        .execute(&mut *transaction)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(ApiError::conflict(
+                "hosted_collection_account_conflict",
+                "The hosted collection is missing or belongs to another account.",
+            ));
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub(super) fn validate_account_limits(&self, limits: &ProviderAccountLimits) -> ApiResult<()> {
+        let valid = limits.hosted_storage_bytes > 0
+            && limits.retained_file_bytes >= limits.hosted_storage_bytes
+            && limits.max_document_bytes > 0
+            && limits.max_single_file_bytes > 0
+            && limits.max_replicas_per_collection > 0
+            && limits.max_hosted_collections > 0
+            && limits.max_files_per_collection > 0
+            && limits.hosted_storage_bytes <= self.limits.max_bytes_per_collection
+            && limits.hosted_storage_bytes <= self.limits.max_file_bytes_per_collection
+            && limits.retained_file_bytes <= self.limits.max_stored_file_bytes_per_collection
+            && limits.max_document_bytes <= self.limits.max_bytes_per_document
+            && limits.max_single_file_bytes <= self.limits.max_bytes_per_file
+            && limits.max_replicas_per_collection <= self.limits.max_replicas_per_collection
+            && limits.max_files_per_collection <= self.limits.max_files_per_collection;
+        if !valid {
+            return Err(ApiError::bad_request(
+                "invalid_account_limits",
+                "Hosted account limits are invalid or exceed provider safety ceilings.",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub(super) async fn load_account_limits(
+    transaction: &mut Transaction<'_, Postgres>,
+    account_id: Uuid,
+    lock: bool,
+) -> ApiResult<StoredAccountLimits> {
+    let sql = if lock {
+        r#"SELECT entitlement_revision, max_live_storage_bytes,
+                  max_retained_file_bytes, max_document_bytes,
+                  max_single_file_bytes, max_replicas_per_collection,
+                  max_collections, max_files_per_collection
+           FROM hosted_provider_accounts WHERE id = $1 FOR UPDATE"#
+    } else {
+        r#"SELECT entitlement_revision, max_live_storage_bytes,
+                  max_retained_file_bytes, max_document_bytes,
+                  max_single_file_bytes, max_replicas_per_collection,
+                  max_collections, max_files_per_collection
+           FROM hosted_provider_accounts WHERE id = $1"#
+    };
+    let row = sqlx::query(sql)
+        .bind(account_id)
+        .fetch_optional(&mut **transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_account_not_found",
+                "Hosted storage account not found.",
+            )
+        })?;
+    stored_account_limits(&row)
+}
+
+fn stored_account_limits(row: &PgRow) -> ApiResult<StoredAccountLimits> {
+    Ok(StoredAccountLimits {
+        entitlement_revision: number(row.get("entitlement_revision"), "entitlement revision")?,
+        limits: ProviderAccountLimits {
+            hosted_storage_bytes: number(row.get("max_live_storage_bytes"), "live storage limit")?,
+            retained_file_bytes: number(
+                row.get("max_retained_file_bytes"),
+                "retained storage limit",
+            )?,
+            max_document_bytes: number(row.get("max_document_bytes"), "document limit")?,
+            max_single_file_bytes: number(row.get("max_single_file_bytes"), "file limit")?,
+            max_replicas_per_collection: number(
+                row.get("max_replicas_per_collection"),
+                "replica limit",
+            )?,
+            max_hosted_collections: number(row.get("max_collections"), "collection limit")?,
+            max_files_per_collection: number(
+                row.get("max_files_per_collection"),
+                "file count limit",
+            )?,
+        },
+    })
+}
+
+async fn account_usage(
+    transaction: &mut Transaction<'_, Postgres>,
+    account_id: Uuid,
+) -> ApiResult<ProviderAccountUsage> {
+    let row = sqlx::query(
+        r#"SELECT entitlement_revision, max_live_storage_bytes,
+                  max_retained_file_bytes, max_document_bytes,
+                  max_single_file_bytes, max_replicas_per_collection,
+                  max_collections, max_files_per_collection,
+                  collection_count, live_content_bytes, live_file_bytes,
+                  retained_file_bytes
+           FROM hosted_provider_accounts WHERE id = $1"#,
+    )
+    .bind(account_id)
+    .fetch_optional(&mut **transaction)
+    .await?
+    .ok_or_else(|| {
+        ApiError::not_found(
+            "hosted_account_not_found",
+            "Hosted storage account not found.",
+        )
+    })?;
+    let stored = stored_account_limits(&row)?;
+    Ok(ProviderAccountUsage {
+        account_id,
+        entitlement_revision: stored.entitlement_revision,
+        collection_count: number(row.get("collection_count"), "collection count")?,
+        live_content_bytes: number(row.get("live_content_bytes"), "content size")?,
+        live_file_bytes: number(row.get("live_file_bytes"), "file size")?,
+        retained_file_bytes: number(row.get("retained_file_bytes"), "retained file size")?,
+        limits: stored.limits,
+    })
+}

--- a/crates/connect-hosted-provider/src/provider/authority_imports.rs
+++ b/crates/connect-hosted-provider/src/provider/authority_imports.rs
@@ -33,8 +33,13 @@ impl HostedProvider {
         .fetch_optional(&self.pool)
         .await?;
         if existing_state.is_none() {
-            self.create_collection(input.collection_id, "mdbase", &input.display_name)
-                .await?;
+            self.create_collection(
+                input.account_id,
+                input.collection_id,
+                "mdbase",
+                &input.display_name,
+            )
+            .await?;
         } else if !matches!(existing_state.as_deref(), Some("importing" | "transferred")) {
             return Err(ApiError::conflict(
                 "authority_import_target_unavailable",

--- a/crates/connect-hosted-provider/src/provider/collections.rs
+++ b/crates/connect-hosted-provider/src/provider/collections.rs
@@ -7,7 +7,10 @@ impl HostedProvider {
     ) -> ApiResult<ProviderCollectionUsage> {
         let row = sqlx::query(
             r#"SELECT record_count, content_bytes, max_records,
-                      max_content_bytes, max_document_bytes
+                      max_content_bytes, max_document_bytes, file_count,
+                      file_bytes, stored_file_bytes, max_files,
+                      max_file_bytes, max_stored_file_bytes,
+                      max_single_file_bytes
                FROM hosted_provider_collections
                WHERE id = $1 AND state <> 'deleting'"#,
         )
@@ -27,11 +30,25 @@ impl HostedProvider {
             max_records: number(row.get::<i64, _>("max_records"), "record quota")?,
             max_content_bytes: number(row.get::<i64, _>("max_content_bytes"), "content quota")?,
             max_document_bytes: number(row.get::<i64, _>("max_document_bytes"), "document quota")?,
+            file_count: number(row.get::<i64, _>("file_count"), "file count")?,
+            file_bytes: number(row.get::<i64, _>("file_bytes"), "file size")?,
+            stored_file_bytes: number(row.get::<i64, _>("stored_file_bytes"), "stored file size")?,
+            max_files: number(row.get::<i64, _>("max_files"), "file quota")?,
+            max_file_bytes: number(row.get::<i64, _>("max_file_bytes"), "file byte quota")?,
+            max_stored_file_bytes: number(
+                row.get::<i64, _>("max_stored_file_bytes"),
+                "stored file quota",
+            )?,
+            max_single_file_bytes: number(
+                row.get::<i64, _>("max_single_file_bytes"),
+                "single file quota",
+            )?,
         })
     }
 
     pub async fn create_collection(
         &self,
+        account_id: Uuid,
         collection_id: Uuid,
         template_name: &str,
         display_name: &str,
@@ -52,17 +69,19 @@ impl HostedProvider {
             self.crypto
                 .encrypt_json(&data_key, &resources, &resources_aad(collection_id))?;
         let mut transaction = self.pool.begin().await?;
+        let account = load_account_limits(&mut transaction, account_id, true).await?;
         let inserted = sqlx::query(
             r#"INSERT INTO hosted_provider_collections
-                 (id, template, display_name, spec_version, resource_revision, wrapped_data_key,
+                 (id, account_id, template, display_name, spec_version, resource_revision, wrapped_data_key,
                   resources_ciphertext, max_records, max_content_bytes,
                   max_document_bytes, max_replicas, max_files, max_file_bytes,
                   max_stored_file_bytes, max_single_file_bytes)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-                       $13, $14, $15)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                       $14, $15, $16)
                ON CONFLICT (id) DO NOTHING"#,
         )
         .bind(collection_id)
+        .bind(account_id)
         .bind(template_name)
         .bind(display_name)
         .bind(&resources.spec_version)
@@ -74,41 +93,42 @@ impl HostedProvider {
             "record quota",
         )?)
         .bind(to_i64(
-            self.limits.max_bytes_per_collection,
+            account.limits.hosted_storage_bytes,
             "collection byte quota",
         )?)
         .bind(to_i64(
-            self.limits.max_bytes_per_document,
+            account.limits.max_document_bytes,
             "document byte quota",
         )?)
         .bind(to_i64(
-            self.limits.max_replicas_per_collection,
+            account.limits.max_replicas_per_collection,
             "replica quota",
         )?)
-        .bind(to_i64(self.limits.max_files_per_collection, "file quota")?)
+        .bind(to_i64(account.limits.max_files_per_collection, "file quota")?)
         .bind(to_i64(
-            self.limits.max_file_bytes_per_collection,
+            account.limits.hosted_storage_bytes,
             "current file byte quota",
         )?)
         .bind(to_i64(
-            self.limits.max_stored_file_bytes_per_collection,
+            account.limits.retained_file_bytes,
             "stored file byte quota",
         )?)
         .bind(to_i64(
-            self.limits.max_bytes_per_file,
+            account.limits.max_single_file_bytes,
             "single file byte quota",
         )?)
         .execute(&mut *transaction)
         .await?;
         if inserted.rows_affected() == 0 {
             let existing = sqlx::query(
-                "SELECT template, display_name, spec_version, resource_revision FROM hosted_provider_collections WHERE id = $1",
+                "SELECT account_id, template, display_name, spec_version, resource_revision FROM hosted_provider_collections WHERE id = $1",
             )
             .bind(collection_id)
             .fetch_one(&mut *transaction)
             .await?;
             let existing_template: String = existing.get("template");
-            if existing_template != template_name
+            if existing.get::<Option<Uuid>, _>("account_id") != Some(account_id)
+                || existing_template != template_name
                 || existing.get::<String, _>("display_name") != display_name
             {
                 return Err(ApiError::conflict(

--- a/crates/connect-hosted-provider/tests/support/fixture.rs
+++ b/crates/connect-hosted-provider/tests/support/fixture.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use mdbase_connect_hosted_provider::{
-    HostedProvider, ProviderCrypto, ProviderLimits, RegisterReplica, ReplicaPurpose,
+    HostedProvider, ProviderAccountLimits, ProviderCrypto, ProviderLimits, RegisterReplica,
+    ReplicaPurpose,
 };
 use mdbase_connect_protocol::{
     AbortFileTransferRequest, AbortFileTransferRequestKind, CommitFileUploadRequest,
@@ -44,8 +45,25 @@ impl FileLifecycleFixture {
             .await
             .expect("test database connects");
         let collection_id = Uuid::now_v7();
+        let account_id = Uuid::now_v7();
         provider
-            .create_collection(collection_id, "mdbase", "Adversarial files")
+            .upsert_account(
+                account_id,
+                1,
+                ProviderAccountLimits {
+                    hosted_storage_bytes: 1024 * 1024 * 1024,
+                    retained_file_bytes: 2 * 1024 * 1024 * 1024,
+                    max_document_bytes: 2 * 1024 * 1024,
+                    max_single_file_bytes: 250 * 1024 * 1024,
+                    max_replicas_per_collection: 10,
+                    max_hosted_collections: 10,
+                    max_files_per_collection: 10_000,
+                },
+            )
+            .await
+            .expect("account is provisioned");
+        provider
+            .create_collection(account_id, collection_id, "mdbase", "Adversarial files")
             .await
             .expect("collection is created");
         let token = format!("adversarial-{}-{}", Uuid::new_v4(), Uuid::new_v4());

--- a/crates/connect-protocol/src/tests.rs
+++ b/crates/connect-protocol/src/tests.rs
@@ -432,7 +432,7 @@ fn rust_relay_messages_match_the_canonical_wire_schema() {
     for message in [
         RelayMessage::RelayHello {
             protocol_version: CONTROL_PROTOCOL_VERSION,
-            connector_version: "0.1.0-beta.21".to_string(),
+            connector_version: "0.1.0-beta.22".to_string(),
             capabilities: RELAY_CAPABILITIES
                 .iter()
                 .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "clap",
  "directories",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "chrono",
  "directories",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "async-trait",
  "axum",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.21"
+version = "0.1.0-beta.22"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -114,9 +114,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.21
-git tag -a v0.1.0-beta.21 -m "mdbase connect 0.1.0-beta.21"
-git push origin v0.1.0-beta.21
+pnpm version:check v0.1.0-beta.22
+git tag -a v0.1.0-beta.22 -m "mdbase connect 0.1.0-beta.22"
+git push origin v0.1.0-beta.22
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -662,7 +662,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.21",
+    connector_version: "0.1.0-beta.22",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       fastify:
         specifier: ^5.10.0
         version: 5.10.0
+      fastify-raw-body:
+        specifier: ^5.0.0
+        version: 5.0.0
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0(supports-color@8.1.1)
@@ -472,6 +475,9 @@ importers:
       pg-mem:
         specifier: ^3.0.14
         version: 3.0.14
+      svix:
+        specifier: ^1.99.1
+        version: 1.99.1
       web-push:
         specifier: ^3.6.7
         version: 3.6.7(supports-color@8.1.1)
@@ -1419,6 +1425,9 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2438,6 +2447,9 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.4:
     resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
@@ -2449,6 +2461,10 @@ packages:
 
   fastify-plugin@6.0.0:
     resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
+
+  fastify-raw-body@5.0.0:
+    resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
+    engines: {node: '>= 10'}
 
   fastify@5.10.0:
     resolution: {integrity: sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==}
@@ -3831,6 +3847,9 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -3974,6 +3993,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4061,6 +4083,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.99.1:
+    resolution: {integrity: sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5658,6 +5683,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@szmarczak/http-timer@4.0.6':
@@ -6743,6 +6770,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.4: {}
 
   fast-uri@4.1.1: {}
@@ -6750,6 +6779,12 @@ snapshots:
   fastify-plugin@5.1.0: {}
 
   fastify-plugin@6.0.0: {}
+
+  fastify-raw-body@5.0.0:
+    dependencies:
+      fastify-plugin: 5.1.0
+      raw-body: 3.0.2
+      secure-json-parse: 2.7.0
 
   fastify@5.10.0:
     dependencies:
@@ -8124,6 +8159,8 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
+  secure-json-parse@2.7.0: {}
+
   secure-json-parse@4.1.0: {}
 
   semver-compare@1.0.0:
@@ -8293,6 +8330,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.2.0: {}
@@ -8379,6 +8421,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.99.1:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   symbol-tree@3.2.4: {}
 

--- a/scripts/hosted-files-e2e.mjs
+++ b/scripts/hosted-files-e2e.mjs
@@ -26,7 +26,23 @@ try {
   assert.equal((await request(provider.url, "/ready")).status, 200);
 
   const collectionId = randomUUID();
+  const accountId = randomUUID();
+  await ok(request(provider.url, `/internal/v1/accounts/${accountId}`, {
+    method: "PUT",
+    token: internalToken,
+    body: {
+      entitlement_revision: 1,
+      hosted_storage_bytes: 1024 * 1024 * 1024,
+      retained_file_bytes: 2 * 1024 * 1024 * 1024,
+      max_document_bytes: 2 * 1024 * 1024,
+      max_single_file_bytes: 250 * 1024 * 1024,
+      max_replicas_per_collection: 10,
+      max_hosted_collections: 10,
+      max_files_per_collection: 10_000
+    }
+  }));
   await internal(provider.url, "/internal/v1/collections", {
+    account_id: accountId,
     collection_id: collectionId,
     template: "mdbase",
     display_name: "Hosted files"

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -135,9 +135,10 @@ try {
 
   phase("provisioning and enforcing portable data-contract views");
   const provisionCollectionId = crypto.randomUUID();
+  const provisionAccountId = await provisionProviderAccount(provider.url);
   await internalRequest(provider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: provisionCollectionId, template: "mdbase", display_name: "Provision probe" }
+    body: { account_id: provisionAccountId, collection_id: provisionCollectionId, template: "mdbase", display_name: "Provision probe" }
   });
   const typeProvision = workItemTypePack({
     packId: "example.workouts",
@@ -404,6 +405,7 @@ try {
   assert.equal(notificationReady.body.notifications.consecutive_failures, 0);
   assert.match(notificationReady.body.notifications.last_success_at, /^\d{4}-\d{2}-\d{2}T/);
   const notificationCollectionId = crypto.randomUUID();
+  const notificationAccountId = await provisionProviderAccount(notificationProvider.url);
   const notificationReplicaId = crypto.randomUUID();
   const notificationToken = `notification-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   const notificationGrantId = crypto.randomUUID();
@@ -412,6 +414,7 @@ try {
   await internalRequest(notificationProvider.url, "/internal/v1/collections", {
     method: "POST",
     body: {
+      account_id: notificationAccountId,
       collection_id: notificationCollectionId,
       template: "mdbase",
       display_name: "Notification records"
@@ -606,11 +609,19 @@ try {
     MDBASE_CONNECT_HOSTED_MAX_REPLICAS_PER_COLLECTION: "1"
   });
   const quotaCollectionId = crypto.randomUUID();
+  const quotaAccountId = await provisionProviderAccount(quotaProvider.url, {
+    hosted_storage_bytes: 500,
+    retained_file_bytes: 1000,
+    max_document_bytes: 512,
+    max_replicas_per_collection: 1,
+    max_hosted_collections: 2
+  });
   const quotaReplicaId = crypto.randomUUID();
   const quotaToken = `quota-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(quotaProvider.url, "/internal/v1/collections", {
     method: "POST",
     body: {
+      account_id: quotaAccountId,
       collection_id: quotaCollectionId,
       template: "mdbase",
       display_name: "Quota worklog"
@@ -619,6 +630,7 @@ try {
   await internalRequest(quotaProvider.url, "/internal/v1/collections", {
     method: "POST",
     body: {
+      account_id: quotaAccountId,
       collection_id: quotaCollectionId,
       template: "mdbase",
       display_name: "Quota worklog"
@@ -707,6 +719,85 @@ try {
   });
   assert.equal(documentQuota.status, "rejected");
   assert.equal(documentQuota.error.code, "document_quota_exceeded");
+  const accountBeforeAggregateProbe = (
+    await internalRequest(
+      quotaProvider.url,
+      `/internal/v1/accounts/${quotaAccountId}`
+    )
+  ).account;
+  const aggregateCollectionId = crypto.randomUUID();
+  const aggregateReplicaId = crypto.randomUUID();
+  const aggregateToken = `aggregate-${crypto.randomUUID()}-${crypto.randomUUID()}`;
+  await internalRequest(quotaProvider.url, "/internal/v1/collections", {
+    method: "POST",
+    body: {
+      account_id: quotaAccountId,
+      collection_id: aggregateCollectionId,
+      template: "mdbase",
+      display_name: "Aggregate quota probe"
+    }
+  });
+  await provisionTypes(quotaProvider.url, aggregateCollectionId, [WORK_ITEM_PROVISION]);
+  await internalRequest(
+    quotaProvider.url,
+    `/internal/v1/collections/${aggregateCollectionId}/replicas`,
+    {
+      method: "POST",
+      body: {
+        replica_id: aggregateReplicaId,
+        name: "Aggregate writer",
+        mode: "read_write",
+        allowed_types: ["task"],
+        token: aggregateToken
+      }
+    }
+  );
+  const aggregateTransport = new HttpSyncTransport(
+    authoritySyncUrl(quotaProvider.url, aggregateCollectionId),
+    aggregateToken
+  );
+  const aggregateMutation = createMutation(
+    aggregateReplicaId,
+    crypto.randomUUID(),
+    "tasks/aggregate.md",
+    "Aggregate"
+  );
+  aggregateMutation.input.body = "x".repeat(
+    500 - accountBeforeAggregateProbe.live_content_bytes + 1
+  );
+  await expectSyncError(
+    () => aggregateTransport.mutate(aggregateMutation),
+    "account_storage_quota_exceeded"
+  );
+  const accountAfterAggregateProbe = (
+    await internalRequest(
+      quotaProvider.url,
+      `/internal/v1/accounts/${quotaAccountId}`
+    )
+  ).account;
+  assert.equal(
+    accountAfterAggregateProbe.live_content_bytes,
+    accountBeforeAggregateProbe.live_content_bytes
+  );
+  const collectionQuota = await rawRequest(
+    quotaProvider.url,
+    "/internal/v1/collections",
+    {
+      method: "POST",
+      token: internalToken,
+      body: {
+        account_id: quotaAccountId,
+        collection_id: crypto.randomUUID(),
+        template: "mdbase",
+        display_name: "Too many collections"
+      }
+    }
+  );
+  assert.equal(collectionQuota.status, 429);
+  assert.equal(
+    collectionQuota.body.error.code,
+    "account_collection_quota_exceeded"
+  );
   await stopProvider(quotaProvider);
 
   phase("automatically bounding retained change history");
@@ -723,11 +814,12 @@ try {
     MDBASE_CONNECT_HOSTED_MAINTENANCE_INTERVAL_SECONDS: "1"
   });
   const maintenanceCollectionId = crypto.randomUUID();
+  const maintenanceAccountId = await provisionProviderAccount(maintenanceProvider.url);
   const maintenanceReplicaId = crypto.randomUUID();
   const maintenanceToken = `maintenance-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(maintenanceProvider.url, "/internal/v1/collections", {
     method: "POST",
-    body: { collection_id: maintenanceCollectionId, template: "mdbase", display_name: "Maintenance records" }
+    body: { account_id: maintenanceAccountId, collection_id: maintenanceCollectionId, template: "mdbase", display_name: "Maintenance records" }
   });
   await provisionTypes(maintenanceProvider.url, maintenanceCollectionId, [WORK_ITEM_PROVISION]);
   await internalRequest(
@@ -1640,11 +1732,13 @@ schema:
 
   phase("fencing, proving, completing, and cancelling authority transfers");
   const authorityCollectionId = crypto.randomUUID();
+  const authorityAccountId = await provisionProviderAccount(provider.url);
   const authorityReplicaId = crypto.randomUUID();
   const authorityToken = `authority-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(provider.url, "/internal/v1/collections", {
     method: "POST",
     body: {
+      account_id: authorityAccountId,
       collection_id: authorityCollectionId,
       template: "mdbase",
       display_name: "Authority transfer probe"
@@ -1810,11 +1904,13 @@ schema:
   );
 
   const cancelledCollectionId = crypto.randomUUID();
+  const cancelledAccountId = await provisionProviderAccount(provider.url);
   const cancelledReplicaId = crypto.randomUUID();
   const cancelledToken = `authority-cancel-${crypto.randomUUID()}-${crypto.randomUUID()}`;
   await internalRequest(provider.url, "/internal/v1/collections", {
     method: "POST",
     body: {
+      account_id: cancelledAccountId,
       collection_id: cancelledCollectionId,
       template: "mdbase",
       display_name: "Cancelled authority probe"
@@ -3985,6 +4081,24 @@ async function internalRequest(url, path, options = {}) {
     throw new Error(`${path} returned HTTP ${response.status}: ${JSON.stringify(response.body)}`);
   }
   return response.body;
+}
+
+async function provisionProviderAccount(url, overrides = {}, accountId = crypto.randomUUID()) {
+  await internalRequest(url, `/internal/v1/accounts/${accountId}`, {
+    method: "PUT",
+    body: {
+      entitlement_revision: 1,
+      hosted_storage_bytes: 1024 * 1024 * 1024,
+      retained_file_bytes: 2 * 1024 * 1024 * 1024,
+      max_document_bytes: 2 * 1024 * 1024,
+      max_single_file_bytes: 250 * 1024 * 1024,
+      max_replicas_per_collection: 10,
+      max_hosted_collections: 10,
+      max_files_per_collection: 10_000,
+      ...overrides
+    }
+  });
+  return accountId;
 }
 
 function provisionTypes(url, collectionId, typePacks) {

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.21" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.22" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/migrations/0010_beta_entitlements_and_email.sql
+++ b/services/server/migrations/0010_beta_entitlements_and_email.sql
@@ -1,0 +1,157 @@
+CREATE TABLE entitlement_profiles (
+  code text PRIMARY KEY,
+  hosted_storage_bytes bigint NOT NULL CHECK (hosted_storage_bytes > 0),
+  retained_file_bytes bigint NOT NULL CHECK (retained_file_bytes >= hosted_storage_bytes),
+  max_document_bytes bigint NOT NULL CHECK (max_document_bytes > 0),
+  max_single_file_bytes bigint NOT NULL CHECK (max_single_file_bytes > 0),
+  max_replicas_per_collection bigint NOT NULL CHECK (max_replicas_per_collection > 0),
+  max_hosted_collections bigint NOT NULL CHECK (max_hosted_collections > 0),
+  max_files_per_collection bigint NOT NULL CHECK (max_files_per_collection > 0),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO entitlement_profiles
+  (code, hosted_storage_bytes, retained_file_bytes, max_document_bytes,
+   max_single_file_bytes, max_replicas_per_collection,
+   max_hosted_collections, max_files_per_collection)
+VALUES
+  ('beta_v1', 1073741824, 2147483648, 2097152, 262144000, 10, 10, 10000);
+
+CREATE TABLE invitation_entitlements (
+  invitation_id uuid PRIMARY KEY REFERENCES invitations(id) ON DELETE CASCADE,
+  profile_code text NOT NULL REFERENCES entitlement_profiles(code),
+  assigned_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE account_entitlement_grants (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  profile_code text NOT NULL REFERENCES entitlement_profiles(code),
+  source text NOT NULL CHECK (source IN ('invitation', 'operator', 'subscription')),
+  source_reference text,
+  source_invitation_id uuid REFERENCES invitations(id) ON DELETE SET NULL,
+  starts_at timestamptz NOT NULL DEFAULT now(),
+  ends_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (ends_at IS NULL OR ends_at > starts_at),
+  CHECK (
+    (source = 'invitation' AND source_invitation_id IS NOT NULL)
+    OR source <> 'invitation'
+  )
+);
+
+CREATE UNIQUE INDEX account_entitlement_grants_invitation_idx
+  ON account_entitlement_grants(source_invitation_id)
+  WHERE source_invitation_id IS NOT NULL;
+
+CREATE UNIQUE INDEX account_entitlement_grants_source_reference_idx
+  ON account_entitlement_grants(user_id, source, source_reference)
+  WHERE source_reference IS NOT NULL;
+
+CREATE INDEX account_entitlement_grants_active_idx
+  ON account_entitlement_grants(user_id, starts_at, ends_at)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE account_storage_accounts (
+  user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  provider_account_id uuid NOT NULL UNIQUE,
+  entitlement_revision bigint NOT NULL DEFAULT 1 CHECK (entitlement_revision > 0),
+  provider_revision bigint NOT NULL DEFAULT 0 CHECK (provider_revision >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (provider_revision <= entitlement_revision)
+);
+
+CREATE TABLE account_email_preferences (
+  user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  onboarding_enabled boolean NOT NULL DEFAULT true,
+  product_enabled boolean NOT NULL DEFAULT false,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Accounts that predate the Beta invitation flow are themselves early Beta
+-- users. Preserve that status explicitly so hosted storage never falls back to
+-- an implicit, unmetered tier during rollout.
+INSERT INTO account_entitlement_grants
+  (id, user_id, profile_code, source, source_reference)
+SELECT account.id, account.id, 'beta_v1', 'operator', 'beta_v1_existing_account'
+FROM users account
+ON CONFLICT DO NOTHING;
+
+INSERT INTO account_storage_accounts (user_id, provider_account_id)
+SELECT account.id, account.id
+FROM users account
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO account_email_preferences (user_id)
+SELECT account.id
+FROM users account
+ON CONFLICT (user_id) DO NOTHING;
+
+CREATE TABLE email_jobs (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  email_identity_id uuid NOT NULL REFERENCES email_identities(id) ON DELETE CASCADE,
+  message_kind text NOT NULL,
+  template_version integer NOT NULL CHECK (template_version > 0),
+  category text NOT NULL CHECK (category IN ('essential', 'onboarding', 'product')),
+  deduplication_key text NOT NULL UNIQUE,
+  idempotency_key text NOT NULL UNIQUE,
+  state text NOT NULL DEFAULT 'scheduled'
+    CHECK (state IN ('scheduled', 'sending', 'accepted', 'delivered', 'failed', 'cancelled', 'uncertain')),
+  scheduled_for timestamptz NOT NULL,
+  next_attempt_at timestamptz NOT NULL,
+  lease_token uuid,
+  lease_expires_at timestamptz,
+  attempt_count integer NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  provider text,
+  provider_message_id text,
+  last_error_code text,
+  accepted_at timestamptz,
+  delivered_at timestamptz,
+  last_provider_event_at timestamptz,
+  cancelled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK ((lease_token IS NULL) = (lease_expires_at IS NULL)),
+  CHECK ((provider IS NULL) = (provider_message_id IS NULL)),
+  CHECK (next_attempt_at >= scheduled_for)
+);
+
+CREATE INDEX email_jobs_due_idx
+  ON email_jobs(next_attempt_at, id)
+  WHERE state IN ('scheduled', 'sending');
+
+CREATE TABLE email_delivery_attempts (
+  id uuid PRIMARY KEY,
+  job_id uuid NOT NULL REFERENCES email_jobs(id) ON DELETE CASCADE,
+  attempt_number integer NOT NULL CHECK (attempt_number > 0),
+  state text NOT NULL CHECK (state IN ('started', 'accepted', 'failed', 'uncertain')),
+  provider text,
+  provider_message_id text,
+  error_code text,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  UNIQUE(job_id, attempt_number)
+);
+
+CREATE TABLE email_provider_events (
+  provider text NOT NULL,
+  event_id text NOT NULL,
+  provider_message_id text NOT NULL,
+  event_type text NOT NULL,
+  event_created_at timestamptz NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY(provider, event_id)
+);
+
+CREATE INDEX email_provider_events_message_idx
+  ON email_provider_events(provider, provider_message_id, event_created_at);
+
+CREATE TABLE email_suppressions (
+  email_identity_id uuid PRIMARY KEY REFERENCES email_identities(id) ON DELETE CASCADE,
+  reason text NOT NULL CHECK (reason IN ('unsubscribed', 'bounced', 'complained', 'operator')),
+  source_event_id text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -26,9 +26,11 @@
     "@nats-io/transport-node": "^3.4.0",
     "@node-rs/argon2": "^2.0.2",
     "fastify": "^5.10.0",
+    "fastify-raw-body": "^5.0.0",
     "google-auth-library": "^10.9.0",
     "pg": "^8.22.0",
     "pg-mem": "^3.0.14",
+    "svix": "^1.99.1",
     "web-push": "^3.6.7",
     "ws": "^8.21.1",
     "zod": "^4.4.3"

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/account-management.test.ts
+++ b/services/server/src/account-management.test.ts
@@ -25,7 +25,14 @@ describe("account management", () => {
       content_bytes: 4_096,
       max_records: 100_000,
       max_content_bytes: 1_073_741_824,
-      max_document_bytes: 2_097_152
+      max_document_bytes: 2_097_152,
+      file_count: 0,
+      file_bytes: 0,
+      stored_file_bytes: 0,
+      max_files: 10_000,
+      max_file_bytes: 1_073_741_824,
+      max_stored_file_bytes: 2_147_483_648,
+      max_single_file_bytes: 262_144_000
     }));
     const { app, db } = await fixture({
       hostedCollections: true,
@@ -71,6 +78,9 @@ describe("account management", () => {
       storage: {
         status: "available",
         total_content_bytes: 4_096,
+        total_file_bytes: 0,
+        total_storage_bytes: 4_096,
+        total_stored_file_bytes: 0,
         total_records: 12,
         collections: [expect.objectContaining({
           display_name: "Research",

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -1228,6 +1228,7 @@ describe("mdbase connect server", () => {
     const hostedProvider = {
       url: "https://sync.example",
       ready: vi.fn(),
+      upsertAccount: vi.fn().mockResolvedValue({}),
       createCollection: vi.fn(),
       renameCollection: vi.fn(),
       deleteCollection: vi.fn(),
@@ -1456,6 +1457,7 @@ describe("mdbase connect server", () => {
     const hostedProvider = {
       url: "https://sync.example",
       ready: vi.fn(),
+      upsertAccount: vi.fn().mockResolvedValue({}),
       createCollection: vi.fn(),
       renameCollection: vi.fn(),
       deleteCollection: vi.fn(),
@@ -1503,6 +1505,7 @@ describe("mdbase connect server", () => {
     expect(created.statusCode, JSON.stringify(created.json())).toBe(201);
     const collectionId = created.json().collection.id as string;
     expect(hostedProvider.createCollection).toHaveBeenCalledWith(
+      expect.any(String),
       collectionId,
       "mdbase",
       "Desktop notes"
@@ -1623,6 +1626,7 @@ describe("mdbase connect server", () => {
     const hostedProvider = {
       url: "https://sync.example",
       ready: vi.fn(),
+      upsertAccount: vi.fn().mockResolvedValue({}),
       createCollection: vi.fn(),
       renameCollection: vi.fn(),
       deleteCollection: vi.fn(),
@@ -1871,6 +1875,7 @@ describe("mdbase connect server", () => {
     const hostedProvider = {
       url: "https://sync.example",
       ready: vi.fn(),
+      upsertAccount: vi.fn().mockResolvedValue({}),
       createCollection: vi.fn(),
       renameCollection: vi.fn(),
       deleteCollection: vi.fn(),

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -13,6 +13,8 @@ import { AuthenticationPolicyStore } from "./authentication-policy.js";
 import type { DatabasePool } from "./db.js";
 import type { EmailTransport } from "./email.js";
 import { registerResendWebhookRoute } from "./email-provider-webhooks.js";
+import { renderScheduledEmail } from "./beta-welcome-email.js";
+import { ScheduledEmailWorker } from "./scheduled-email.js";
 import type { GitHubAuthConfig } from "./github-auth.js";
 import type { GoogleAuthConfig } from "./google-auth.js";
 import { HostedAuthorityRegistry } from "./hosted.js";
@@ -115,6 +117,18 @@ export async function buildApp(options: BuildOptions) {
         (error) => app.log.error({ err: error }, "notification delivery worker failed")
       )
     : undefined;
+  const scheduledEmails = options.emailTransport
+    ? new ScheduledEmailWorker(
+        options.db,
+        options.emailTransport,
+        renderScheduledEmail,
+        undefined,
+        (error) => app.log.error(
+          { err: error },
+          "scheduled email delivery worker failed"
+        )
+      )
+    : undefined;
   if (options.hostedProvider && options.hostedReferenceAuthority) {
     throw new Error("Hosted provider and reference authority modes are mutually exclusive.");
   }
@@ -182,6 +196,7 @@ export async function buildApp(options: BuildOptions) {
   );
 
   app.addHook("onClose", async () => {
+    await scheduledEmails?.close();
     await providerRevocations?.close();
     await notifications?.close();
     await relay.close();
@@ -405,6 +420,8 @@ export async function buildApp(options: BuildOptions) {
       return reply.code(404).send(apiError("not_found", "Not found."));
     });
   }
+
+  scheduledEmails?.start();
 
   return { app, relay };
 }

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -7,10 +7,12 @@ import helmet from "@fastify/helmet";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
+import rawBody from "fastify-raw-body";
 import Fastify, { LogController } from "fastify";
 import { AuthenticationPolicyStore } from "./authentication-policy.js";
 import type { DatabasePool } from "./db.js";
 import type { EmailTransport } from "./email.js";
+import { registerResendWebhookRoute } from "./email-provider-webhooks.js";
 import type { GitHubAuthConfig } from "./github-auth.js";
 import type { GoogleAuthConfig } from "./google-auth.js";
 import { HostedAuthorityRegistry } from "./hosted.js";
@@ -69,6 +71,7 @@ interface BuildOptions {
   editorOrigin?: string;
   authenticationLegalDocuments?: AuthenticationLegalDocuments;
   emailTransport?: EmailTransport;
+  resendWebhookSecret?: string;
   hostedCollections?: boolean;
   hostedProvider?: HostedProviderClient;
   hostedReferenceAuthority?: boolean;
@@ -161,6 +164,11 @@ export async function buildApp(options: BuildOptions) {
     timeWindow: "1 minute"
   });
   await app.register(formbody);
+  await app.register(rawBody, {
+    global: false,
+    encoding: "utf8",
+    runFirst: true
+  });
   await app.register(cors, {
     origin: true,
     credentials: true,
@@ -228,6 +236,12 @@ export async function buildApp(options: BuildOptions) {
     publicUrl,
     editorOrigin: options.editorOrigin
   });
+  if (options.resendWebhookSecret) {
+    registerResendWebhookRoute(app, {
+      db: options.db,
+      signingSecret: options.resendWebhookSecret
+    });
+  }
   if (options.betaAccessOrigin) {
     if (!options.authRateLimitSecret) {
       throw new Error("Beta access requests require a rate-limit secret.");

--- a/services/server/src/auth-admin-cli.ts
+++ b/services/server/src/auth-admin-cli.ts
@@ -32,6 +32,7 @@ try {
     ...(emailTransport ? { emailTransport } : {}),
     ...(hostedProvider
       ? {
+          hostedProvider,
           hostedReplicaRevoker: {
             async revokeReplica(replicaId: string) {
               try {

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -376,6 +376,40 @@ describe("authentication operator command", () => {
       Buffer.from(JSON.stringify(["request", envelope])).toString("base64url")
     ], context)).rejects.toBeInstanceOf(AuthAdminUsageError);
   });
+
+  it("grants and reports durable Beta entitlements idempotently", async () => {
+    const context = await fixture();
+    const userId = "10000000-0000-4000-8000-000000000089";
+    await context.db.query(
+      `INSERT INTO users (id, email, name)
+       VALUES ($1, 'beta-target@example.com', 'Beta target')`,
+      [userId]
+    );
+    const command = [
+      "entitlements", "grant",
+      "--user", "beta-target@example.com",
+      "--profile", "beta_v1",
+      "--operation-id", "20000000-0000-4000-8000-000000000089",
+      "--actor", "operator:test",
+      "--reason", "Private beta storage"
+    ];
+    expect(await runAuthAdminCommand(command, context)).toEqual(
+      expect.objectContaining({
+        user_id: userId,
+        changed: true,
+        entitlementRevision: 1,
+        reconciliation: null
+      })
+    );
+    expect(await runAuthAdminCommand(command, context)).toEqual(
+      expect.objectContaining({ changed: false, entitlementRevision: 1 })
+    );
+    const shown = await runAuthAdminCommand([
+      "entitlements", "show", "--user", userId
+    ], context) as { effective: { hostedStorageBytes: number }; grants: unknown[] };
+    expect(shown.effective.hostedStorageBytes).toBe(1024 * 1024 * 1024);
+    expect(shown.grants).toHaveLength(1);
+  });
 });
 
 let messageSequence = 0;

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { DatabasePool } from "./db.js";
 import {
   AuthenticationPolicyStore,
@@ -183,7 +184,12 @@ async function reconcileEntitlements(
       "Entitlement reconciliation requires a configured hosted provider."
     );
   }
-  const flags = parseFlags(argv, new Set(["user", "all"]));
+  const flags = parseFlags(argv, new Set([
+    "user", "all", "operation-id", "actor", "reason"
+  ]));
+  const operationId = requiredFlag(flags, "operation-id");
+  const actor = requiredFlag(flags, "actor");
+  const reason = requiredFlag(flags, "reason");
   const all = flags.has("all")
     && enabledFlag(requiredFlag(flags, "all"), "all");
   if (all === flags.has("user")) {
@@ -214,8 +220,24 @@ async function reconcileEntitlements(
       reconciled_collections: result.reconciledCollections,
       usage: result.usage
     });
+    await context.db.query(
+      `INSERT INTO audit_events
+         (id, user_id, event_type, subject_id, metadata)
+       VALUES ($1, $2, 'entitlement.reconciled', $2, $3::jsonb)`,
+      [
+        randomUUID(),
+        userId,
+        JSON.stringify({
+          actor,
+          reason,
+          operation_id: operationId,
+          entitlement_revision: result.entitlementRevision,
+          reconciled_collections: result.reconciledCollections
+        })
+      ]
+    );
   }
-  return { reconciled };
+  return { operation_id: operationId, reconciled };
 }
 
 export class AuthAdminUsageError extends Error {
@@ -903,7 +925,7 @@ export function usage(): string {
     "  auth-admin beta list [--status pending|invited] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin entitlements show --user <uuid|email>",
     "  auth-admin entitlements grant --user <uuid|email> --profile <code> --operation-id <uuid> --actor <id> --reason <text>",
-    "  auth-admin entitlements reconcile (--user <uuid|email> | --all enabled)",
+    "  auth-admin entitlements reconcile (--user <uuid|email> | --all enabled) --operation-id <uuid> --actor <id> --reason <text>",
     "  auth-admin users list [--status active|suspended] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin users show --user <uuid|email>",
     "  auth-admin users suspend --user <uuid|email> --operation-id <uuid> --actor <id> --reason <text>",

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -6,6 +6,12 @@ import {
 import { PasswordAccountService } from "./password-auth.js";
 import { normalizeEmailAddress } from "./email-identity.js";
 import type { RegistrationMode } from "./runtime-config.js";
+import type { HostedProviderClient } from "./hosted-provider.js";
+import {
+  effectiveEntitlement,
+  grantOperatorEntitlement,
+  reconcileHostedAccountCollections
+} from "./entitlements.js";
 import {
   EmailDeliveryError,
   type EmailTransport
@@ -23,6 +29,7 @@ export interface AuthAdminContext {
   publicUrl?: string;
   emailTransport?: EmailTransport;
   hostedReplicaRevoker?: HostedReplicaRevoker;
+  hostedProvider?: HostedProviderClient;
 }
 
 export async function runAuthAdminCommand(
@@ -75,6 +82,15 @@ async function runCommand(
   if (area === "beta" && action === "list") {
     return listBetaAccessRequests(rest, context);
   }
+  if (area === "entitlements" && action === "show") {
+    return showEntitlements(rest, context);
+  }
+  if (area === "entitlements" && action === "grant") {
+    return grantEntitlements(rest, context);
+  }
+  if (area === "entitlements" && action === "reconcile") {
+    return reconcileEntitlements(rest, context);
+  }
   if (area === "users" && action === "list") {
     return listUsers(rest, context);
   }
@@ -94,6 +110,112 @@ async function runCommand(
     return listAudit(rest, context);
   }
   throw new AuthAdminUsageError(usage());
+}
+
+async function showEntitlements(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<unknown> {
+  const flags = parseFlags(argv, new Set(["user"]));
+  const found = await instanceAdmin(context).showUser(requiredFlag(flags, "user"));
+  const userId = found.user.id;
+  const entitlement = await effectiveEntitlement(context.db, userId);
+  const storage = await context.db.query(
+    `SELECT provider_account_id, entitlement_revision, provider_revision,
+            created_at, updated_at
+     FROM account_storage_accounts WHERE user_id = $1`,
+    [userId]
+  );
+  const grants = await context.db.query(
+    `SELECT profile_code, source, source_reference, starts_at, ends_at,
+            revoked_at, created_at
+     FROM account_entitlement_grants WHERE user_id = $1
+     ORDER BY created_at, id`,
+    [userId]
+  );
+  const providerUsage = context.hostedProvider && storage.rows[0]
+    ? await context.hostedProvider.accountUsage(storage.rows[0].provider_account_id)
+    : null;
+  return {
+    user: { id: userId, email: found.user.email, name: found.user.name },
+    effective: entitlement,
+    storage_account: storage.rows[0] ?? null,
+    provider_usage: providerUsage,
+    grants: grants.rows
+  };
+}
+
+async function grantEntitlements(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<unknown> {
+  const flags = parseFlags(argv, new Set([
+    "user", "profile", "operation-id", "actor", "reason"
+  ]));
+  const found = await instanceAdmin(context).showUser(requiredFlag(flags, "user"));
+  const result = await grantOperatorEntitlement(context.db, {
+    userId: found.user.id,
+    profileCode: entitlementProfile(requiredFlag(flags, "profile")),
+    operationId: requiredFlag(flags, "operation-id"),
+    actor: requiredFlag(flags, "actor"),
+    reason: requiredFlag(flags, "reason")
+  });
+  const reconciliation = context.hostedProvider
+    ? await reconcileHostedAccountCollections(
+        context.db,
+        context.hostedProvider,
+        found.user.id
+      )
+    : null;
+  return {
+    user_id: found.user.id,
+    ...result,
+    reconciliation
+  };
+}
+
+async function reconcileEntitlements(
+  argv: string[],
+  context: AuthAdminContext
+): Promise<unknown> {
+  if (!context.hostedProvider) {
+    throw new AuthAdminUsageError(
+      "Entitlement reconciliation requires a configured hosted provider."
+    );
+  }
+  const flags = parseFlags(argv, new Set(["user", "all"]));
+  const all = flags.has("all")
+    && enabledFlag(requiredFlag(flags, "all"), "all");
+  if (all === flags.has("user")) {
+    throw new AuthAdminUsageError(
+      "Entitlement reconciliation requires exactly one of --user or --all enabled."
+    );
+  }
+  const userIds = all
+    ? (await context.db.query<{ id: string }>(
+        "SELECT id FROM users WHERE suspended_at IS NULL ORDER BY id"
+      )).rows.map((row) => row.id)
+    : [
+        (await instanceAdmin(context).showUser(
+          requiredFlag(flags, "user")
+        )).user.id
+      ];
+  const reconciled = [];
+  for (const userId of userIds) {
+    const result = await reconcileHostedAccountCollections(
+      context.db,
+      context.hostedProvider,
+      userId
+    );
+    reconciled.push({
+      user_id: userId,
+      provider_account_id: result.providerAccountId,
+      entitlement_revision: result.entitlementRevision,
+      reconciled_collections: result.reconciledCollections,
+      usage: result.usage
+    });
+  }
+  return { reconciled };
 }
 
 export class AuthAdminUsageError extends Error {
@@ -230,6 +352,7 @@ async function createInvitation(
     "actor",
     "reason",
     "expires-in",
+    "entitlement-profile",
     "send-email",
     "token-output"
   ]));
@@ -272,6 +395,13 @@ async function createAndDeliverInvitation(
     email: requiredFlag(flags, "email"),
     actor: requiredFlag(flags, "actor"),
     reason: requiredFlag(flags, "reason"),
+    ...(flags.has("entitlement-profile")
+      ? {
+          entitlementProfile: entitlementProfile(
+            requiredFlag(flags, "entitlement-profile")
+          )
+        }
+      : {}),
     ...(flags.has("expires-in")
       ? {
           expiresInSeconds: positiveInteger(
@@ -297,6 +427,7 @@ async function createAndDeliverInvitation(
     expires_at: invitation.expiresAt.toISOString(),
     terms_version: invitation.termsVersion,
     privacy_version: invitation.privacyVersion,
+    entitlement_profile: invitation.entitlementProfile,
     ...(showToken
       ? {
           token: invitation.token,
@@ -437,7 +568,11 @@ async function resendInvitation(
   );
   const invitationId = requiredFlag(flags, "id");
   const existing = await instanceAdmin(context).showInvitation(invitationId) as {
-    invitation: { email: string; status: string };
+    invitation: {
+      email: string;
+      status: string;
+      entitlement_profile: string | null;
+    };
   };
   if (existing.invitation.status === "accepted") {
     throw new AuthAdminUsageError(
@@ -453,6 +588,12 @@ async function resendInvitation(
   ]);
   if (flags.has("expires-in")) {
     createFlags.set("expires-in", requiredFlag(flags, "expires-in"));
+  }
+  if (existing.invitation.entitlement_profile) {
+    createFlags.set(
+      "entitlement-profile",
+      existing.invitation.entitlement_profile
+    );
   }
   const result = await createAndDeliverInvitation(createFlags, context) as {
     invitation: Record<string, unknown>;
@@ -649,6 +790,11 @@ function tokenOutput(value: string): "shown" | "omitted" {
   );
 }
 
+function entitlementProfile(value: string): string {
+  if (/^[a-z][a-z0-9_]{0,99}$/u.test(value)) return value;
+  throw new AuthAdminUsageError("Entitlement profile is invalid.");
+}
+
 function invitationStatus(
   value: string
 ): "active" | "accepted" | "revoked" | "expired" {
@@ -749,12 +895,15 @@ export function usage(): string {
     "  auth-admin policy show",
     "  auth-admin policy history [--limit <n>] [--before-revision <n>]",
     "  auth-admin policy update --expected-revision <n> --actor <id> --reason <text> [changes]",
-    "  auth-admin invite create --email <address> --actor <id> --reason <text> [--expires-in <seconds>] [--send-email enabled] [--token-output shown|omitted]",
+    "  auth-admin invite create --email <address> --actor <id> --reason <text> [--entitlement-profile <code>] [--expires-in <seconds>] [--send-email enabled] [--token-output shown|omitted]",
     "  auth-admin invite list [--status <status>] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin invite show --id <uuid>",
     "  auth-admin invite revoke --id <uuid> --operation-id <uuid> --actor <id> --reason <text>",
     "  auth-admin invite resend --id <uuid> --actor <id> --reason <text> [--expires-in <seconds>]",
     "  auth-admin beta list [--status pending|invited] [--limit <n>] [--cursor <cursor>]",
+    "  auth-admin entitlements show --user <uuid|email>",
+    "  auth-admin entitlements grant --user <uuid|email> --profile <code> --operation-id <uuid> --actor <id> --reason <text>",
+    "  auth-admin entitlements reconcile (--user <uuid|email> | --all enabled)",
     "  auth-admin users list [--status active|suspended] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin users show --user <uuid|email>",
     "  auth-admin users suspend --user <uuid|email> --operation-id <uuid> --actor <id> --reason <text>",

--- a/services/server/src/authority-adoption.test.ts
+++ b/services/server/src/authority-adoption.test.ts
@@ -33,6 +33,7 @@ describe("portable local collection adoption", () => {
     let completionAttempts = 0;
     const registeredReplicas: Array<{ collectionId: string; id: string }> = [];
     const provider = {
+      upsertAccount: async () => ({}),
       url: "https://provider.example",
       prepareAuthorityImport: async (input: {
         transferId: string;
@@ -250,6 +251,7 @@ describe("portable local collection adoption", () => {
     resources.push(() => db.end());
     let aborts = 0;
     const provider = {
+      upsertAccount: async () => ({}),
       url: "https://provider.example",
       prepareAuthorityImport: async (input: {
         transferId: string;

--- a/services/server/src/authority-transfer.test.ts
+++ b/services/server/src/authority-transfer.test.ts
@@ -437,6 +437,7 @@ describe("local-to-hosted authority transfer", () => {
     resources.push(() => db.end());
     let completionAttempts = 0;
     const provider = {
+      upsertAccount: async () => ({}),
       url: "https://provider.example",
       prepareAuthorityImport: async (input: {
         transferId: string;

--- a/services/server/src/beta-welcome-email.test.ts
+++ b/services/server/src/beta-welcome-email.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderBetaWelcomeEmail,
+  renderScheduledEmail
+} from "./beta-welcome-email.js";
+
+const APPROVED_TEXT = `Hi Person Example,
+
+Thanks for signing up for mdbase Connect.
+
+My name is Callum. I've been working on mdbase as a tool for doing more with markdown files, and as you are getting started with mdbase, I want to say a few words about its philosophy, how it works, and some precautions that you might need to take.
+
+I think markdown files are great because they are human readable, work with ordinary text-editing tools, and they remain useful even as the software around them changes or disappears. mdbase Connect is designed to keep these qualities while making it easier to build applications on top of collections of markdown files and providing a secure way to connect to these files over the internet.
+
+A lot of the software that we use, especially SaaS software, puts your data in its own database. This can make it difficult to use elsewhere or leave with the data when the software becomes unsuitable to your needs. The goal of mdbase is to enable users to enjoy good software while maintaining control of their data, with or without mdbase.
+
+There is one important thing to keep in mind, though. By design, an application you connect may be able to read data from a collection. If you give it write access, it may also be able to create, change, move, or delete files in that collection, and, again by design, those changes can be synchronized back to your computer. mdbase checks that each application stays within the permissions you've granted, but you should still only connect applications you trust, especially when they ask for write access.
+
+You can also build applications using the mdbase SDK. This is a way to make your own tools that work with your data online or offline, without giving a third-party application access to it.
+
+Because you joined during the beta, your account has a 1 GB hosted-storage allowance that does not expire when the beta ends. It is shared across your Markdown files and other files. You can create up to 10 hosted collections, connect up to 10 replicas to each collection, store Markdown documents up to 2 MB, and store individual files up to 250 MB. I hope to offer paid plans with more storage later, and you'll be able to add one without losing your beta allowance.
+
+There will probably be some rough edges, so please let me know when something breaks, behaves unexpectedly, or is confusing. You can send an email to support@mdbase.dev or open an issue on GitHub. mdbase is early in its development and so feedback is super-helpful!
+
+Best,
+Callum.`;
+
+describe("Beta welcome email", () => {
+  it("renders the approved plain-text copy exactly", () => {
+    const message = renderBetaWelcomeEmail({
+      name: "Person Example",
+      email: "person@example.com"
+    });
+    expect(message).toMatchObject({
+      to: "person@example.com",
+      subject: "A note about mdbase Connect",
+      text: APPROVED_TEXT
+    });
+    expect(message.text).toMatch(/^[\x00-\x7f]*$/u);
+  });
+
+  it("escapes recipient names in the matching HTML version", () => {
+    const message = renderBetaWelcomeEmail({
+      name: "<Person & Friend>",
+      email: "person@example.com"
+    });
+    expect(message.html).toContain("Hi &lt;Person &amp; Friend&gt;,");
+    expect(message.html).not.toContain("Hi <Person & Friend>,");
+    expect(message.html).toContain("1 GB hosted-storage allowance");
+  });
+
+  it("fails closed for an unknown kind or template version", () => {
+    expect(() => renderScheduledEmail({
+      userId: "user-1",
+      name: "Person",
+      email: "person@example.com",
+      messageKind: "unknown",
+      templateVersion: 1
+    })).toThrow("Scheduled email template is unavailable.");
+  });
+});

--- a/services/server/src/beta-welcome-email.ts
+++ b/services/server/src/beta-welcome-email.ts
@@ -1,0 +1,98 @@
+import type { DatabaseQueryable } from "./database-types.js";
+import type { TransactionalEmail } from "./email.js";
+import {
+  scheduleEmail,
+  type EmailRenderContext
+} from "./scheduled-email.js";
+
+export const BETA_WELCOME_MESSAGE_KIND = "beta_welcome";
+export const BETA_WELCOME_TEMPLATE_VERSION = 1;
+const BETA_WELCOME_DELAY_MS = 24 * 60 * 60 * 1_000;
+
+const SUBJECT = "A note about mdbase Connect";
+
+export async function scheduleBetaWelcomeEmail(
+  db: DatabaseQueryable,
+  input: {
+    userId: string;
+    emailIdentityId: string;
+    signedUpAt?: Date;
+  }
+): Promise<{ id: string; duplicate: boolean }> {
+  return scheduleEmail(db, {
+    userId: input.userId,
+    emailIdentityId: input.emailIdentityId,
+    messageKind: BETA_WELCOME_MESSAGE_KIND,
+    templateVersion: BETA_WELCOME_TEMPLATE_VERSION,
+    category: "onboarding",
+    deduplicationKey:
+      `${BETA_WELCOME_MESSAGE_KIND}:${input.userId}:v${BETA_WELCOME_TEMPLATE_VERSION}`,
+    scheduledFor: new Date(
+      (input.signedUpAt ?? new Date()).getTime() + BETA_WELCOME_DELAY_MS
+    )
+  });
+}
+
+export function renderScheduledEmail(
+  context: EmailRenderContext
+): TransactionalEmail {
+  if (
+    context.messageKind !== BETA_WELCOME_MESSAGE_KIND
+    || context.templateVersion !== BETA_WELCOME_TEMPLATE_VERSION
+  ) {
+    throw new TypeError("Scheduled email template is unavailable.");
+  }
+  return renderBetaWelcomeEmail(context);
+}
+
+export function renderBetaWelcomeEmail(
+  input: Pick<EmailRenderContext, "name" | "email">
+): TransactionalEmail {
+  const paragraphs = [
+    `Hi ${input.name},`,
+    "Thanks for signing up for mdbase Connect.",
+    "My name is Callum. I've been working on mdbase as a tool for doing more with markdown files, and as you are getting started with mdbase, I want to say a few words about its philosophy, how it works, and some precautions that you might need to take.",
+    "I think markdown files are great because they are human readable, work with ordinary text-editing tools, and they remain useful even as the software around them changes or disappears. mdbase Connect is designed to keep these qualities while making it easier to build applications on top of collections of markdown files and providing a secure way to connect to these files over the internet.",
+    "A lot of the software that we use, especially SaaS software, puts your data in its own database. This can make it difficult to use elsewhere or leave with the data when the software becomes unsuitable to your needs. The goal of mdbase is to enable users to enjoy good software while maintaining control of their data, with or without mdbase.",
+    "There is one important thing to keep in mind, though. By design, an application you connect may be able to read data from a collection. If you give it write access, it may also be able to create, change, move, or delete files in that collection, and, again by design, those changes can be synchronized back to your computer. mdbase checks that each application stays within the permissions you've granted, but you should still only connect applications you trust, especially when they ask for write access.",
+    "You can also build applications using the mdbase SDK. This is a way to make your own tools that work with your data online or offline, without giving a third-party application access to it.",
+    "Because you joined during the beta, your account has a 1 GB hosted-storage allowance that does not expire when the beta ends. It is shared across your Markdown files and other files. You can create up to 10 hosted collections, connect up to 10 replicas to each collection, store Markdown documents up to 2 MB, and store individual files up to 250 MB. I hope to offer paid plans with more storage later, and you'll be able to add one without losing your beta allowance.",
+    "There will probably be some rough edges, so please let me know when something breaks, behaves unexpectedly, or is confusing. You can send an email to support@mdbase.dev or open an issue on GitHub. mdbase is early in its development and so feedback is super-helpful!",
+    "Best,\nCallum."
+  ];
+  return {
+    to: input.email,
+    subject: SUBJECT,
+    text: paragraphs.join("\n\n"),
+    html: renderHtml(paragraphs)
+  };
+}
+
+function renderHtml(paragraphs: string[]): string {
+  const body = paragraphs.map((paragraph) => {
+    const lines = escapeHtml(paragraph).replaceAll("\n", "<br>");
+    return `    <p style="margin:0 0 20px">${lines}</p>`;
+  }).join("\n");
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${SUBJECT}</title>
+</head>
+<body style="margin:0;background:#ffffff;color:#222831;font-family:Arial,sans-serif">
+  <div style="max-width:640px;margin:0 auto;padding:36px 24px;font-size:16px;line-height:1.6">
+${body}
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -43,7 +43,8 @@ describe("database migrations", () => {
       "0007_beta_access_requests",
       "0007_oauth_login_state_foundation",
       "0008_account_management",
-      "0009_grant_file_capabilities"
+      "0009_grant_file_capabilities",
+      "0010_beta_entitlements_and_email"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -313,7 +314,8 @@ describe("database migrations", () => {
       "0007_beta_access_requests",
       "0007_oauth_login_state_foundation",
       "0008_account_management",
-      "0009_grant_file_capabilities"
+      "0009_grant_file_capabilities",
+      "0010_beta_entitlements_and_email"
     ]);
   });
 

--- a/services/server/src/email-provider-webhooks.test.ts
+++ b/services/server/src/email-provider-webhooks.test.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from "node:crypto";
+import { Webhook } from "svix";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildApp } from "./app.js";
+import { createDatabase } from "./db.js";
+import type { DatabasePool } from "./database-types.js";
+import { scheduleEmail } from "./scheduled-email.js";
+
+const resources: Array<() => Promise<void>> = [];
+const signingSecret = `whsec_${Buffer.alloc(32, "w").toString("base64")}`;
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("Resend provider webhooks", () => {
+  it("verifies, deduplicates, and applies delivery events", async () => {
+    const { db, jobId } = await fixture();
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test",
+      resendWebhookSecret: signingSecret
+    });
+    resources.push(() => app.close());
+    const event = {
+      type: "email.delivered",
+      created_at: new Date().toISOString(),
+      data: { email_id: "resend-message-1" }
+    };
+    const payload = JSON.stringify(event);
+    const headers = signedHeaders(payload, "event-1");
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/email/provider-events/resend",
+      headers: { "content-type": "application/json", ...headers },
+      payload
+    });
+    const duplicate = await app.inject({
+      method: "POST",
+      url: "/v1/email/provider-events/resend",
+      headers: { "content-type": "application/json", ...headers },
+      payload
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(duplicate.statusCode).toBe(200);
+    const job = await db.query(
+      "SELECT state, delivered_at FROM email_jobs WHERE id = $1",
+      [jobId]
+    );
+    expect(job.rows[0]?.state).toBe("delivered");
+    expect(job.rows[0]?.delivered_at).not.toBeNull();
+    const events = await db.query("SELECT event_id FROM email_provider_events");
+    expect(events.rows).toHaveLength(1);
+  });
+
+  it("rejects invalid signatures and suppresses bounced identities", async () => {
+    const { db, emailIdentityId } = await fixture();
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test",
+      resendWebhookSecret: signingSecret
+    });
+    resources.push(() => app.close());
+    const event = {
+      type: "email.bounced",
+      created_at: new Date().toISOString(),
+      data: { email_id: "resend-message-1" }
+    };
+    const payload = JSON.stringify(event);
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/v1/email/provider-events/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": "event-invalid",
+        "svix-timestamp": `${Math.floor(Date.now() / 1_000)}`,
+        "svix-signature": "v1,invalid"
+      },
+      payload
+    });
+    expect(invalid.statusCode).toBe(400);
+
+    const accepted = await app.inject({
+      method: "POST",
+      url: "/v1/email/provider-events/resend",
+      headers: {
+        "content-type": "application/json",
+        ...signedHeaders(payload, "event-bounced")
+      },
+      payload
+    });
+    expect(accepted.statusCode).toBe(200);
+    const suppression = await db.query(
+      `SELECT reason, source_event_id FROM email_suppressions
+       WHERE email_identity_id = $1`,
+      [emailIdentityId]
+    );
+    expect(suppression.rows[0]).toEqual({
+      reason: "bounced",
+      source_event_id: "event-bounced"
+    });
+  });
+});
+
+async function fixture(): Promise<{
+  db: DatabasePool;
+  jobId: string;
+  emailIdentityId: string;
+}> {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  const userId = randomUUID();
+  const emailIdentityId = randomUUID();
+  await db.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, NULL, 'Webhook user')",
+    [userId]
+  );
+  await db.query(
+    `INSERT INTO email_identities
+       (id, user_id, email, normalized_email, normalization_version,
+        verified_at, is_primary)
+     VALUES ($1, $2, 'webhook@example.com', 'webhook@example.com', 1, now(), true)`,
+    [emailIdentityId, userId]
+  );
+  await db.query(
+    "INSERT INTO account_email_preferences (user_id) VALUES ($1)",
+    [userId]
+  );
+  const scheduled = await scheduleEmail(db, {
+    userId,
+    emailIdentityId,
+    messageKind: "test_webhook",
+    templateVersion: 1,
+    category: "essential",
+    deduplicationKey: `test_webhook:${userId}:v1`,
+    scheduledFor: new Date()
+  });
+  await db.query(
+    `UPDATE email_jobs SET state = 'accepted', provider = 'resend',
+       provider_message_id = 'resend-message-1', accepted_at = now()
+     WHERE id = $1`,
+    [scheduled.id]
+  );
+  return { db, jobId: scheduled.id, emailIdentityId };
+}
+
+function signedHeaders(payload: string, eventId: string): Record<string, string> {
+  const timestamp = new Date();
+  const signature = new Webhook(signingSecret).sign(eventId, timestamp, payload);
+  return {
+    "svix-id": eventId,
+    "svix-timestamp": `${Math.floor(timestamp.getTime() / 1_000)}`,
+    "svix-signature": signature
+  };
+}

--- a/services/server/src/email-provider-webhooks.ts
+++ b/services/server/src/email-provider-webhooks.ts
@@ -1,0 +1,179 @@
+import type { FastifyInstance } from "fastify";
+import { Webhook } from "svix";
+import type { DatabasePool, DatabaseQueryable } from "./database-types.js";
+import { apiError } from "./platform/http-errors.js";
+
+interface ResendWebhookOptions {
+  db: DatabasePool;
+  signingSecret: string;
+}
+
+interface ResendEvent {
+  type: string;
+  created_at: string;
+  data: {
+    email_id: string;
+  };
+}
+
+const TRACKED_EVENTS = new Set([
+  "email.sent",
+  "email.delivered",
+  "email.delivery_delayed",
+  "email.failed",
+  "email.bounced",
+  "email.complained",
+  "email.suppressed"
+]);
+
+export function registerResendWebhookRoute(
+  app: FastifyInstance,
+  options: ResendWebhookOptions
+): void {
+  const webhook = new Webhook(options.signingSecret);
+  app.post(
+    "/v1/email/provider-events/resend",
+    { config: { rawBody: true } },
+    async (request, reply) => {
+      const rawBody = request.rawBody;
+      const eventId = oneHeader(request.headers["svix-id"]);
+      const timestamp = oneHeader(request.headers["svix-timestamp"]);
+      const signature = oneHeader(request.headers["svix-signature"]);
+      if (
+        typeof rawBody !== "string"
+        || !eventId
+        || !timestamp
+        || !signature
+      ) {
+        return reply.code(400).send(
+          apiError("invalid_webhook", "The webhook request is invalid.")
+        );
+      }
+
+      let verified: unknown;
+      try {
+        verified = webhook.verify(rawBody, {
+          "svix-id": eventId,
+          "svix-timestamp": timestamp,
+          "svix-signature": signature
+        });
+      } catch {
+        return reply.code(400).send(
+          apiError("invalid_webhook", "The webhook signature is invalid.")
+        );
+      }
+      if (!isResendEvent(verified)) {
+        return reply.code(400).send(
+          apiError("invalid_webhook", "The webhook payload is invalid.")
+        );
+      }
+
+      await ingestResendEvent(options.db, eventId, verified);
+      return reply.code(200).send({ ok: true });
+    }
+  );
+}
+
+export async function ingestResendEvent(
+  db: DatabasePool,
+  eventId: string,
+  event: ResendEvent
+): Promise<boolean> {
+  if (!TRACKED_EVENTS.has(event.type)) return false;
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const inserted = await connection.query<{ event_id: string }>(
+      `INSERT INTO email_provider_events
+         (provider, event_id, provider_message_id, event_type, event_created_at)
+       VALUES ('resend', $1, $2, $3, $4)
+       ON CONFLICT DO NOTHING
+       RETURNING event_id`,
+      [eventId, event.data.email_id, event.type, event.created_at]
+    );
+    if (!inserted.rows[0]) {
+      await connection.query("COMMIT");
+      return false;
+    }
+    await applyEvent(connection, eventId, event);
+    await connection.query("COMMIT");
+    return true;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+async function applyEvent(
+  db: DatabaseQueryable,
+  eventId: string,
+  event: ResendEvent
+): Promise<void> {
+  const state = eventState(event.type);
+  if (state) {
+    await db.query(
+      `UPDATE email_jobs SET
+         state = $3,
+         delivered_at = CASE WHEN $3 = 'delivered' THEN $4 ELSE delivered_at END,
+         last_error_code = CASE
+           WHEN $3 = 'failed' THEN replace($5, 'email.', '')
+           ELSE last_error_code
+         END,
+         last_provider_event_at = $4,
+         updated_at = now()
+       WHERE provider = 'resend'
+         AND provider_message_id = $1
+         AND (last_provider_event_at IS NULL OR last_provider_event_at <= $4)
+         AND state NOT IN ('cancelled', 'uncertain')`,
+      [event.data.email_id, eventId, state, event.created_at, event.type]
+    );
+  }
+
+  const suppressionReason = event.type === "email.complained"
+    ? "complained"
+    : event.type === "email.bounced" || event.type === "email.suppressed"
+      ? "bounced"
+      : null;
+  if (!suppressionReason) return;
+  await db.query(
+    `INSERT INTO email_suppressions
+       (email_identity_id, reason, source_event_id)
+     SELECT job.email_identity_id, $3, $2
+     FROM email_jobs job
+     WHERE job.provider = 'resend' AND job.provider_message_id = $1
+     ON CONFLICT (email_identity_id) DO UPDATE SET
+       reason = EXCLUDED.reason,
+       source_event_id = EXCLUDED.source_event_id,
+       created_at = now()`,
+    [event.data.email_id, eventId, suppressionReason]
+  );
+}
+
+function eventState(type: string): "accepted" | "delivered" | "failed" | null {
+  if (type === "email.sent" || type === "email.delivery_delayed") return "accepted";
+  if (type === "email.delivered") return "delivered";
+  if (
+    type === "email.failed"
+    || type === "email.bounced"
+    || type === "email.complained"
+    || type === "email.suppressed"
+  ) return "failed";
+  return null;
+}
+
+function isResendEvent(value: unknown): value is ResendEvent {
+  if (!value || typeof value !== "object") return false;
+  const event = value as Partial<ResendEvent>;
+  return typeof event.type === "string"
+    && typeof event.created_at === "string"
+    && Number.isFinite(Date.parse(event.created_at))
+    && Boolean(event.data)
+    && typeof event.data?.email_id === "string"
+    && event.data.email_id.length > 0;
+}
+
+function oneHeader(value: string | string[] | undefined): string | null {
+  return typeof value === "string" && value ? value : null;
+}

--- a/services/server/src/entitlements.test.ts
+++ b/services/server/src/entitlements.test.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DatabasePool } from "./database-types.js";
+import { createDatabase } from "./db.js";
+import {
+  attachInvitationEntitlement,
+  BETA_ENTITLEMENT_PROFILE,
+  effectiveEntitlement,
+  materializeInvitationEntitlement
+} from "./entitlements.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("account entitlements", () => {
+  it("materializes one permanent Beta grant from an invitation", async () => {
+    const { db, userId, invitationId } = await fixture();
+    await attachInvitationEntitlement(
+      db,
+      invitationId,
+      BETA_ENTITLEMENT_PROFILE
+    );
+
+    const first = await materializeInvitationEntitlement(
+      db,
+      userId,
+      invitationId,
+      BETA_ENTITLEMENT_PROFILE
+    );
+    const replay = await materializeInvitationEntitlement(
+      db,
+      userId,
+      invitationId,
+      BETA_ENTITLEMENT_PROFILE
+    );
+
+    expect(replay).toEqual(first);
+    const grants = await db.query(
+      "SELECT id FROM account_entitlement_grants WHERE user_id = $1",
+      [userId]
+    );
+    expect(grants.rowCount).toBe(1);
+    expect(await effectiveEntitlement(db, userId)).toEqual({
+      profileCodes: ["beta_v1"],
+      hostedStorageBytes: 1_073_741_824,
+      retainedFileBytes: 2_147_483_648,
+      maxDocumentBytes: 2_097_152,
+      maxSingleFileBytes: 262_144_000,
+      maxReplicasPerCollection: 10,
+      maxHostedCollections: 10,
+      maxFilesPerCollection: 10_000
+    });
+  });
+
+  it("takes the maximum active limit and retains the Beta floor", async () => {
+    const { db, userId, invitationId } = await fixture();
+    await materializeInvitationEntitlement(
+      db,
+      userId,
+      invitationId,
+      BETA_ENTITLEMENT_PROFILE
+    );
+    await db.query(
+      `INSERT INTO entitlement_profiles
+         (code, hosted_storage_bytes, retained_file_bytes, max_document_bytes,
+          max_single_file_bytes, max_replicas_per_collection,
+          max_hosted_collections, max_files_per_collection)
+       VALUES ('plus_test', 10737418240, 21474836480, 2097152,
+               1073741824, 20, 100, 50000)`
+    );
+    const paidGrantId = randomUUID();
+    await db.query(
+      `INSERT INTO account_entitlement_grants
+         (id, user_id, profile_code, source, source_reference)
+       VALUES ($1, $2, 'plus_test', 'subscription', 'test-subscription')`,
+      [paidGrantId, userId]
+    );
+    expect((await effectiveEntitlement(db, userId))?.hostedStorageBytes)
+      .toBe(10_737_418_240);
+
+    await db.query(
+      `UPDATE account_entitlement_grants SET ends_at = now()
+       WHERE id = $1`,
+      [paidGrantId]
+    );
+    expect((await effectiveEntitlement(db, userId))?.hostedStorageBytes)
+      .toBe(1_073_741_824);
+  });
+
+  it("rejects an unknown invitation profile", async () => {
+    const { db, invitationId } = await fixture();
+    await expect(attachInvitationEntitlement(db, invitationId, "missing_v1"))
+      .rejects.toThrow("Unknown entitlement profile");
+  });
+});
+
+async function fixture(): Promise<{
+  db: DatabasePool;
+  userId: string;
+  invitationId: string;
+}> {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  const userId = randomUUID();
+  const invitationId = randomUUID();
+  await db.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, NULL, 'Beta user')",
+    [userId]
+  );
+  await db.query(
+    `INSERT INTO invitations
+       (id, email, normalized_email, token_hash, created_by, expires_at)
+     VALUES ($1, 'beta@example.com', 'beta@example.com', $2,
+             'operator:test', now() + interval '1 day')`,
+    [invitationId, `hash-${invitationId}`]
+  );
+  return { db, userId, invitationId };
+}

--- a/services/server/src/entitlements.ts
+++ b/services/server/src/entitlements.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from "node:crypto";
+import type { DatabasePool, DatabaseQueryable } from "./database-types.js";
+import type {
+  HostedAccountLimits,
+  HostedAccountUsage,
+  HostedProviderClient
+} from "./hosted-provider.js";
+
+export const BETA_ENTITLEMENT_PROFILE = "beta_v1";
+
+export interface EffectiveEntitlement {
+  profileCodes: string[];
+  hostedStorageBytes: number;
+  retainedFileBytes: number;
+  maxDocumentBytes: number;
+  maxSingleFileBytes: number;
+  maxReplicasPerCollection: number;
+  maxHostedCollections: number;
+  maxFilesPerCollection: number;
+}
+
+export class HostedEntitlementRequiredError extends Error {
+  constructor() {
+    super("This account does not have hosted storage access.");
+    this.name = "HostedEntitlementRequiredError";
+  }
+}
+
+export interface ReconciledHostedAccount {
+  providerAccountId: string;
+  entitlementRevision: number;
+  entitlement: EffectiveEntitlement;
+  usage: HostedAccountUsage;
+}
+
+interface EntitlementProfileRow {
+  profile_code: string;
+  hosted_storage_bytes: string | number;
+  retained_file_bytes: string | number;
+  max_document_bytes: string | number;
+  max_single_file_bytes: string | number;
+  max_replicas_per_collection: string | number;
+  max_hosted_collections: string | number;
+  max_files_per_collection: string | number;
+}
+
+export async function attachInvitationEntitlement(
+  db: DatabaseQueryable,
+  invitationId: string,
+  profileCode: string
+): Promise<void> {
+  const attached = await db.query(
+    `INSERT INTO invitation_entitlements (invitation_id, profile_code)
+     SELECT $1, profile.code
+     FROM entitlement_profiles profile
+     WHERE profile.code = $2
+     ON CONFLICT (invitation_id) DO UPDATE SET
+       profile_code = EXCLUDED.profile_code
+     RETURNING invitation_id`,
+    [invitationId, profileCode]
+  );
+  if (!attached.rows[0]) {
+    throw new TypeError(`Unknown entitlement profile: ${profileCode}`);
+  }
+}
+
+export async function materializeInvitationEntitlement(
+  db: DatabaseQueryable,
+  userId: string,
+  invitationId: string,
+  profileCode: string | null
+): Promise<{ providerAccountId: string; entitlementRevision: number } | null> {
+  if (!profileCode) return null;
+  await db.query(
+    `INSERT INTO account_entitlement_grants
+       (id, user_id, profile_code, source, source_invitation_id)
+     VALUES ($1, $2, $3, 'invitation', $4)
+     ON CONFLICT DO NOTHING`,
+    [randomUUID(), userId, profileCode, invitationId]
+  );
+  const providerAccountId = randomUUID();
+  const account = await db.query<{
+    provider_account_id: string;
+    entitlement_revision: string | number;
+  }>(
+    `INSERT INTO account_storage_accounts
+       (user_id, provider_account_id)
+     VALUES ($1, $2)
+     ON CONFLICT (user_id) DO UPDATE SET
+       updated_at = account_storage_accounts.updated_at
+     RETURNING provider_account_id, entitlement_revision`,
+    [userId, providerAccountId]
+  );
+  await db.query(
+    `INSERT INTO account_email_preferences (user_id)
+     VALUES ($1)
+     ON CONFLICT (user_id) DO NOTHING`,
+    [userId]
+  );
+  return {
+    providerAccountId: account.rows[0]!.provider_account_id,
+    entitlementRevision: safeNumber(
+      account.rows[0]!.entitlement_revision,
+      "entitlement revision"
+    )
+  };
+}
+
+export async function ensureDevelopmentEntitlement(
+  db: DatabaseQueryable,
+  userId: string
+): Promise<void> {
+  await db.query(
+    `INSERT INTO account_entitlement_grants
+       (id, user_id, profile_code, source, source_reference)
+     VALUES ($1, $2, $3, 'operator', 'development_auth')
+     ON CONFLICT DO NOTHING`,
+    [randomUUID(), userId, BETA_ENTITLEMENT_PROFILE]
+  );
+  await db.query(
+    `INSERT INTO account_storage_accounts (user_id, provider_account_id)
+     VALUES ($1, $2)
+     ON CONFLICT (user_id) DO NOTHING`,
+    [userId, randomUUID()]
+  );
+  await db.query(
+    `INSERT INTO account_email_preferences (user_id)
+     VALUES ($1)
+     ON CONFLICT (user_id) DO NOTHING`,
+    [userId]
+  );
+}
+
+export async function effectiveEntitlement(
+  db: DatabaseQueryable,
+  userId: string
+): Promise<EffectiveEntitlement | null> {
+  const profiles = await db.query<EntitlementProfileRow>(
+    `SELECT entitlement_grant.profile_code,
+            profile.hosted_storage_bytes, profile.retained_file_bytes,
+            profile.max_document_bytes, profile.max_single_file_bytes,
+            profile.max_replicas_per_collection, profile.max_hosted_collections,
+            profile.max_files_per_collection
+     FROM account_entitlement_grants entitlement_grant
+     JOIN entitlement_profiles profile
+       ON profile.code = entitlement_grant.profile_code
+     WHERE entitlement_grant.user_id = $1
+       AND entitlement_grant.revoked_at IS NULL
+       AND entitlement_grant.starts_at <= now()
+       AND (entitlement_grant.ends_at IS NULL
+            OR entitlement_grant.ends_at > now())
+     ORDER BY entitlement_grant.profile_code`,
+    [userId]
+  );
+  if (profiles.rows.length === 0) return null;
+  return {
+    profileCodes: profiles.rows.map((profile) => profile.profile_code),
+    hostedStorageBytes: maximum(profiles.rows, "hosted_storage_bytes"),
+    retainedFileBytes: maximum(profiles.rows, "retained_file_bytes"),
+    maxDocumentBytes: maximum(profiles.rows, "max_document_bytes"),
+    maxSingleFileBytes: maximum(profiles.rows, "max_single_file_bytes"),
+    maxReplicasPerCollection: maximum(
+      profiles.rows,
+      "max_replicas_per_collection"
+    ),
+    maxHostedCollections: maximum(profiles.rows, "max_hosted_collections"),
+    maxFilesPerCollection: maximum(profiles.rows, "max_files_per_collection")
+  };
+}
+
+export async function reconcileHostedAccount(
+  db: DatabaseQueryable,
+  provider: HostedProviderClient,
+  userId: string
+): Promise<ReconciledHostedAccount> {
+  const entitlement = await effectiveEntitlement(db, userId);
+  if (!entitlement) throw new HostedEntitlementRequiredError();
+  const account = await db.query<{
+    provider_account_id: string;
+    entitlement_revision: string | number;
+  }>(
+    `SELECT provider_account_id, entitlement_revision
+     FROM account_storage_accounts WHERE user_id = $1`,
+    [userId]
+  );
+  const row = account.rows[0];
+  if (!row) throw new HostedEntitlementRequiredError();
+  const entitlementRevision = safeNumber(
+    row.entitlement_revision,
+    "entitlement revision"
+  );
+  const limits: HostedAccountLimits = {
+    hosted_storage_bytes: entitlement.hostedStorageBytes,
+    retained_file_bytes: entitlement.retainedFileBytes,
+    max_document_bytes: entitlement.maxDocumentBytes,
+    max_single_file_bytes: entitlement.maxSingleFileBytes,
+    max_replicas_per_collection: entitlement.maxReplicasPerCollection,
+    max_hosted_collections: entitlement.maxHostedCollections,
+    max_files_per_collection: entitlement.maxFilesPerCollection
+  };
+  const usage = await provider.upsertAccount(
+    row.provider_account_id,
+    entitlementRevision,
+    limits
+  );
+  await db.query(
+    `UPDATE account_storage_accounts SET provider_revision = $2,
+            updated_at = now()
+     WHERE user_id = $1 AND entitlement_revision = $2`,
+    [userId, entitlementRevision]
+  );
+  return {
+    providerAccountId: row.provider_account_id,
+    entitlementRevision,
+    entitlement,
+    usage
+  };
+}
+
+export async function reconcileHostedAccountCollections(
+  db: DatabaseQueryable,
+  provider: HostedProviderClient,
+  userId: string
+): Promise<ReconciledHostedAccount & { reconciledCollections: number }> {
+  const account = await reconcileHostedAccount(db, provider, userId);
+  const collections = await db.query<{ id: string }>(
+    `SELECT id FROM hosted_collections
+     WHERE user_id = $1
+       AND authority_state IN ('importing', 'active', 'transferring')
+     ORDER BY id`,
+    [userId]
+  );
+  let reconciledCollections = 0;
+  for (const collection of collections.rows) {
+    await provider.reconcileCollectionAccount(
+      account.providerAccountId,
+      collection.id
+    );
+    reconciledCollections += 1;
+  }
+  const usage = await provider.accountUsage(account.providerAccountId);
+  return { ...account, usage, reconciledCollections };
+}
+
+export async function grantOperatorEntitlement(
+  db: DatabasePool,
+  input: {
+    userId: string;
+    profileCode: string;
+    actor: string;
+    reason: string;
+    operationId: string;
+  }
+): Promise<{ changed: boolean; entitlementRevision: number }> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const user = await connection.query(
+      "SELECT id FROM users WHERE id = $1 FOR UPDATE",
+      [input.userId]
+    );
+    if (!user.rows[0]) throw new HostedEntitlementRequiredError();
+    const profile = await connection.query(
+      "SELECT code FROM entitlement_profiles WHERE code = $1",
+      [input.profileCode]
+    );
+    if (!profile.rows[0]) {
+      throw new TypeError(`Unknown entitlement profile: ${input.profileCode}`);
+    }
+    const active = await connection.query(
+      `SELECT id FROM account_entitlement_grants
+       WHERE user_id = $1 AND profile_code = $2
+         AND revoked_at IS NULL AND starts_at <= now()
+         AND (ends_at IS NULL OR ends_at > now())
+       LIMIT 1`,
+      [input.userId, input.profileCode]
+    );
+    let changed = false;
+    if (!active.rows[0]) {
+      const inserted = await connection.query(
+        `INSERT INTO account_entitlement_grants
+           (id, user_id, profile_code, source, source_reference)
+         VALUES ($1, $2, $3, 'operator', $4)
+         ON CONFLICT DO NOTHING RETURNING id`,
+        [randomUUID(), input.userId, input.profileCode, input.operationId]
+      );
+      changed = Boolean(inserted.rows[0]);
+    }
+    const existingAccount = await connection.query<{
+      entitlement_revision: string | number;
+    }>(
+      `SELECT entitlement_revision FROM account_storage_accounts
+       WHERE user_id = $1 FOR UPDATE`,
+      [input.userId]
+    );
+    let entitlementRevision = existingAccount.rows[0]
+      ? safeNumber(
+          existingAccount.rows[0].entitlement_revision,
+          "entitlement revision"
+        )
+      : 1;
+    if (!existingAccount.rows[0]) {
+      await connection.query(
+        `INSERT INTO account_storage_accounts (user_id, provider_account_id)
+         VALUES ($1, $2)`,
+        [input.userId, randomUUID()]
+      );
+    } else if (changed) {
+      entitlementRevision += 1;
+      await connection.query(
+        `UPDATE account_storage_accounts SET
+           entitlement_revision = $2, updated_at = now()
+         WHERE user_id = $1`,
+        [input.userId, entitlementRevision]
+      );
+    }
+    await connection.query(
+      `INSERT INTO account_email_preferences (user_id)
+       VALUES ($1) ON CONFLICT (user_id) DO NOTHING`,
+      [input.userId]
+    );
+    await connection.query(
+      `INSERT INTO audit_events
+         (id, user_id, event_type, subject_id, metadata)
+       VALUES ($1, $2, 'entitlement.granted', $2, $3::jsonb)`,
+      [
+        randomUUID(),
+        input.userId,
+        JSON.stringify({
+          profile: input.profileCode,
+          actor: input.actor,
+          reason: input.reason,
+          operation_id: input.operationId,
+          changed,
+          entitlement_revision: entitlementRevision
+        })
+      ]
+    );
+    await connection.query("COMMIT");
+    return { changed, entitlementRevision };
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+function maximum(
+  rows: EntitlementProfileRow[],
+  key: Exclude<keyof EntitlementProfileRow, "profile_code">
+): number {
+  return Math.max(...rows.map((row) => safeNumber(row[key], key)));
+}
+
+function safeNumber(value: string | number, label: string): number {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) {
+    throw new Error(`Stored ${label} is invalid.`);
+  }
+  return number;
+}

--- a/services/server/src/features/account/management-routes.ts
+++ b/services/server/src/features/account/management-routes.ts
@@ -273,6 +273,9 @@ async function storageSnapshot(
     return {
       status: "available" as const,
       total_content_bytes: 0,
+      total_file_bytes: 0,
+      total_storage_bytes: 0,
+      total_stored_file_bytes: 0,
       total_records: 0,
       collections: []
     };
@@ -281,6 +284,9 @@ async function storageSnapshot(
     return {
       status: "unavailable" as const,
       total_content_bytes: null,
+      total_file_bytes: null,
+      total_storage_bytes: null,
+      total_stored_file_bytes: null,
       total_records: null,
       collections: collections.map((collection) => ({
         ...collection,
@@ -310,6 +316,18 @@ async function storageSnapshot(
         : "unavailable" as const,
     total_content_bytes: available.length > 0
       ? available.reduce((total, value) => total + value.content_bytes, 0)
+      : null,
+    total_file_bytes: available.length > 0
+      ? available.reduce((total, value) => total + value.file_bytes, 0)
+      : null,
+    total_storage_bytes: available.length > 0
+      ? available.reduce(
+          (total, value) => total + value.content_bytes + value.file_bytes,
+          0
+        )
+      : null,
+    total_stored_file_bytes: available.length > 0
+      ? available.reduce((total, value) => total + value.stored_file_bytes, 0)
       : null,
     total_records: available.length > 0
       ? available.reduce((total, value) => total + value.record_count, 0)

--- a/services/server/src/features/account/me-routes.ts
+++ b/services/server/src/features/account/me-routes.ts
@@ -5,6 +5,7 @@ import {
   listLocalCollectionsVisibleToUser
 } from "../../collection-catalog.js";
 import type { DatabasePool } from "../../db.js";
+import { effectiveEntitlement } from "../../entitlements.js";
 import {
   contractRequirements,
   effectiveHostedContractDescriptors,
@@ -181,8 +182,56 @@ export function registerAccountOverviewRoute(
       [user.id]
     );
     const authenticationSettings = await options.authenticationPolicy.current();
+    const entitlement = await effectiveEntitlement(options.db, user.id);
+    const storageAccount = entitlement
+      ? await options.db.query<{
+          provider_account_id: string;
+          entitlement_revision: string | number;
+          provider_revision: string | number;
+        }>(
+          `SELECT provider_account_id, entitlement_revision, provider_revision
+           FROM account_storage_accounts WHERE user_id = $1`,
+          [user.id]
+        )
+      : { rows: [] };
+    let hostedUsage = null;
+    if (options.hostedProvider && storageAccount.rows[0]) {
+      try {
+        hostedUsage = await options.hostedProvider.accountUsage(
+          storageAccount.rows[0].provider_account_id
+        );
+      } catch (error) {
+        request.log.warn({ error }, "Hosted account usage is unavailable");
+      }
+    }
     return {
       user,
+      subscription: entitlement ? {
+        kind: entitlement.profileCodes.includes("beta_v1") ? "beta" : "entitled",
+        profiles: entitlement.profileCodes,
+        permanent: true,
+        limits: {
+          hosted_storage_bytes: entitlement.hostedStorageBytes,
+          retained_file_bytes: entitlement.retainedFileBytes,
+          max_document_bytes: entitlement.maxDocumentBytes,
+          max_single_file_bytes: entitlement.maxSingleFileBytes,
+          max_replicas_per_collection: entitlement.maxReplicasPerCollection,
+          max_hosted_collections: entitlement.maxHostedCollections,
+          max_files_per_collection: entitlement.maxFilesPerCollection
+        },
+        usage: hostedUsage ? {
+          hosted_collections: hostedUsage.collection_count,
+          live_content_bytes: hostedUsage.live_content_bytes,
+          live_file_bytes: hostedUsage.live_file_bytes,
+          live_storage_bytes:
+            hostedUsage.live_content_bytes + hostedUsage.live_file_bytes,
+          retained_file_bytes: hostedUsage.retained_file_bytes
+        } : null,
+        reconciliation: storageAccount.rows[0] ? {
+          entitlement_revision: Number(storageAccount.rows[0].entitlement_revision),
+          provider_revision: Number(storageAccount.rows[0].provider_revision)
+        } : null
+      } : null,
       hosted_collections_available: options.hostedCollections === true,
       authentication: {
         provider: authenticationProvider ?? (options.tailscaleAuth ? "tailscale" : "session"),

--- a/services/server/src/features/account/session-routes.ts
+++ b/services/server/src/features/account/session-routes.ts
@@ -6,6 +6,7 @@ import {
   sessionClientName
 } from "../../account-sessions.js";
 import type { DatabasePool } from "../../database-types.js";
+import { ensureDevelopmentEntitlement } from "../../entitlements.js";
 import { randomToken, tokenHash } from "../../security.js";
 import { apiError } from "../../platform/http-errors.js";
 import {
@@ -47,6 +48,7 @@ export function registerAccountSessionRoutes(
       [randomUUID(), input.email.toLowerCase(), input.name]
     );
     const token = randomToken("ses");
+    await ensureDevelopmentEntitlement(options.db, user.rows[0].id);
     await options.db.query(
       `INSERT INTO sessions
          (id, user_id, token_hash, account_session_epoch,

--- a/services/server/src/features/authority-adoption/routes.ts
+++ b/services/server/src/features/authority-adoption/routes.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { DatabasePool } from "../../database-types.js";
+import { reconcileHostedAccount } from "../../entitlements.js";
 import {
   HostedProviderResponseError,
   type HostedProviderClient
@@ -307,8 +308,19 @@ export function registerAuthorityAdoptionRoutes(
         ));
       }
       const importToken = randomToken("ati");
+      if (!adoption.user_id) {
+        throw new RequestValidationError(
+          "Collection adoption has not been assigned to an account."
+        );
+      }
+      const account = await reconcileHostedAccount(
+        options.db,
+        options.hostedProvider,
+        adoption.user_id
+      );
       const prepared = await options.hostedProvider.prepareAuthorityImport({
         transferId: adoption.id,
+        accountId: account.providerAccountId,
         collectionId: adoption.collection_id,
         displayName: adoption.display_name,
         token: importToken,

--- a/services/server/src/features/authority-transfer/local-to-hosted-routes.ts
+++ b/services/server/src/features/authority-transfer/local-to-hosted-routes.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from "fastify";
 import type { CollectionContractDescriptor } from "@mdbase-dev/connect-protocol";
 import { z } from "zod";
 import type { DatabasePool } from "../../database-types.js";
+import { reconcileHostedAccount } from "../../entitlements.js";
 import type { HostedAuthorityRegistry } from "../../hosted.js";
 import {
   HostedProviderResponseError,
@@ -137,8 +138,14 @@ export function registerLocalToHostedTransferRoutes(
       }
       const transferId = transfer.id;
       const importToken = randomToken("ati");
+      const account = await reconcileHostedAccount(
+        options.db,
+        options.hostedProvider,
+        connector.user_id
+      );
       const prepared = await options.hostedProvider.prepareAuthorityImport({
         transferId,
+        accountId: account.providerAccountId,
         collectionId: local.local_id,
         displayName: local.display_name,
         token: importToken,

--- a/services/server/src/features/hosted/account-routes.ts
+++ b/services/server/src/features/hosted/account-routes.ts
@@ -3,7 +3,6 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { resolveHostedCollectionAccess } from "../../collection-access.js";
 import {
-  hostedContractDescriptors,
   type HostedAuthorityRegistry
 } from "../../hosted.js";
 import { randomToken, tokenHash } from "../../security.js";
@@ -12,6 +11,7 @@ import { authorityUrl } from "../../platform/authority-url.js";
 import { apiError } from "../../platform/http-errors.js";
 import { requireUser } from "../../platform/request-authentication.js";
 import {
+  createHostedCollectionForUser,
   canManageHostedReplica,
   permitsHostedCollectionAction,
   type HostedServiceOptions
@@ -39,57 +39,15 @@ export function registerHostedAccountRoutes(
       display_name: z.string().trim().min(1).max(200),
       template: z.literal("mdbase").default("mdbase")
     }).strict().parse(request.body);
-    const collectionId = randomUUID();
-    try {
-      if (options.hostedProvider) {
-        await options.hostedProvider.createCollection(
-          collectionId,
-          input.template,
-          input.display_name
-        );
-      } else {
-        await options.hostedReference!.create(
-          collectionId,
-          input.template
-        );
-      }
-      await options.db.query(
-        `INSERT INTO hosted_collections
-           (id, user_id, display_name, template, provider_url, contracts)
-         VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
-        [
-          collectionId,
-          user.id,
-          input.display_name,
-          input.template,
-          options.hostedProvider?.url ?? null,
-          JSON.stringify(hostedContractDescriptors(input.template))
-        ]
-      );
-    } catch (error) {
-      if (options.hostedProvider) {
-        await options.hostedProvider
-          .deleteCollection(collectionId)
-          .catch((cleanupError) => {
-            request.log.error(
-              { cleanupError, collectionId },
-              "Failed to compensate hosted collection creation"
-            );
-          });
-      } else {
-        await options.hostedReference!
-          .delete(collectionId)
-          .catch(() => undefined);
-      }
-      throw error;
-    }
-    await audit(
-      options.db,
+    const collection = await createHostedCollectionForUser(
+      options,
+      options.hostedReference,
+      options.publicUrl,
       user.id,
-      "hosted_collection.created",
-      collectionId,
-      { template: input.template }
+      input.display_name,
+      input.template
     );
+    const collectionId = String(collection.id);
     return reply.code(201).send({
       collection: {
         id: collectionId,

--- a/services/server/src/features/hosted/service.ts
+++ b/services/server/src/features/hosted/service.ts
@@ -30,6 +30,7 @@ import {
   typesForContracts
 } from "../../hosted.js";
 import type { HostedProviderClient } from "../../hosted-provider.js";
+import { reconcileHostedAccount } from "../../entitlements.js";
 import {
   hostedGrantRevocationStatus,
   hostedReplicaRevocationStatus,
@@ -301,7 +302,13 @@ export async function createHostedCollectionForUser(
   const collectionId = randomUUID();
   try {
     if (options.hostedProvider) {
+      const account = await reconcileHostedAccount(
+        options.db,
+        options.hostedProvider,
+        userId
+      );
       await options.hostedProvider.createCollection(
+        account.providerAccountId,
         collectionId,
         template,
         displayName

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -84,7 +84,14 @@ describe("hosted provider control client", () => {
       content_bytes: 12_345,
       max_records: 100_000,
       max_content_bytes: 1_073_741_824,
-      max_document_bytes: 2_097_152
+      max_document_bytes: 2_097_152,
+      file_count: 3,
+      file_bytes: 50_000,
+      stored_file_bytes: 75_000,
+      max_files: 10_000,
+      max_file_bytes: 1_073_741_824,
+      max_stored_file_bytes: 2_147_483_648,
+      max_single_file_bytes: 262_144_000
     };
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ usage }), {
@@ -199,7 +206,7 @@ describe("hosted provider control client", () => {
       url: "https://provider.example",
       internalToken: "internal-secret"
     });
-    await provider.createCollection("collection", "mdbase", "Writing");
+    await provider.createCollection("account", "collection", "mdbase", "Writing");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(fetchMock.mock.calls[1]?.[1]?.body);
   });

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -47,6 +47,32 @@ export interface HostedCollectionUsage {
   max_records: number;
   max_content_bytes: number;
   max_document_bytes: number;
+  file_count: number;
+  file_bytes: number;
+  stored_file_bytes: number;
+  max_files: number;
+  max_file_bytes: number;
+  max_stored_file_bytes: number;
+  max_single_file_bytes: number;
+}
+
+export interface HostedAccountLimits {
+  hosted_storage_bytes: number;
+  retained_file_bytes: number;
+  max_document_bytes: number;
+  max_single_file_bytes: number;
+  max_replicas_per_collection: number;
+  max_hosted_collections: number;
+  max_files_per_collection: number;
+}
+
+export interface HostedAccountUsage extends HostedAccountLimits {
+  account_id: string;
+  entitlement_revision: number;
+  collection_count: number;
+  live_content_bytes: number;
+  live_file_bytes: number;
+  retained_file_bytes: number;
 }
 
 export interface HostedAuthorityTransfer {
@@ -96,8 +122,57 @@ export class HostedProviderClient {
     return candidate !== null && safeEqual(candidate, this.internalToken);
   }
 
-  async createCollection(collectionId: string, template: string, displayName: string): Promise<void> {
+  async upsertAccount(
+    accountId: string,
+    entitlementRevision: number,
+    limits: HostedAccountLimits
+  ): Promise<HostedAccountUsage> {
+    const result = await this.request(
+      "PUT",
+      `/internal/v1/accounts/${encodeURIComponent(accountId)}`,
+      { entitlement_revision: entitlementRevision, ...limits }
+    ) as { account?: HostedAccountUsage } | undefined;
+    if (!result?.account) {
+      throw new HostedProviderResponseError(
+        502,
+        "invalid_provider_response",
+        "Hosted account usage was missing from the provider response."
+      );
+    }
+    return result.account;
+  }
+
+  async accountUsage(accountId: string): Promise<HostedAccountUsage> {
+    const result = await this.request(
+      "GET",
+      `/internal/v1/accounts/${encodeURIComponent(accountId)}`
+    ) as { account?: HostedAccountUsage } | undefined;
+    if (!result?.account) {
+      throw new HostedProviderResponseError(
+        502,
+        "invalid_provider_response",
+        "Hosted account usage was missing from the provider response."
+      );
+    }
+    return result.account;
+  }
+
+  async reconcileCollectionAccount(accountId: string, collectionId: string): Promise<void> {
+    await this.request(
+      "PUT",
+      `/internal/v1/accounts/${encodeURIComponent(accountId)}/collections/${encodeURIComponent(collectionId)}`,
+      {}
+    );
+  }
+
+  async createCollection(
+    accountId: string,
+    collectionId: string,
+    template: string,
+    displayName: string
+  ): Promise<void> {
     await this.request("POST", "/internal/v1/collections", {
+      account_id: accountId,
       collection_id: collectionId,
       template,
       display_name: displayName
@@ -298,6 +373,7 @@ export class HostedProviderClient {
 
   async prepareAuthorityImport(input: {
     transferId: string;
+    accountId: string;
     collectionId: string;
     displayName: string;
     token: string;
@@ -306,6 +382,7 @@ export class HostedProviderClient {
   }): Promise<AuthorityImport> {
     return await this.request("POST", "/internal/v1/authority-imports", {
       transfer_id: input.transferId,
+      account_id: input.accountId,
       collection_id: input.collectionId,
       display_name: input.displayName,
       token: input.token,

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -39,6 +39,7 @@ const { app } = await buildApp({
   emailTransport: runtime.transactionalEmail
     ? new ResendEmailTransport(runtime.transactionalEmail)
     : undefined,
+  resendWebhookSecret: runtime.resendWebhookSecret ?? undefined,
   hostedCollections: runtime.hostedCollections,
   hostedProvider: runtime.hostedProvider
     ? new HostedProviderClient(runtime.hostedProvider)

--- a/services/server/src/instance-admin-invitations.ts
+++ b/services/server/src/instance-admin-invitations.ts
@@ -1,0 +1,68 @@
+export interface InvitationPageInput {
+  limit?: number;
+  cursor?: string;
+  status?: "active" | "accepted" | "revoked" | "expired";
+}
+
+export interface InvitationRow {
+  id: string;
+  email: string;
+  created_by: string;
+  expires_at: Date | string;
+  accepted_at: Date | string | null;
+  revoked_at: Date | string | null;
+  revoked_by: string | null;
+  revocation_reason: string | null;
+  send_count: number | string;
+  last_sent_at: Date | string | null;
+  entitlement_profile: string | null;
+  created_at: Date | string;
+}
+
+export function invitationSummary(row: InvitationRow) {
+  return {
+    id: row.id,
+    email: row.email,
+    status: invitationStatus(row),
+    created_by: row.created_by,
+    created_at: iso(row.created_at),
+    expires_at: iso(row.expires_at),
+    accepted_at: nullableIso(row.accepted_at),
+    revoked_at: nullableIso(row.revoked_at),
+    revoked_by: row.revoked_by,
+    revocation_reason: row.revocation_reason,
+    send_count: Number(row.send_count),
+    last_sent_at: nullableIso(row.last_sent_at),
+    entitlement_profile: row.entitlement_profile
+  };
+}
+
+export function invitationStatusCondition(
+  status: NonNullable<InvitationPageInput["status"]>
+): string {
+  if (status === "accepted") return "accepted_at IS NOT NULL";
+  if (status === "revoked") {
+    return "accepted_at IS NULL AND revoked_at IS NOT NULL";
+  }
+  if (status === "expired") {
+    return "accepted_at IS NULL AND revoked_at IS NULL AND expires_at <= now()";
+  }
+  return "accepted_at IS NULL AND revoked_at IS NULL AND expires_at > now()";
+}
+
+function invitationStatus(
+  row: Pick<InvitationRow, "accepted_at" | "revoked_at" | "expires_at">
+): "active" | "accepted" | "revoked" | "expired" {
+  if (row.accepted_at) return "accepted";
+  if (row.revoked_at) return "revoked";
+  if (new Date(row.expires_at).getTime() <= Date.now()) return "expired";
+  return "active";
+}
+
+function iso(value: Date | string): string {
+  return new Date(value).toISOString();
+}
+
+function nullableIso(value: Date | string | null): string | null {
+  return value === null ? null : iso(value);
+}

--- a/services/server/src/instance-admin.ts
+++ b/services/server/src/instance-admin.ts
@@ -5,6 +5,14 @@ import type {
   DatabaseQueryable
 } from "./db.js";
 import { normalizeEmailAddress } from "./email-identity.js";
+import {
+  invitationStatusCondition,
+  invitationSummary,
+  type InvitationPageInput,
+  type InvitationRow
+} from "./instance-admin-invitations.js";
+
+export type { InvitationPageInput } from "./instance-admin-invitations.js";
 
 const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 100;
@@ -28,12 +36,6 @@ export interface UserPageInput {
   status?: "active" | "suspended";
 }
 
-export interface InvitationPageInput {
-  limit?: number;
-  cursor?: string;
-  status?: "active" | "accepted" | "revoked" | "expired";
-}
-
 export interface BetaAccessRequestPageInput {
   limit?: number;
   cursor?: string;
@@ -52,21 +54,6 @@ interface UserSummaryRow {
   email: string | null;
   name: string;
   suspended_at: Date | string | null;
-  created_at: Date | string;
-}
-
-interface InvitationRow {
-  id: string;
-  email: string;
-  created_by: string;
-  expires_at: Date | string;
-  accepted_at: Date | string | null;
-  revoked_at: Date | string | null;
-  revoked_by: string | null;
-  revocation_reason: string | null;
-  send_count: number | string;
-  last_sent_at: Date | string | null;
-  entitlement_profile: string | null;
   created_at: Date | string;
 }
 
@@ -809,46 +796,6 @@ async function countByUser(
   return new Map(
     result.rows.map((row) => [row.user_id, Number(row.count)])
   );
-}
-
-function invitationSummary(row: InvitationRow) {
-  return {
-    id: row.id,
-    email: row.email,
-    status: invitationStatus(row),
-    created_by: row.created_by,
-    created_at: iso(row.created_at),
-    expires_at: iso(row.expires_at),
-    accepted_at: nullableIso(row.accepted_at),
-    revoked_at: nullableIso(row.revoked_at),
-    revoked_by: row.revoked_by,
-    revocation_reason: row.revocation_reason,
-    send_count: Number(row.send_count),
-    last_sent_at: nullableIso(row.last_sent_at),
-    entitlement_profile: row.entitlement_profile
-  };
-}
-
-function invitationStatus(
-  row: Pick<InvitationRow, "accepted_at" | "revoked_at" | "expires_at">
-): "active" | "accepted" | "revoked" | "expired" {
-  if (row.accepted_at) return "accepted";
-  if (row.revoked_at) return "revoked";
-  if (new Date(row.expires_at).getTime() <= Date.now()) return "expired";
-  return "active";
-}
-
-function invitationStatusCondition(
-  status: NonNullable<InvitationPageInput["status"]>
-): string {
-  if (status === "accepted") return "accepted_at IS NOT NULL";
-  if (status === "revoked") {
-    return "accepted_at IS NULL AND revoked_at IS NOT NULL";
-  }
-  if (status === "expired") {
-    return "accepted_at IS NULL AND revoked_at IS NULL AND expires_at <= now()";
-  }
-  return "accepted_at IS NULL AND revoked_at IS NULL AND expires_at > now()";
 }
 
 function pageSize(value: number | undefined): number {

--- a/services/server/src/instance-admin.ts
+++ b/services/server/src/instance-admin.ts
@@ -66,6 +66,7 @@ interface InvitationRow {
   revocation_reason: string | null;
   send_count: number | string;
   last_sent_at: Date | string | null;
+  entitlement_profile: string | null;
   created_at: Date | string;
 }
 
@@ -302,10 +303,15 @@ export class InstanceAdminService {
     }
     values.push(limit + 1);
     const result = await this.db.query<InvitationRow>(
-      `SELECT id, email, created_by, expires_at, accepted_at, revoked_at,
-              revoked_by, revocation_reason, send_count, last_sent_at,
-              created_at
-       FROM invitations
+      `SELECT invitation.id, invitation.email, invitation.created_by,
+              invitation.expires_at, invitation.accepted_at,
+              invitation.revoked_at, invitation.revoked_by,
+              invitation.revocation_reason, invitation.send_count,
+              invitation.last_sent_at, entitlement.profile_code AS entitlement_profile,
+              invitation.created_at
+       FROM invitations invitation
+       LEFT JOIN invitation_entitlements entitlement
+         ON entitlement.invitation_id = invitation.id
        ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
        ORDER BY created_at DESC, id DESC
        LIMIT $${values.length}`,
@@ -323,10 +329,16 @@ export class InstanceAdminService {
   async showInvitation(invitationId: string) {
     requireUuid(invitationId, "Invitation ID");
     const result = await this.db.query<InvitationRow>(
-      `SELECT id, email, created_by, expires_at, accepted_at, revoked_at,
-              revoked_by, revocation_reason, send_count, last_sent_at,
-              created_at
-       FROM invitations WHERE id = $1`,
+      `SELECT invitation.id, invitation.email, invitation.created_by,
+              invitation.expires_at, invitation.accepted_at,
+              invitation.revoked_at, invitation.revoked_by,
+              invitation.revocation_reason, invitation.send_count,
+              invitation.last_sent_at, entitlement.profile_code AS entitlement_profile,
+              invitation.created_at
+       FROM invitations invitation
+       LEFT JOIN invitation_entitlements entitlement
+         ON entitlement.invitation_id = invitation.id
+       WHERE invitation.id = $1`,
       [invitationId]
     );
     if (!result.rows[0]) {
@@ -397,7 +409,7 @@ export class InstanceAdminService {
       const invitation = await connection.query<InvitationRow>(
         `SELECT id, email, created_by, expires_at, accepted_at, revoked_at,
                 revoked_by, revocation_reason, send_count, last_sent_at,
-                created_at
+                NULL::text AS entitlement_profile, created_at
          FROM invitations WHERE id = $1 FOR UPDATE`,
         [invitationId]
       );
@@ -410,6 +422,12 @@ export class InstanceAdminService {
           "An accepted invitation cannot be revoked."
         );
       }
+      const entitlement = await connection.query<{ profile_code: string }>(
+        `SELECT profile_code FROM invitation_entitlements
+         WHERE invitation_id = $1`,
+        [invitationId]
+      );
+      row.entitlement_profile = entitlement.rows[0]?.profile_code ?? null;
       const changed = row.revoked_at === null;
       if (changed) {
         await connection.query(
@@ -806,7 +824,8 @@ function invitationSummary(row: InvitationRow) {
     revoked_by: row.revoked_by,
     revocation_reason: row.revocation_reason,
     send_count: Number(row.send_count),
-    last_sent_at: nullableIso(row.last_sent_at)
+    last_sent_at: nullableIso(row.last_sent_at),
+    entitlement_profile: row.entitlement_profile
   };
 }
 

--- a/services/server/src/password-auth.test.ts
+++ b/services/server/src/password-auth.test.ts
@@ -76,12 +76,13 @@ describe("invite-only password accounts", () => {
       .toBeNull();
   });
 
-  it("atomically creates a verified account, credential, agreements, and session", async () => {
+  it("atomically creates a verified account, Beta entitlement, and session", async () => {
     const { db, service } = await fixture();
     const invitation = await service.createInvitation({
       email: "person@example.com",
       actor: "operator:test",
-      reason: "Private beta"
+      reason: "Private beta",
+      entitlementProfile: "beta_v1"
     });
     const accepted = await service.acceptInvitation({
       invitationToken: invitation.token,
@@ -146,6 +147,28 @@ describe("invite-only password accounts", () => {
     expect(acceptedInvitation.rows[0]?.accepted_by_user_id)
       .toBe(accepted.user.id);
     expect(acceptedInvitation.rows[0]?.accepted_at).toBeInstanceOf(Date);
+    const entitlement = await db.query<{
+      profile_code: string;
+      provider_account_id: string;
+      onboarding_enabled: boolean;
+    }>(
+      `SELECT entitlement.profile_code, storage.provider_account_id,
+              preferences.onboarding_enabled
+       FROM account_entitlement_grants entitlement
+       JOIN account_storage_accounts storage
+         ON storage.user_id = entitlement.user_id
+       JOIN account_email_preferences preferences
+         ON preferences.user_id = entitlement.user_id
+       WHERE entitlement.user_id = $1`,
+      [accepted.user.id]
+    );
+    expect(entitlement.rows[0]).toMatchObject({
+      profile_code: "beta_v1",
+      onboarding_enabled: true
+    });
+    expect(entitlement.rows[0]?.provider_account_id).toMatch(
+      /^[0-9a-f-]{36}$/u
+    );
   });
 
   it("supports password login without exposing unknown, wrong, or suspended accounts", async () => {

--- a/services/server/src/password-auth.test.ts
+++ b/services/server/src/password-auth.test.ts
@@ -169,6 +169,31 @@ describe("invite-only password accounts", () => {
     expect(entitlement.rows[0]?.provider_account_id).toMatch(
       /^[0-9a-f-]{36}$/u
     );
+    const welcome = await db.query<{
+      message_kind: string;
+      template_version: number;
+      category: string;
+      state: string;
+      scheduled_for: Date;
+      created_at: Date;
+    }>(
+      `SELECT message_kind, template_version, category, state,
+              scheduled_for, created_at
+       FROM email_jobs WHERE user_id = $1`,
+      [accepted.user.id]
+    );
+    expect(welcome.rows).toHaveLength(1);
+    expect(welcome.rows[0]).toMatchObject({
+      message_kind: "beta_welcome",
+      template_version: 1,
+      category: "onboarding",
+      state: "scheduled"
+    });
+    const welcomeDelayMs =
+      welcome.rows[0]!.scheduled_for.getTime()
+        - welcome.rows[0]!.created_at.getTime();
+    expect(welcomeDelayMs).toBeGreaterThanOrEqual(86_399_000);
+    expect(welcomeDelayMs).toBeLessThanOrEqual(86_401_000);
   });
 
   it("supports password login without exposing unknown, wrong, or suspended accounts", async () => {

--- a/services/server/src/password-auth.ts
+++ b/services/server/src/password-auth.ts
@@ -18,9 +18,11 @@ import {
 } from "./password.js";
 import { randomToken, tokenHash } from "./security.js";
 import {
+  BETA_ENTITLEMENT_PROFILE,
   attachInvitationEntitlement,
   materializeInvitationEntitlement
 } from "./entitlements.js";
+import { scheduleBetaWelcomeEmail } from "./beta-welcome-email.js";
 
 const DEFAULT_INVITATION_LIFETIME_SECONDS = 7 * 24 * 60 * 60;
 const MIN_INVITATION_LIFETIME_SECONDS = 5 * 60;
@@ -342,6 +344,12 @@ export class PasswordAccountService {
         row.id,
         row.entitlement_profile
       );
+      if (row.entitlement_profile === BETA_ENTITLEMENT_PROFILE) {
+        await scheduleBetaWelcomeEmail(connection, {
+          userId,
+          emailIdentityId
+        });
+      }
       await connection.query(
         `INSERT INTO sessions
            (id, user_id, token_hash, provider, account_session_epoch,

--- a/services/server/src/password-auth.ts
+++ b/services/server/src/password-auth.ts
@@ -17,6 +17,10 @@ import {
   verifyPassword
 } from "./password.js";
 import { randomToken, tokenHash } from "./security.js";
+import {
+  attachInvitationEntitlement,
+  materializeInvitationEntitlement
+} from "./entitlements.js";
 
 const DEFAULT_INVITATION_LIFETIME_SECONDS = 7 * 24 * 60 * 60;
 const MIN_INVITATION_LIFETIME_SECONDS = 5 * 60;
@@ -30,6 +34,7 @@ export interface CreateInvitationInput {
   actor: string;
   reason: string;
   expiresInSeconds?: number;
+  entitlementProfile?: string;
 }
 
 export interface CreatedInvitation {
@@ -39,6 +44,7 @@ export interface CreatedInvitation {
   expiresAt: Date;
   termsVersion: string;
   privacyVersion: string;
+  entitlementProfile: string | null;
 }
 
 export interface AcceptInvitationInput {
@@ -99,6 +105,7 @@ interface InvitationRow {
   terms_version: string | null;
   privacy_version: string | null;
   expires_at: Date | string;
+  entitlement_profile: string | null;
 }
 
 interface PasswordCredentialRow {
@@ -208,9 +215,17 @@ export class PasswordAccountService {
           expiresAt
         ]
       );
+      if (input.entitlementProfile) {
+        await attachInvitationEntitlement(
+          connection,
+          id,
+          input.entitlementProfile
+        );
+      }
       await audit(connection, null, "invitation.created", id, {
         actor,
-        reason
+        reason,
+        entitlement_profile: input.entitlementProfile ?? null
       });
       await connection.query("COMMIT");
       return {
@@ -218,6 +233,7 @@ export class PasswordAccountService {
         email,
         token,
         expiresAt,
+        entitlementProfile: input.entitlementProfile ?? null,
         ...agreements
       };
     } catch (error) {
@@ -234,8 +250,12 @@ export class PasswordAccountService {
     requireSignupEnabled(await this.policy.current());
     const invitationHash = tokenHash(input.invitationToken);
     const preliminary = await this.db.query<InvitationRow>(
-      `SELECT id, email, normalized_email, terms_version, privacy_version
-       FROM invitations
+      `SELECT invitation.id, invitation.email, invitation.normalized_email,
+              invitation.terms_version, invitation.privacy_version,
+              entitlement.profile_code AS entitlement_profile
+       FROM invitations invitation
+       LEFT JOIN invitation_entitlements entitlement
+         ON entitlement.invitation_id = invitation.id
        WHERE token_hash = $1
          AND accepted_at IS NULL
          AND revoked_at IS NULL
@@ -254,8 +274,12 @@ export class PasswordAccountService {
       const settings = await this.policy.currentForAccountChange(connection);
       requireSignupEnabled(settings);
       const invitation = await connection.query<InvitationRow>(
-        `SELECT id, email, normalized_email, terms_version, privacy_version
-         FROM invitations
+        `SELECT invitation.id, invitation.email, invitation.normalized_email,
+                invitation.terms_version, invitation.privacy_version,
+                entitlement.profile_code AS entitlement_profile
+         FROM invitations invitation
+         LEFT JOIN invitation_entitlements entitlement
+           ON entitlement.invitation_id = invitation.id
          WHERE token_hash = $1
            AND accepted_at IS NULL
            AND revoked_at IS NULL
@@ -280,13 +304,14 @@ export class PasswordAccountService {
         "INSERT INTO users (id, email, name) VALUES ($1, NULL, $2)",
         [userId, name]
       );
+      const emailIdentityId = randomUUID();
       await connection.query(
         `INSERT INTO email_identities
            (id, user_id, email, normalized_email, normalization_version,
             verified_at, is_primary)
          VALUES ($1, $2, $3, $4, $5, now(), true)`,
         [
-          randomUUID(),
+          emailIdentityId,
           userId,
           row.email,
           row.normalized_email,
@@ -310,6 +335,12 @@ export class PasswordAccountService {
         `UPDATE invitations SET accepted_by_user_id = $2, accepted_at = now()
          WHERE id = $1`,
         [row.id, userId]
+      );
+      await materializeInvitationEntitlement(
+        connection,
+        userId,
+        row.id,
+        row.entitlement_profile
       );
       await connection.query(
         `INSERT INTO sessions

--- a/services/server/src/platform/error-handler.ts
+++ b/services/server/src/platform/error-handler.ts
@@ -7,6 +7,7 @@ import {
   IdentityRemovalForbiddenError
 } from "../account-management.js";
 import { AccountUnavailableError } from "../external-auth.js";
+import { HostedEntitlementRequiredError } from "../entitlements.js";
 import { GitHubIdentityError } from "../github-auth.js";
 import { GoogleIdentityError } from "../google-auth.js";
 import {
@@ -99,6 +100,12 @@ export function registerErrorHandler(app: FastifyInstance): void {
     if (error instanceof HostedProviderUnavailableError) {
       request.log.error({ error: error.cause }, "Hosted provider is unavailable");
       return reply.code(503).send(apiError("hosted_provider_unavailable", error.message));
+    }
+    if (error instanceof HostedEntitlementRequiredError) {
+      return reply.code(403).send(apiError(
+        "hosted_entitlement_required",
+        error.message
+      ));
     }
     if (error instanceof GitHubIdentityError) {
       request.log.warn({ error: error.message }, "GitHub authentication failed");

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -20,6 +20,7 @@ function config(overrides: Partial<Parameters<typeof validateRuntimeConfig>[0]> 
     editorOrigin: null,
     authenticationLegalDocuments: null,
     transactionalEmail: null,
+    resendWebhookSecret: null,
     hostedCollections: false,
     hostedProvider: null,
     allowInsecureHostedProvider: false,

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -31,6 +31,7 @@ export interface RuntimeConfig {
   editorOrigin: string | null;
   authenticationLegalDocuments: AuthenticationLegalDocuments | null;
   transactionalEmail: TransactionalEmailConfig | null;
+  resendWebhookSecret: string | null;
   hostedCollections: boolean;
   hostedProvider: HostedProviderConfig | null;
   allowInsecureHostedProvider: boolean;
@@ -133,6 +134,12 @@ export function validateRuntimeConfig(config: RuntimeConfig): RuntimeConfig {
     ) {
       throw new Error("Transactional email configuration is invalid.");
     }
+  }
+  if (
+    config.resendWebhookSecret !== null
+    && !/^whsec_[A-Za-z0-9+/=_-]{16,}$/u.test(config.resendWebhookSecret)
+  ) {
+    throw new Error("MDBASE_CONNECT_RESEND_WEBHOOK_SECRET is invalid.");
   }
   const hostedProvider = config.hostedProvider
     ? validateHostedProviderConfig(
@@ -248,6 +255,8 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
   const transactionalEmail = resendApiKey && emailFrom
     ? { apiKey: resendApiKey, from: emailFrom }
     : null;
+  const resendWebhookSecret =
+    env.MDBASE_CONNECT_RESEND_WEBHOOK_SECRET?.trim() || null;
   const port = Number(env.PORT ?? 8787);
   const host = env.HOST ?? "127.0.0.1";
   const hostedProvider = hostedProviderConfigFromEnv(env);
@@ -307,6 +316,7 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
     editorOrigin,
     authenticationLegalDocuments,
     transactionalEmail,
+    resendWebhookSecret,
     hostedCollections: env.MDBASE_CONNECT_HOSTED_COLLECTIONS === "1",
     hostedProvider,
     allowInsecureHostedProvider:

--- a/services/server/src/scheduled-email.test.ts
+++ b/services/server/src/scheduled-email.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DatabasePool } from "./database-types.js";
+import { createDatabase } from "./db.js";
+import { EmailDeliveryError, type EmailTransport } from "./email.js";
+import { scheduleEmail, ScheduledEmailWorker } from "./scheduled-email.js";
+
+const resources: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (resources.length) await resources.pop()?.();
+});
+
+describe("scheduled account email", () => {
+  it("deduplicates scheduling and delivers one due message", async () => {
+    const { db, userId, emailIdentityId } = await fixture();
+    const input = {
+      userId,
+      emailIdentityId,
+      messageKind: "test_welcome",
+      templateVersion: 1,
+      category: "onboarding" as const,
+      deduplicationKey: `test_welcome:${userId}:v1`,
+      scheduledFor: new Date(Date.now() - 1_000)
+    };
+    const first = await scheduleEmail(db, input);
+    const duplicate = await scheduleEmail(db, input);
+    expect(duplicate).toEqual({ id: first.id, duplicate: true });
+
+    const send = vi.fn(async () => ({
+      provider: "test",
+      messageId: "message-1"
+    }));
+    const worker = new ScheduledEmailWorker(
+      db,
+      { send },
+      ({ email }) => ({
+        to: email,
+        subject: "Test",
+        text: "Test message",
+        html: "<p>Test message</p>"
+      })
+    );
+    expect(await worker.drainOnce()).toBe(1);
+    expect(send).toHaveBeenCalledOnce();
+    expect(send.mock.calls[0]?.[1]).toBe(`email/${first.id}`);
+    const job = await db.query(
+      "SELECT state, provider_message_id FROM email_jobs WHERE id = $1",
+      [first.id]
+    );
+    expect(job.rows[0]).toEqual({
+      state: "accepted",
+      provider_message_id: "message-1"
+    });
+  });
+
+  it("cancels optional messages after suppression", async () => {
+    const { db, userId, emailIdentityId } = await fixture();
+    const scheduled = await scheduleEmail(db, {
+      userId,
+      emailIdentityId,
+      messageKind: "test_product",
+      templateVersion: 1,
+      category: "product",
+      deduplicationKey: `test_product:${userId}:v1`,
+      scheduledFor: new Date(Date.now() - 1_000)
+    });
+    await db.query(
+      `INSERT INTO email_suppressions (email_identity_id, reason)
+       VALUES ($1, 'unsubscribed')`,
+      [emailIdentityId]
+    );
+    const send = vi.fn<EmailTransport["send"]>();
+    const worker = new ScheduledEmailWorker(db, { send }, () => {
+      throw new Error("A cancelled job must not render.");
+    });
+
+    expect(await worker.drainOnce()).toBe(1);
+    expect(send).not.toHaveBeenCalled();
+    const job = await db.query(
+      "SELECT state, last_error_code FROM email_jobs WHERE id = $1",
+      [scheduled.id]
+    );
+    expect(job.rows[0]).toEqual({
+      state: "cancelled",
+      last_error_code: "preference_or_suppression"
+    });
+  });
+
+  it("retries a temporary provider failure without changing its identity", async () => {
+    const { db, userId, emailIdentityId } = await fixture();
+    const scheduled = await scheduleEmail(db, {
+      userId,
+      emailIdentityId,
+      messageKind: "test_retry",
+      templateVersion: 1,
+      category: "essential",
+      deduplicationKey: `test_retry:${userId}:v1`,
+      scheduledFor: new Date(Date.now() - 1_000)
+    });
+    const send = vi.fn(async () => {
+      throw new EmailDeliveryError("rate_limited", true, 429);
+    });
+    const worker = new ScheduledEmailWorker(db, { send }, ({ email }) => ({
+      to: email,
+      subject: "Retry",
+      text: "Retry",
+      html: "<p>Retry</p>"
+    }));
+
+    expect(await worker.drainOnce()).toBe(1);
+    const job = await db.query<{
+      state: string;
+      attempt_count: number;
+      idempotency_key: string;
+      next_attempt_at: Date;
+    }>(
+      `SELECT state, attempt_count, idempotency_key, next_attempt_at
+       FROM email_jobs WHERE id = $1`,
+      [scheduled.id]
+    );
+    expect(job.rows[0]).toMatchObject({
+      state: "scheduled",
+      attempt_count: 1,
+      idempotency_key: `email/${scheduled.id}`
+    });
+    expect(job.rows[0]!.next_attempt_at.getTime()).toBeGreaterThan(Date.now());
+  });
+});
+
+async function fixture(): Promise<{
+  db: DatabasePool;
+  userId: string;
+  emailIdentityId: string;
+}> {
+  const db = await createDatabase("memory");
+  resources.push(() => db.end());
+  const userId = randomUUID();
+  const emailIdentityId = randomUUID();
+  await db.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, NULL, 'Email user')",
+    [userId]
+  );
+  await db.query(
+    `INSERT INTO email_identities
+       (id, user_id, email, normalized_email, normalization_version,
+        verified_at, is_primary)
+     VALUES ($1, $2, 'email@example.com', 'email@example.com', 1, now(), true)`,
+    [emailIdentityId, userId]
+  );
+  await db.query(
+    "INSERT INTO account_email_preferences (user_id) VALUES ($1)",
+    [userId]
+  );
+  return { db, userId, emailIdentityId };
+}

--- a/services/server/src/scheduled-email.ts
+++ b/services/server/src/scheduled-email.ts
@@ -1,0 +1,330 @@
+import { randomUUID } from "node:crypto";
+import type { DatabasePool, DatabaseQueryable } from "./database-types.js";
+import {
+  EmailDeliveryError,
+  type EmailTransport,
+  type TransactionalEmail
+} from "./email.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const MAX_ATTEMPTS = 8;
+const PROVIDER_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1_000;
+
+export type EmailCategory = "essential" | "onboarding" | "product";
+
+export interface ScheduleEmailInput {
+  userId: string;
+  emailIdentityId: string;
+  messageKind: string;
+  templateVersion: number;
+  category: EmailCategory;
+  deduplicationKey: string;
+  scheduledFor: Date;
+}
+
+export interface EmailRenderContext {
+  userId: string;
+  name: string;
+  email: string;
+  messageKind: string;
+  templateVersion: number;
+}
+
+export type EmailRenderer = (
+  context: EmailRenderContext
+) => TransactionalEmail;
+
+interface EmailJobRow {
+  id: string;
+  user_id: string;
+  email_identity_id: string;
+  message_kind: string;
+  template_version: number;
+  category: EmailCategory;
+  idempotency_key: string;
+  attempt_count: number;
+  created_at: Date | string;
+}
+
+interface EmailRecipientRow {
+  name: string;
+  email: string;
+  verified_at: Date | string | null;
+  retired_at: Date | string | null;
+  suspended_at: Date | string | null;
+  onboarding_enabled: boolean | null;
+  product_enabled: boolean | null;
+  suppression_reason: string | null;
+}
+
+export async function scheduleEmail(
+  db: DatabaseQueryable,
+  input: ScheduleEmailInput
+): Promise<{ id: string; duplicate: boolean }> {
+  validateSchedule(input);
+  const id = randomUUID();
+  const inserted = await db.query<{ id: string }>(
+    `INSERT INTO email_jobs
+       (id, user_id, email_identity_id, message_kind, template_version,
+        category, deduplication_key, idempotency_key, scheduled_for,
+        next_attempt_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+     ON CONFLICT DO NOTHING
+     RETURNING id`,
+    [
+      id,
+      input.userId,
+      input.emailIdentityId,
+      input.messageKind,
+      input.templateVersion,
+      input.category,
+      input.deduplicationKey,
+      `email/${id}`,
+      input.scheduledFor
+    ]
+  );
+  if (inserted.rows[0]) return { id, duplicate: false };
+  const existing = await db.query<{ id: string }>(
+    "SELECT id FROM email_jobs WHERE deduplication_key = $1",
+    [input.deduplicationKey]
+  );
+  return { id: existing.rows[0]!.id, duplicate: true };
+}
+
+export class ScheduledEmailWorker {
+  private timer: NodeJS.Timeout | undefined;
+  private draining: Promise<number> | null = null;
+
+  constructor(
+    private readonly db: DatabasePool,
+    private readonly transport: EmailTransport,
+    private readonly render: EmailRenderer,
+    private readonly pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    private readonly onError: (error: unknown) => void = () => undefined
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(
+      () => void this.drainOnce().catch(this.onError),
+      this.pollIntervalMs
+    );
+    this.timer.unref();
+    void this.drainOnce().catch(this.onError);
+  }
+
+  async close(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+    await this.draining;
+  }
+
+  drainOnce(limit = 25): Promise<number> {
+    if (this.draining) return this.draining;
+    this.draining = this.performDrain(Math.max(1, Math.min(limit, 100)))
+      .finally(() => {
+        this.draining = null;
+      });
+    return this.draining;
+  }
+
+  private async performDrain(limit: number): Promise<number> {
+    const ready = await this.db.query<{ id: string }>(
+      `SELECT id FROM email_jobs
+       WHERE next_attempt_at <= now()
+         AND (
+           state = 'scheduled'
+           OR (state = 'sending' AND lease_expires_at <= now())
+         )
+       ORDER BY next_attempt_at, id
+       LIMIT $1`,
+      [limit]
+    );
+    let processed = 0;
+    for (const candidate of ready.rows) {
+      const claimed = await this.claim(candidate.id);
+      if (!claimed) continue;
+      processed += 1;
+      await this.deliver(claimed);
+    }
+    return processed;
+  }
+
+  private async claim(id: string): Promise<EmailJobRow | null> {
+    const leaseToken = randomUUID();
+    const claimed = await this.db.query<EmailJobRow>(
+      `UPDATE email_jobs SET
+         state = 'sending', lease_token = $2,
+         lease_expires_at = now() + interval '2 minutes',
+         attempt_count = attempt_count + 1, updated_at = now()
+       WHERE id = $1
+         AND next_attempt_at <= now()
+         AND (
+           state = 'scheduled'
+           OR (state = 'sending' AND lease_expires_at <= now())
+         )
+       RETURNING id, user_id, email_identity_id, message_kind,
+                 template_version, category, idempotency_key,
+                 attempt_count, created_at`,
+      [id, leaseToken]
+    );
+    const job = claimed.rows[0];
+    if (!job) return null;
+    await this.db.query(
+      `INSERT INTO email_delivery_attempts
+         (id, job_id, attempt_number, state)
+       VALUES ($1, $2, $3, 'started')`,
+      [randomUUID(), job.id, job.attempt_count]
+    );
+    return job;
+  }
+
+  private async deliver(job: EmailJobRow): Promise<void> {
+    const recipient = await this.recipient(job);
+    if (!recipient || !eligible(job.category, recipient)) {
+      await this.cancel(job, recipient ? "preference_or_suppression" : "recipient_unavailable");
+      return;
+    }
+    let message: TransactionalEmail;
+    try {
+      message = this.render({
+        userId: job.user_id,
+        name: recipient.name,
+        email: recipient.email,
+        messageKind: job.message_kind,
+        templateVersion: job.template_version
+      });
+    } catch {
+      await this.fail(job, new EmailDeliveryError("template_error", false));
+      return;
+    }
+    try {
+      const delivery = await this.transport.send(message, job.idempotency_key);
+      await this.db.query(
+        `UPDATE email_jobs SET
+           state = 'accepted', provider = $3, provider_message_id = $4,
+           accepted_at = now(), lease_token = NULL, lease_expires_at = NULL,
+           last_error_code = NULL, updated_at = now()
+         WHERE id = $1 AND state = 'sending' AND attempt_count = $2`,
+        [job.id, job.attempt_count, delivery.provider, delivery.messageId]
+      );
+      await this.finishAttempt(
+        job,
+        "accepted",
+        delivery.provider,
+        delivery.messageId
+      );
+    } catch (error) {
+      await this.fail(
+        job,
+        error instanceof EmailDeliveryError
+          ? error
+          : new EmailDeliveryError("unknown_error", false)
+      );
+    }
+  }
+
+  private async recipient(job: EmailJobRow): Promise<EmailRecipientRow | null> {
+    const result = await this.db.query<EmailRecipientRow>(
+      `SELECT account.name, account.suspended_at, identity.email,
+              identity.verified_at, identity.retired_at,
+              preferences.onboarding_enabled, preferences.product_enabled,
+              suppression.reason AS suppression_reason
+       FROM users account
+       JOIN email_identities identity
+         ON identity.id = $2 AND identity.user_id = account.id
+       LEFT JOIN account_email_preferences preferences
+         ON preferences.user_id = account.id
+       LEFT JOIN email_suppressions suppression
+         ON suppression.email_identity_id = identity.id
+       WHERE account.id = $1`,
+      [job.user_id, job.email_identity_id]
+    );
+    return result.rows[0] ?? null;
+  }
+
+  private async cancel(job: EmailJobRow, reason: string): Promise<void> {
+    await this.db.query(
+      `UPDATE email_jobs SET state = 'cancelled', cancelled_at = now(),
+              last_error_code = $3, lease_token = NULL,
+              lease_expires_at = NULL, updated_at = now()
+       WHERE id = $1 AND state = 'sending' AND attempt_count = $2`,
+      [job.id, job.attempt_count, reason]
+    );
+    await this.finishAttempt(job, "failed", null, null, reason);
+  }
+
+  private async fail(job: EmailJobRow, error: EmailDeliveryError): Promise<void> {
+    const age = Date.now() - new Date(job.created_at).getTime();
+    const uncertain = error.code === "network_error"
+      && age >= PROVIDER_IDEMPOTENCY_WINDOW_MS;
+    const retry = error.retryable && !uncertain && job.attempt_count < MAX_ATTEMPTS;
+    const state = uncertain ? "uncertain" : retry ? "scheduled" : "failed";
+    const delaySeconds = retry ? retryDelaySeconds(job.attempt_count) : 0;
+    const nextAttemptAt = new Date(Date.now() + delaySeconds * 1_000);
+    await this.db.query(
+      `UPDATE email_jobs SET state = $3,
+              next_attempt_at = CASE WHEN $4
+                THEN $5
+                ELSE next_attempt_at END,
+              last_error_code = $6, lease_token = NULL,
+              lease_expires_at = NULL, updated_at = now()
+       WHERE id = $1 AND state = 'sending' AND attempt_count = $2`,
+      [job.id, job.attempt_count, state, retry, nextAttemptAt, error.code]
+    );
+    await this.finishAttempt(
+      job,
+      uncertain ? "uncertain" : "failed",
+      null,
+      null,
+      error.code
+    );
+  }
+
+  private async finishAttempt(
+    job: EmailJobRow,
+    state: "accepted" | "failed" | "uncertain",
+    provider: string | null,
+    providerMessageId: string | null,
+    errorCode: string | null = null
+  ): Promise<void> {
+    await this.db.query(
+      `UPDATE email_delivery_attempts SET
+         state = $3, provider = $4, provider_message_id = $5,
+         error_code = $6, completed_at = now()
+       WHERE job_id = $1 AND attempt_number = $2 AND state = 'started'`,
+      [job.id, job.attempt_count, state, provider, providerMessageId, errorCode]
+    );
+  }
+}
+
+function eligible(category: EmailCategory, recipient: EmailRecipientRow): boolean {
+  if (
+    recipient.suspended_at
+    || !recipient.verified_at
+    || recipient.retired_at
+    || recipient.suppression_reason
+  ) return false;
+  if (category === "onboarding") return recipient.onboarding_enabled ?? true;
+  if (category === "product") return recipient.product_enabled ?? false;
+  return true;
+}
+
+function retryDelaySeconds(attempt: number): number {
+  return Math.min(6 * 60 * 60, 30 * 2 ** Math.max(0, attempt - 1));
+}
+
+function validateSchedule(input: ScheduleEmailInput): void {
+  if (!/^[a-z][a-z0-9_.-]{0,99}$/u.test(input.messageKind)) {
+    throw new TypeError("Scheduled email kind is invalid.");
+  }
+  if (!Number.isSafeInteger(input.templateVersion) || input.templateVersion < 1) {
+    throw new TypeError("Scheduled email template version is invalid.");
+  }
+  if (!input.deduplicationKey || input.deduplicationKey.length > 200) {
+    throw new TypeError("Scheduled email deduplication key is invalid.");
+  }
+  if (!Number.isFinite(input.scheduledFor.getTime())) {
+    throw new TypeError("Scheduled email time is invalid.");
+  }
+}


### PR DESCRIPTION
## What changed

- adds a durable `beta_v1` entitlement profile and grants it atomically when an invitation is accepted
- enforces account-wide hosted storage, collection, document, file, and replica limits in the hosted provider
- exposes effective limits and usage through account management
- adds a generic persisted scheduled-email queue with retries, idempotency, preferences, suppressions, and signed Resend event handling
- sends Callum's approved welcome email 24 hours after Beta signup
- adds audited operator commands to inspect, grant, and reconcile entitlements

## Why

Beta accounts need a permanent 1 GB allowance and production must enforce the same limits that later paid tiers will use. Post-signup email also needs durable delivery infrastructure rather than an in-process timer.

## User impact

Invited Beta users receive 1 GB shared Markdown/file storage, 10 hosted collections, 10 replicas per collection, a 2 MB Markdown document limit, and a 250 MB single-file limit. Their welcome email is scheduled 24 hours after signup and their Beta allowance has no expiry.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm typecheck` on Node 24.13.0
- `pnpm test` on Node 24.13.0
- `pnpm e2e` on Node 24.13.0
- hosted-provider and hosted-files PostgreSQL end-to-end suites
