### PR TITLE
Fix PostgreSQL entitlement reconciliation for beta.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "clap",
  "directories",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "chrono",
  "directories",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "async-trait",
  "axum",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -432,7 +432,7 @@ describe("mdbase editor", () => {
 
     expect(await screen.findByRole("heading", { name: "project" })).toBeInTheDocument();
     expect((await gateway.describe()).types.map((type) => type.name)).toContain("project");
-  });
+  }, 15_000);
 
   it("keeps the note frame stable while a note is loading", async () => {
     const gateway = new SlowReadGateway();

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -441,7 +441,11 @@ describe("mdbase editor", () => {
     const loading = await screen.findByLabelText("Loading note");
     expect(loading).toHaveAttribute("aria-busy", "true");
     gateway.releaseRead();
-    expect(await screen.findByRole("textbox", { name: "Note title" })).toHaveValue("The shape of useful tools");
+    expect(await screen.findByRole(
+      "textbox",
+      { name: "Note title" },
+      { timeout: 5_000 }
+    )).toHaveValue("The shape of useful tools");
     expect(screen.queryByLabelText("Loading note")).not.toBeInTheDocument();
   });
 

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-protocol/src/tests.rs
+++ b/crates/connect-protocol/src/tests.rs
@@ -432,7 +432,7 @@ fn rust_relay_messages_match_the_canonical_wire_schema() {
     for message in [
         RelayMessage::RelayHello {
             protocol_version: CONTROL_PROTOCOL_VERSION,
-            connector_version: "0.1.0-beta.22".to_string(),
+            connector_version: "0.1.0-beta.23".to_string(),
             capabilities: RELAY_CAPABILITIES
                 .iter()
                 .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "clap",
  "directories",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "chrono",
  "directories",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "async-trait",
  "axum",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.22"
+version = "0.1.0-beta.23"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -114,9 +114,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.22
-git tag -a v0.1.0-beta.22 -m "mdbase connect 0.1.0-beta.22"
-git push origin v0.1.0-beta.22
+pnpm version:check v0.1.0-beta.23
+git tag -a v0.1.0-beta.23 -m "mdbase connect 0.1.0-beta.23"
+git push origin v0.1.0-beta.23
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -662,7 +662,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.22",
+    connector_version: "0.1.0-beta.23",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/src/mirror-files.test.ts
+++ b/packages/sync/src/mirror-files.test.ts
@@ -445,7 +445,7 @@ describe("portable collection file mirror", () => {
 
     await target.sync();
     expect(transport.downloads).toBe(1);
-  });
+  }, 15_000);
 
   it("applies folder exclusions to Markdown and files without prefix-neighbor mistakes", async () => {
     const transport = new FileTransport();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.22" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.23" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.22",
+  "version": "0.1.0-beta.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -9,6 +9,11 @@ import {
   EmailDeliveryError,
   type EmailTransport
 } from "./email.js";
+import type {
+  HostedAccountLimits,
+  HostedAccountUsage,
+  HostedProviderClient
+} from "./hosted-provider.js";
 import { tokenHash } from "./security.js";
 
 const resources: Array<() => Promise<void>> = [];
@@ -409,8 +414,74 @@ describe("authentication operator command", () => {
     ], context) as { effective: { hostedStorageBytes: number }; grants: unknown[] };
     expect(shown.effective.hostedStorageBytes).toBe(1024 * 1024 * 1024);
     expect(shown.grants).toHaveLength(1);
+    const grantedAudit = await context.db.query<{
+      user_id: string;
+      subject_id: string;
+    }>(
+      `SELECT user_id, subject_id FROM audit_events
+       WHERE event_type = 'entitlement.granted' ORDER BY created_at`
+    );
+    expect(grantedAudit.rows).toEqual([
+      { user_id: userId, subject_id: userId },
+      { user_id: userId, subject_id: userId }
+    ]);
+
+    const provider = fakeHostedProvider();
+    const reconciled = await runAuthAdminCommand([
+      "entitlements", "reconcile",
+      "--user", userId,
+      "--operation-id", "20000000-0000-4000-8000-000000000090",
+      "--actor", "operator:test",
+      "--reason", "Reconcile private beta storage"
+    ], { ...context, hostedProvider: provider }) as {
+      reconciled: Array<{ user_id: string; reconciled_collections: number }>;
+    };
+    expect(reconciled.reconciled).toEqual([{
+      user_id: userId,
+      provider_account_id: expect.any(String),
+      entitlement_revision: 1,
+      reconciled_collections: 0,
+      usage: expect.objectContaining({ account_id: expect.any(String) })
+    }]);
+    const reconciledAudit = await context.db.query<{
+      user_id: string;
+      subject_id: string;
+    }>(
+      `SELECT user_id, subject_id FROM audit_events
+       WHERE event_type = 'entitlement.reconciled'`
+    );
+    expect(reconciledAudit.rows).toEqual([
+      { user_id: userId, subject_id: userId }
+    ]);
   });
 });
+
+function fakeHostedProvider(): HostedProviderClient {
+  let usage: HostedAccountUsage | undefined;
+  return {
+    async upsertAccount(
+      accountId: string,
+      entitlementRevision: number,
+      limits: HostedAccountLimits
+    ) {
+      usage = {
+        account_id: accountId,
+        entitlement_revision: entitlementRevision,
+        collection_count: 0,
+        live_content_bytes: 0,
+        live_file_bytes: 0,
+        retained_file_bytes: 0,
+        ...limits
+      };
+      return usage;
+    },
+    async reconcileCollectionAccount() {},
+    async accountUsage() {
+      if (!usage) throw new Error("Hosted account was not reconciled.");
+      return usage;
+    }
+  } as unknown as HostedProviderClient;
+}
 
 let messageSequence = 0;
 function randomMessageId(): string {

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -223,7 +223,7 @@ async function reconcileEntitlements(
     await context.db.query(
       `INSERT INTO audit_events
          (id, user_id, event_type, subject_id, metadata)
-       VALUES ($1, $2, 'entitlement.reconciled', $2, $3::jsonb)`,
+       VALUES ($1, $2, 'entitlement.reconciled', $4, $3::jsonb)`,
       [
         randomUUID(),
         userId,
@@ -233,7 +233,8 @@ async function reconcileEntitlements(
           operation_id: operationId,
           entitlement_revision: result.entitlementRevision,
           reconciled_collections: result.reconciledCollections
-        })
+        }),
+        userId
       ]
     );
   }

--- a/services/server/src/entitlements.ts
+++ b/services/server/src/entitlements.ts
@@ -322,7 +322,7 @@ export async function grantOperatorEntitlement(
     await connection.query(
       `INSERT INTO audit_events
          (id, user_id, event_type, subject_id, metadata)
-       VALUES ($1, $2, 'entitlement.granted', $2, $3::jsonb)`,
+       VALUES ($1, $2, 'entitlement.granted', $4, $3::jsonb)`,
       [
         randomUUID(),
         input.userId,
@@ -333,7 +333,8 @@ export async function grantOperatorEntitlement(
           operation_id: input.operationId,
           changed,
           entitlement_revision: entitlementRevision
-        })
+        }),
+        input.userId
       ]
     );
     await connection.query("COMMIT");


### PR DESCRIPTION
Fix the PostgreSQL parameter-type conflict found by the staging beta.22 deployment in entitlement audit writes. Grant and reconcile audit inserts now use distinct UUID and text parameters, with operator-command regression coverage for both paths. This also advances the release candidate to v0.1.0-beta.23.\n\nThree unrelated asynchronous CI tests receive approved, test-local wait bounds: 15 seconds for the 1 MiB R2 streaming test, 5 seconds for the editor loading assertion, and 15 seconds for the long type-editor interaction. Production behavior is unchanged.\n\nValidation: cargo fmt --all -- --check; cargo test --workspace; pnpm typecheck; pnpm test; pnpm e2e; pnpm version:check v0.1.0-beta.23; all adjusted tests run individually.