### PR TITLE
Finish Connect beta UI and entitlement reporting

### DIFF
--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -272,7 +272,7 @@ try {
     .locator("details.connect-grant")
     .filter({ hasText: "Docker fixture" });
   await portalGrant.locator(":scope > summary").click();
-  await portalPage.evaluate(() => { window.confirm = () => true; });
+  await portalGrant.getByRole("button", { name: "Revoke", exact: true }).click();
   await portalGrant.getByRole("button", { name: "Revoke", exact: true }).click();
   await portalApplication.waitFor({ state: "detached" });
   await waitForValue(

--- a/apps/editor/DESIGN.md
+++ b/apps/editor/DESIGN.md
@@ -56,8 +56,11 @@ states, or collection controls.
 The desktop app uses three persistent panes: a 176px collection rail, a 304px
 virtualized note list, and the editor. A properties inspector appears only when
 requested. Types reuse the list-and-document rhythm; settings become one quiet
-document rather than a dashboard. Mobile presents each level as a separate
-navigable screen.
+document rather than a dashboard. In the collection rail, Notes, Types, and
+Settings remain the primary editing group. Connect sits in a bottom-aligned
+Manage group above connection and account status, visibly secondary until a
+pending authorization count requires attention. Mobile presents each level as
+a separate navigable screen.
 
 ## Editing
 

--- a/apps/editor/PRODUCT.md
+++ b/apps/editor/PRODUCT.md
@@ -1,17 +1,21 @@
 # Product
 
-## Register
+<!-- impeccable:product-schema 1 -->
 
-product
+## Platform
+
+web
 
 ## Users
 
-People who keep notes and other durable records in an mdbase collection and
-want a calm, fast writing surface in the browser. They understand notes,
-folders, search, and properties. They should not need to understand relays,
-tokens, or collection runtimes.
+People who keep notes and other durable records in mdbase-backed Markdown
+collections and want a calm, fast writing surface in the browser. They
+understand notes, folders, search, and properties, but should not need to
+understand relays, tokens, or collection runtimes. Editing is their primary
+activity; they enter Connect occasionally to manage storage, applications,
+computers, browser sessions, and account access.
 
-## Product purpose
+## Product Purpose
 
 mdbase editor is a general Markdown collection editor and the web home for
 mdbase Connect. Its editing workspace opens one separately authorized
@@ -19,22 +23,72 @@ collection, presents every record as a note, and preserves the collection's
 files, frontmatter, types, and revision checks. Its `/connect` workspace uses
 the user's Connect account session to manage collection inventory, hosted
 storage, sign-in methods, application grants, computers, browser sessions, and
-account deletion without receiving collection content.
-It is also the reference full-access consumer for the mdbase connect SDK.
+account deletion without receiving collection content. It is also the
+reference full-access consumer for the mdbase connect SDK.
 
-## Brand personality
+Success means writing feels local and immediate, durable files remain useful
+outside the editor, and consequential access or collection-wide changes remain
+deliberate and understandable.
 
-Quiet, direct, spacious, and dependable. The writing surface should disappear
-while someone works, with technical detail available at the edges when it is
-useful.
+## Positioning
 
-## Anti-references
+mdbase editor keeps application data as portable, human-readable Markdown files
+while adding the structure needed for capable applications. mdbase Connect
+makes those collections available to independent applications without turning
+account administration into implicit access to collection content. This
+separates durable user-controlled data from the software used to work with it.
 
-Avoid a dashboard, IDE, knowledge-management cockpit, file-manager toolbar, or
-imitation native window. Avoid cards, dark controls, decorative gradients,
-toolbar clutter, and permanent technical metadata around the document.
+## Operating Context
 
-## Principles
+The editor is primarily used in a desktop browser for sustained writing and
+collection maintenance. A collection may be hosted by mdbase or remain
+authoritative on a user's computer through mdbase Connect. The collection rail
+switches among Notes, Types, Settings, and the less-frequent Connect management
+workspace. Mobile layouts present each navigation level as a separate screen.
+
+Users may also work with the same files through ordinary text editors, Obsidian,
+the mdbase SDK, or other authorized applications. Paths and frontmatter are
+durable provenance rather than editor-private metadata.
+
+## Capabilities and Constraints
+
+- The editor opens one separately authorized collection and supports notes,
+  paths, frontmatter, types, application contracts, search, and revision-aware
+  mutations.
+- The Connect workspace manages collection inventory, storage, application
+  grants, computers, sign-in methods, browser sessions, and the account.
+- An account-management session may reveal that a collection exists but never
+  grants the editor access to its contents. Each collection requires its own
+  exact application grant.
+- Collections may be hosted or locally authoritative. The interface must make
+  local, hosted, connected, reconnecting, and unavailable states understandable.
+- Record creation is delayed until its path, selected type, required fields,
+  and initial content are complete.
+- Type behavior follows declared collection metadata and schemas; the editor
+  must not infer semantics from familiar property names.
+- Google access and refresh tokens are not requested or stored for account
+  sign-in.
+
+## Brand Commitments
+
+The product name is `mdbase editor`; the connected service is `mdbase connect`.
+The voice is quiet, direct, spacious, dependable, and explicit about security
+consequences. The shared Frontmatter mark and wordmark assets are canonical.
+
+The product must not resemble a growth-oriented SaaS dashboard, IDE,
+knowledge-management cockpit, generic cloud file manager, or imitation native
+window. Avoid security theatre, toolbar clutter, and permanent technical
+metadata around the document.
+
+## Evidence on Hand
+
+The repository's implementation, unit and browser tests, product documentation,
+and assets are the evidence for current behavior and identity. The deployed
+editor and Connect service provide integration evidence. No customer
+testimonials, usage claims, adoption metrics, or third-party endorsements are
+currently established; future work must not fabricate them.
+
+## Product Principles
 
 1. Open into the last note and put the cursor near the writing.
 2. Save continuously and report conflicts clearly.
@@ -52,3 +106,10 @@ toolbar clutter, and permanent technical metadata around the document.
 9. Keep account management and collection content authorization separate. An
    account may reveal that a collection exists; opening it still requires the
    editor application's exact collection grant.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.2 AA for contrast, keyboard navigation, focus visibility, form
+labels, and semantic status announcements. Respect reduced motion. Never encode
+connection or permission state by color alone, and keep security language in
+plain language.

--- a/apps/editor/src/AccountManagement.tsx
+++ b/apps/editor/src/AccountManagement.tsx
@@ -5,7 +5,12 @@ import {
   type ConnectManagementClient,
   type ManagementOverview
 } from "@mdbase/connect-management";
-import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import {
+  ConnectEmpty as Empty,
+  ConnectPage as Page,
+  ConnectSectionTitle as SectionTitle
+} from "./ConnectPrimitives";
 import { GoogleIdentityButton } from "./GoogleIdentityButton";
 
 export function AccountManagement({ client, overview, sessions, onOverviewRefresh, onDeleted }: {
@@ -227,18 +232,6 @@ export function DeletedAccount({ client }: { client: ConnectManagementClient }) 
   return <main className="connect-deleted-account"><div><p>Account deleted</p><h1>Your account has been deleted.</h1><span>Hosted data and access credentials were removed. Any local collection and mirror files remain on your computers.</span><a className="connect-account-action" href={new URL("/login", client.baseUrl).href}>Return to sign in</a></div></main>;
 }
 
-function Page({ title, intro, children }: { title: string; intro: string; children: ReactNode }) {
-  return <div className="connect-page"><header><p>mdbase Connect</p><h1>{title}</h1><span>{intro}</span></header>{children}</div>;
-}
-
-function SectionTitle({ title, note, count, action }: { title: string; note?: string; count?: number; action?: ReactNode }) {
-  return <header className="connect-section-title"><div><h2>{title}</h2>{count !== undefined && <span>{count}</span>}</div>{note && <p>{note}</p>}{action}</header>;
-}
-
-function Empty({ title, body }: { title: string; body: string }) {
-  return <div className="connect-empty"><div><strong>{title}</strong><p>{body}</p></div></div>;
-}
-
 function StorageRow({ collection }: { collection: AccountData["storage"]["collections"][number] }) {
   const usage = collection.usage;
   const liveBytes = usage ? usage.content_bytes + usage.file_bytes : null;
@@ -348,6 +341,6 @@ function loginUrl(client: ConnectManagementClient): string {
 function errorMessage(value: unknown): string {
   const detail = value instanceof Error ? value.message : String(value);
   return /failed to fetch|networkerror|network request failed/i.test(detail)
-    ? "Connect could not be reached. Check your connection and try again."
+    ? "mdbase connect could not be reached. Check your connection and try again."
     : detail;
 }

--- a/apps/editor/src/AccountManagement.tsx
+++ b/apps/editor/src/AccountManagement.tsx
@@ -141,10 +141,11 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
 
     <section>
       <SectionTitle title="Hosted storage" note="Local collection files stay on your computers and are not measured here." />
+      {overview.subscription && <SubscriptionStorage subscription={overview.subscription} fallbackStorage={account.storage} />}
       <div className="connect-account-list">
         <div className="connect-account-row">
           <div><strong>Used by hosted collections</strong><small>{storageDetail(account)}</small></div>
-          <span>{account.storage.total_content_bytes === null ? "Unavailable" : formatBytes(account.storage.total_content_bytes)}</span>
+          <span>{account.storage.total_storage_bytes === null ? "Unavailable" : formatBytes(account.storage.total_storage_bytes)}</span>
         </div>
         {account.storage.collections.map((collection) => <StorageRow key={collection.id} collection={collection} />)}
       </div>
@@ -240,8 +241,45 @@ function Empty({ title, body }: { title: string; body: string }) {
 
 function StorageRow({ collection }: { collection: AccountData["storage"]["collections"][number] }) {
   const usage = collection.usage;
-  const percentage = usage && usage.max_content_bytes > 0 ? Math.min(100, usage.content_bytes / usage.max_content_bytes * 100) : 0;
-  return <div className="connect-account-row connect-storage-row"><div><strong>{collection.display_name}</strong><small>{usage ? `${pluralLabel(usage.record_count, "record", "records")} · ${formatBytes(usage.content_bytes)} of ${formatBytes(usage.max_content_bytes)}` : "Usage temporarily unavailable"}</small></div>{usage && <div className="connect-storage-progress" role="progressbar" aria-label={`${collection.display_name} storage`} aria-valuemin={0} aria-valuemax={usage.max_content_bytes} aria-valuenow={usage.content_bytes}><span style={{ width: `${percentage}%` }} /></div>}</div>;
+  const liveBytes = usage ? usage.content_bytes + usage.file_bytes : null;
+  return <div className="connect-account-row">
+    <div>
+      <strong>{collection.display_name}</strong>
+      <small>{usage
+        ? `${pluralLabel(usage.record_count, "record", "records")} · ${pluralLabel(usage.file_count, "file", "files")} · ${formatBytes(usage.content_bytes)} Markdown · ${formatBytes(usage.file_bytes)} files`
+        : "Usage temporarily unavailable"}</small>
+    </div>
+    <span>{liveBytes === null ? "Unavailable" : formatBytes(liveBytes)}</span>
+  </div>;
+}
+
+function SubscriptionStorage({ subscription, fallbackStorage }: {
+  subscription: NonNullable<ManagementOverview["subscription"]>;
+  fallbackStorage: AccountData["storage"];
+}) {
+  const liveStorageBytes = subscription.usage?.live_storage_bytes ?? fallbackStorage.total_storage_bytes;
+  const liveContentBytes = subscription.usage?.live_content_bytes ?? fallbackStorage.total_content_bytes;
+  const liveFileBytes = subscription.usage?.live_file_bytes ?? fallbackStorage.total_file_bytes;
+  const limit = subscription.limits.hosted_storage_bytes;
+  const percentage = liveStorageBytes !== null && limit > 0
+    ? Math.min(100, liveStorageBytes / limit * 100)
+    : 0;
+  const tier = subscription.kind === "beta" ? "Beta" : "Included storage";
+  const permanence = subscription.permanent ? "Permanent allowance" : "Current allowance";
+  return <div className="connect-subscription-storage">
+    <div className="connect-subscription-heading">
+      <div><strong>{tier}</strong><small>{permanence}</small></div>
+      <span>{liveStorageBytes === null ? "Usage unavailable" : `${formatBytes(liveStorageBytes)} of ${formatBytes(limit)}`}</span>
+    </div>
+    {liveStorageBytes !== null && <div className="connect-storage-progress" role="progressbar" aria-label={`${tier} hosted storage`} aria-valuemin={0} aria-valuemax={limit} aria-valuenow={liveStorageBytes} aria-valuetext={`${formatBytes(liveStorageBytes)} of ${formatBytes(limit)} used`}><span style={{ width: `${percentage}%` }} /></div>}
+    <p>{liveContentBytes === null || liveFileBytes === null
+      ? "Markdown and file usage is temporarily unavailable."
+      : `${formatBytes(liveContentBytes)} Markdown · ${formatBytes(liveFileBytes)} files`}</p>
+    {subscription.limits.retained_file_bytes > 0 && <p>{subscription.usage
+      ? `${formatBytes(subscription.usage.retained_file_bytes)} of ${formatBytes(subscription.limits.retained_file_bytes)} retained file storage`
+      : `${formatBytes(subscription.limits.retained_file_bytes)} retained file storage included`}</p>}
+    <p>Documents up to {formatBytes(subscription.limits.max_document_bytes)} · files up to {formatBytes(subscription.limits.max_single_file_bytes)} · {pluralLabel(subscription.limits.max_replicas_per_collection, "synced folder", "synced folders")} per collection</p>
+  </div>;
 }
 
 function tokenFromFragment(): string | null {
@@ -253,7 +291,8 @@ function storageDetail(account: AccountData): string {
   const collections = pluralLabel(account.storage.collections.length, "hosted collection", "hosted collections");
   if (account.storage.status === "unavailable") return `${collections} · usage temporarily unavailable`;
   const records = pluralLabel(account.storage.total_records ?? 0, "record", "records");
-  return `${collections} · ${records}${account.storage.status === "partial" ? " · partial usage" : ""}`;
+  const files = account.storage.collections.reduce((total, collection) => total + (collection.usage?.file_count ?? 0), 0);
+  return `${collections} · ${records} · ${pluralLabel(files, "file", "files")}${account.storage.status === "partial" ? " · partial usage" : ""}`;
 }
 
 function providerLabel(provider: string): string {

--- a/apps/editor/src/AccountManagement.tsx
+++ b/apps/editor/src/AccountManagement.tsx
@@ -5,7 +5,7 @@ import {
   type ConnectManagementClient,
   type ManagementOverview
 } from "@mdbase/connect-management";
-import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
 import {
   ConnectEmpty as Empty,
   ConnectPage as Page,
@@ -23,7 +23,8 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
   const [account, setAccount] = useState<AccountData>();
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
-  const [busy, setBusy] = useState("");
+  const [busy, setBusy] = useState<ReadonlySet<string>>(() => new Set());
+  const busyRef = useRef(new Set<string>());
   const [passwordOpen, setPasswordOpen] = useState(false);
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -64,7 +65,7 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
   }, []);
 
   async function run(id: string, action: () => Promise<void>, success?: string): Promise<boolean> {
-    setBusy(id);
+    if (!beginOperation(id)) return false;
     setError("");
     setNotice("");
     try {
@@ -76,8 +77,20 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
       setError(errorMessage(reason));
       return false;
     } finally {
-      setBusy("");
+      finishOperation(id);
     }
+  }
+
+  function beginOperation(id: string): boolean {
+    if (busyRef.current.has(id)) return false;
+    busyRef.current.add(id);
+    setBusy(new Set(busyRef.current));
+    return true;
+  }
+
+  function finishOperation(id: string): void {
+    busyRef.current.delete(id);
+    setBusy(new Set(busyRef.current));
   }
 
   async function changePassword(event: FormEvent) {
@@ -98,7 +111,7 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
 
   async function deleteAccount(event: FormEvent) {
     event.preventDefault();
-    setBusy("delete");
+    if (!beginOperation("delete")) return;
     setError("");
     try {
       await client.deleteAccount({
@@ -115,7 +128,7 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
       onDeleted();
     } catch (reason) {
       setError(errorMessage(reason));
-      setBusy("");
+      finishOperation("delete");
     }
   }
 
@@ -167,7 +180,7 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
               {!identity && provider === "github" && <a className="connect-account-action" href={client.githubAccountFlowUrl("link")}>Connect</a>}
               {!identity && provider === "google" && googleAction !== "link" && <button className="connect-account-action" onClick={() => setGoogleAction("link")}>Connect</button>}
               {!identity && provider === "google" && googleAction === "link" && <GoogleIdentityButton client={client} purpose="link" onComplete={googleCompleted} onError={googleFailed} />}
-              {identity && <button className="connect-account-action" disabled={!identity.removable || busy === `disconnect-${provider}`} title={!identity.removable ? identity.current ? "This method is used by the current session." : "This is your only sign-in method." : undefined} onClick={() => void run(`disconnect-${provider}`, () => client.disconnectIdentity(provider), `${providerLabel(provider)} disconnected.`)}>{busy === `disconnect-${provider}` ? "Disconnecting…" : "Disconnect"}</button>}
+              {identity && <button className="connect-account-action" disabled={!identity.removable || busy.has(`disconnect-${provider}`)} title={!identity.removable ? identity.current ? "This method is used by the current session." : "This is your only sign-in method." : undefined} onClick={() => void run(`disconnect-${provider}`, () => client.disconnectIdentity(provider), `${providerLabel(provider)} disconnected.`)}>{busy.has(`disconnect-${provider}`) ? "Disconnecting…" : "Disconnect"}</button>}
             </div>
           </div>;
         })}
@@ -180,19 +193,19 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
             <label><span>New password</span><input type="password" autoComplete="new-password" minLength={15} required aria-describedby="account-password-guidance" value={newPassword} onChange={(event) => setNewPassword(event.target.value)} /></label>
             <p className="connect-muted" id="account-password-guidance">Use at least 15 characters. Spaces are welcome.</p>
             <label><span>Confirm new password</span><input type="password" autoComplete="new-password" minLength={15} required value={passwordConfirmation} onChange={(event) => setPasswordConfirmation(event.target.value)} /></label>
-            <button className="connect-primary-action" disabled={busy === "password"}>{busy === "password" ? "Changing password…" : "Change password"}</button>
+            <button className="connect-primary-action" disabled={busy.has("password")}>{busy.has("password") ? "Changing password…" : "Change password"}</button>
           </form>}
         </div>}
       </div>}
     </section>
 
     {account.authentication.managed && <section>
-      <SectionTitle title="Browser sessions" count={sessions?.length} action={otherSessions.length > 0 && <button className="danger" disabled={busy === "sessions-others"} onClick={() => void run("sessions-others", () => client.revokeOtherSessions())}>Sign out other sessions</button>} />
+      <SectionTitle title="Browser sessions" count={sessions?.length} action={otherSessions.length > 0 && <button className="danger" disabled={busy.has("sessions-others")} onClick={() => void run("sessions-others", () => client.revokeOtherSessions())}>Sign out other sessions</button>} />
       {!sessions && <p className="connect-muted">Checking active sessions…</p>}
       {sessions?.map((session) => <div className="connect-row" key={session.id}>
         <div><strong>{session.client_name}</strong><small>{session.current ? "This browser, active now" : `Last used ${relativeTime(session.last_seen_at)}`}</small></div>
         <span>{providerLabel(session.provider)}</span>
-        {session.current ? <span className="connect-current">Current</span> : <button className="danger" disabled={busy === `session-${session.id}`} onClick={() => void run(`session-${session.id}`, () => client.revokeSession(session.id))}>Sign out</button>}
+        {session.current ? <span className="connect-current">Current</span> : <button className="danger" disabled={busy.has(`session-${session.id}`)} onClick={() => void run(`session-${session.id}`, () => client.revokeSession(session.id))}>Sign out</button>}
       </div>)}
       <button className="connect-sign-out" onClick={() => void client.logout().then(() => { location.href = loginUrl(client); })}>Sign out of this browser</button>
     </section>}
@@ -222,14 +235,14 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
         </div>}
         {reauthenticationToken && <p className="connect-current" role="status">Identity confirmed for this deletion.</p>}
         <label><span>Type DELETE to confirm</span><input autoComplete="off" spellCheck={false} value={deletionConfirmation} onChange={(event) => setDeletionConfirmation(event.target.value)} /></label>
-        <div className="connect-account-actions"><button type="button" className="connect-account-action" disabled={busy === "delete"} onClick={() => { setDeletionOpen(false); setDeletionConfirmation(""); setDeletionPassword(""); }}>Cancel</button><button className="connect-account-danger" disabled={busy === "delete" || deletionConfirmation !== "DELETE" || !deletionAuthorized}>{busy === "delete" ? "Deleting account…" : "Delete account permanently"}</button></div>
+        <div className="connect-account-actions"><button type="button" className="connect-account-action" disabled={busy.has("delete")} onClick={() => { setDeletionOpen(false); setDeletionConfirmation(""); setDeletionPassword(""); }}>Cancel</button><button className="connect-account-danger" disabled={busy.has("delete") || deletionConfirmation !== "DELETE" || !deletionAuthorized}>{busy.has("delete") ? "Deleting account…" : "Delete account permanently"}</button></div>
       </form>}
     </section>
   </Page>;
 }
 
 export function DeletedAccount({ client }: { client: ConnectManagementClient }) {
-  return <main className="connect-deleted-account"><div><p>Account deleted</p><h1>Your account has been deleted.</h1><span>Hosted data and access credentials were removed. Any local collection and mirror files remain on your computers.</span><a className="connect-account-action" href={new URL("/login", client.baseUrl).href}>Return to sign in</a></div></main>;
+  return <main className="connect-deleted-account"><div><h1>Your account has been deleted.</h1><span>Hosted data and access credentials were removed. Any local collection and mirror files remain on your computers.</span><a className="connect-account-action" href={new URL("/login", client.baseUrl).href}>Return to sign in</a></div></main>;
 }
 
 function StorageRow({ collection }: { collection: AccountData["storage"]["collections"][number] }) {

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -34,7 +34,7 @@ describe("ConnectApp", () => {
     expect(calls).toEqual(expect.arrayContaining(["/v1/me", "/v1/account/sessions"]));
     expect(calls.some((path) => path.includes("authorization"))).toBe(false);
 
-    await user.click(screen.getByRole("button", { name: /Applications/ }));
+    await user.click(screen.getByRole("link", { name: /Applications/ }));
     await waitFor(() => expect(location.pathname).toBe("/connect/applications"));
     expect(screen.getByRole("heading", { name: "Applications" })).toBeInTheDocument();
   });
@@ -51,13 +51,13 @@ describe("ConnectApp", () => {
     expect(collectionNavigation).toHaveTextContent("Manage");
     expect(screen.getByRole("link", { name: /Connect/ })).toHaveAttribute("aria-current", "page");
     expect(screen.queryByRole("complementary", { name: "Product navigation" })).not.toBeInTheDocument();
-    expect(screen.getByText("This collection")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Garden notes" })).toBeInTheDocument();
     expect(screen.getByText("Account", { selector: "p" })).toBeInTheDocument();
 
     const notes = screen.getByRole("link", { name: "Notes" });
     expect(new URL(notes.getAttribute("href")!).searchParams.get("collection")).toBe("collection");
 
-    await user.click(screen.getByRole("button", { name: "Storage & sync" }));
+    await user.click(screen.getByRole("link", { name: "Storage & sync" }));
     await waitFor(() => expect(location.pathname).toBe("/connect/storage"));
     expect(screen.getByRole("heading", { name: "Storage & sync" })).toBeInTheDocument();
   });
@@ -76,7 +76,7 @@ describe("ConnectApp", () => {
     render(<ConnectApp />);
 
     expect(await screen.findByRole("heading", { name: "Collections" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "All collections" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "All collections" })).toHaveAttribute("aria-current", "page");
     await waitFor(() => expect(location.pathname).toBe("/connect/collections"));
     expect(new URLSearchParams(location.search).has("collection")).toBe(false);
   });
@@ -105,7 +105,7 @@ describe("ConnectApp", () => {
     const user = userEvent.setup();
     render(<ConnectApp />);
     await screen.findByRole("heading", { name: "Garden notes" });
-    await user.click(screen.getByRole("button", { name: "All collections" }));
+    await user.click(screen.getByRole("link", { name: "All collections" }));
     await user.click(await screen.findByRole("button", { name: "New hosted collection" }));
 
     const originalFetch = vi.mocked(fetch).getMockImplementation()!;
@@ -147,7 +147,7 @@ describe("ConnectApp", () => {
     expect(screen.getAllByText("Reading list is waiting")).toHaveLength(1);
     expect(screen.getByText("Read and update records")).toBeInTheDocument();
     expect(screen.queryByText(/allowed actions/)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "App access" })).not.toHaveTextContent("1");
+    expect(screen.getByRole("link", { name: "App access" })).not.toHaveTextContent("1");
   });
 
   it("keeps provider-pending revocations visible without claiming success", async () => {
@@ -165,7 +165,7 @@ describe("ConnectApp", () => {
     render(<ConnectApp />);
 
     await screen.findByRole("heading", { name: "Garden notes" });
-    await user.click(screen.getByRole("button", { name: /Applications/ }));
+    await user.click(screen.getByRole("link", { name: /Applications/ }));
 
     expect(await screen.findByText("Revoking…")).toBeInTheDocument();
     expect(screen.getByText(/Waiting for the hosted authority to confirm revocation/)).toBeInTheDocument();
@@ -176,7 +176,7 @@ describe("ConnectApp", () => {
     const user = userEvent.setup();
     render(<ConnectApp />);
 
-    await user.click(await screen.findByRole("button", { name: "Open account and sessions" }));
+    await user.click(await screen.findByRole("link", { name: "Open account and sessions" }));
     expect(await screen.findByRole("heading", { name: "Hosted storage" })).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
     expect(screen.getByText("Permanent allowance")).toBeInTheDocument();

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -143,7 +143,11 @@ describe("ConnectApp", () => {
 
     await user.click(await screen.findByRole("button", { name: "Open account and sessions" }));
     expect(await screen.findByRole("heading", { name: "Hosted storage" })).toBeInTheDocument();
-    expect(screen.getByText("4 KB")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.getByText("Permanent allowance")).toBeInTheDocument();
+    expect(screen.getByText("10 MB of 1 GB")).toBeInTheDocument();
+    expect(screen.getByText("4 KB Markdown · 10 MB files")).toBeInTheDocument();
+    expect(screen.getByText("2 MB of 1 GB retained file storage")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Sign-in methods" })).toBeInTheDocument();
     expect(screen.getByText("Local collection files stay on your computers and are not measured here.")).toBeInTheDocument();
 
@@ -161,6 +165,28 @@ function overviewFixture(): ManagementOverview {
   const now = new Date().toISOString();
   return {
     user: { id: "person", name: "Example Person", email: "person@example.com", login: null },
+    subscription: {
+      kind: "beta",
+      profiles: ["beta_v1"],
+      permanent: true,
+      limits: {
+        hosted_storage_bytes: 1_073_741_824,
+        retained_file_bytes: 1_073_741_824,
+        max_document_bytes: 2_097_152,
+        max_single_file_bytes: 262_144_000,
+        max_replicas_per_collection: 10,
+        max_hosted_collections: 250,
+        max_files_per_collection: 10_000
+      },
+      usage: {
+        hosted_collections: 1,
+        live_content_bytes: 4_096,
+        live_file_bytes: 10_485_760,
+        live_storage_bytes: 10_489_856,
+        retained_file_bytes: 2_097_152
+      },
+      reconciliation: { entitlement_revision: 1, provider_revision: 1 }
+    },
     hosted_collections_available: true,
     authentication: { provider: "github", registration: "closed" },
     connectors: [{ id: "computer", name: "Home computer", last_seen_at: now, created_at: now }],
@@ -199,6 +225,9 @@ function accountFixture(): AccountData {
     storage: {
       status: "available",
       total_content_bytes: 4_096,
+      total_file_bytes: 10_485_760,
+      total_storage_bytes: 10_489_856,
+      total_stored_file_bytes: 12_582_912,
       total_records: 2,
       collections: [{
         id: "hosted",
@@ -209,7 +238,14 @@ function accountFixture(): AccountData {
           content_bytes: 4_096,
           max_records: 100_000,
           max_content_bytes: 1_073_741_824,
-          max_document_bytes: 2_097_152
+          max_document_bytes: 2_097_152,
+          file_count: 2,
+          file_bytes: 10_485_760,
+          stored_file_bytes: 12_582_912,
+          max_files: 10_000,
+          max_file_bytes: 1_073_741_824,
+          max_stored_file_bytes: 2_147_483_648,
+          max_single_file_bytes: 262_144_000
         }
       }]
     },

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -241,7 +241,7 @@ describe("ConnectApp", () => {
     expect(screen.getByText("Permanent allowance")).toBeInTheDocument();
     expect(screen.getByText("10 MB of 1 GB")).toBeInTheDocument();
     expect(screen.getByText("4 KB Markdown · 10 MB files")).toBeInTheDocument();
-    expect(screen.getByText("2 MB of 1 GB retained file storage")).toBeInTheDocument();
+    expect(screen.getByText("2 MB of 2 GB retained file storage")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Sign-in methods" })).toBeInTheDocument();
     expect(screen.getByText("Local collection files stay on your computers and are not measured here.")).toBeInTheDocument();
 
@@ -265,7 +265,7 @@ function overviewFixture(): ManagementOverview {
       permanent: true,
       limits: {
         hosted_storage_bytes: 1_073_741_824,
-        retained_file_bytes: 1_073_741_824,
+        retained_file_bytes: 2_147_483_648,
         max_document_bytes: 2_097_152,
         max_single_file_bytes: 262_144_000,
         max_replicas_per_collection: 10,

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { AccountData, ManagementOverview } from "@mdbase/connect-management";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -22,7 +22,11 @@ beforeEach(() => {
   }));
 });
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("ConnectApp", () => {
   it("opens account management without requesting a collection grant", async () => {
@@ -101,6 +105,26 @@ describe("ConnectApp", () => {
     expect(screen.getAllByText("Offline").length).toBeGreaterThan(0);
     expect(screen.getByText("Open mdbase connect on Home computer to make this collection available.")).toBeInTheDocument();
     expect(screen.queryByText("The editor can reach this collection now.")).not.toBeInTheDocument();
+  });
+
+  it("pauses background refresh while the page is hidden and refreshes on return", async () => {
+    const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    vi.useFakeTimers();
+    render(<ConnectApp />);
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const overviewCalls = () => vi.mocked(fetch).mock.calls.filter(([input]) => new URL(String(input)).pathname === "/v1/me").length;
+    expect(overviewCalls()).toBe(1);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+    expect(overviewCalls()).toBe(1);
+
+    visibility.mockReturnValue("visible");
+    await act(async () => {
+      fireEvent(document, new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(overviewCalls()).toBe(2);
   });
 
   it("keeps collection input open after a failed creation", async () => {

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -91,6 +91,41 @@ describe("ConnectApp", () => {
     await waitFor(() => expect(new URLSearchParams(location.search).get("collection")).toBe("collection-two"));
   });
 
+  it("does not claim an enabled collection is connected when its computer is offline", async () => {
+    overview.connectors[0].last_seen_at = new Date(Date.now() - 60_000).toISOString();
+    render(<ConnectApp />);
+
+    expect(await screen.findByRole("heading", { name: "Garden notes" })).toBeInTheDocument();
+    expect(screen.getAllByText("Offline").length).toBeGreaterThan(0);
+    expect(screen.getByText("Open mdbase connect on Home computer to make this collection available.")).toBeInTheDocument();
+    expect(screen.queryByText("The editor can reach this collection now.")).not.toBeInTheDocument();
+  });
+
+  it("keeps collection input open after a failed creation", async () => {
+    const user = userEvent.setup();
+    render(<ConnectApp />);
+    await screen.findByRole("heading", { name: "Garden notes" });
+    await user.click(screen.getByRole("button", { name: "All collections" }));
+    await user.click(await screen.findByRole("button", { name: "New hosted collection" }));
+
+    const originalFetch = vi.mocked(fetch).getMockImplementation()!;
+    vi.mocked(fetch).mockImplementation((input, init) => {
+      const path = new URL(String(input)).pathname;
+      if (path === "/v1/hosted/collections" && init?.method === "POST") {
+        return Promise.resolve(Response.json({ error: { message: "Storage is temporarily unavailable." } }, { status: 503 }));
+      }
+      return originalFetch(input, init);
+    });
+    const input = screen.getByLabelText("Collection name");
+    await user.clear(input);
+    await user.type(input, "Field notes");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Storage is temporarily unavailable.");
+    expect(input).toHaveValue("Field notes");
+    expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
+  });
+
   it("shows each pending request once and describes application access plainly", async () => {
     const now = new Date().toISOString();
     overview.pending_authorizations = [{

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -60,6 +60,8 @@ describe("ConnectApp", () => {
     await user.click(screen.getByRole("link", { name: "Storage & sync" }));
     await waitFor(() => expect(location.pathname).toBe("/connect/storage"));
     expect(screen.getByRole("heading", { name: "Storage & sync" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Storage & sync" })).toHaveFocus();
+    expect(document.title).toBe("Storage & sync - mdbase connect");
   });
 
   it("opens the only collection directly and records its context in the URL", async () => {
@@ -124,6 +126,39 @@ describe("ConnectApp", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("Storage is temporarily unavailable.");
     expect(input).toHaveValue("Field notes");
     expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
+  });
+
+  it("renames inline and confirms destructive collection actions in the page", async () => {
+    overview.hosted_collections = [hostedCollection()];
+    const user = userEvent.setup();
+    render(<ConnectApp />);
+    await user.click(await screen.findByRole("link", { name: "All collections" }));
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    const rename = screen.getByLabelText("Rename Hosted research");
+    await user.clear(rename);
+    await user.type(rename, "Shared research");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(screen.queryByLabelText("Rename Hosted research")).not.toBeInTheDocument());
+    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "PATCH" && init.body === JSON.stringify({ display_name: "Shared research" }))).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.getByRole("group", { name: /Delete Hosted research and all of its hosted data/ })).toBeInTheDocument();
+    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("button", { name: "Delete permanently" })).not.toBeInTheDocument();
+  });
+
+  it("offers recovery actions when no computer is connected", async () => {
+    overview.connectors = [];
+    overview.collections = [];
+    const user = userEvent.setup();
+    render(<ConnectApp />);
+    await user.click(await screen.findByRole("link", { name: "Computers" }));
+
+    expect(await screen.findByText("No computers connected")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open mdbase connect" })).toHaveAttribute("href", "mdbase-connect://open");
+    expect(screen.getByRole("link", { name: "Install the latest release" })).toHaveAttribute("href", "https://github.com/mdbase-dev/mdbase-connect/releases/latest");
   });
 
   it("shows each pending request once and describes application access plainly", async () => {
@@ -239,6 +274,22 @@ function secondCollection(): ManagementOverview["collections"][number] {
   return {
     id: "collection-two", connector_id: "computer", local_id: "local-two", connector_name: "Home computer",
     display_name: "Research notes", spec_version: "1", enabled: true, contracts: [], last_seen_at: new Date().toISOString()
+  };
+}
+
+function hostedCollection(): ManagementOverview["hosted_collections"][number] {
+  return {
+    id: "hosted",
+    display_name: "Hosted research",
+    template: "mdbase",
+    provider_url: "https://storage.example",
+    spec_version: "1",
+    contracts: [],
+    authority_state: "active",
+    authority_epoch: 1,
+    transferred_collection_id: null,
+    created_at: new Date().toISOString(),
+    replicas: []
   };
 }
 

--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -9,9 +9,16 @@ import {
   groupApplicationAccess,
   type ApplicationAccessGroup
 } from "@mdbase/connect-ui/access";
-import { useCallback, useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type FormEvent, type MouseEvent, type ReactNode } from "react";
 import { AccountManagement, DeletedAccount } from "./AccountManagement";
 import { MdbaseMark } from "./Brand";
+import {
+  ConfirmAction,
+  ConnectEmpty as Empty,
+  ConnectPage as Page,
+  ConnectSectionTitle as SectionTitle,
+  InlineRename
+} from "./ConnectPrimitives";
 import { EditorRail } from "./EditorRail";
 import {
   BracketsCurlyIcon as Braces,
@@ -19,9 +26,7 @@ import {
   InfoIcon as Info,
   NotebookIcon as Notebook,
   PackageIcon as Package,
-  PencilSimpleIcon as Pencil,
   PlusIcon as Plus,
-  TrashIcon as Trash,
   WarningCircleIcon as Warning
 } from "./icons";
 import "./connect.css";
@@ -35,6 +40,7 @@ const serverUrl = new URLSearchParams(location.search).get("server")
   ?? import.meta.env.VITE_MDBASE_CONNECT_URL
   ?? "https://connect.mdbase.dev";
 const management = new ConnectManagementClient(serverUrl);
+const desktopReleaseUrl = "https://github.com/mdbase-dev/mdbase-connect/releases/latest";
 const allOperations = [
   "describe", "changes", "read", "query", "list_views", "execute_view", "read_view_source", "validate",
   "create", "update", "delete", "rename", "create_view_source", "update_view_source", "delete_view_source",
@@ -49,6 +55,7 @@ export function ConnectApp() {
   const [sessions, setSessions] = useState<Awaited<ReturnType<typeof management.sessions>>["sessions"]>();
   const [refreshError, setRefreshError] = useState("");
   const [mutationError, setMutationError] = useState("");
+  const [navigationOpen, setNavigationOpen] = useState(false);
   const [busy, setBusy] = useState<ReadonlySet<string>>(() => new Set());
   const busyRef = useRef(new Set<string>());
   const refreshPromiseRef = useRef<Promise<void> | null>(null);
@@ -132,6 +139,7 @@ export function ConnectApp() {
     }
     history.pushState(null, "", `${url.pathname}${url.search}`);
     setView(next);
+    setNavigationOpen(false);
   }
 
 
@@ -187,27 +195,28 @@ export function ConnectApp() {
       settings={{ href: editorLinks.settings }}
       connectHref={connectViewUrl(activeView, selectedCollection?.id)}
       connectCount={data.pending_authorizations.length || undefined}
+      mobileReturn={{ href: editorLinks.notes, label: "Back to editor" }}
       onSwitch={() => navigate("collections", selectedCollection?.id)}
       footer={<>
         {selectedCollection && <p role="status"><span className={`status-dot ${selectedCollection.available ? "connected" : "reconnecting"}`} aria-hidden="true" /><span>{selectedCollection.status}</span></p>}
-        <button className="connect-rail-account" aria-label="Open account and sessions" onClick={() => navigate("account", selectedCollection?.id)}><span className="connect-avatar" aria-hidden="true">{initials(data.user.name)}</span><span><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></span></button>
+        <RouteLink className="connect-rail-account" view="account" collectionId={selectedCollection?.id} navigate={navigate} ariaLabel="Open account and sessions"><span className="connect-avatar" aria-hidden="true">{initials(data.user.name)}</span><span><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></span></RouteLink>
       </>}
     />
-    <aside className="connect-nav" aria-label="Connect navigation">
-      <header><strong>Connect</strong></header>
-      <nav>
+    <aside className="connect-nav" aria-label="mdbase connect navigation">
+      <header><strong>mdbase connect</strong><button className="connect-mobile-nav-toggle" aria-expanded={navigationOpen} aria-controls="connect-section-navigation" onClick={() => setNavigationOpen((open) => !open)}><span>{viewLabel(activeView)}</span><small>{navigationOpen ? "Close menu" : "Open menu"}</small></button></header>
+      <nav id="connect-section-navigation" className={navigationOpen ? "open" : ""}>
         {selectedCollection && <section className="connect-nav-group" aria-labelledby="current-collection-navigation">
-          <p id="current-collection-navigation">This collection</p>
-          <NavButton label="Overview" icon={<Info />} selected={activeView === "overview"} onClick={() => navigate("overview", selectedCollection.id)} />
-          <NavButton label="Storage & sync" icon={<Notebook />} selected={activeView === "storage"} onClick={() => navigate("storage", selectedCollection.id)} />
-          <NavButton label="App access" icon={<Package />} selected={activeView === "access"} onClick={() => navigate("access", selectedCollection.id)} />
+          <p id="current-collection-navigation">{selectedCollection.name}</p>
+          <NavLink label="Overview" icon={<Info />} selected={activeView === "overview"} view="overview" collectionId={selectedCollection.id} navigate={navigate} />
+          <NavLink label="Storage & sync" icon={<Notebook />} selected={activeView === "storage"} view="storage" collectionId={selectedCollection.id} navigate={navigate} />
+          <NavLink label="App access" icon={<Package />} selected={activeView === "access"} view="access" collectionId={selectedCollection.id} navigate={navigate} />
         </section>}
         <section className="connect-nav-group" aria-labelledby="account-navigation">
           <p id="account-navigation">Account</p>
-          <NavButton label="All collections" icon={<Notebook />} selected={activeView === "collections"} onClick={() => navigate("collections", selectedCollection?.id)} />
-          <NavButton label="Applications" icon={<Package />} selected={activeView === "applications"} onClick={() => navigate("applications", selectedCollection?.id)} />
-          <NavButton label="Computers" icon={<Braces />} selected={activeView === "computers"} onClick={() => navigate("computers", selectedCollection?.id)} />
-          <NavButton label="Account & sessions" icon={<Settings />} selected={activeView === "account"} onClick={() => navigate("account", selectedCollection?.id)} />
+          <NavLink label="All collections" icon={<Notebook />} selected={activeView === "collections"} view="collections" collectionId={selectedCollection?.id} navigate={navigate} />
+          <NavLink label="Applications" icon={<Package />} selected={activeView === "applications"} view="applications" collectionId={selectedCollection?.id} navigate={navigate} />
+          <NavLink label="Computers" icon={<Braces />} selected={activeView === "computers"} view="computers" collectionId={selectedCollection?.id} navigate={navigate} />
+          <NavLink label="Account & sessions" icon={<Settings />} selected={activeView === "account"} view="account" collectionId={selectedCollection?.id} navigate={navigate} />
         </section>
       </nav>
     </aside>
@@ -248,14 +257,14 @@ function CollectionOverview({ collection, applications, navigate }: {
   applications: ApplicationAccessGroup<Grant>[];
   navigate(view: ConnectView, collectionId?: string): void;
 }) {
-  return <Page eyebrow="Current collection" title={collection.name} intro="Manage where this collection lives and which applications can use it.">
+  return <Page title={collection.name} intro="Manage where this collection lives and which applications can use it.">
     <section>
-      <SectionTitle title="Storage" action={<button onClick={() => navigate("storage", collection.id)}>Manage</button>} />
+      <SectionTitle title="Storage" action={<RouteLink view="storage" collectionId={collection.id} navigate={navigate}>Manage</RouteLink>} />
       <div className="connect-row connect-storage-summary"><div><strong>Main copy</strong><small>{collection.kind === "hosted" ? "Stored by mdbase" : `Stored on ${collection.detail}`}</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span></div>
     </section>
     <section>
-      <SectionTitle title="Application access" count={applications.length} action={<button onClick={() => navigate("access", collection.id)}>Review all</button>} />
-      {applications.map((application) => <div className="connect-row" key={application.applicationId}><div><strong>{application.applicationName}</strong><small>{host(application.grants[0].homepage)}</small></div><span>{permissionSummary(application.grants)}</span><button onClick={() => navigate("access", collection.id)}>Review</button></div>)}
+      <SectionTitle title="Application access" count={applications.length} action={<RouteLink view="access" collectionId={collection.id} navigate={navigate}>Review all</RouteLink>} />
+      {applications.map((application) => <div className="connect-row" key={application.applicationId}><div><strong>{application.applicationName}</strong><small>{host(application.grants[0].homepage)}</small></div><span>{permissionSummary(application.grants)}</span><RouteLink view="access" collectionId={collection.id} navigate={navigate}>Review</RouteLink></div>)}
       {applications.length === 0 && <Empty title="No connected applications" body="Applications appear after you approve access to this collection." />}
     </section>
     <section>
@@ -272,22 +281,24 @@ function Storage({ collection, busy, perform }: {
 }) {
   if (collection.kind === "hosted") {
     const replicas = collection.source.replicas.filter((replica) => replica.revocation_status !== "revoked");
-    return <Page eyebrow={collection.name} title="Storage & sync" intro="Manage the main copy and its synced Markdown folders.">
+    return <Page title="Storage & sync" intro={`Manage the main copy of ${collection.name} and its synced Markdown folders.`}>
       <section>
         <SectionTitle title="Main copy" />
         <HostedCollectionRow collection={collection.source} busy={busy} perform={perform} showReplicas={false} />
       </section>
       <section>
         <SectionTitle title="Synced folders" count={replicas.length} action={<a href={`mdbase-connect://mirror?collection=${encodeURIComponent(collection.source.id)}`}><Plus aria-hidden="true" />Sync a folder</a>} />
-        {replicas.map((replica) => <div className="connect-row" key={replica.id}><div><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Downloads only" : "Edits sync both ways"}</small></div><span>{replica.revocation_status === "revoking" ? "Disconnecting…" : replica.sync_status ? `Seen ${relativeTime(replica.sync_status.last_seen_at ?? collection.source.created_at)}` : "Waiting to sync"}</span><button className="danger" disabled={replica.revocation_status === "revoking" || busy.has(`replica-${replica.id}`)} onClick={() => window.confirm(`Revoke ${replica.name}?`) && void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))}>{replica.revocation_status === "revoking" ? "Disconnecting…" : "Disconnect"}</button></div>)}
+        {replicas.map((replica) => <div className="connect-row" key={replica.id}><div><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Downloads only" : "Edits sync both ways"}</small></div><span>{replica.revocation_status === "revoking" ? "Disconnecting…" : replica.sync_status ? `Seen ${relativeTime(replica.sync_status.last_seen_at ?? collection.source.created_at)}` : "Waiting to sync"}</span><ConfirmAction className="danger" label={replica.revocation_status === "revoking" ? "Disconnecting…" : "Disconnect"} question={`Disconnect ${replica.name}?`} confirmLabel="Disconnect" busy={replica.revocation_status === "revoking" || busy.has(`replica-${replica.id}`)} onConfirm={() => void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))} /></div>)}
         {replicas.length === 0 && <Empty title="No synced folders" body="Use the desktop app to keep an ordinary Markdown folder on a computer." />}
+        <DesktopRecoveryHelp action="sync a folder" />
       </section>
     </Page>;
   }
-  return <Page eyebrow={collection.name} title="Storage & sync" intro="This collection’s main copy stays in a folder on a connected computer.">
+  return <Page title="Storage & sync" intro={`${collection.name} keeps its main copy in a folder on a connected computer.`}>
     <section>
       <SectionTitle title="Main copy" />
       <div className="connect-row"><div><strong>{collection.detail}</strong><small>The folder remains the authority for this collection.</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span><a href="mdbase-connect://open">Open desktop app</a></div>
+      <DesktopRecoveryHelp action="open this collection" />
     </section>
   </Page>;
 }
@@ -298,19 +309,18 @@ function CollectionAccess({ collection, groups, busy, perform }: {
   busy: BusyOperations;
   perform: PerformOperation;
 }) {
-  return <Page eyebrow={collection.name} title="Application access" intro="Review the exact actions each application can perform in this collection.">
+  return <Page title="Application access" intro={`Review the exact actions each application can perform in ${collection.name}.`}>
     <section>
       <SectionTitle title="Connected applications" count={groups.length} />
       {groups.map((group) => <details className="connect-application" key={group.applicationId}>
         <summary><span><strong>{group.applicationName}</strong><small>{host(group.grants[0].homepage)}</small></span><b>Review</b></summary>
         <div className="connect-application-body">
           {group.grants.map((grant) => <GrantEditor key={grant.id} grant={grant} busy={busy} perform={perform} />)}
-          <button className="danger connect-revoke-application" disabled={busy.has(`application-${group.applicationId}`)} onClick={() => {
-            if (!window.confirm(`Revoke ${group.applicationName} access to ${collection.name}?`)) return;
+          <ConfirmAction className="danger connect-revoke-application" label="Revoke access" question={`Revoke ${group.applicationName} access to ${collection.name}?`} confirmLabel="Revoke access" busy={busy.has(`application-${group.applicationId}`)} onConfirm={() => {
             void perform(`application-${group.applicationId}`, async () => {
               for (const grant of group.grants) await management.revokeGrant(grant.id);
             });
-          }}>Revoke access</button>
+          }} />
         </div>
       </details>)}
       {groups.length === 0 && <Empty title="No connected applications" body="Applications appear here after you approve access to this collection." />}
@@ -345,45 +355,37 @@ function Collections({ data, busy, perform, navigate }: {
         <div><button type="button" onClick={() => setCreating(false)}>Cancel</button><button className="connect-primary-action" disabled={busy.has("create-collection") || !name.trim()}>{busy.has("create-collection") ? "Creating…" : "Create"}</button></div>
       </form>}
       {rows.map((collection) => collection.kind === "hosted"
-        ? <HostedCollectionRow key={collection.id} collection={collection.source} busy={busy} perform={perform} onManage={() => navigate("overview", collection.id)} />
-        : <CollectionSummary key={collection.id} collection={collection} onManage={() => navigate("overview", collection.id)} />)}
+        ? <HostedCollectionRow key={collection.id} collection={collection.source} busy={busy} perform={perform} manage={{ collectionId: collection.id, navigate }} />
+        : <CollectionSummary key={collection.id} collection={collection} navigate={navigate} />)}
       {rows.length === 0 && <Empty title="No collections" body="Connect a computer or create a hosted collection to get started." />}
+      {rows.some((collection) => collection.kind === "hosted" && collection.source.authority_state === "active") && <DesktopRecoveryHelp action="sync a folder" />}
     </section>
   </Page>;
 }
 
-function HostedCollectionRow({ collection, busy, perform, onManage, showReplicas = true }: {
+function HostedCollectionRow({ collection, busy, perform, manage, showReplicas = true }: {
   collection: HostedCollection;
   busy: BusyOperations;
   perform: PerformOperation;
-  onManage?: () => void;
+  manage?: { collectionId: string; navigate(view: ConnectView, collectionId?: string): void };
   showReplicas?: boolean;
 }) {
   const active = collection.authority_state === "active";
   const editorId = active ? collection.id : collection.transferred_collection_id;
-  async function rename() {
-    const name = window.prompt("Collection name", collection.display_name)?.trim();
-    if (name && name !== collection.display_name) await perform(`collection-${collection.id}`, () => management.renameHostedCollection(collection.id, name));
-  }
-  async function remove() {
-    if (window.confirm(`Delete ${collection.display_name} and all hosted Markdown? This cannot be undone.`)) {
-      await perform(`collection-${collection.id}`, () => management.deleteHostedCollection(collection.id));
-    }
-  }
   const replicas = collection.replicas.filter((replica) => replica.revocation_status !== "revoked");
   return <div className="connect-row connect-collection-row">
     <div><strong>{collection.display_name}</strong><small>{active ? `Hosted by mdbase · ${replicas.length} synced ${replicas.length === 1 ? "folder" : "folders"}` : collection.authority_state === "transferring" ? "Moving to a computer" : "Main copy moved to a computer"}</small></div>
     <span className={`connect-status ${active ? "online" : "idle"}`}><i />{active ? "Hosted" : "Moved"}</span>
     <div className="connect-row-actions">
-      {onManage && <button onClick={onManage}>Manage</button>}
+      {manage && <RouteLink view="overview" collectionId={manage.collectionId} navigate={manage.navigate}>Manage</RouteLink>}
       {editorId && <a href={editorCollectionUrl(editorId)}>Open</a>}
       {active && <a href={`mdbase-connect://mirror?collection=${encodeURIComponent(collection.id)}`}>Sync folder</a>}
-      {active && <button disabled={busy.has(`collection-${collection.id}`)} onClick={() => void rename()}><Pencil aria-hidden="true" />Rename</button>}
-      <button className="danger" disabled={busy.has(`collection-${collection.id}`)} onClick={() => void remove()}><Trash aria-hidden="true" />Delete</button>
+      {active && <InlineRename value={collection.display_name} inputLabel={`Rename ${collection.display_name}`} busy={busy.has(`collection-${collection.id}`)} onSubmit={(name) => perform(`collection-${collection.id}`, () => management.renameHostedCollection(collection.id, name))} />}
+      <ConfirmAction className="danger" label="Delete" question={`Delete ${collection.display_name} and all of its hosted data? This cannot be undone.`} confirmLabel="Delete permanently" busy={busy.has(`collection-${collection.id}`)} onConfirm={() => void perform(`collection-${collection.id}`, () => management.deleteHostedCollection(collection.id))} />
     </div>
     {showReplicas && replicas.length > 0 && <details className="connect-row-detail"><summary>Synced folders</summary>{replicas.map((replica) => <div key={replica.id}>
       <span><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Downloads only" : "Two-way sync"}</small></span>
-      <button className="danger" disabled={replica.revocation_status === "revoking" || busy.has(`replica-${replica.id}`)} onClick={() => window.confirm(`Revoke ${replica.name}?`) && void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))}>{replica.revocation_status === "revoking" ? "Revoking…" : "Revoke"}</button>
+      <ConfirmAction className="danger" label={replica.revocation_status === "revoking" ? "Revoking…" : "Revoke"} question={`Revoke ${replica.name}?`} confirmLabel="Revoke" busy={replica.revocation_status === "revoking" || busy.has(`replica-${replica.id}`)} onConfirm={() => void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))} />
     </div>)}</details>}
   </div>;
 }
@@ -400,12 +402,11 @@ function Applications({ groups, busy, perform }: {
         <summary><span><strong>{group.applicationName}</strong><small>{group.collectionCount} {group.collectionCount === 1 ? "collection" : "collections"}</small></span><b>Review</b></summary>
         <div className="connect-application-body">
           {group.grants.map((grant) => <GrantEditor key={grant.id} grant={grant} busy={busy} perform={perform} />)}
-          <button className="danger connect-revoke-application" disabled={busy.has(`application-${group.applicationId}`)} onClick={() => {
-            if (!window.confirm(`Revoke all ${group.applicationName} access?`)) return;
+          <ConfirmAction className="danger connect-revoke-application" label="Revoke application" question={`Revoke all ${group.applicationName} access?`} confirmLabel="Revoke application" busy={busy.has(`application-${group.applicationId}`)} onConfirm={() => {
             void perform(`application-${group.applicationId}`, async () => {
               for (const grant of group.grants) await management.revokeGrant(grant.id);
             });
-          }}>Revoke application</button>
+          }} />
         </div>
       </details>)}
       {groups.length === 0 && <Empty title="No connected applications" body="Applications appear here after you approve their first collection request." />}
@@ -434,7 +435,7 @@ function GrantEditor({ grant, busy, perform }: {
         return next;
       })} /><span>{authorizationOperationLabel(operation)}</span></label>)}</div>
       <div className="connect-grant-meta"><span>Scope</span><strong>{grant.scope.access === "full_collection" ? "Full collection" : `${grant.scope.contracts.length} contract types`}</strong><span>Origin</span><strong>{grant.application_origin}</strong></div>
-      <div className="connect-row-actions"><button className="connect-primary-action" disabled={!changed || operations.size === 0 || busy.has(`grant-${grant.id}`)} onClick={() => void perform(`grant-${grant.id}`, () => management.updateGrant(grant.id, ordered.filter((operation) => operations.has(operation))))}>Save narrower access</button><button className="danger" disabled={busy.has(`grant-${grant.id}`)} onClick={() => window.confirm(`Revoke access to ${grant.collection_name}?`) && void perform(`grant-${grant.id}`, () => management.revokeGrant(grant.id))}>Revoke</button></div>
+      <div className="connect-row-actions"><button className="connect-primary-action" disabled={!changed || operations.size === 0 || busy.has(`grant-${grant.id}`)} onClick={() => void perform(`grant-${grant.id}`, () => management.updateGrant(grant.id, ordered.filter((operation) => operations.has(operation))))}>Save narrower access</button><ConfirmAction className="danger" label="Revoke" question={`Revoke access to ${grant.collection_name}?`} confirmLabel="Revoke" busy={busy.has(`grant-${grant.id}`)} onConfirm={() => void perform(`grant-${grant.id}`, () => management.revokeGrant(grant.id))} /></div>
     </div>
   </details>;
 }
@@ -453,13 +454,10 @@ function Computers({ data, busy, perform }: {
         return <div className="connect-row" key={connector.id}>
           <div><strong>{connector.name}</strong><small>{collections.length} {collections.length === 1 ? "collection" : "collections"} · {connector.last_seen_at ? `Seen ${relativeTime(connector.last_seen_at)}` : "Not connected yet"}</small></div>
           <span className={`connect-status ${online ? "online" : "idle"}`}><i />{online ? "Online" : "Offline"}</span>
-          <div className="connect-row-actions"><button disabled={busy.has(`computer-${connector.id}`)} onClick={() => {
-            const name = window.prompt("Computer name", connector.name)?.trim();
-            if (name && name !== connector.name) void perform(`computer-${connector.id}`, () => management.renameConnector(connector.id, name));
-          }}><Pencil aria-hidden="true" />Rename</button><button className="danger" disabled={busy.has(`computer-${connector.id}`)} onClick={() => window.confirm(`Revoke ${connector.name}?`) && void perform(`computer-${connector.id}`, () => management.revokeConnector(connector.id))}><Trash aria-hidden="true" />Revoke</button></div>
+          <div className="connect-row-actions"><InlineRename value={connector.name} inputLabel={`Rename ${connector.name}`} busy={busy.has(`computer-${connector.id}`)} onSubmit={(name) => perform(`computer-${connector.id}`, () => management.renameConnector(connector.id, name))} /><ConfirmAction className="danger" label="Revoke" question={`Revoke ${connector.name} and the application grants routed through it?`} confirmLabel="Revoke computer" busy={busy.has(`computer-${connector.id}`)} onConfirm={() => void perform(`computer-${connector.id}`, () => management.revokeConnector(connector.id))} /></div>
         </div>;
       })}
-      {data.connectors.length === 0 && <Empty title="No computers connected" body="Open the mdbase Connect desktop app and choose Connect this computer." />}
+      {data.connectors.length === 0 && <Empty title="No computers connected" body="Open the mdbase connect desktop app and choose Connect this computer." action={<span className="connect-empty-actions"><a href="mdbase-connect://open">Open mdbase connect</a><a href={desktopReleaseUrl} target="_blank" rel="noreferrer">Install the latest release</a></span>} />}
     </section>
   </Page>;
 }
@@ -501,8 +499,8 @@ function collectionRows(data: ManagementOverview): CollectionRow[] {
   return [...hosted, ...local].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function CollectionSummary({ collection, onManage }: { collection: CollectionRow; onManage?: () => void }) {
-  return <div className="connect-row"><div><strong>{collection.name}</strong><small>{collection.detail}</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span><div className="connect-row-actions">{onManage && <button onClick={onManage}>Manage</button>}<a href={editorCollectionUrl(collection.id)}>Open in editor</a></div></div>;
+function CollectionSummary({ collection, navigate }: { collection: CollectionRow; navigate(view: ConnectView, collectionId?: string): void }) {
+  return <div className="connect-row"><div><strong>{collection.name}</strong><small>{collection.detail}</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span><div className="connect-row-actions"><RouteLink view="overview" collectionId={collection.id} navigate={navigate}>Manage</RouteLink><a href={editorCollectionUrl(collection.id)}>Open in editor</a></div></div>;
 }
 
 function connectionDescription(collection: CollectionRow): string {
@@ -521,24 +519,40 @@ function isConnectorOnline(lastSeenAt: string | null): boolean {
   return lastSeenAt !== null && Date.now() - new Date(lastSeenAt).getTime() < 45_000;
 }
 
-function Page({ eyebrow = "mdbase Connect", title, intro, children }: { eyebrow?: string; title: string; intro: string; children: ReactNode }) {
-  return <div className="connect-page"><header><p>{eyebrow}</p><h1>{title}</h1><span>{intro}</span></header>{children}</div>;
+function NavLink({ label, icon, selected, view, collectionId, navigate }: {
+  label: string;
+  icon: ReactNode;
+  selected: boolean;
+  view: ConnectView;
+  collectionId?: string;
+  navigate(view: ConnectView, collectionId?: string): void;
+}) {
+  return <RouteLink className={selected ? "selected" : ""} ariaCurrent={selected ? "page" : undefined} view={view} collectionId={collectionId} navigate={navigate}><span aria-hidden="true">{icon}</span><strong>{label}</strong></RouteLink>;
 }
 
-function SectionTitle({ title, count, action }: { title: string; count?: number; action?: ReactNode }) {
-  return <header className="connect-section-title"><div><h2>{title}</h2>{count !== undefined && <span>{count}</span>}</div>{action}</header>;
-}
-
-function NavButton({ label, icon, selected, onClick }: { label: string; icon: ReactNode; selected: boolean; onClick(): void }) {
-  return <button className={selected ? "selected" : ""} aria-current={selected ? "page" : undefined} onClick={onClick}><span aria-hidden="true">{icon}</span><strong>{label}</strong></button>;
-}
-
-function Empty({ title, body }: { title: string; body: string }) {
-  return <div className="connect-empty"><Info aria-hidden="true" /><div><strong>{title}</strong><p>{body}</p></div></div>;
+function RouteLink({ view, collectionId, navigate, children, className = "", ariaLabel, ariaCurrent }: {
+  view: ConnectView;
+  collectionId?: string;
+  navigate(view: ConnectView, collectionId?: string): void;
+  children: ReactNode;
+  className?: string;
+  ariaLabel?: string;
+  ariaCurrent?: "page";
+}) {
+  function activate(event: MouseEvent<HTMLAnchorElement>) {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    navigate(view, collectionId);
+  }
+  return <a className={className} href={connectViewUrl(view, collectionId)} aria-label={ariaLabel} aria-current={ariaCurrent} onClick={activate}>{children}</a>;
 }
 
 function ConnectLoading({ error }: { error: string }) {
-  return <div className="connect-loading"><MdbaseMark /><strong>{error ? "Connect is unavailable" : "Opening Connect"}</strong><p>{error || "Loading your account and collections…"}</p></div>;
+  return <div className="connect-loading"><MdbaseMark /><strong>{error ? "mdbase connect is unavailable" : "Opening mdbase connect"}</strong><p>{error || "Loading your account and collections…"}</p></div>;
+}
+
+function DesktopRecoveryHelp({ action }: { action: string }) {
+  return <p className="connect-desktop-help">If the desktop app does not open when you {action}, <a href={desktopReleaseUrl} target="_blank" rel="noreferrer">install the latest release</a> and try again.</p>;
 }
 
 function viewFromPath(): ConnectView {
@@ -548,6 +562,16 @@ function viewFromPath(): ConnectView {
 
 function isCollectionView(view: ConnectView): boolean {
   return view === "overview" || view === "storage" || view === "access";
+}
+
+function viewLabel(view: ConnectView): string {
+  if (view === "overview") return "Overview";
+  if (view === "storage") return "Storage & sync";
+  if (view === "access") return "App access";
+  if (view === "collections") return "All collections";
+  if (view === "applications") return "Applications";
+  if (view === "computers") return "Computers";
+  return "Account & sessions";
 }
 
 function collectionPreferenceKey(): string {
@@ -620,7 +644,7 @@ function editorCollectionUrl(collectionId: string): string {
 function errorMessage(value: unknown): string {
   const detail = value instanceof Error ? value.message : String(value);
   return /failed to fetch|networkerror|network request failed/i.test(detail)
-    ? "Connect could not be reached. Check your connection and try again."
+    ? "mdbase connect could not be reached. Check your connection and try again."
     : detail;
 }
 

--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -9,7 +9,7 @@ import {
   groupApplicationAccess,
   type ApplicationAccessGroup
 } from "@mdbase/connect-ui/access";
-import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { AccountManagement, DeletedAccount } from "./AccountManagement";
 import { MdbaseMark } from "./Brand";
 import { EditorRail } from "./EditorRail";
@@ -28,6 +28,8 @@ import "./connect.css";
 
 type ConnectView = "overview" | "storage" | "access" | "collections" | "applications" | "computers" | "account";
 type Grant = ManagementOverview["grants"][number];
+type BusyOperations = ReadonlySet<string>;
+type PerformOperation = (id: string, action: () => Promise<void>) => Promise<boolean>;
 
 const serverUrl = new URLSearchParams(location.search).get("server")
   ?? import.meta.env.VITE_MDBASE_CONNECT_URL
@@ -45,35 +47,53 @@ export function ConnectApp() {
   const [view, setView] = useState<ConnectView>(viewFromPath);
   const [data, setData] = useState<ManagementOverview>();
   const [sessions, setSessions] = useState<Awaited<ReturnType<typeof management.sessions>>["sessions"]>();
-  const [error, setError] = useState("");
-  const [busy, setBusy] = useState("");
+  const [refreshError, setRefreshError] = useState("");
+  const [mutationError, setMutationError] = useState("");
+  const [busy, setBusy] = useState<ReadonlySet<string>>(() => new Set());
+  const busyRef = useRef(new Set<string>());
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
 
-  const refresh = useCallback(async (signal?: AbortSignal) => {
-    if (accountDeleted) return;
-    try {
-      const next = await management.overview(signal);
-      setData(next);
-      setError("");
-      if (next.authentication.provider !== "tailscale") {
-        const sessionResult = await management.sessions(signal);
-        setSessions(sessionResult.sessions);
+  const refresh = useCallback((signal?: AbortSignal): Promise<void> => {
+    if (accountDeleted) return Promise.resolve();
+    if (refreshPromiseRef.current) return refreshPromiseRef.current;
+    const request = (async () => {
+      try {
+        const next = await management.overview(signal);
+        setData(next);
+        setRefreshError("");
+        if (next.authentication.provider !== "tailscale") {
+          const sessionResult = await management.sessions(signal);
+          setSessions(sessionResult.sessions);
+        }
+      } catch (reason) {
+        if (signal?.aborted) return;
+        if (reason instanceof ManagementApiError && reason.status === 401) {
+          location.href = new URL("/login", management.baseUrl).href;
+          return;
+        }
+        setRefreshError(errorMessage(reason));
       }
-    } catch (reason) {
-      if (signal?.aborted) return;
-      if (reason instanceof ManagementApiError && reason.status === 401) {
-        location.href = new URL("/login", management.baseUrl).href;
-        return;
-      }
-      setError(errorMessage(reason));
-    }
+    })();
+    refreshPromiseRef.current = request;
+    void request.finally(() => {
+      if (refreshPromiseRef.current === request) refreshPromiseRef.current = null;
+    });
+    return request;
   }, [accountDeleted]);
 
   useEffect(() => {
     const controller = new AbortController();
     void refresh(controller.signal);
-    const timer = window.setInterval(() => void refresh(), 15_000);
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh();
+    }, 15_000);
+    document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
       controller.abort();
+      document.removeEventListener("visibilitychange", refreshWhenVisible);
       window.clearInterval(timer);
     };
   }, [refresh]);
@@ -83,6 +103,24 @@ export function ConnectApp() {
     window.addEventListener("popstate", update);
     return () => window.removeEventListener("popstate", update);
   }, []);
+
+  async function perform(id: string, action: () => Promise<void>): Promise<boolean> {
+    if (busyRef.current.has(id)) return false;
+    busyRef.current.add(id);
+    setBusy(new Set(busyRef.current));
+    setMutationError("");
+    try {
+      await action();
+      await refresh();
+      return true;
+    } catch (reason) {
+      setMutationError(errorMessage(reason));
+      return false;
+    } finally {
+      busyRef.current.delete(id);
+      setBusy(new Set(busyRef.current));
+    }
+  }
 
   function navigate(next: ConnectView, collectionId?: string) {
     const path = next === "overview" ? "/connect" : `/connect/${next}`;
@@ -96,17 +134,6 @@ export function ConnectApp() {
     setView(next);
   }
 
-  async function perform(id: string, action: () => Promise<void>) {
-    setBusy(id);
-    try {
-      await action();
-      await refresh();
-    } catch (reason) {
-      setError(errorMessage(reason));
-    } finally {
-      setBusy("");
-    }
-  }
 
   const collections = data ? collectionRows(data) : [];
   const requestedCollectionId = new URLSearchParams(location.search).get("collection");
@@ -137,7 +164,7 @@ export function ConnectApp() {
   }, [accountDeleted, data, requestedCollectionId, selectedCollectionId, view]);
 
   if (accountDeleted) return <DeletedAccount client={management} />;
-  if (!data) return <ConnectLoading error={error} />;
+  if (!data) return <ConnectLoading error={refreshError} />;
 
   const activeView = selectedCollection || !isCollectionView(view) ? view : "collections";
   const activeGrants = data.grants.filter((grant) => grant.revocation_status !== "revoked");
@@ -162,7 +189,7 @@ export function ConnectApp() {
       connectCount={data.pending_authorizations.length || undefined}
       onSwitch={() => navigate("collections", selectedCollection?.id)}
       footer={<>
-        {selectedCollection && <p role="status"><span className={`status-dot ${selectedCollection.online ? "connected" : "reconnecting"}`} aria-hidden="true" /><span>{selectedCollection.online ? "Connected" : "Unavailable"}</span></p>}
+        {selectedCollection && <p role="status"><span className={`status-dot ${selectedCollection.available ? "connected" : "reconnecting"}`} aria-hidden="true" /><span>{selectedCollection.status}</span></p>}
         <button className="connect-rail-account" aria-label="Open account and sessions" onClick={() => navigate("account", selectedCollection?.id)}><span className="connect-avatar" aria-hidden="true">{initials(data.user.name)}</span><span><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></span></button>
       </>}
     />
@@ -185,7 +212,7 @@ export function ConnectApp() {
       </nav>
     </aside>
     <main className="connect-main">
-      {error && <div className="connect-notice error" role="alert"><Warning aria-hidden="true" />{error}<button onClick={() => setError("")}>Dismiss</button></div>}
+      {(mutationError || refreshError) && <div className="connect-notice error" role="alert"><Warning aria-hidden="true" />{mutationError || refreshError}<button onClick={() => mutationError ? setMutationError("") : setRefreshError("")}>Dismiss</button></div>}
       {pendingRequest && <PendingRequestBanner request={pendingRequest} collectionName={pendingCollection?.name} count={data.pending_authorizations.length} />}
       {activeView === "overview" && (selectedCollection
         ? <CollectionOverview collection={selectedCollection} applications={selectedApplications} navigate={navigate} />
@@ -224,7 +251,7 @@ function CollectionOverview({ collection, applications, navigate }: {
   return <Page eyebrow="Current collection" title={collection.name} intro="Manage where this collection lives and which applications can use it.">
     <section>
       <SectionTitle title="Storage" action={<button onClick={() => navigate("storage", collection.id)}>Manage</button>} />
-      <div className="connect-row connect-storage-summary"><div><strong>Main copy</strong><small>{collection.kind === "hosted" ? "Stored by mdbase" : `Stored on ${collection.detail}`}</small></div><span className={`connect-status ${collection.online ? "online" : "idle"}`}><i />{collection.status}</span></div>
+      <div className="connect-row connect-storage-summary"><div><strong>Main copy</strong><small>{collection.kind === "hosted" ? "Stored by mdbase" : `Stored on ${collection.detail}`}</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span></div>
     </section>
     <section>
       <SectionTitle title="Application access" count={applications.length} action={<button onClick={() => navigate("access", collection.id)}>Review all</button>} />
@@ -233,15 +260,15 @@ function CollectionOverview({ collection, applications, navigate }: {
     </section>
     <section>
       <SectionTitle title="Connection" />
-      <div className="connect-row"><div><strong>{collection.online ? "Connected" : "Unavailable"}</strong><small>{collection.online ? "The editor can reach this collection now." : "The editor cannot reach this collection."}</small></div><span className={`connect-status ${collection.online ? "online" : "idle"}`}><i />{collection.online ? "Connected" : "Unavailable"}</span></div>
+      <div className="connect-row"><div><strong>{collection.status}</strong><small>{connectionDescription(collection)}</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span></div>
     </section>
   </Page>;
 }
 
 function Storage({ collection, busy, perform }: {
   collection: CollectionRow;
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
 }) {
   if (collection.kind === "hosted") {
     const replicas = collection.source.replicas.filter((replica) => replica.revocation_status !== "revoked");
@@ -252,7 +279,7 @@ function Storage({ collection, busy, perform }: {
       </section>
       <section>
         <SectionTitle title="Synced folders" count={replicas.length} action={<a href={`mdbase-connect://mirror?collection=${encodeURIComponent(collection.source.id)}`}><Plus aria-hidden="true" />Sync a folder</a>} />
-        {replicas.map((replica) => <div className="connect-row" key={replica.id}><div><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Downloads only" : "Edits sync both ways"}</small></div><span>{replica.revocation_status === "revoking" ? "Disconnecting…" : replica.sync_status ? `Seen ${relativeTime(replica.sync_status.last_seen_at ?? collection.source.created_at)}` : "Waiting to sync"}</span><button className="danger" disabled={replica.revocation_status === "revoking" || busy === `replica-${replica.id}`} onClick={() => window.confirm(`Revoke ${replica.name}?`) && void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))}>{replica.revocation_status === "revoking" ? "Disconnecting…" : "Disconnect"}</button></div>)}
+        {replicas.map((replica) => <div className="connect-row" key={replica.id}><div><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Downloads only" : "Edits sync both ways"}</small></div><span>{replica.revocation_status === "revoking" ? "Disconnecting…" : replica.sync_status ? `Seen ${relativeTime(replica.sync_status.last_seen_at ?? collection.source.created_at)}` : "Waiting to sync"}</span><button className="danger" disabled={replica.revocation_status === "revoking" || busy.has(`replica-${replica.id}`)} onClick={() => window.confirm(`Revoke ${replica.name}?`) && void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))}>{replica.revocation_status === "revoking" ? "Disconnecting…" : "Disconnect"}</button></div>)}
         {replicas.length === 0 && <Empty title="No synced folders" body="Use the desktop app to keep an ordinary Markdown folder on a computer." />}
       </section>
     </Page>;
@@ -260,7 +287,7 @@ function Storage({ collection, busy, perform }: {
   return <Page eyebrow={collection.name} title="Storage & sync" intro="This collection’s main copy stays in a folder on a connected computer.">
     <section>
       <SectionTitle title="Main copy" />
-      <div className="connect-row"><div><strong>{collection.detail}</strong><small>The folder remains the authority for this collection.</small></div><span className={`connect-status ${collection.online ? "online" : "idle"}`}><i />{collection.status}</span><a href="mdbase-connect://open">Open desktop app</a></div>
+      <div className="connect-row"><div><strong>{collection.detail}</strong><small>The folder remains the authority for this collection.</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span><a href="mdbase-connect://open">Open desktop app</a></div>
     </section>
   </Page>;
 }
@@ -268,8 +295,8 @@ function Storage({ collection, busy, perform }: {
 function CollectionAccess({ collection, groups, busy, perform }: {
   collection: CollectionRow;
   groups: ApplicationAccessGroup<Grant>[];
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
 }) {
   return <Page eyebrow={collection.name} title="Application access" intro="Review the exact actions each application can perform in this collection.">
     <section>
@@ -278,7 +305,7 @@ function CollectionAccess({ collection, groups, busy, perform }: {
         <summary><span><strong>{group.applicationName}</strong><small>{host(group.grants[0].homepage)}</small></span><b>Review</b></summary>
         <div className="connect-application-body">
           {group.grants.map((grant) => <GrantEditor key={grant.id} grant={grant} busy={busy} perform={perform} />)}
-          <button className="danger connect-revoke-application" disabled={busy === `application-${group.applicationId}`} onClick={() => {
+          <button className="danger connect-revoke-application" disabled={busy.has(`application-${group.applicationId}`)} onClick={() => {
             if (!window.confirm(`Revoke ${group.applicationName} access to ${collection.name}?`)) return;
             void perform(`application-${group.applicationId}`, async () => {
               for (const grant of group.grants) await management.revokeGrant(grant.id);
@@ -293,8 +320,8 @@ function CollectionAccess({ collection, groups, busy, perform }: {
 
 function Collections({ data, busy, perform, navigate }: {
   data: ManagementOverview;
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
   navigate(view: ConnectView, collectionId?: string): void;
 }) {
   const [creating, setCreating] = useState(false);
@@ -304,16 +331,18 @@ function Collections({ data, busy, perform, navigate }: {
     event.preventDefault();
     const displayName = name.trim();
     if (!displayName) return;
-    await perform("create-collection", () => management.createHostedCollection(displayName));
-    setCreating(false);
-    setName("My collection");
+    const created = await perform("create-collection", () => management.createHostedCollection(displayName));
+    if (created) {
+      setCreating(false);
+      setName("My collection");
+    }
   }
   return <Page title="Collections" intro="Open a collection in the editor or manage where its main copy lives.">
     <section>
       <SectionTitle title="All collections" count={rows.length} action={data.hosted_collections_available !== false && <button onClick={() => setCreating(true)}><Plus aria-hidden="true" />New hosted collection</button>} />
       {creating && <form className="connect-inline-form" onSubmit={(event) => void create(event)}>
         <label><span>Collection name</span><input autoFocus maxLength={200} value={name} onChange={(event) => setName(event.target.value)} /></label>
-        <div><button type="button" onClick={() => setCreating(false)}>Cancel</button><button className="connect-primary-action" disabled={busy === "create-collection" || !name.trim()}>{busy === "create-collection" ? "Creating…" : "Create"}</button></div>
+        <div><button type="button" onClick={() => setCreating(false)}>Cancel</button><button className="connect-primary-action" disabled={busy.has("create-collection") || !name.trim()}>{busy.has("create-collection") ? "Creating…" : "Create"}</button></div>
       </form>}
       {rows.map((collection) => collection.kind === "hosted"
         ? <HostedCollectionRow key={collection.id} collection={collection.source} busy={busy} perform={perform} onManage={() => navigate("overview", collection.id)} />
@@ -325,8 +354,8 @@ function Collections({ data, busy, perform, navigate }: {
 
 function HostedCollectionRow({ collection, busy, perform, onManage, showReplicas = true }: {
   collection: HostedCollection;
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
   onManage?: () => void;
   showReplicas?: boolean;
 }) {
@@ -349,20 +378,20 @@ function HostedCollectionRow({ collection, busy, perform, onManage, showReplicas
       {onManage && <button onClick={onManage}>Manage</button>}
       {editorId && <a href={editorCollectionUrl(editorId)}>Open</a>}
       {active && <a href={`mdbase-connect://mirror?collection=${encodeURIComponent(collection.id)}`}>Sync folder</a>}
-      {active && <button disabled={busy === `collection-${collection.id}`} onClick={() => void rename()}><Pencil aria-hidden="true" />Rename</button>}
-      <button className="danger" disabled={busy === `collection-${collection.id}`} onClick={() => void remove()}><Trash aria-hidden="true" />Delete</button>
+      {active && <button disabled={busy.has(`collection-${collection.id}`)} onClick={() => void rename()}><Pencil aria-hidden="true" />Rename</button>}
+      <button className="danger" disabled={busy.has(`collection-${collection.id}`)} onClick={() => void remove()}><Trash aria-hidden="true" />Delete</button>
     </div>
     {showReplicas && replicas.length > 0 && <details className="connect-row-detail"><summary>Synced folders</summary>{replicas.map((replica) => <div key={replica.id}>
       <span><strong>{replica.name}</strong><small>{replica.mode === "read_only" ? "Downloads only" : "Two-way sync"}</small></span>
-      <button className="danger" disabled={replica.revocation_status === "revoking" || busy === `replica-${replica.id}`} onClick={() => window.confirm(`Revoke ${replica.name}?`) && void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))}>{replica.revocation_status === "revoking" ? "Revoking…" : "Revoke"}</button>
+      <button className="danger" disabled={replica.revocation_status === "revoking" || busy.has(`replica-${replica.id}`)} onClick={() => window.confirm(`Revoke ${replica.name}?`) && void perform(`replica-${replica.id}`, () => management.revokeReplica(replica.id))}>{replica.revocation_status === "revoking" ? "Revoking…" : "Revoke"}</button>
     </div>)}</details>}
   </div>;
 }
 
 function Applications({ groups, busy, perform }: {
   groups: ApplicationAccessGroup<Grant>[];
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
 }) {
   return <Page title="Applications" intro="Each application receives a separate grant for each collection. Your account session is never shared with it.">
     <section>
@@ -371,7 +400,7 @@ function Applications({ groups, busy, perform }: {
         <summary><span><strong>{group.applicationName}</strong><small>{group.collectionCount} {group.collectionCount === 1 ? "collection" : "collections"}</small></span><b>Review</b></summary>
         <div className="connect-application-body">
           {group.grants.map((grant) => <GrantEditor key={grant.id} grant={grant} busy={busy} perform={perform} />)}
-          <button className="danger connect-revoke-application" disabled={busy === `application-${group.applicationId}`} onClick={() => {
+          <button className="danger connect-revoke-application" disabled={busy.has(`application-${group.applicationId}`)} onClick={() => {
             if (!window.confirm(`Revoke all ${group.applicationName} access?`)) return;
             void perform(`application-${group.applicationId}`, async () => {
               for (const grant of group.grants) await management.revokeGrant(grant.id);
@@ -386,8 +415,8 @@ function Applications({ groups, busy, perform }: {
 
 function GrantEditor({ grant, busy, perform }: {
   grant: Grant;
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
 }) {
   if (grant.revocation_status === "revoking") {
     return <div className="connect-grant connect-row"><span><strong>{grant.collection_name}</strong><small>Local access is disabled. Waiting for the hosted authority to confirm revocation.</small></span><b>Revoking…</b></div>;
@@ -405,29 +434,29 @@ function GrantEditor({ grant, busy, perform }: {
         return next;
       })} /><span>{authorizationOperationLabel(operation)}</span></label>)}</div>
       <div className="connect-grant-meta"><span>Scope</span><strong>{grant.scope.access === "full_collection" ? "Full collection" : `${grant.scope.contracts.length} contract types`}</strong><span>Origin</span><strong>{grant.application_origin}</strong></div>
-      <div className="connect-row-actions"><button className="connect-primary-action" disabled={!changed || operations.size === 0 || busy === `grant-${grant.id}`} onClick={() => void perform(`grant-${grant.id}`, () => management.updateGrant(grant.id, ordered.filter((operation) => operations.has(operation))))}>Save narrower access</button><button className="danger" disabled={busy === `grant-${grant.id}`} onClick={() => window.confirm(`Revoke access to ${grant.collection_name}?`) && void perform(`grant-${grant.id}`, () => management.revokeGrant(grant.id))}>Revoke</button></div>
+      <div className="connect-row-actions"><button className="connect-primary-action" disabled={!changed || operations.size === 0 || busy.has(`grant-${grant.id}`)} onClick={() => void perform(`grant-${grant.id}`, () => management.updateGrant(grant.id, ordered.filter((operation) => operations.has(operation))))}>Save narrower access</button><button className="danger" disabled={busy.has(`grant-${grant.id}`)} onClick={() => window.confirm(`Revoke access to ${grant.collection_name}?`) && void perform(`grant-${grant.id}`, () => management.revokeGrant(grant.id))}>Revoke</button></div>
     </div>
   </details>;
 }
 
 function Computers({ data, busy, perform }: {
   data: ManagementOverview;
-  busy: string;
-  perform(id: string, action: () => Promise<void>): Promise<void>;
+  busy: BusyOperations;
+  perform: PerformOperation;
 }) {
   return <Page title="Computers" intro="Computers make local collections available. Revoking one also invalidates grants routed through it.">
     <section>
       <SectionTitle title="Connected computers" count={data.connectors.length} />
       {data.connectors.map((connector) => {
-        const online = connector.last_seen_at !== null && Date.now() - new Date(connector.last_seen_at).getTime() < 45_000;
+        const online = isConnectorOnline(connector.last_seen_at);
         const collections = data.collections.filter((collection) => collection.connector_id === connector.id);
         return <div className="connect-row" key={connector.id}>
           <div><strong>{connector.name}</strong><small>{collections.length} {collections.length === 1 ? "collection" : "collections"} · {connector.last_seen_at ? `Seen ${relativeTime(connector.last_seen_at)}` : "Not connected yet"}</small></div>
           <span className={`connect-status ${online ? "online" : "idle"}`}><i />{online ? "Online" : "Offline"}</span>
-          <div className="connect-row-actions"><button disabled={busy === `computer-${connector.id}`} onClick={() => {
+          <div className="connect-row-actions"><button disabled={busy.has(`computer-${connector.id}`)} onClick={() => {
             const name = window.prompt("Computer name", connector.name)?.trim();
             if (name && name !== connector.name) void perform(`computer-${connector.id}`, () => management.renameConnector(connector.id, name));
-          }}><Pencil aria-hidden="true" />Rename</button><button className="danger" disabled={busy === `computer-${connector.id}`} onClick={() => window.confirm(`Revoke ${connector.name}?`) && void perform(`computer-${connector.id}`, () => management.revokeConnector(connector.id))}><Trash aria-hidden="true" />Revoke</button></div>
+          }}><Pencil aria-hidden="true" />Rename</button><button className="danger" disabled={busy.has(`computer-${connector.id}`)} onClick={() => window.confirm(`Revoke ${connector.name}?`) && void perform(`computer-${connector.id}`, () => management.revokeConnector(connector.id))}><Trash aria-hidden="true" />Revoke</button></div>
         </div>;
       })}
       {data.connectors.length === 0 && <Empty title="No computers connected" body="Open the mdbase Connect desktop app and choose Connect this computer." />}
@@ -440,7 +469,7 @@ interface CollectionRowBase {
   name: string;
   detail: string;
   status: string;
-  online: boolean;
+  available: boolean;
 }
 
 type CollectionRow =
@@ -448,20 +477,24 @@ type CollectionRow =
   | CollectionRowBase & { kind: "hosted"; source: HostedCollection };
 
 function collectionRows(data: ManagementOverview): CollectionRow[] {
-  const local = data.collections.map((collection) => ({
-    id: collection.id,
-    name: collection.display_name,
-    detail: collection.connector_name,
-    status: collection.enabled ? "Available" : "Paused",
-    online: collection.enabled,
-    kind: "local" as const
-  }));
+  const connectors = new Map(data.connectors.map((connector) => [connector.id, connector]));
+  const local = data.collections.map((collection) => {
+    const online = isConnectorOnline(connectors.get(collection.connector_id)?.last_seen_at ?? null);
+    return {
+      id: collection.id,
+      name: collection.display_name,
+      detail: collection.connector_name,
+      status: !collection.enabled ? "Paused" : online ? "Connected" : "Offline",
+      available: collection.enabled && online,
+      kind: "local" as const
+    };
+  });
   const hosted = data.hosted_collections.map((collection) => ({
     id: collection.authority_state === "transferred" && collection.transferred_collection_id ? collection.transferred_collection_id : collection.id,
     name: collection.display_name,
     detail: collection.authority_state === "active" ? "Hosted by mdbase" : "Main copy moved to a computer",
     status: collection.authority_state === "active" ? "Hosted" : "Moved",
-    online: collection.authority_state === "active",
+    available: collection.authority_state === "active",
     kind: "hosted" as const,
     source: collection
   }));
@@ -469,7 +502,23 @@ function collectionRows(data: ManagementOverview): CollectionRow[] {
 }
 
 function CollectionSummary({ collection, onManage }: { collection: CollectionRow; onManage?: () => void }) {
-  return <div className="connect-row"><div><strong>{collection.name}</strong><small>{collection.detail}</small></div><span className={`connect-status ${collection.online ? "online" : "idle"}`}><i />{collection.status}</span><div className="connect-row-actions">{onManage && <button onClick={onManage}>Manage</button>}<a href={editorCollectionUrl(collection.id)}>Open in editor</a></div></div>;
+  return <div className="connect-row"><div><strong>{collection.name}</strong><small>{collection.detail}</small></div><span className={`connect-status ${collection.available ? "online" : "idle"}`}><i />{collection.status}</span><div className="connect-row-actions">{onManage && <button onClick={onManage}>Manage</button>}<a href={editorCollectionUrl(collection.id)}>Open in editor</a></div></div>;
+}
+
+function connectionDescription(collection: CollectionRow): string {
+  if (collection.kind === "hosted") {
+    return collection.available
+      ? "The hosted collection is available to the editor."
+      : "The main copy has moved away from hosted storage.";
+  }
+  if (collection.status === "Paused") return "Access to this collection is paused on its computer.";
+  return collection.available
+    ? `The editor can reach this collection through ${collection.detail}.`
+    : `Open mdbase connect on ${collection.detail} to make this collection available.`;
+}
+
+function isConnectorOnline(lastSeenAt: string | null): boolean {
+  return lastSeenAt !== null && Date.now() - new Date(lastSeenAt).getTime() < 45_000;
 }
 
 function Page({ eyebrow = "mdbase Connect", title, intro, children }: { eyebrow?: string; title: string; intro: string; children: ReactNode }) {

--- a/apps/editor/src/ConnectPrimitives.tsx
+++ b/apps/editor/src/ConnectPrimitives.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
+import { InfoIcon as Info } from "./icons";
+
+export function ConnectPage({ title, intro, children }: {
+  title: string;
+  intro: string;
+  children: ReactNode;
+}) {
+  const heading = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    document.title = `${title} - mdbase connect`;
+    const main = heading.current?.closest(".connect-main");
+    if (main instanceof HTMLElement) main.scrollTo?.({ top: 0 });
+    heading.current?.focus({ preventScroll: true });
+  }, [title]);
+  return <div className="connect-page">
+    <header><h1 ref={heading} tabIndex={-1}>{title}</h1><span>{intro}</span></header>
+    {children}
+  </div>;
+}
+
+export function ConnectSectionTitle({ title, note, count, action }: {
+  title: string;
+  note?: string;
+  count?: number;
+  action?: ReactNode;
+}) {
+  return <header className="connect-section-title">
+    <div><h2>{title}</h2>{count !== undefined && <span>{count}</span>}</div>
+    {note && <p>{note}</p>}
+    {action}
+  </header>;
+}
+
+export function ConnectEmpty({ title, body, action, icon = true }: {
+  title: string;
+  body: string;
+  action?: ReactNode;
+  icon?: boolean;
+}) {
+  return <div className="connect-empty">
+    {icon && <Info aria-hidden="true" />}
+    <div><strong>{title}</strong><p>{body}</p>{action}</div>
+  </div>;
+}
+
+export function ConfirmAction({ label, question, confirmLabel, busy = false, onConfirm, className = "" }: {
+  label: string;
+  question: string;
+  confirmLabel: string;
+  busy?: boolean;
+  onConfirm(): void;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  if (!open) return <button className={className} disabled={busy} onClick={() => setOpen(true)}>{label}</button>;
+  return <span className="connect-confirm-action" role="group" aria-label={question}>
+    <span>{question}</span>
+    <button disabled={busy} onClick={() => setOpen(false)}>Cancel</button>
+    <button className={className} disabled={busy} onClick={() => { onConfirm(); setOpen(false); }}>{busy ? `${confirmLabel}…` : confirmLabel}</button>
+  </span>;
+}
+
+export function InlineRename({ value, label, inputLabel, busy = false, onSubmit }: {
+  value: string;
+  label?: string;
+  inputLabel: string;
+  busy?: boolean;
+  onSubmit(value: string): Promise<boolean>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(value);
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const next = draft.trim();
+    if (!next || next === value) return;
+    if (await onSubmit(next)) setOpen(false);
+  }
+  if (!open) return <button disabled={busy} onClick={() => { setDraft(value); setOpen(true); }}>{label ?? "Rename"}</button>;
+  return <form className="connect-inline-rename" onSubmit={(event) => void submit(event)}>
+    <label><span className="sr-only">{inputLabel}</span><input autoFocus maxLength={200} value={draft} onChange={(event) => setDraft(event.target.value)} /></label>
+    <button type="button" disabled={busy} onClick={() => setOpen(false)}>Cancel</button>
+    <button className="connect-primary-action" disabled={busy || !draft.trim() || draft.trim() === value}>{busy ? "Saving…" : "Save"}</button>
+  </form>;
+}

--- a/apps/editor/src/EditorRail.tsx
+++ b/apps/editor/src/EditorRail.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import {
+  ArrowLeftIcon as ArrowLeft,
   BracketsCurlyIcon as Braces,
   CaretDownIcon as ChevronDown,
   GearSixIcon as Settings,
@@ -26,6 +27,7 @@ export function EditorRail({
   settings,
   connectHref,
   connectCount,
+  mobileReturn,
   onSwitch,
   onCollapse,
   children,
@@ -40,6 +42,7 @@ export function EditorRail({
   settings: RailDestination;
   connectHref: string;
   connectCount?: number;
+  mobileReturn?: RailDestination & { label: string };
   onSwitch: () => void;
   onCollapse?: () => void;
   children?: ReactNode;
@@ -48,6 +51,7 @@ export function EditorRail({
   return <aside className="collection-rail" aria-label="Collection navigation">
     <div className="rail-header"><Wordmark />{onCollapse && <RailCollapseButton onClick={onCollapse} />}</div>
     <nav>
+      {mobileReturn && <a className="mobile-editor-return" href={mobileReturn.href} onClick={mobileReturn.onClick}><span><ArrowLeft aria-hidden="true" />{mobileReturn.label}</span></a>}
       <button className="collection-name" aria-label={`Switch collection, current collection ${collectionName}`} onClick={onSwitch}><span>{collectionName}</span><ChevronDown aria-hidden="true" /></button>
       <RailLink destination={notes} selected={surface === "notes"} label="Notes" ariaLabel={noteCount === undefined ? "Notes" : `Notes, ${noteCount} total`} icon={<Notebook aria-hidden="true" />} count={noteCount} />
       <RailLink destination={types} selected={surface === "types"} label="Types" ariaLabel={typeCount === undefined ? "Types" : `Types (${typeCount})`} icon={<Braces aria-hidden="true" />} count={typeCount} />

--- a/apps/editor/src/connect.css
+++ b/apps/editor/src/connect.css
@@ -65,6 +65,7 @@
   border-radius: 6px;
   color: var(--muted);
   text-align: left;
+  text-decoration: none;
 }
 
 .connect-nav > nav > .connect-nav-group > a span,
@@ -93,10 +94,6 @@
 
 .connect-nav > nav > .connect-nav-group > a.selected strong {
   font-weight: 700;
-}
-
-.connect-nav > nav > .connect-nav-group > a {
-  text-decoration: none;
 }
 
 .connect-avatar {
@@ -746,10 +743,6 @@ button.danger:disabled {
   font-weight: 400;
 }
 
-.connect-storage-row {
-  grid-template-columns: minmax(190px, 1fr) minmax(112px, 190px);
-}
-
 .connect-storage-progress {
   height: 4px;
   overflow: hidden;
@@ -1150,7 +1143,6 @@ button.danger:disabled {
   }
 
   .connect-account-row,
-  .connect-storage-row,
   .connect-account-row-main {
     grid-template-columns: 1fr;
     gap: 8px;

--- a/apps/editor/src/connect.css
+++ b/apps/editor/src/connect.css
@@ -28,6 +28,10 @@
   letter-spacing: -0.01em;
 }
 
+.connect-mobile-nav-toggle {
+  display: none;
+}
+
 .connect-nav > nav {
   flex: 1;
   display: grid;
@@ -51,8 +55,8 @@
   text-transform: uppercase;
 }
 
-.connect-nav > nav button {
-  min-height: 38px;
+.connect-nav > nav > .connect-nav-group > a {
+  min-height: 40px;
   display: grid;
   grid-template-columns: 22px minmax(0, 1fr);
   align-items: center;
@@ -63,13 +67,13 @@
   text-align: left;
 }
 
-.connect-nav > nav button span,
-.connect-nav > nav button span svg {
+.connect-nav > nav > .connect-nav-group > a span,
+.connect-nav > nav > .connect-nav-group > a span svg {
   width: 18px;
   height: 18px;
 }
 
-.connect-nav > nav button strong {
+.connect-nav > nav > .connect-nav-group > a strong {
   overflow: hidden;
   font-size: 0.92rem;
   font-weight: 400;
@@ -77,18 +81,22 @@
   white-space: nowrap;
 }
 
-.connect-nav > nav button:hover {
+.connect-nav > nav > .connect-nav-group > a:hover {
   background: var(--hover);
   color: var(--ink);
 }
 
-.connect-nav > nav button.selected {
+.connect-nav > nav > .connect-nav-group > a.selected {
   background: var(--selected);
   color: var(--accent-strong);
 }
 
-.connect-nav > nav button.selected strong {
+.connect-nav > nav > .connect-nav-group > a.selected strong {
   font-weight: 700;
+}
+
+.connect-nav > nav > .connect-nav-group > a {
+  text-decoration: none;
 }
 
 .connect-avatar {
@@ -129,7 +137,9 @@
   gap: 8px;
   padding: 5px 3px;
   border-radius: 4px;
+  color: inherit;
   text-align: left;
+  text-decoration: none;
 }
 
 .connect-rail-account:hover {
@@ -193,15 +203,6 @@
   margin-bottom: 52px;
 }
 
-.connect-page > header p {
-  margin: 0 0 10px;
-  color: var(--faint);
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
 .connect-page > header h1 {
   margin: 0;
   font-size: 27px;
@@ -247,27 +248,31 @@
 .connect-section-title span {
   color: var(--faint);
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 0.75rem;
 }
 
 .connect-section-title > p {
   flex: 1;
   margin: 0;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 0.75rem;
   text-align: right;
 }
 
 .connect-section-title button,
 .connect-row-actions button,
 .connect-row-actions a,
-.connect-section-title a {
+.connect-section-title a,
+.connect-row > a {
+  min-height: 36px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
+  padding: 6px 2px;
   color: var(--accent-strong);
   text-decoration: none;
-  font-size: 10px;
+  font-size: 0.75rem;
 }
 
 .connect-section-title svg,
@@ -299,12 +304,13 @@
 }
 
 .connect-row strong {
-  font-size: 12px;
+  font-size: 0.82rem;
 }
 
 .connect-row small {
   color: var(--muted);
-  font-size: 10px;
+  font-size: 0.75rem;
+  line-height: 1.4;
 }
 
 .connect-row-actions {
@@ -312,6 +318,40 @@
   align-items: center;
   justify-content: flex-end;
   gap: 15px;
+}
+
+.connect-confirm-action {
+  max-width: 420px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.connect-confirm-action > span:first-child {
+  flex-basis: 100%;
+  color: var(--ink);
+  text-align: right;
+}
+
+.connect-inline-rename {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.connect-inline-rename input {
+  width: min(220px, 38vw);
+  min-height: 36px;
+  padding: 7px 9px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--ink);
+  background: var(--white);
+  font: inherit;
 }
 
 .connect-row-actions .danger,
@@ -331,7 +371,7 @@ button.danger:disabled {
   align-items: center;
   gap: 7px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 0.75rem;
   white-space: nowrap;
 }
 
@@ -347,7 +387,7 @@ button.danger:disabled {
 }
 
 .connect-primary-action {
-  min-height: 32px;
+  min-height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -364,39 +404,6 @@ button.danger:disabled {
   background: var(--accent-strong);
 }
 
-.connect-overview-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1px;
-  border: 1px solid var(--line);
-  background: var(--line);
-}
-
-.connect-overview-grid button {
-  min-height: 134px;
-  display: grid;
-  align-content: center;
-  gap: 3px;
-  padding: 24px;
-  background: var(--white);
-  text-align: left;
-}
-
-.connect-overview-grid button:hover {
-  background: var(--hover);
-}
-
-.connect-overview-grid strong {
-  color: var(--accent-strong);
-  font-family: var(--mono);
-  font-size: 1.7rem;
-}
-
-.connect-overview-grid span {
-  font-weight: 700;
-}
-
-.connect-overview-grid small,
 .connect-muted {
   color: var(--muted);
 }
@@ -864,6 +871,26 @@ button.danger:disabled {
   font-size: 0.84rem;
 }
 
+.connect-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-top: 8px;
+}
+
+.connect-empty-actions a,
+.connect-desktop-help a {
+  color: var(--accent-strong);
+}
+
+.connect-desktop-help {
+  max-width: 68ch;
+  margin: 16px 4px 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
 .connect-notice {
   position: sticky;
   z-index: 2;
@@ -911,7 +938,11 @@ button.danger:disabled {
   color: var(--muted);
 }
 
-@media (max-width: 820px) {
+.connect-shell .mobile-editor-return {
+  display: none;
+}
+
+@media (max-width: 1020px) {
   .connect-shell {
     grid-template-columns: 156px 210px minmax(0, 1fr);
   }
@@ -977,14 +1008,27 @@ button.danger:disabled {
     overflow: visible;
   }
 
-  .connect-shell > .collection-rail nav > :not(.collection-name) {
+  .connect-shell > .collection-rail nav > :not(.mobile-editor-return) {
     display: none;
   }
 
-  .connect-shell > .collection-rail nav .collection-name {
-    width: min(210px, 100%);
-    min-height: 36px;
+  .connect-shell .mobile-editor-return {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     margin: 0 auto;
+    padding: 8px 10px;
+    color: var(--accent-strong);
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .connect-shell .mobile-editor-return svg {
+    width: 16px;
+    height: 16px;
   }
 
   .connect-shell > .collection-rail .connection-footer {
@@ -1013,36 +1057,55 @@ button.danger:disabled {
     border-bottom: 1px solid var(--line);
   }
 
-  .connect-nav > header,
   .connect-nav > header {
-    display: none;
+    min-height: 54px;
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 5px 14px;
+  }
+
+  .connect-nav > header > strong {
+    font-size: 0.82rem;
+  }
+
+  .connect-mobile-nav-toggle {
+    min-width: 0;
+    min-height: 44px;
+    display: grid;
+    justify-items: end;
+    align-content: center;
+    padding: 4px 0;
+    color: var(--accent-strong);
+    text-align: right;
+  }
+
+  .connect-mobile-nav-toggle span {
+    overflow: hidden;
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .connect-mobile-nav-toggle small {
+    color: var(--faint);
+    font-size: 0.68rem;
   }
 
   .connect-nav > nav {
-    display: flex;
-    gap: 12px;
-    padding: 7px 10px;
-    overflow-x: auto;
-  }
-
-  .connect-nav-group {
-    display: flex;
-    gap: 2px;
-  }
-
-  .connect-nav-group + .connect-nav-group {
-    margin-left: 2px;
-    padding-left: 10px;
-    border-left: 1px solid var(--line-strong);
-  }
-
-  .connect-nav-group > p {
     display: none;
+    gap: 20px;
+    padding: 8px 10px 18px;
+    border-top: 1px solid var(--line);
   }
 
-  .connect-nav > nav button {
-    min-width: max-content;
-    grid-template-columns: 18px auto;
+  .connect-nav > nav.open {
+    display: grid;
+  }
+
+  .connect-nav > nav > .connect-nav-group > a {
+    min-height: 44px;
   }
 
   .connect-main {
@@ -1068,7 +1131,6 @@ button.danger:disabled {
     margin-bottom: 32px;
   }
 
-  .connect-overview-grid,
   .connect-permissions {
     grid-template-columns: 1fr;
   }
@@ -1104,6 +1166,26 @@ button.danger:disabled {
   }
 
   .connect-account-actions { justify-content: flex-start; }
+
+  .connect-row-actions,
+  .connect-confirm-action {
+    justify-content: flex-start;
+  }
+
+  .connect-confirm-action > span:first-child {
+    text-align: left;
+  }
+
+  .connect-row-actions button,
+  .connect-row-actions a,
+  .connect-section-title button,
+  .connect-section-title a,
+  .connect-row > a,
+  .connect-account-action,
+  .connect-account-danger,
+  .connect-primary-action {
+    min-height: 44px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/editor/src/connect.css
+++ b/apps/editor/src/connect.css
@@ -50,7 +50,7 @@
   margin: 0 10px 7px;
   color: var(--faint);
   font-family: var(--mono);
-  font-size: 0.62rem;
+  font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -163,8 +163,8 @@
   white-space: nowrap;
 }
 
-.connect-rail-account strong { font-size: 0.75rem; }
-.connect-rail-account small { color: var(--faint); font-size: 0.66rem; }
+.connect-rail-account strong { font-size: 0.8rem; }
+.connect-rail-account small { color: var(--faint); font-size: 0.75rem; }
 
 .connect-pending-banner {
   width: min(734px, calc(100% - 116px));
@@ -184,8 +184,8 @@
 .connect-pending-banner > svg { width: 16px; height: 16px; }
 .connect-pending-banner > span { min-width: 0; display: grid; gap: 2px; }
 .connect-pending-banner strong { font-size: 0.76rem; }
-.connect-pending-banner small { color: var(--muted); font-size: 0.68rem; }
-.connect-pending-banner b { color: var(--accent-strong); font-size: 0.7rem; white-space: nowrap; }
+.connect-pending-banner small { color: var(--muted); font-size: 0.75rem; }
+.connect-pending-banner b { color: var(--accent-strong); font-size: 0.75rem; white-space: nowrap; }
 
 .connect-main {
   min-width: 0;
@@ -672,9 +672,9 @@ button.danger:disabled {
   gap: 2px;
 }
 
-.connect-account-row strong { font-size: 12px; }
-.connect-account-row small { color: var(--muted); font-size: 10px; }
-.connect-account-row > span { color: var(--muted); font-size: 11px; text-align: right; }
+.connect-account-row strong { font-size: 0.82rem; }
+.connect-account-row small { color: var(--muted); font-size: 0.75rem; line-height: 1.4; }
+.connect-account-row > span { color: var(--muted); font-size: 0.75rem; text-align: right; }
 
 .connect-account-actions {
   display: flex;
@@ -686,7 +686,7 @@ button.danger:disabled {
 
 .connect-account-action,
 .connect-account-danger {
-  min-height: 32px;
+  min-height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -811,7 +811,7 @@ button.danger:disabled {
   color: var(--muted);
   background: var(--white);
   font-family: var(--mono);
-  font-size: 0.66rem;
+  font-size: 0.75rem;
 }
 
 .connect-deleted-account {
@@ -828,15 +828,6 @@ button.danger:disabled {
   padding: 42px;
   border: 1px solid var(--line);
   background: var(--white);
-}
-
-.connect-deleted-account p {
-  margin: 0 0 10px;
-  color: var(--faint);
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
 }
 
 .connect-deleted-account h1 { margin: 0; font-size: 27px; }
@@ -1032,8 +1023,8 @@ button.danger:disabled {
   }
 
   .connect-shell > .collection-rail .connection-footer {
-    width: 34px;
-    min-height: 34px;
+    width: 44px;
+    min-height: 44px;
     display: block;
     padding: 0;
     border: 0;
@@ -1045,8 +1036,8 @@ button.danger:disabled {
   }
 
   .connect-rail-account {
-    width: 34px;
-    height: 34px;
+    width: 44px;
+    height: 44px;
     display: grid;
     grid-template-columns: 1fr;
     padding: 2px;
@@ -1090,7 +1081,7 @@ button.danger:disabled {
 
   .connect-mobile-nav-toggle small {
     color: var(--faint);
-    font-size: 0.68rem;
+    font-size: 0.75rem;
   }
 
   .connect-nav > nav {

--- a/apps/editor/src/connect.css
+++ b/apps/editor/src/connect.css
@@ -610,6 +610,44 @@ button.danger:disabled {
   border-top: 1px solid var(--line);
 }
 
+.connect-subscription-storage {
+  display: grid;
+  gap: 10px;
+  margin: 14px 0 30px;
+  padding: 16px 4px 18px;
+  border-bottom: 1px solid var(--line-strong);
+}
+
+.connect-subscription-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.connect-subscription-heading > div {
+  display: grid;
+  gap: 2px;
+}
+
+.connect-subscription-heading strong {
+  font-size: 0.9rem;
+}
+
+.connect-subscription-heading small,
+.connect-subscription-storage p {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.connect-subscription-heading > span {
+  font-weight: 700;
+}
+
+.connect-subscription-storage p {
+  margin: 0;
+}
+
 .connect-account-row {
   min-height: 66px;
   display: grid;

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -856,6 +856,8 @@ select:focus-visible {
 
 .collection-rail nav {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   margin-top: 35px;
   overflow-y: auto;
 }
@@ -976,7 +978,8 @@ select:focus-visible {
 }
 
 .rail-manage-label {
-  margin: 24px 9px 7px;
+  margin: auto 9px 7px;
+  padding-top: 24px;
   color: var(--faint);
   font-family: var(--mono);
   font-size: 9px;

--- a/apps/editor/tests/connect.spec.ts
+++ b/apps/editor/tests/connect.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 const now = new Date().toISOString();
 const overview = {
   user: { id: "person", name: "Example Person", email: "person@example.com", login: null },
+  subscription: null,
   hosted_collections_available: true,
   authentication: { provider: "github", registration: "closed" },
   connectors: [{ id: "computer", name: "Home computer", last_seen_at: now, created_at: now }],

--- a/apps/editor/tests/connect.spec.ts
+++ b/apps/editor/tests/connect.spec.ts
@@ -41,11 +41,11 @@ test("places Connect inside the editor collection shell", async ({ page }) => {
   await expect(collectionRail.getByRole("link", { name: "Types" })).toBeVisible();
   await expect(collectionRail.getByRole("link", { name: "Settings" })).toBeVisible();
   await expect(collectionRail.getByRole("link", { name: "Connect" })).toHaveAttribute("aria-current", "page");
-  await expect(page.getByText("This collection", { exact: true })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Garden notes" })).toBeVisible();
   await expect(page.getByText("Account", { exact: true })).toBeVisible();
   await expect(page.getByRole("complementary", { name: "Product navigation" })).toHaveCount(0);
 
-  await page.getByRole("button", { name: "Storage & sync" }).click();
+  await page.getByRole("link", { name: "Storage & sync" }).click();
   await expect(page).toHaveURL(/\/connect\/storage\?.*collection=collection/);
   await expect(page.getByRole("heading", { name: "Storage & sync" })).toBeVisible();
 });
@@ -57,10 +57,16 @@ test("condenses the shared editor shell on mobile", async ({ page }) => {
   const collectionRail = page.getByRole("complementary", { name: "Collection navigation" });
   await expect(page.getByRole("heading", { name: "Garden notes" })).toBeVisible();
   await expect(collectionRail).toHaveCSS("height", "58px");
-  await expect(collectionRail.getByRole("button", { name: /Switch collection/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Overview" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "All collections" })).toBeVisible();
-  await expect(page.locator(".connect-nav-group").nth(1)).toHaveCSS("border-left-width", "1px");
+  await expect(collectionRail.getByRole("link", { name: "Back to editor" })).toBeVisible();
+  await expect(collectionRail.getByRole("button", { name: /Switch collection/ })).toBeHidden();
+  const menu = page.getByRole("button", { name: /Overview.*Open menu/ });
+  await expect(menu).toBeVisible();
+  await expect(page.getByRole("link", { name: "All collections" })).toBeHidden();
+  await menu.click();
+  await expect(page.getByRole("link", { name: "Overview" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "All collections" })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Garden notes" })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Account" })).toBeVisible();
 });
 
 test("uses a collection chooser when direct entry is ambiguous", async ({ page }) => {
@@ -83,5 +89,22 @@ test("uses a collection chooser when direct entry is ambiguous", async ({ page }
 
   await expect(page).toHaveURL(/\/connect\/collections\?server=/);
   await expect(page.getByRole("heading", { name: "Collections", exact: true })).toBeVisible();
-  await expect(page.getByRole("button", { name: "All collections" })).toHaveAttribute("aria-current", "page");
+  await expect(page.getByRole("link", { name: "All collections" })).toHaveAttribute("aria-current", "page");
 });
+
+for (const width of [834, 900]) {
+  test(`keeps the Connect workspace usable at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 800 });
+    await page.goto("connect?server=http%3A%2F%2Fconnect.test&collection=collection");
+
+    await expect(page.getByRole("heading", { name: "Garden notes" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Storage & sync" })).toBeVisible();
+    const layout = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      documentWidth: document.documentElement.scrollWidth,
+      mainWidth: document.querySelector(".connect-main")?.getBoundingClientRect().width ?? 0
+    }));
+    expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewport);
+    expect(layout.mainWidth).toBeGreaterThan(360);
+  });
+}

--- a/docs/google-auth.md
+++ b/docs/google-auth.md
@@ -1,7 +1,7 @@
 # Google authentication
 
 mdbase connect supports Google Identity Services alongside GitHub OAuth. The
-portal uses Google's rendered button, receives a signed ID token in the browser,
+editor uses Google's rendered button, receives a signed ID token in the browser,
 and sends it to the Connect server. The server validates the signature, issuer,
 audience, expiry, and a one-time nonce before creating its own session. Google
 access and refresh tokens are neither requested nor stored.
@@ -12,22 +12,34 @@ Use separate Google Cloud projects for development and production. In each
 project, configure Google Auth Platform branding and create a **Web
 application** client.
 
-For the production client, add this authorized JavaScript origin:
+For the production client, add these authorized JavaScript origins:
 
 ```text
 https://connect.mdbase.dev
+https://editor.mdbase.dev
+https://editor-staging.mdbase.dev
 ```
 
-For local development, add the exact loopback origins in use, such as:
+`https://connect.mdbase.dev` preserves compatibility with the former Connect
+portal. Google Identity Services now runs in the editor, so
+`https://editor.mdbase.dev` is required for production sign-in. Managed staging
+currently uses the same web client and therefore also requires its exact editor
+origin.
+
+For local development, add the exact editor origins in use, such as:
 
 ```text
-http://localhost:8787
-http://127.0.0.1:8787
+http://localhost:5173
+http://127.0.0.1:5173
 ```
 
 The integration uses the popup callback from Google Identity Services, so it
-does not require a Google authorization redirect URI. Keep the production
-client ID in deployment configuration:
+does not require a Google authorization redirect URI. Configure these values
+under **Authorized JavaScript origins**, not **Authorized redirect URIs**. An
+origin contains only the scheme, hostname, and optional port; do not include a
+path or trailing slash.
+
+Keep the production client ID in deployment configuration:
 
 ```text
 MDBASE_CONNECT_GOOGLE_CLIENT_ID=…apps.googleusercontent.com

--- a/packages/management/index.ts
+++ b/packages/management/index.ts
@@ -38,6 +38,9 @@ export interface AccountData {
   storage: {
     status: "available" | "partial" | "unavailable";
     total_content_bytes: number | null;
+    total_file_bytes: number | null;
+    total_storage_bytes: number | null;
+    total_stored_file_bytes: number | null;
     total_records: number | null;
     collections: Array<{
       id: string;
@@ -49,6 +52,13 @@ export interface AccountData {
         max_records: number;
         max_content_bytes: number;
         max_document_bytes: number;
+        file_count: number;
+        file_bytes: number;
+        stored_file_bytes: number;
+        max_files: number;
+        max_file_bytes: number;
+        max_stored_file_bytes: number;
+        max_single_file_bytes: number;
       };
     }>;
   };
@@ -100,6 +110,31 @@ export interface HostedCollection {
 
 export interface ManagementOverview {
   user: { id: string; name: string; email: string | null; login: string | null };
+  subscription: null | {
+    kind: "beta" | "entitled";
+    profiles: string[];
+    permanent: boolean;
+    limits: {
+      hosted_storage_bytes: number;
+      retained_file_bytes: number;
+      max_document_bytes: number;
+      max_single_file_bytes: number;
+      max_replicas_per_collection: number;
+      max_hosted_collections: number;
+      max_files_per_collection: number;
+    };
+    usage: null | {
+      hosted_collections: number;
+      live_content_bytes: number;
+      live_file_bytes: number;
+      live_storage_bytes: number;
+      retained_file_bytes: number;
+    };
+    reconciliation: null | {
+      entitlement_revision: number;
+      provider_revision: number;
+    };
+  };
   hosted_collections_available?: boolean;
   authentication: {
     provider: "google" | "github" | "password" | "tailscale" | "session";

--- a/scripts/browser-accessibility.test.mjs
+++ b/scripts/browser-accessibility.test.mjs
@@ -89,7 +89,7 @@ async function auditEditorConnect() {
             permanent: true,
             limits: {
               hosted_storage_bytes: 1_073_741_824,
-              retained_file_bytes: 1_073_741_824,
+              retained_file_bytes: 2_147_483_648,
               max_document_bytes: 2_097_152,
               max_single_file_bytes: 262_144_000,
               max_replicas_per_collection: 10,

--- a/scripts/browser-accessibility.test.mjs
+++ b/scripts/browser-accessibility.test.mjs
@@ -71,6 +71,7 @@ async function auditPortalLogin() {
 async function auditEditorConnect() {
   const page = await browser.newPage();
   const errors = watchPageErrors(page);
+  const now = new Date().toISOString();
   await page.route("**/v1/**", async (route) => {
     const pathname = new URL(route.request().url()).pathname;
     if (pathname === "/v1/me") {
@@ -81,6 +82,28 @@ async function auditEditorConnect() {
             name: "Example User",
             email: "user@example.com",
             login: "example"
+          },
+          subscription: {
+            kind: "beta",
+            profiles: ["beta_v1"],
+            permanent: true,
+            limits: {
+              hosted_storage_bytes: 1_073_741_824,
+              retained_file_bytes: 1_073_741_824,
+              max_document_bytes: 2_097_152,
+              max_single_file_bytes: 262_144_000,
+              max_replicas_per_collection: 10,
+              max_hosted_collections: 250,
+              max_files_per_collection: 10_000
+            },
+            usage: {
+              hosted_collections: 1,
+              live_content_bytes: 4_096,
+              live_file_bytes: 10_485_760,
+              live_storage_bytes: 10_489_856,
+              retained_file_bytes: 2_097_152
+            },
+            reconciliation: { entitlement_revision: 1, provider_revision: 1 }
           },
           hosted_collections_available: true,
           authentication: { provider: "github", registration: "open" },
@@ -97,14 +120,109 @@ async function auditEditorConnect() {
             last_seen_at: new Date().toISOString()
           }],
           hosted_collections: [],
-          grants: [],
-          pending_authorizations: []
+          grants: [{
+            id: "grant-active",
+            operations: ["read", "query", "update"],
+            scope: { contracts: [], access: "full_collection" },
+            created_at: now,
+            revoked_at: null,
+            revocation_status: "active",
+            collection_id: "22222222-2222-4222-8222-222222222222",
+            collection_name: "Accessibility collection",
+            collection_kind: "local",
+            application_id: "photo-catalog",
+            application_name: "Photo catalog",
+            distribution: "web",
+            homepage: "https://photos.example",
+            project_url: null,
+            application_origin: "https://photos.example",
+            icon: null
+          }, {
+            id: "grant-revoking",
+            operations: ["read"],
+            scope: { contracts: [], access: "full_collection" },
+            created_at: now,
+            revoked_at: now,
+            revocation_status: "revoking",
+            collection_id: "22222222-2222-4222-8222-222222222222",
+            collection_name: "Accessibility collection",
+            collection_kind: "local",
+            application_id: "archive-tool",
+            application_name: "Archive tool",
+            distribution: "web",
+            homepage: "https://archive.example",
+            project_url: null,
+            application_origin: "https://archive.example",
+            icon: null
+          }],
+          pending_authorizations: [{
+            id: "pending-request",
+            flow: "authorization_code",
+            requested_operations: ["read"],
+            collection_id: "22222222-2222-4222-8222-222222222222",
+            expires_at: "2099-08-01T00:00:00.000Z",
+            application_id: "reading-list",
+            application_name: "Reading list",
+            distribution: "web",
+            homepage: "https://reading.example",
+            project_url: null,
+            icon: null
+          }]
         }
       });
       return;
     }
     if (pathname === "/v1/account/sessions") {
-      await route.fulfill({ json: { sessions: [] } });
+      await route.fulfill({ json: { sessions: [{
+        id: "current-session",
+        provider: "password",
+        client_name: "Accessibility browser",
+        created_at: now,
+        last_seen_at: now,
+        expires_at: "2099-08-01T00:00:00.000Z",
+        current: true
+      }] } });
+      return;
+    }
+    if (pathname === "/v1/account") {
+      await route.fulfill({ json: {
+        user: { id: "user", name: "Example User", email: "user@example.com", login: "example" },
+        authentication: {
+          managed: true,
+          current_provider: "password",
+          available_providers: { github: false, google: false, password: true },
+          identities: [],
+          password: { configured: true, email: "user@example.com", current: true, change_available: true }
+        },
+        storage: {
+          status: "available",
+          total_content_bytes: 4_096,
+          total_file_bytes: 10_485_760,
+          total_storage_bytes: 10_489_856,
+          total_stored_file_bytes: 12_582_912,
+          total_records: 2,
+          collections: [{
+            id: "hosted",
+            display_name: "Hosted research",
+            usage: {
+              collection_id: "hosted",
+              record_count: 2,
+              content_bytes: 4_096,
+              max_records: 100_000,
+              max_content_bytes: 1_073_741_824,
+              max_document_bytes: 2_097_152,
+              file_count: 2,
+              file_bytes: 10_485_760,
+              stored_file_bytes: 12_582_912,
+              max_files: 10_000,
+              max_file_bytes: 1_073_741_824,
+              max_stored_file_bytes: 2_147_483_648,
+              max_single_file_bytes: 262_144_000
+            }
+          }]
+        },
+        deletion: { available: true, hosted_collections: 1, local_collections: 1, computers: 1, development_confirmation: true }
+      } });
       return;
     }
     await route.fulfill({ json: {} });
@@ -112,6 +230,23 @@ async function auditEditorConnect() {
   await page.goto(`${servers[2].origin}/connect`);
   await page.getByRole("heading", { name: "Accessibility collection" }).waitFor();
   await auditPage(page, "editor Connect workspace", { keyboard: true });
+
+  await page.getByRole("link", { name: "App access" }).click();
+  await page.getByRole("heading", { name: "Application access" }).waitFor();
+  await page.getByText("Photo catalog", { exact: true }).click();
+  await page.getByText("Permissions", { exact: true }).click();
+  await auditPage(page, "editor Connect expanded permissions", { keyboard: true });
+
+  await page.getByRole("link", { name: "Account & sessions" }).click();
+  await page.getByRole("heading", { name: "Hosted storage" }).waitFor();
+  await page.getByRole("button", { name: "Change password" }).click();
+  await page.getByRole("button", { name: "Delete account…" }).click();
+  await auditPage(page, "editor Connect account forms", { keyboard: true });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: /Account & sessions.*Open menu/ }).click();
+  await page.getByRole("link", { name: "Back to editor" }).waitFor();
+  await auditPage(page, "editor Connect mobile navigation", { keyboard: true });
   assert.deepEqual(errors, []);
   await page.close();
 }
@@ -376,6 +511,11 @@ async function auditPage(page, label, options = {}) {
 
   const structuralProblems = await page.evaluate(() => {
     const visible = (element) => {
+      const closedDetails = element.closest("details:not([open])");
+      if (closedDetails) {
+        const summary = closedDetails.querySelector(":scope > summary");
+        if (!summary?.contains(element)) return false;
+      }
       const style = getComputedStyle(element);
       const bounds = element.getBoundingClientRect();
       return style.visibility !== "hidden"
@@ -392,7 +532,7 @@ async function auditPage(page, label, options = {}) {
       .map(([id]) => id);
     const unnamedControls = [
       ...document.querySelectorAll(
-        "button, a[href], input, select, textarea, [role=button], [role=switch]"
+        "button, a[href], input, select, textarea, summary, [role=button], [role=switch]"
       )
     ].filter((element) => {
       if (!visible(element) || element.matches(":disabled")) return false;
@@ -474,6 +614,11 @@ async function auditPage(page, label, options = {}) {
 async function assertKeyboardReachability(page, label) {
   const expected = await page.evaluate(() => {
     const visible = (element) => {
+      const closedDetails = element.closest("details:not([open])");
+      if (closedDetails) {
+        const summary = closedDetails.querySelector(":scope > summary");
+        if (!summary?.contains(element)) return false;
+      }
       const style = getComputedStyle(element);
       const bounds = element.getBoundingClientRect();
       return style.visibility !== "hidden"
@@ -483,12 +628,12 @@ async function assertKeyboardReachability(page, label) {
     };
     return [
       ...document.querySelectorAll(
-        "a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled)"
+        "a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), summary"
       )
     ].filter(visible).map((element, index) => {
       const id = `a11y-${index}`;
       element.setAttribute("data-a11y-test", id);
-      return id;
+      return { id, element: element.outerHTML.slice(0, 180) };
     });
   });
   await page.evaluate(() => {
@@ -498,18 +643,17 @@ async function assertKeyboardReachability(page, label) {
     document.body.focus();
   });
   const reached = new Set();
-  for (let index = 0; index < expected.length + 2; index += 1) {
+  for (let index = 0; index < expected.length * 2 + 2 && reached.size < expected.length; index += 1) {
     await page.keyboard.press("Tab");
     const active = await page.evaluate(() =>
       document.activeElement?.getAttribute("data-a11y-test") ?? ""
     );
     if (active) reached.add(active);
   }
-  assert.deepEqual(
-    [...reached].sort(),
-    [...expected].sort(),
-    `${label}: every visible control is keyboard reachable`
-  );
+  const expectedIds = expected.map(({ id }) => id);
+  const missing = expected.filter(({ id }) => !reached.has(id));
+  assert.deepEqual([...reached].sort(), expectedIds.sort(),
+    `${label}: every visible control is keyboard reachable; missing ${missing.map(({ element }) => element).join(", ")}`);
 }
 
 function watchPageErrors(page) {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2479,7 +2479,7 @@ async function portalLifecycleE2E(controlUrl, providerUrl, browserMirrorDirector
     await page.getByRole("button", { name: "New hosted collection" }).click();
     await page.getByLabel("Collection name").fill("Browser E2E collection");
     await page.getByRole("button", { name: "Create", exact: true }).click();
-    await page.getByRole("button", { name: "All collections" }).click();
+    await page.getByRole("link", { name: "All collections" }).click();
     const row = page.locator(".connect-collection-row").filter({
       hasText: "Browser E2E collection"
     });
@@ -2549,28 +2549,29 @@ async function portalLifecycleE2E(controlUrl, providerUrl, browserMirrorDirector
     assert.equal(browserStatus.state, "up_to_date");
 
     await page.goto(controlUrl);
-    await page.getByRole("button", { name: "All collections" }).click();
+    await page.getByRole("link", { name: "All collections" }).click();
     const connectedRow = page.locator(".connect-collection-row").filter({
       hasText: "Browser E2E collection"
     });
     await connectedRow.getByText("Synced folders", { exact: true }).click();
     await expect(connectedRow).toContainText("Browser writable mirror");
     await expect(connectedRow).toContainText("Two-way sync");
-    await page.evaluate(() => {
-      window.confirm = () => true;
-      window.prompt = () => "Browser renamed collection";
-    });
     await connectedRow.getByRole("button", { name: "Revoke" }).click();
+    await connectedRow.getByRole("button", { name: "Revoke", exact: true }).click();
     await expect(connectedRow.getByText("Browser writable mirror")).toHaveCount(0, {
       timeout: 20_000
     });
 
     await connectedRow.getByRole("button", { name: "Rename" }).click();
+    await connectedRow.getByLabel("Rename Browser E2E collection")
+      .fill("Browser renamed collection");
+    await connectedRow.getByRole("button", { name: "Save", exact: true }).click();
     const renamedRow = page.locator(".connect-collection-row").filter({
       hasText: "Browser renamed collection"
     });
     await expect(renamedRow).toBeVisible({ timeout: 20_000 });
     await renamedRow.getByRole("button", { name: "Delete" }).click();
+    await renamedRow.getByRole("button", { name: "Delete permanently" }).click();
     await expect(page.getByText("Browser renamed collection", { exact: true })).toHaveCount(0, {
       timeout: 20_000
     });
@@ -2590,7 +2591,7 @@ async function portalLifecycleE2E(controlUrl, providerUrl, browserMirrorDirector
       (collection) => collection.display_name === "Account deletion collection"
     ).id;
 
-    await page.getByRole("button", { name: "Account & sessions" }).click();
+    await page.getByRole("link", { name: "Account & sessions" }).click();
     await expect(page.getByRole("heading", { name: "Account", exact: true })).toBeVisible();
     await expect(page.getByRole("main").getByText(
       "Account deletion collection",


### PR DESCRIPTION
## Summary

- finish the Connect pages inside the editor with responsive hierarchical navigation, route semantics, focus management, and consistent product-owned actions
- report the complete beta hosted-storage entitlement, retained-file usage, and per-collection Markdown/file breakdown
- make collection availability, mutation failures, refreshes, and visibility-aware polling truthful and race-safe
- improve onboarding and desktop recovery paths while removing browser prompts and confirmations
- expand component, accessibility, viewport, and hosted lifecycle coverage

## Scope

This PR is intentionally limited to the editor, the management response fields required to render entitlements, browser test infrastructure, and Google OAuth-origin documentation. It contains no Rust connector, CLI, first-contact protocol, application-identity, or public SDK changes. Those are isolated in draft PR #154.

## Verification

- cargo fmt --all -- --check
- cargo test --workspace
- pnpm typecheck
- pnpm test, with the editor suite rerun alone: 33 files and 241 tests passed
- pnpm test:accessibility
- pnpm --filter mdbase-editor test:e2e: 47 passed
- pnpm e2e
- node scripts/hosted-provider-e2e.mjs

The local Node runtime is v22 while the repository requests v24; CI runs the required Node version.