### PR TITLE
Add mdbase icon motion system

### DIFF
--- a/apps/editor/src/Brand.test.tsx
+++ b/apps/editor/src/Brand.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MdbaseMark } from "./Brand";
+import { OpeningScreen } from "./LoadingScreens";
+
+describe("mdbase motion mark", () => {
+  it("keeps the canonical segments and clipped conveyor in one SVG", () => {
+    const { container } = render(<MdbaseMark motion="bootstrap" />);
+    const mark = container.querySelector("svg");
+
+    expect(mark).toHaveClass("mdbase-motion-bootstrap");
+    expect(mark?.querySelectorAll(".mdbase-mark-segment")).toHaveLength(10);
+    expect(mark?.querySelectorAll(".mdbase-mark-conveyor-track rect")).toHaveLength(10);
+    expect(mark?.querySelector("clipPath rect")).toHaveAttribute("width", "76");
+  });
+
+  it("unfolds the existing editor wordmark while opening a collection", () => {
+    const { container } = render(<OpeningScreen />);
+
+    expect(screen.getByLabelText("Opening collection")).toHaveAttribute("aria-busy", "true");
+    expect(container.querySelector(".wordmark .mdbase-motion-unfold")).toBeInTheDocument();
+    expect(container.querySelector(".opening-pulse")).not.toBeInTheDocument();
+  });
+});

--- a/apps/editor/src/Brand.tsx
+++ b/apps/editor/src/Brand.tsx
@@ -1,20 +1,63 @@
-export function MdbaseMark() {
-  return <svg className="wordmark-mark" viewBox="18 18 84 84" aria-hidden="true" focusable="false">
-    <g className="wordmark-mark-ink">
-      <rect x="22" y="22" width="20" height="10" rx="2" />
-      <rect x="50" y="22" width="20" height="10" rx="2" />
-      <rect x="78" y="22" width="20" height="10" rx="2" />
-      <rect x="22" y="44" width="12" height="10" rx="2" />
-      <rect x="22" y="66" width="28" height="10" rx="2" />
-      <rect x="58" y="66" width="40" height="10" rx="2" />
-      <rect x="22" y="88" width="20" height="10" rx="2" />
-      <rect x="50" y="88" width="20" height="10" rx="2" />
-      <rect x="78" y="88" width="20" height="10" rx="2" />
+import {
+  MDBASE_MARK_VIEW_BOX,
+  mdbaseMarkAccentRect,
+  mdbaseMarkInkRects,
+  mdbaseMarkMotionClass,
+  type MdbaseMarkMotion,
+  type MdbaseMarkRect
+} from "@mdbase/connect-ui/brand";
+import { useId } from "react";
+
+const conveyorXs = [-6, 22, 50, 78, 106] as const;
+
+function Segment({ rect, index, accent = false }: {
+  rect: MdbaseMarkRect;
+  index: number;
+  accent?: boolean;
+}) {
+  return <rect
+    className={`mdbase-mark-segment mdbase-mark-segment-${index} ${accent ? "mdbase-mark-accent wordmark-mark-accent" : "mdbase-mark-ink"}`}
+    pathLength={1}
+    {...rect}
+  />;
+}
+
+export function MdbaseMark({ motion }: { motion?: MdbaseMarkMotion }) {
+  const clipId = `mdbase-fences-${useId().replaceAll(":", "")}`;
+  return <svg
+    className={`wordmark-mark mdbase-motion-mark${mdbaseMarkMotionClass(motion)}`}
+    viewBox={MDBASE_MARK_VIEW_BOX}
+    aria-hidden="true"
+    focusable="false"
+  >
+    <defs>
+      <clipPath id={clipId}>
+        <rect x="22" y="22" width="76" height="10" rx="2" />
+        <rect x="22" y="88" width="76" height="10" rx="2" />
+      </clipPath>
+    </defs>
+    <g className="mdbase-mark-fence mdbase-mark-fence-top wordmark-mark-ink">
+      {mdbaseMarkInkRects.slice(0, 3).map((rect, index) => <Segment key={`${rect.x}-${rect.y}`} rect={rect} index={index + 1} />)}
     </g>
-    <rect className="wordmark-mark-accent" x="42" y="44" width="56" height="10" rx="2" />
+    <g className="mdbase-mark-row mdbase-mark-row-top">
+      <Segment rect={mdbaseMarkInkRects[3]} index={4} />
+      <Segment rect={mdbaseMarkAccentRect} index={5} accent />
+    </g>
+    <g className="mdbase-mark-row mdbase-mark-row-bottom wordmark-mark-ink">
+      <Segment rect={mdbaseMarkInkRects[4]} index={6} />
+      <Segment rect={mdbaseMarkInkRects[5]} index={7} />
+    </g>
+    <g className="mdbase-mark-fence mdbase-mark-fence-bottom wordmark-mark-ink">
+      {mdbaseMarkInkRects.slice(6).map((rect, index) => <Segment key={`${rect.x}-${rect.y}`} rect={rect} index={index + 8} />)}
+    </g>
+    <g clipPath={`url(#${clipId})`}>
+      <g className="mdbase-mark-conveyor-track">
+        {conveyorXs.flatMap((x) => [22, 88].map((y) => <rect key={`${x}-${y}`} x={x} y={y} width="20" height="10" rx="2" />))}
+      </g>
+    </g>
   </svg>;
 }
 
-export function Wordmark() {
-  return <div className="wordmark"><MdbaseMark /><span className="wordmark-label"><span>mdbase</span><strong>editor</strong></span></div>;
+export function Wordmark({ motion }: { motion?: MdbaseMarkMotion }) {
+  return <div className="wordmark"><MdbaseMark motion={motion} /><span className="wordmark-label"><span>mdbase</span><strong>editor</strong></span></div>;
 }

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -29,6 +29,15 @@ afterEach(() => {
 });
 
 describe("ConnectApp", () => {
+  it("traces into bounded activity while Connect is opening", () => {
+    vi.mocked(fetch).mockImplementation(() => new Promise<Response>(() => {}));
+    const { container } = render(<ConnectApp />);
+
+    expect(screen.getByText("Opening mdbase connect")).toBeInTheDocument();
+    expect(container.querySelector(".connect-loading .mdbase-motion-bootstrap")).toBeInTheDocument();
+    expect(container.querySelector(".mdbase-mark-conveyor-track")).toBeInTheDocument();
+  });
+
   it("opens account management without requesting a collection grant", async () => {
     const user = userEvent.setup();
     render(<ConnectApp />);

--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -548,7 +548,7 @@ function RouteLink({ view, collectionId, navigate, children, className = "", ari
 }
 
 function ConnectLoading({ error }: { error: string }) {
-  return <div className="connect-loading"><MdbaseMark /><strong>{error ? "mdbase connect is unavailable" : "Opening mdbase connect"}</strong><p>{error || "Loading your account and collections…"}</p></div>;
+  return <div className="connect-loading" aria-busy={!error}><MdbaseMark motion={error ? undefined : "bootstrap"} /><strong>{error ? "mdbase connect is unavailable" : "Opening mdbase connect"}</strong><p>{error || "Loading your account and collections…"}</p></div>;
 }
 
 function DesktopRecoveryHelp({ action }: { action: string }) {

--- a/apps/editor/src/LoadingScreens.tsx
+++ b/apps/editor/src/LoadingScreens.tsx
@@ -8,11 +8,11 @@ export function TypeWorkspaceLoading() {
 }
 export function OpeningScreen() {
   return <main className="opening-shell" aria-label="Opening collection" aria-busy="true">
-    <aside className="opening-rail"><Wordmark /><div className="opening-rail-lines"><span /><span /><span /></div></aside>
+    <aside className="opening-rail"><Wordmark motion="unfold" /><div className="opening-rail-lines"><span /><span /><span /></div></aside>
     <section className="opening-list" aria-hidden="true"><div className="opening-list-heading"><span /><small /></div><div className="opening-search" />{Array.from({ length: 7 }, (_, index) => <div className="opening-row" key={index}><span /><small /></div>)}</section>
     <section className="opening-document">
       <div className="opening-document-bar" aria-hidden="true"><span /></div>
-      <div className="opening-message"><span className="opening-pulse" aria-hidden="true" /><div><p>Opening collection</p><small>Reading its notes and types</small></div></div>
+      <div className="opening-message"><div><p>Opening collection</p><small>Reading its notes and types</small></div></div>
       <div className="opening-document-lines" aria-hidden="true"><strong /><span /><span /><span /></div>
     </section>
   </main>;

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import { AppErrorBoundary } from "./AppErrorBoundary";
 import { DemoCollectionGateway } from "./demo-gateway";
 import { ConnectCollectionGateway } from "./gateway";
+import "@mdbase/connect-ui/motion.css";
 import "./phosphor-icons.generated.css";
 import "./styles.css";
 

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -737,7 +737,6 @@ select:focus-visible {
   left: clamp(28px, 7vw, 112px);
   display: flex;
   align-items: flex-start;
-  gap: 11px;
 }
 
 .opening-message p,

--- a/apps/portal/src/authorization-view.tsx
+++ b/apps/portal/src/authorization-view.tsx
@@ -112,6 +112,7 @@ export function Authorization({ requestId }: { requestId: string }) {
     unavailable_connectors: UnavailableConnector[];
   } | null>(null);
   const [status, setStatus] = useState<"pending" | "setting_up" | "approved" | "denied">("pending");
+  const [structuralSetupRequested, setStructuralSetupRequested] = useState(false);
   const [continuingInDesktop, setContinuingInDesktop] = useState(
     () => new URLSearchParams(location.search).get("continue_in_desktop") === "1"
   );
@@ -174,6 +175,12 @@ export function Authorization({ requestId }: { requestId: string }) {
 
   if (!request) return <Loading error={error} />;
   const authorization = request.authorization;
+  const preparingStructure = structuralSetupRequested || authorizationNeedsTypeSetup(
+    authorization,
+    request.collections
+  );
+  const setupMotionActive = status === "setting_up"
+    || (status === "pending" && structuralSetupRequested);
   function continueInDesktop(value: boolean) {
     const url = new URL(location.href);
     if (value) url.searchParams.set("continue_in_desktop", "1");
@@ -183,7 +190,11 @@ export function Authorization({ requestId }: { requestId: string }) {
   }
   return (
     <main className="center-page">
-      <PageBrand label="Application request" themePicker={false} />
+      <PageBrand
+        label="Application request"
+        themePicker={false}
+        markMotion={setupMotionActive ? (preparingStructure ? "rebalance" : "conveyor") : undefined}
+      />
       <section className="decision-panel authorization-panel">
         <RequestIdentity request={authorization} large />
         {status === "pending" && continuingInDesktop ? (
@@ -201,6 +212,7 @@ export function Authorization({ requestId }: { requestId: string }) {
             unavailableConnectors={request.unavailable_connectors}
             onContinueInDesktop={() => continueInDesktop(true)}
             onDecision={(decision) => setStatus(decision)}
+            onSetupActivityChange={setStructuralSetupRequested}
             onCollectionCreated={(collection) => setRequest((current) => current ? {
               ...current,
               collections: current.collections.some((existing) => existing.id === collection.id)
@@ -411,6 +423,7 @@ export function ApprovalForm({
   unavailableConnectors = [],
   onContinueInDesktop,
   onDecision,
+  onSetupActivityChange,
   onCollectionCreated
 }: {
   request: PendingAuthorization;
@@ -419,6 +432,7 @@ export function ApprovalForm({
   unavailableConnectors?: UnavailableConnector[];
   onContinueInDesktop?(): void;
   onDecision(decision: "approved" | "denied"): void | Promise<void>;
+  onSetupActivityChange?(active: boolean): void;
   onCollectionCreated(collection: AvailableCollection): void;
 }) {
   const [createdCollections, setCreatedCollections] = useState<AvailableCollection[]>([]);
@@ -559,6 +573,8 @@ export function ApprovalForm({
   }
 
   async function decide(decision: "approved" | "denied") {
+    const preparingTypeSetup = decision === "approved" && contractSetups.length > 0;
+    if (preparingTypeSetup) onSetupActivityChange?.(true);
     setSubmitting(decision);
     setError("");
     try {
@@ -575,6 +591,7 @@ export function ApprovalForm({
       });
       await onDecision(decision);
     } catch (decisionError) {
+      if (preparingTypeSetup) onSetupActivityChange?.(false);
       setError(message(decisionError));
       setSubmitting(null);
     }
@@ -791,6 +808,20 @@ export function ApprovalForm({
         </div>
       </footer>
     </div>
+  );
+}
+
+function authorizationNeedsTypeSetup(
+  request: PendingAuthorization,
+  collections: AvailableCollection[]
+): boolean {
+  if (!request.collection_id) return false;
+  const collection = collections.find((candidate) => candidate.id === request.collection_id);
+  if (!collection) return false;
+  return request.requirements.contracts.some((required) =>
+    !collection.contracts.some((contract) =>
+      contract.id === required.id && contract.version === required.version
+    ) && Boolean(provisionedContract(required, request.provisions.type_packs))
   );
 }
 

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -4,6 +4,7 @@ import "@fontsource/azeret-mono/latin-400.css";
 import "@fontsource/azeret-mono/latin-500.css";
 import "@fontsource/azeret-mono/latin-600.css";
 import "@mdbase/connect-ui/styles.css";
+import "@mdbase/connect-ui/motion.css";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import {

--- a/apps/portal/src/portal-ui.tsx
+++ b/apps/portal/src/portal-ui.tsx
@@ -1,7 +1,10 @@
 import {
   MDBASE_MARK_VIEW_BOX,
   mdbaseMarkAccentRect,
-  mdbaseMarkInkRects
+  mdbaseMarkInkRects,
+  mdbaseMarkMotionClass,
+  type MdbaseMarkMotion,
+  type MdbaseMarkRect
 } from "@mdbase/connect-ui/brand";
 import {
   applyThemePreference,
@@ -9,7 +12,7 @@ import {
   saveThemePreference,
   type ThemePreference
 } from "@mdbase/connect-ui/theme";
-import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { type MouseEvent, useEffect, useId, useRef, useState } from "react";
 
 const themeChoices: Array<{ value: ThemePreference; label: string }> = [
   { value: "system", label: "System" },
@@ -176,12 +179,47 @@ export function useSystemTheme() {
     return () => media.removeEventListener("change", update);
   }, []);
 }
-export function PageBrand({ label, themePicker = true }: { label: string; themePicker?: boolean }) { return <div className="page-brand-row"><div className="page-brand"><Brand /><span>{label}</span></div>{themePicker && <ThemeMenu />}</div>; }
-export function Brand({ productLabel = false }: { productLabel?: boolean }) { return <div className="product-brand"><MdbaseMark /><strong>mdbase</strong>{productLabel && <span className="product-brand-label">connect</span>}</div>; }
-function MdbaseMark() { return <svg className="product-brand-mark" viewBox={MDBASE_MARK_VIEW_BOX} aria-hidden="true" focusable="false"><g className="product-brand-mark-ink">{mdbaseMarkInkRects.map((rect) => <rect key={`${rect.x}-${rect.y}`} {...rect} />)}</g><rect className="product-brand-mark-accent" {...mdbaseMarkAccentRect} /></svg>; }
+export function PageBrand({ label, themePicker = true, markMotion }: { label: string; themePicker?: boolean; markMotion?: MdbaseMarkMotion }) { return <div className="page-brand-row"><div className="page-brand"><Brand markMotion={markMotion} /><span>{label}</span></div>{themePicker && <ThemeMenu />}</div>; }
+export function Brand({ productLabel = false, markMotion }: { productLabel?: boolean; markMotion?: MdbaseMarkMotion }) { return <div className="product-brand"><MdbaseMark motion={markMotion} /><strong>mdbase</strong>{productLabel && <span className="product-brand-label">connect</span>}</div>; }
+
+const conveyorXs = [-6, 22, 50, 78, 106] as const;
+
+function MarkSegment({ rect, index, accent = false }: {
+  rect: MdbaseMarkRect;
+  index: number;
+  accent?: boolean;
+}) {
+  return <rect
+    className={`mdbase-mark-segment mdbase-mark-segment-${index} ${accent ? "mdbase-mark-accent product-brand-mark-accent" : "mdbase-mark-ink"}`}
+    pathLength={1}
+    {...rect}
+  />;
+}
+
+function MdbaseMark({ motion }: { motion?: MdbaseMarkMotion }) {
+  const clipId = `mdbase-fences-${useId().replaceAll(":", "")}`;
+  return <svg className={`product-brand-mark mdbase-motion-mark${mdbaseMarkMotionClass(motion)}`} viewBox={MDBASE_MARK_VIEW_BOX} aria-hidden="true" focusable="false">
+    <defs><clipPath id={clipId}><rect x="22" y="22" width="76" height="10" rx="2" /><rect x="22" y="88" width="76" height="10" rx="2" /></clipPath></defs>
+    <g className="mdbase-mark-fence mdbase-mark-fence-top product-brand-mark-ink">
+      {mdbaseMarkInkRects.slice(0, 3).map((rect, index) => <MarkSegment key={`${rect.x}-${rect.y}`} rect={rect} index={index + 1} />)}
+    </g>
+    <g className="mdbase-mark-row mdbase-mark-row-top">
+      <MarkSegment rect={mdbaseMarkInkRects[3]} index={4} />
+      <MarkSegment rect={mdbaseMarkAccentRect} index={5} accent />
+    </g>
+    <g className="mdbase-mark-row mdbase-mark-row-bottom product-brand-mark-ink">
+      <MarkSegment rect={mdbaseMarkInkRects[4]} index={6} />
+      <MarkSegment rect={mdbaseMarkInkRects[5]} index={7} />
+    </g>
+    <g className="mdbase-mark-fence mdbase-mark-fence-bottom product-brand-mark-ink">
+      {mdbaseMarkInkRects.slice(6).map((rect, index) => <MarkSegment key={`${rect.x}-${rect.y}`} rect={rect} index={index + 8} />)}
+    </g>
+    <g clipPath={`url(#${clipId})`}><g className="mdbase-mark-conveyor-track">{conveyorXs.flatMap((x) => [22, 88].map((y) => <rect key={`${x}-${y}`} x={x} y={y} width="20" height="10" rx="2" />))}</g></g>
+  </svg>;
+}
 export function SectionHeading({ title, note, count }: { title: string; note: string; count?: number }) { return <div className="section-heading"><div><h2>{title}</h2><p>{note}</p></div>{count !== undefined && <span>{count}</span>}</div>; }
 export function Empty({ title, text }: { title: string; text: string }) { return <div className="empty"><span className="empty-folder" /><strong>{title}</strong><p>{text}</p></div>; }
-export function Loading({ error = "" }: { error?: string }) { return <main className="loading"><Brand /><p>{error || "Opening mdbase connect…"}</p></main>; }
+export function Loading({ error = "" }: { error?: string }) { return <main className="loading" aria-busy={!error}><Brand productLabel markMotion={error ? undefined : "bootstrap"} /><p>{error || "Opening mdbase connect…"}</p></main>; }
 
 function ThemeGlyph({ preference }: { preference: ThemePreference }) {
   if (preference === "light") return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="3" /><path d="M10 2.4v1.2M10 16.4v1.2M2.4 10h1.2M16.4 10h1.2M4.6 4.6l.9.9M14.5 14.5l.9.9M15.4 4.6l-.9.9M5.5 14.5l-.9.9" /></svg>;

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -2016,6 +2016,11 @@ select {
   font-size: 0.78rem;
 }
 
+.loading .product-brand-mark {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
 @media (max-width: 760px) {
   .account-main {
     padding: 2.5rem 1.5rem 4rem;

--- a/docs/product-design/icon-motion-system.html
+++ b/docs/product-design/icon-motion-system.html
@@ -1,0 +1,375 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="The adopted motion system for the mdbase Frontmatter mark.">
+  <title>mdbase icon motion system</title>
+  <link rel="stylesheet" href="../../packages/ui/motion.css">
+  <script>
+    (() => {
+      const saved = localStorage.getItem("mdbase:theme");
+      const dark = matchMedia("(prefers-color-scheme: dark)").matches;
+      document.documentElement.dataset.theme = saved === "dark" || (saved !== "light" && dark) ? "dark" : "light";
+    })();
+  </script>
+  <style>
+    :root {
+      color-scheme: light;
+      --paper: oklch(99.5% 0.002 255);
+      --surface: oklch(98% 0.003 255);
+      --ink: oklch(21% 0.018 255);
+      --ink-soft: oklch(39% 0.016 255);
+      --muted: oklch(54% 0.014 255);
+      --line: oklch(92% 0.006 255);
+      --line-strong: oklch(82% 0.008 255);
+      --accent: oklch(45% 0.105 238);
+      --ease: cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    :root[data-theme="dark"] {
+      color-scheme: dark;
+      --paper: oklch(17.5% 0.012 255);
+      --surface: oklch(19.5% 0.012 255);
+      --ink: oklch(92% 0.008 255);
+      --ink-soft: oklch(80% 0.01 255);
+      --muted: oklch(68% 0.012 255);
+      --line: oklch(29% 0.012 255);
+      --line-strong: oklch(40% 0.014 255);
+      --accent: oklch(73% 0.105 238);
+    }
+
+    * { box-sizing: border-box; }
+
+    html {
+      min-width: 320px;
+      background: var(--paper);
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--paper);
+      font-family: "Atkinson Hyperlegible", Atkinson, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    button { font: inherit; }
+
+    button:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 3px;
+    }
+
+    .topbar {
+      position: sticky;
+      z-index: 10;
+      top: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 58px;
+      padding: 0 clamp(18px, 4vw, 64px);
+      gap: 20px;
+      background: color-mix(in oklch, var(--paper) 94%, transparent);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(12px);
+    }
+
+    .brand {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      font: 650 13px/1 "Azeret Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: -0.025em;
+    }
+
+    .brand span {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 450;
+    }
+
+    .controls {
+      display: flex;
+      gap: 7px;
+    }
+
+    .controls button {
+      min-height: 34px;
+      padding: 0 11px;
+      color: var(--ink-soft);
+      background: transparent;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 620;
+      transition: color 170ms var(--ease), border-color 170ms var(--ease), background-color 170ms var(--ease);
+    }
+
+    .controls button:hover,
+    .controls button[aria-pressed="true"] {
+      color: var(--ink);
+      background: var(--surface);
+      border-color: var(--line-strong);
+    }
+
+    main {
+      width: min(1120px, calc(100% - 36px));
+      margin: 0 auto;
+      padding: clamp(70px, 10vw, 132px) 0 110px;
+    }
+
+    .intro {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 0.7fr);
+      align-items: end;
+      gap: clamp(42px, 8vw, 112px);
+    }
+
+    h1 {
+      max-width: 10ch;
+      margin: 0;
+      font-size: clamp(48px, 7vw, 88px);
+      font-weight: 720;
+      line-height: 0.95;
+      letter-spacing: -0.04em;
+      text-wrap: balance;
+    }
+
+    .intro p {
+      max-width: 55ch;
+      margin: 0;
+      color: var(--ink-soft);
+      font-size: clamp(15px, 1.5vw, 18px);
+      line-height: 1.55;
+    }
+
+    .usage {
+      width: 100%;
+      margin-top: clamp(64px, 9vw, 108px);
+      border-collapse: collapse;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .usage th,
+    .usage td {
+      padding: 14px 16px 14px 0;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .usage th {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 650;
+    }
+
+    .usage td:first-child {
+      width: 22%;
+      color: var(--ink);
+      font-weight: 700;
+    }
+
+    .usage td:nth-child(2) {
+      width: 34%;
+      color: var(--ink-soft);
+    }
+
+    .usage code {
+      color: var(--muted);
+      font: 520 10px/1.5 "Azeret Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .studies {
+      margin-top: clamp(76px, 10vw, 124px);
+      border-top: 1px solid var(--line-strong);
+    }
+
+    .study {
+      display: grid;
+      grid-template-columns: minmax(260px, 0.8fr) minmax(320px, 1.2fr);
+      min-height: 260px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .stage {
+      display: grid;
+      place-items: center;
+      min-height: 260px;
+      padding: 34px;
+      color: var(--ink);
+      background: var(--surface);
+      border: 0;
+      border-right: 1px solid var(--line);
+      cursor: pointer;
+    }
+
+    .stage:hover { background: color-mix(in oklch, var(--surface) 75%, var(--accent) 2%); }
+
+    .stage .mdbase-motion-mark {
+      width: 132px;
+      height: 132px;
+    }
+
+    .study-copy {
+      align-self: center;
+      padding: clamp(34px, 5vw, 62px);
+    }
+
+    .study-copy h2 {
+      margin: 0;
+      font-size: clamp(24px, 3vw, 34px);
+      line-height: 1;
+      letter-spacing: -0.03em;
+    }
+
+    .study-copy p {
+      max-width: 59ch;
+      margin: 14px 0 0;
+      color: var(--ink-soft);
+      font-size: 13px;
+      line-height: 1.55;
+    }
+
+    .study-copy code {
+      display: block;
+      margin-top: 18px;
+      color: var(--muted);
+      font: 520 10px/1.5 "Azeret Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    body[data-paused="true"] .mdbase-motion-mark * {
+      animation-play-state: paused !important;
+    }
+
+    footer {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 64px;
+      padding-top: 20px;
+      gap: 28px;
+      color: var(--muted);
+      border-top: 1px solid var(--line-strong);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    footer p { max-width: 62ch; margin: 0; }
+
+    @media (max-width: 720px) {
+      .intro,
+      .study { grid-template-columns: 1fr; }
+      .stage { border-right: 0; border-bottom: 1px solid var(--line); }
+      .usage th:nth-child(3), .usage td:nth-child(3) { display: none; }
+      footer { flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">mdbase <span>icon motion system</span></div>
+    <div class="controls" aria-label="Preview controls">
+      <button id="pause" type="button" aria-pressed="false">Pause</button>
+      <button id="theme" type="button">Dark</button>
+    </div>
+  </header>
+
+  <main>
+    <section class="intro">
+      <h1>Motion with a job.</h1>
+      <p>Four adopted behaviors for the Frontmatter mark. They identify mdbase while clarifying opening, structural preparation, or active machine work; they never replace status text.</p>
+    </section>
+
+    <table class="usage">
+      <thead><tr><th>Motion</th><th>Approved use</th><th>Production integration</th></tr></thead>
+      <tbody>
+        <tr><td>Trace → conveyor</td><td>Initial Connect and portal bootstrap loading.</td><td><code>motion="bootstrap"</code></td></tr>
+        <tr><td>Unfold</td><td>Opening a collection in the editor.</td><td><code>motion="unfold"</code></td></tr>
+        <tr><td>Field rebalance</td><td>Preparing a real type-contract setup.</td><td><code>motion="rebalance"</code></td></tr>
+        <tr><td>Gap conveyor</td><td>Indeterminate machine work with no meaningful progress count.</td><td><code>motion="conveyor"</code></td></tr>
+      </tbody>
+    </table>
+
+    <section class="studies" aria-label="Adopted motion previews">
+      <article class="study">
+        <button class="stage" type="button" data-motion="bootstrap" aria-label="Replay trace into gap conveyor"></button>
+        <div class="study-copy"><h2>Trace → gap conveyor</h2><p>The record draws once in reading order. If loading continues, the fixed fence bounds become a continuous conveyor while the key-value rows remain stable.</p><code>720ms trace · conveyor begins at 1.12s · 900ms linear loop</code></div>
+      </article>
+      <article class="study">
+        <button class="stage" type="button" data-motion="unfold" aria-label="Replay unfold"></button>
+        <div class="study-copy"><h2>Unfold</h2><p>The frontmatter fences open to reveal the two structured rows. This runs once when the editor opens a collection.</p><code>760ms · ease-out · one shot</code></div>
+      </article>
+      <article class="study">
+        <button class="stage" type="button" data-motion="rebalance" aria-label="Replay field rebalance"></button>
+        <div class="study-copy"><h2>Field rebalance</h2><p>The upper divider moves right while the lower divider moves left. Both row bounds and both 8px gaps remain exact.</p><code>1.8s · opposing structure loop</code></div>
+      </article>
+      <article class="study">
+        <button class="stage" type="button" data-motion="conveyor" aria-label="Replay gap conveyor"></button>
+        <div class="study-copy"><h2>Gap conveyor</h2><p>Repeated fence segments travel left beneath two exact 76 × 10 clips. Nothing overflows the canonical fence bounds.</p><code>900ms · linear · continuous only while work is active</code></div>
+      </article>
+    </section>
+
+    <footer>
+      <p>Use the static mark for errors, completion, connection health, approval, revocation, routine saves, and any reduced-motion preference.</p>
+      <p>The previews load <code>packages/ui/motion.css</code>, the same motion implementation used by the product.</p>
+    </footer>
+  </main>
+
+  <script>
+    const xs = [-6, 22, 50, 78, 106];
+    const segments = [
+      [22, 22, 20, 10], [50, 22, 20, 10], [78, 22, 20, 10],
+      [22, 44, 12, 10], [42, 44, 56, 10],
+      [22, 66, 28, 10], [58, 66, 40, 10],
+      [22, 88, 20, 10], [50, 88, 20, 10], [78, 88, 20, 10]
+    ];
+
+    function rect([x, y, width, height], index) {
+      const tone = index === 4 ? "mdbase-mark-accent" : "mdbase-mark-ink";
+      return `<rect class="mdbase-mark-segment mdbase-mark-segment-${index + 1} ${tone}" x="${x}" y="${y}" width="${width}" height="${height}" rx="2" pathLength="1"/>`;
+    }
+
+    function mark(motion, id) {
+      const conveyor = xs.flatMap((x) => [22, 88].map((y) => `<rect x="${x}" y="${y}" width="20" height="10" rx="2"/>`)).join("");
+      return `<svg class="mdbase-motion-mark mdbase-motion-${motion}" viewBox="18 18 84 84" aria-hidden="true" focusable="false">
+        <defs><clipPath id="fences-${id}"><rect x="22" y="22" width="76" height="10" rx="2"/><rect x="22" y="88" width="76" height="10" rx="2"/></clipPath></defs>
+        <g class="mdbase-mark-fence mdbase-mark-fence-top">${segments.slice(0, 3).map((value, index) => rect(value, index)).join("")}</g>
+        <g class="mdbase-mark-row mdbase-mark-row-top">${segments.slice(3, 5).map((value, index) => rect(value, index + 3)).join("")}</g>
+        <g class="mdbase-mark-row mdbase-mark-row-bottom">${segments.slice(5, 7).map((value, index) => rect(value, index + 5)).join("")}</g>
+        <g class="mdbase-mark-fence mdbase-mark-fence-bottom">${segments.slice(7).map((value, index) => rect(value, index + 7)).join("")}</g>
+        <g clip-path="url(#fences-${id})"><g class="mdbase-mark-conveyor-track">${conveyor}</g></g>
+      </svg>`;
+    }
+
+    const stages = [...document.querySelectorAll("[data-motion]")];
+    function renderStage(stage, index) {
+      stage.innerHTML = mark(stage.dataset.motion, index);
+    }
+    stages.forEach(renderStage);
+    stages.forEach((stage, index) => stage.addEventListener("click", () => renderStage(stage, index)));
+
+    const pause = document.querySelector("#pause");
+    pause.addEventListener("click", () => {
+      const paused = document.body.dataset.paused !== "true";
+      document.body.dataset.paused = String(paused);
+      pause.setAttribute("aria-pressed", String(paused));
+      pause.textContent = paused ? "Play" : "Pause";
+    });
+
+    const theme = document.querySelector("#theme");
+    function syncTheme() { theme.textContent = document.documentElement.dataset.theme === "dark" ? "Light" : "Dark"; }
+    syncTheme();
+    theme.addEventListener("click", () => {
+      const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+      document.documentElement.dataset.theme = next;
+      localStorage.setItem("mdbase:theme", next);
+      syncTheme();
+    });
+  </script>
+</body>
+</html>

--- a/docs/product-design/identity-system.md
+++ b/docs/product-design/identity-system.md
@@ -102,6 +102,11 @@ Good placements include:
 Avoid repeating the mark in section headings, empty states, collection rows,
 or permission controls. Repetition turns a precise identity into decoration.
 
+The adopted loading and transition behaviors, their semantic assignments, and
+live production previews are documented in the
+[icon motion system](icon-motion-system.html). Product implementations consume
+the shared motion classes from `packages/ui/motion.css`.
+
 ## Assets
 
 - [Default mark](../../assets/mdbase-icon.svg)

--- a/packages/ui/brand.test.ts
+++ b/packages/ui/brand.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import {
   mdbaseMarkAccentRect,
   mdbaseMarkInkRects,
+  mdbaseMarkMotionClass,
+  mdbaseMarkMotions,
   type MdbaseMarkRect
 } from "./brand.ts";
 
@@ -30,4 +32,10 @@ test("keeps key and fence proportions aligned", () => {
 
   assert.equal(firstKey.width + gap, dash.width);
   assert.equal(secondKey.width, dash.width + gap);
+});
+
+test("exposes only the adopted product motion vocabulary", () => {
+  assert.deepEqual(mdbaseMarkMotions, ["bootstrap", "unfold", "rebalance", "conveyor"]);
+  assert.equal(mdbaseMarkMotionClass(), "");
+  assert.equal(mdbaseMarkMotionClass("rebalance"), " mdbase-motion-rebalance");
 });

--- a/packages/ui/brand.ts
+++ b/packages/ui/brand.ts
@@ -6,6 +6,19 @@ export type MdbaseMarkRect = Readonly<{
   rx: number;
 }>;
 
+export const mdbaseMarkMotions = [
+  "bootstrap",
+  "unfold",
+  "rebalance",
+  "conveyor"
+] as const;
+
+export type MdbaseMarkMotion = typeof mdbaseMarkMotions[number];
+
+export function mdbaseMarkMotionClass(motion?: MdbaseMarkMotion): string {
+  return motion ? ` mdbase-motion-${motion}` : "";
+}
+
 export const MDBASE_MARK_VIEW_BOX = "18 18 84 84";
 
 export const mdbaseMarkInkRects = [

--- a/packages/ui/motion.css
+++ b/packages/ui/motion.css
@@ -1,0 +1,223 @@
+.mdbase-motion-mark {
+  overflow: visible;
+}
+
+.mdbase-motion-mark .mdbase-mark-segment,
+.mdbase-motion-mark .mdbase-mark-row,
+.mdbase-motion-mark .mdbase-mark-fence,
+.mdbase-motion-mark .mdbase-mark-conveyor-track {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.mdbase-motion-mark .mdbase-mark-ink,
+.mdbase-motion-mark .mdbase-mark-conveyor-track {
+  fill: currentColor;
+}
+
+.mdbase-motion-mark .mdbase-mark-accent {
+  fill: var(--accent);
+}
+
+.mdbase-motion-mark .mdbase-mark-conveyor-track {
+  opacity: 0;
+  transform-box: view-box;
+  transform-origin: 0 0;
+}
+
+/* Bootstrap: trace once in reading order, then continue as bounded I/O. */
+.mdbase-motion-bootstrap .mdbase-mark-segment {
+  --mdbase-trace-delay: 0ms;
+  stroke: currentColor;
+  stroke-width: 3;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  vector-effect: non-scaling-stroke;
+  animation: mdbase-trace-ink 720ms cubic-bezier(0.16, 1, 0.3, 1) var(--mdbase-trace-delay) 1 both;
+}
+
+.mdbase-motion-bootstrap .mdbase-mark-accent {
+  stroke: var(--accent);
+  animation-name: mdbase-trace-accent;
+}
+
+.mdbase-motion-bootstrap .mdbase-mark-segment-2 { --mdbase-trace-delay: 35ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-3 { --mdbase-trace-delay: 70ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-4 { --mdbase-trace-delay: 125ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-5 { --mdbase-trace-delay: 165ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-6 { --mdbase-trace-delay: 220ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-7 { --mdbase-trace-delay: 260ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-8 { --mdbase-trace-delay: 315ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-9 { --mdbase-trace-delay: 350ms; }
+.mdbase-motion-bootstrap .mdbase-mark-segment-10 { --mdbase-trace-delay: 385ms; }
+
+.mdbase-motion-bootstrap .mdbase-mark-fence {
+  animation: mdbase-hide-original-fence 1ms linear 1.12s 1 forwards;
+}
+
+.mdbase-motion-bootstrap .mdbase-mark-conveyor-track {
+  animation:
+    mdbase-show-conveyor 1ms linear 1.12s 1 forwards,
+    mdbase-gap-conveyor 900ms linear 1.12s infinite;
+}
+
+@keyframes mdbase-trace-ink {
+  0% {
+    fill: transparent;
+    opacity: 0;
+    stroke-dashoffset: 1;
+    stroke-opacity: 1;
+  }
+  10% { opacity: 1; }
+  54% {
+    fill: transparent;
+    opacity: 1;
+    stroke-dashoffset: 0;
+    stroke-opacity: 1;
+  }
+  72%,
+  100% {
+    fill: currentColor;
+    opacity: 1;
+    stroke-dashoffset: 0;
+    stroke-opacity: 0;
+  }
+}
+
+@keyframes mdbase-trace-accent {
+  0% {
+    fill: transparent;
+    opacity: 0;
+    stroke-dashoffset: 1;
+    stroke-opacity: 1;
+  }
+  10% { opacity: 1; }
+  54% {
+    fill: transparent;
+    opacity: 1;
+    stroke-dashoffset: 0;
+    stroke-opacity: 1;
+  }
+  72%,
+  100% {
+    fill: var(--accent);
+    opacity: 1;
+    stroke-dashoffset: 0;
+    stroke-opacity: 0;
+  }
+}
+
+@keyframes mdbase-hide-original-fence {
+  to { opacity: 0; }
+}
+
+@keyframes mdbase-show-conveyor {
+  to { opacity: 1; }
+}
+
+/* Unfold: the frontmatter boundary opens once to reveal its fields. */
+.mdbase-motion-unfold .mdbase-mark-fence-top {
+  animation: mdbase-unfold-top 760ms cubic-bezier(0.16, 1, 0.3, 1) 1 both;
+}
+
+.mdbase-motion-unfold .mdbase-mark-fence-bottom {
+  animation: mdbase-unfold-bottom 760ms cubic-bezier(0.16, 1, 0.3, 1) 1 both;
+}
+
+.mdbase-motion-unfold .mdbase-mark-row {
+  animation: mdbase-unfold-row 760ms cubic-bezier(0.16, 1, 0.3, 1) 70ms 1 both;
+}
+
+@keyframes mdbase-unfold-top {
+  from { transform: translateY(27px) scaleX(0.62); }
+  to { transform: translateY(0) scaleX(1); }
+}
+
+@keyframes mdbase-unfold-bottom {
+  from { transform: translateY(-27px) scaleX(0.62); }
+  to { transform: translateY(0) scaleX(1); }
+}
+
+@keyframes mdbase-unfold-row {
+  from { opacity: 0; transform: scaleX(0.45); }
+  to { opacity: 1; transform: scaleX(1); }
+}
+
+/* Rebalance: two fixed-width rows change structure in opposite directions. */
+.mdbase-motion-rebalance .mdbase-mark-segment-4,
+.mdbase-motion-rebalance .mdbase-mark-segment-6 {
+  transform-origin: left center;
+}
+
+.mdbase-motion-rebalance .mdbase-mark-segment-5,
+.mdbase-motion-rebalance .mdbase-mark-segment-7 {
+  transform-origin: right center;
+}
+
+.mdbase-motion-rebalance .mdbase-mark-segment-4 {
+  animation: mdbase-rebalance-top-key 1.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.mdbase-motion-rebalance .mdbase-mark-segment-5 {
+  animation: mdbase-rebalance-top-value 1.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.mdbase-motion-rebalance .mdbase-mark-segment-6 {
+  animation: mdbase-rebalance-bottom-key 1.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.mdbase-motion-rebalance .mdbase-mark-segment-7 {
+  animation: mdbase-rebalance-bottom-value 1.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+@keyframes mdbase-rebalance-top-key {
+  0%, 15%, 100% { transform: scaleX(1); }
+  42%, 72% { transform: scaleX(2.666667); }
+}
+
+@keyframes mdbase-rebalance-top-value {
+  0%, 15%, 100% { transform: scaleX(1); }
+  42%, 72% { transform: scaleX(0.642857); }
+}
+
+@keyframes mdbase-rebalance-bottom-key {
+  0%, 15%, 100% { transform: scaleX(1); }
+  42%, 72% { transform: scaleX(0.428571); }
+}
+
+@keyframes mdbase-rebalance-bottom-value {
+  0%, 15%, 100% { transform: scaleX(1); }
+  42%, 72% { transform: scaleX(1.4); }
+}
+
+/* Conveyor: repeated fence segments travel left inside exact fence clips. */
+.mdbase-motion-conveyor .mdbase-mark-fence {
+  opacity: 0;
+}
+
+.mdbase-motion-conveyor .mdbase-mark-conveyor-track {
+  opacity: 1;
+  animation: mdbase-gap-conveyor 900ms linear infinite;
+}
+
+@keyframes mdbase-gap-conveyor {
+  from { transform: translateX(0); }
+  to { transform: translateX(-28px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mdbase-motion-mark .mdbase-mark-segment,
+  .mdbase-motion-mark .mdbase-mark-row,
+  .mdbase-motion-mark .mdbase-mark-fence,
+  .mdbase-motion-mark .mdbase-mark-conveyor-track {
+    animation: none !important;
+    filter: none !important;
+    opacity: 1;
+    stroke: none;
+    transform: none !important;
+  }
+
+  .mdbase-motion-mark .mdbase-mark-conveyor-track {
+    opacity: 0;
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
     "./access": "./access.ts",
     "./brand": "./brand.ts",
     "./contract-setup": "./contract-setup.ts",
+    "./motion.css": "./motion.css",
     "./theme": "./theme.ts",
     "./styles.css": "./styles.css"
   },


### PR DESCRIPTION
## Summary

- add the shared `bootstrap`, `unfold`, `rebalance`, and `conveyor` mark motions
- use them for editor opening, Connect/portal loading, and structural authorization setup
- respect reduced-motion preferences and keep error marks static
- replace the exploratory study with a canonical production motion reference

## Why

The mdbase mark now communicates a small set of meaningful product states with one shared implementation instead of one-off loading decoration.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test` (two load-related editor timeouts in the concurrent run; standalone editor rerun passed 244/244)
- `pnpm e2e`
