### PR TITLE
Add managed hosted key wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,23 +641,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.15",
- "http 0.2.12",
+ "h2",
  "http 1.4.2",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.11.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -830,7 +824,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1892,25 +1886,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
@@ -2104,30 +2079,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
@@ -2136,7 +2087,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -2150,32 +2101,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.2",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.9",
 ]
@@ -2192,12 +2128,12 @@ dependencies = [
  "futures-util",
  "http 1.4.2",
  "http-body 1.1.0",
- "hyper 1.11.0",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3333,8 +3269,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.42",
- "socket2 0.6.5",
+ "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3354,7 +3290,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -3372,7 +3308,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3552,22 +3488,22 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
@@ -3646,18 +3582,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
@@ -3666,7 +3590,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3691,16 +3615,6 @@ checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3756,16 +3670,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sec1"
@@ -4051,16 +3955,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -4131,7 +4025,7 @@ dependencies = [
  "log",
  "memchr",
  "percent-encoding",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "serde",
  "serde_json",
@@ -4461,7 +4355,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4479,21 +4373,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls",
  "tokio",
 ]
 
@@ -4516,10 +4400,10 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -4713,7 +4597,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.7",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -290,6 +290,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +364,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -353,6 +383,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-kms"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217276b3d948ec05b2726d66b2c9013567ca42751052c287ec45800ee81799c9"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,8 +420,8 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -389,6 +444,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-sso"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sigv4"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,7 +527,7 @@ checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -432,7 +563,7 @@ version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -456,6 +587,27 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -512,6 +664,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
 version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
@@ -531,13 +692,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
 name = "aws-smithy-runtime"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1255,7 +1426,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1365,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2026,7 +2197,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2554,8 +2725,12 @@ version = "0.1.0-beta.23"
 dependencies = [
  "aes-gcm",
  "async-trait",
+ "aws-config",
  "aws-credential-types",
+ "aws-sdk-kms",
  "aws-sdk-s3",
+ "aws-smithy-types",
+ "aws-types",
  "axum",
  "base64",
  "chrono",
@@ -2584,6 +2759,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2782,7 +2958,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,7 +3334,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -3196,9 +3372,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3465,7 +3641,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3890,7 +4066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4183,10 +4359,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4633,6 +4809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,7 +5024,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tower-http = { version = "0.7.0", features = ["cors", "limit", "request-id", "tr
 unicode-normalization = "0.1"
 uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 url = "2"
-zeroize = "1"
+zeroize = { version = "1", features = ["derive"] }
 
 [profile.profiling]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ repository = "https://github.com/mdbase-dev/mdbase-connect"
 aes-gcm = "0.11"
 async-trait = "0.1"
 aws-credential-types = "=1.2.14"
+aws-config = "=1.8.12"
+aws-sdk-kms = "=1.110.0"
 aws-sdk-s3 = "=1.137.0"
+aws-smithy-types = "=1.5.0"
+aws-types = "=1.3.16"
 axum = "0.8.9"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
@@ -58,6 +62,7 @@ tower-http = { version = "0.7.0", features = ["cors", "limit", "request-id", "tr
 unicode-normalization = "0.1"
 uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 url = "2"
+zeroize = "1"
 
 [profile.profiling]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ repository = "https://github.com/mdbase-dev/mdbase-connect"
 aes-gcm = "0.11"
 async-trait = "0.1"
 aws-credential-types = "=1.2.14"
-aws-config = "=1.8.12"
-aws-sdk-kms = "=1.110.0"
-aws-sdk-s3 = "=1.137.0"
+aws-config = { version = "=1.8.12", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio", "sso"] }
+aws-sdk-kms = { version = "=1.110.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { version = "=1.137.0", default-features = false, features = ["default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
 aws-smithy-types = "=1.5.0"
 aws-types = "=1.3.16"
 axum = "0.8.9"

--- a/crates/connect-hosted-provider/Cargo.toml
+++ b/crates/connect-hosted-provider/Cargo.toml
@@ -9,7 +9,11 @@ repository.workspace = true
 aes-gcm.workspace = true
 async-trait.workspace = true
 aws-credential-types.workspace = true
+aws-config.workspace = true
+aws-sdk-kms.workspace = true
 aws-sdk-s3.workspace = true
+aws-smithy-types.workspace = true
+aws-types.workspace = true
 axum.workspace = true
 base64.workspace = true
 clap.workspace = true
@@ -38,5 +42,6 @@ tracing-subscriber.workspace = true
 unicode-normalization.workspace = true
 uuid.workspace = true
 url.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]

--- a/crates/connect-hosted-provider/src/bin/mdbase-hosted-key-admin.rs
+++ b/crates/connect-hosted-provider/src/bin/mdbase-hosted-key-admin.rs
@@ -1,0 +1,192 @@
+use std::{process::ExitCode, time::Duration};
+
+use clap::{Parser, Subcommand, ValueEnum};
+use mdbase_connect_hosted_provider::{
+    HostedKeyAdmin, KeyRewrapOptions, KeyWrapError, KeyWrappingBackend, KeyWrappingConfig,
+    ProviderCrypto,
+};
+use serde::Serialize;
+
+#[derive(Parser)]
+#[command(name = "mdbase-hosted-key-admin")]
+#[command(
+    about = "Inspect and migrate hosted-provider wrapped data keys without exposing key material"
+)]
+struct Arguments {
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KEY_WRAPPER",
+        value_enum,
+        default_value = "local"
+    )]
+    key_wrapper: KeyWrapperArgument,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KEY_ENVIRONMENT",
+        default_value = "local"
+    )]
+    key_environment: String,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_KMS_KEY_ID")]
+    kms_key_id: Option<String>,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_KMS_REGION")]
+    kms_region: Option<String>,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KMS_MAX_ATTEMPTS",
+        default_value_t = 3
+    )]
+    kms_max_attempts: u32,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KMS_TIMEOUT_SECONDS",
+        default_value_t = 10
+    )]
+    kms_timeout_seconds: u64,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum KeyWrapperArgument {
+    Local,
+    AwsKms,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Inspect,
+    Rewrap {
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        finalize_key_check: bool,
+        #[arg(long, default_value_t = 1_000_000)]
+        max_rows: u64,
+    },
+}
+
+#[derive(Serialize)]
+struct Success<T: Serialize> {
+    ok: bool,
+    result: T,
+}
+
+#[derive(Serialize)]
+struct Failure<'a> {
+    ok: bool,
+    error: FailureBody<'a>,
+}
+
+#[derive(Serialize)]
+struct FailureBody<'a> {
+    code: &'a str,
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run(Arguments::parse()).await {
+        Ok(value) => {
+            println!(
+                "{}",
+                serde_json::to_string(&value).expect("admin result serializes")
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!(
+                "{}",
+                serde_json::to_string(&Failure {
+                    ok: false,
+                    error: FailureBody {
+                        code: error.code(),
+                        message: error.to_string(),
+                    },
+                })
+                .expect("admin error serializes")
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(arguments: Arguments) -> Result<serde_json::Value, AdminError> {
+    let database_url = required_environment("DATABASE_URL")?;
+    let master_key = optional_environment("MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY")?;
+    let environment = arguments.key_environment;
+    let runtime = KeyWrappingConfig {
+        backend: match arguments.key_wrapper {
+            KeyWrapperArgument::Local => KeyWrappingBackend::Local,
+            KeyWrapperArgument::AwsKms => KeyWrappingBackend::AwsKms,
+        },
+        environment: environment.clone(),
+        legacy_master_key: master_key,
+        kms_key_id: arguments.kms_key_id,
+        kms_region: arguments.kms_region,
+        kms_max_attempts: arguments.kms_max_attempts,
+        kms_timeout: Duration::from_secs(arguments.kms_timeout_seconds),
+        cache_entries: 0,
+        cache_ttl: Duration::ZERO,
+    }
+    .build()
+    .await?;
+    let crypto = ProviderCrypto::with_key_wrapping(runtime, environment)?;
+    let admin = HostedKeyAdmin::connect(&database_url, crypto).await?;
+    match arguments.command {
+        Command::Inspect => Ok(serde_json::to_value(Success {
+            ok: true,
+            result: admin.inspect().await?,
+        })?),
+        Command::Rewrap {
+            dry_run,
+            finalize_key_check,
+            max_rows,
+        } => Ok(serde_json::to_value(Success {
+            ok: true,
+            result: admin
+                .rewrap(KeyRewrapOptions {
+                    dry_run,
+                    finalize_key_check,
+                    max_rows,
+                })
+                .await?,
+        })?),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum AdminError {
+    #[error("Required environment configuration is missing or invalid: {0}.")]
+    Environment(&'static str),
+    #[error("{0}")]
+    Key(#[from] KeyWrapError),
+    #[error("{0}")]
+    Provider(#[from] mdbase_connect_hosted_provider::ApiError),
+    #[error("The key administration result could not serialize.")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl AdminError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::Environment(_) => "environment_configuration_error",
+            Self::Key(_) => "key_configuration_error",
+            Self::Provider(error) => error.code,
+            Self::Serialization(_) => "serialization_error",
+        }
+    }
+}
+
+fn required_environment(name: &'static str) -> Result<String, AdminError> {
+    optional_environment(name)?.ok_or(AdminError::Environment(name))
+}
+
+fn optional_environment(name: &'static str) -> Result<Option<String>, AdminError> {
+    match std::env::var(name) {
+        Ok(value) if value.trim().is_empty() => Ok(None),
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(AdminError::Environment(name)),
+    }
+}

--- a/crates/connect-hosted-provider/src/crypto.rs
+++ b/crates/connect-hosted-provider/src/crypto.rs
@@ -1,30 +1,43 @@
-use base64::{engine::general_purpose, Engine as _};
 use rand_core::{OsRng, RngCore};
 use serde::{de::DeserializeOwned, Serialize};
 use subtle::ConstantTimeEq;
 
 use crate::{
     error::{ApiError, ApiResult},
+    key_wrapping::{
+        KeyWrapContext, KeyWrapError, KeyWrapErrorKind, KeyWrappingRuntime, LegacyKeyWrapper,
+    },
     symmetric_crypto::{decrypt, encrypt},
 };
 
 const KEY_BYTES: usize = 32;
 const KEY_CHECK_PLAINTEXT: &[u8] = b"mdbase-connect-hosted-provider-key-check-v1";
-const KEY_CHECK_AAD: &[u8] = b"provider-key-check-v1";
 
 #[derive(Clone)]
 pub struct ProviderCrypto {
-    master_key: [u8; KEY_BYTES],
+    key_wrapping: KeyWrappingRuntime,
+    environment: String,
 }
 
 impl ProviderCrypto {
     pub fn from_base64(value: &str) -> ApiResult<Self> {
-        let decoded = general_purpose::URL_SAFE_NO_PAD
-            .decode(value)
-            .or_else(|_| general_purpose::STANDARD.decode(value))
-            .map_err(|_| invalid_master_key())?;
-        let master_key: [u8; KEY_BYTES] = decoded.try_into().map_err(|_| invalid_master_key())?;
-        Ok(Self { master_key })
+        let legacy = LegacyKeyWrapper::from_base64(value).map_err(|_| invalid_master_key())?;
+        Ok(Self {
+            key_wrapping: KeyWrappingRuntime::legacy(legacy),
+            environment: "local".to_string(),
+        })
+    }
+
+    pub fn with_key_wrapping(
+        key_wrapping: KeyWrappingRuntime,
+        environment: impl Into<String>,
+    ) -> ApiResult<Self> {
+        let environment = environment.into();
+        KeyWrapContext::provider_key_check(environment.clone()).map_err(key_wrap_error)?;
+        Ok(Self {
+            key_wrapping,
+            environment,
+        })
     }
 
     pub fn generate_data_key(&self) -> [u8; KEY_BYTES] {
@@ -33,12 +46,19 @@ impl ProviderCrypto {
         key
     }
 
-    pub fn create_key_check(&self) -> ApiResult<Vec<u8>> {
-        encrypt(&self.master_key, KEY_CHECK_PLAINTEXT, KEY_CHECK_AAD)
+    pub async fn create_key_check(&self) -> ApiResult<Vec<u8>> {
+        self.key_wrapping
+            .wrap_bytes(KEY_CHECK_PLAINTEXT, &self.key_check_context()?)
+            .await
+            .map_err(key_wrap_error)
     }
 
-    pub fn verify_key_check(&self, value: &[u8]) -> ApiResult<()> {
-        let plaintext = decrypt(&self.master_key, value, KEY_CHECK_AAD)?;
+    pub async fn verify_key_check(&self, value: &[u8]) -> ApiResult<()> {
+        let plaintext = self
+            .key_wrapping
+            .unwrap_bytes(value, &self.key_check_context()?)
+            .await
+            .map_err(key_wrap_error)?;
         if bool::from(plaintext.ct_eq(KEY_CHECK_PLAINTEXT)) {
             Ok(())
         } else {
@@ -48,14 +68,26 @@ impl ProviderCrypto {
         }
     }
 
-    pub fn wrap_data_key(&self, data_key: &[u8; KEY_BYTES], aad: &[u8]) -> ApiResult<Vec<u8>> {
-        encrypt(&self.master_key, data_key, aad)
+    pub async fn wrap_data_key(
+        &self,
+        data_key: &[u8; KEY_BYTES],
+        collection_id: uuid::Uuid,
+    ) -> ApiResult<Vec<u8>> {
+        self.key_wrapping
+            .wrap_data_key(data_key, &self.collection_context(collection_id)?)
+            .await
+            .map_err(key_wrap_error)
     }
 
-    pub fn unwrap_data_key(&self, wrapped: &[u8], aad: &[u8]) -> ApiResult<[u8; KEY_BYTES]> {
-        decrypt(&self.master_key, wrapped, aad)?
-            .try_into()
-            .map_err(|_| ApiError::internal("The hosted collection data key is invalid."))
+    pub async fn unwrap_data_key(
+        &self,
+        wrapped: &[u8],
+        collection_id: uuid::Uuid,
+    ) -> ApiResult<zeroize::Zeroizing<[u8; KEY_BYTES]>> {
+        self.key_wrapping
+            .unwrap_data_key(wrapped, &self.collection_context(collection_id)?)
+            .await
+            .map_err(key_wrap_error)
     }
 
     pub fn encrypt_json<T: Serialize>(
@@ -101,6 +133,45 @@ impl ProviderCrypto {
     ) -> ApiResult<Vec<u8>> {
         decrypt(data_key, value, aad)
     }
+
+    pub fn active_key_ref(&self) -> &str {
+        self.key_wrapping.active_key_ref()
+    }
+
+    fn collection_context(&self, collection_id: uuid::Uuid) -> ApiResult<KeyWrapContext> {
+        KeyWrapContext::collection(self.environment.clone(), collection_id).map_err(key_wrap_error)
+    }
+
+    fn key_check_context(&self) -> ApiResult<KeyWrapContext> {
+        KeyWrapContext::provider_key_check(self.environment.clone()).map_err(key_wrap_error)
+    }
+}
+
+fn key_wrap_error(error: KeyWrapError) -> ApiError {
+    tracing::error!(kind = ?error.kind, "hosted provider key-wrapping operation failed");
+    match error.kind {
+        KeyWrapErrorKind::Throttled | KeyWrapErrorKind::Timeout | KeyWrapErrorKind::Unavailable => {
+            ApiError::new(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "managed_key_service_unavailable",
+                "The hosted provider key service is temporarily unavailable.",
+            )
+        }
+        KeyWrapErrorKind::AccessDenied
+        | KeyWrapErrorKind::Configuration
+        | KeyWrapErrorKind::Disabled
+        | KeyWrapErrorKind::WrongKey => ApiError::new(
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "key_wrapping_unavailable",
+            "The hosted provider cannot access its configured key hierarchy.",
+        ),
+        KeyWrapErrorKind::InvalidCiphertext
+        | KeyWrapErrorKind::InvalidEnvelope
+        | KeyWrapErrorKind::InvalidResponse
+        | KeyWrapErrorKind::UnsupportedEnvelope => {
+            ApiError::internal("The hosted provider stored key material is invalid or unsupported.")
+        }
+    }
 }
 
 fn invalid_master_key() -> ApiError {
@@ -118,16 +189,24 @@ mod tests {
         ProviderCrypto::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap()
     }
 
-    #[test]
-    fn wraps_keys_and_authenticates_payload_identity() {
+    #[tokio::test]
+    async fn wraps_keys_and_authenticates_payload_identity() {
         let crypto = crypto();
         let data_key = crypto.generate_data_key();
-        let wrapped = crypto.wrap_data_key(&data_key, b"collection:one").unwrap();
+        let collection_id = uuid::Uuid::new_v4();
+        let wrapped = crypto
+            .wrap_data_key(&data_key, collection_id)
+            .await
+            .unwrap();
         assert_ne!(&wrapped[13..45], data_key.as_slice());
-        let unwrapped = crypto.unwrap_data_key(&wrapped, b"collection:one").unwrap();
-        assert_eq!(unwrapped, data_key);
+        let unwrapped = crypto
+            .unwrap_data_key(&wrapped, collection_id)
+            .await
+            .unwrap();
+        assert_eq!(unwrapped.as_ref(), &data_key);
         assert!(crypto
-            .unwrap_data_key(&wrapped, b"collection:other")
+            .unwrap_data_key(&wrapped, uuid::Uuid::new_v4())
+            .await
             .is_err());
     }
 

--- a/crates/connect-hosted-provider/src/crypto.rs
+++ b/crates/connect-hosted-provider/src/crypto.rs
@@ -1,17 +1,14 @@
-use aes_gcm::{
-    aead::{Aead, KeyInit, Payload},
-    Aes256Gcm, Nonce,
-};
 use base64::{engine::general_purpose, Engine as _};
 use rand_core::{OsRng, RngCore};
 use serde::{de::DeserializeOwned, Serialize};
 use subtle::ConstantTimeEq;
 
-use crate::error::{ApiError, ApiResult};
+use crate::{
+    error::{ApiError, ApiResult},
+    symmetric_crypto::{decrypt, encrypt},
+};
 
-const ENVELOPE_VERSION: u8 = 1;
 const KEY_BYTES: usize = 32;
-const NONCE_BYTES: usize = 12;
 const KEY_CHECK_PLAINTEXT: &[u8] = b"mdbase-connect-hosted-provider-key-check-v1";
 const KEY_CHECK_AAD: &[u8] = b"provider-key-check-v1";
 
@@ -104,51 +101,6 @@ impl ProviderCrypto {
     ) -> ApiResult<Vec<u8>> {
         decrypt(data_key, value, aad)
     }
-}
-
-fn encrypt(key: &[u8; KEY_BYTES], plaintext: &[u8], aad: &[u8]) -> ApiResult<Vec<u8>> {
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
-    let mut nonce = [0_u8; NONCE_BYTES];
-    OsRng.fill_bytes(&mut nonce);
-    let nonce = Nonce::from(nonce);
-    let ciphertext = cipher
-        .encrypt(
-            &nonce,
-            Payload {
-                msg: plaintext,
-                aad,
-            },
-        )
-        .map_err(|_| ApiError::internal("The hosted value could not be encrypted."))?;
-    let mut envelope = Vec::with_capacity(1 + NONCE_BYTES + ciphertext.len());
-    envelope.push(ENVELOPE_VERSION);
-    envelope.extend_from_slice(&nonce);
-    envelope.extend_from_slice(&ciphertext);
-    Ok(envelope)
-}
-
-fn decrypt(key: &[u8; KEY_BYTES], envelope: &[u8], aad: &[u8]) -> ApiResult<Vec<u8>> {
-    if envelope.len() <= 1 + NONCE_BYTES || envelope[0] != ENVELOPE_VERSION {
-        return Err(ApiError::internal(
-            "The hosted ciphertext envelope is invalid.",
-        ));
-    }
-    let cipher = Aes256Gcm::new_from_slice(key)
-        .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
-    let nonce_bytes: [u8; NONCE_BYTES] = envelope[1..1 + NONCE_BYTES]
-        .try_into()
-        .map_err(|_| ApiError::internal("The hosted ciphertext envelope is invalid."))?;
-    let nonce = Nonce::from(nonce_bytes);
-    cipher
-        .decrypt(
-            &nonce,
-            Payload {
-                msg: &envelope[1 + NONCE_BYTES..],
-                aad,
-            },
-        )
-        .map_err(|_| ApiError::internal("The hosted ciphertext failed authentication."))
 }
 
 fn invalid_master_key() -> ApiError {

--- a/crates/connect-hosted-provider/src/key_admin.rs
+++ b/crates/connect-hosted-provider/src/key_admin.rs
@@ -1,0 +1,457 @@
+use std::collections::BTreeMap;
+
+use futures_util::TryStreamExt;
+use serde::Serialize;
+use sqlx::{postgres::PgPoolOptions, PgPool, Row};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    key_wrapping::{KeyWrapErrorKind, KeyWrapInspection, KeyWrappingRuntime},
+    provider::hosted_migrator,
+    ProviderCrypto,
+};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct KeyWrapInventory {
+    pub active_key_ref: String,
+    pub collections_total: u64,
+    pub collections_active: u64,
+    pub collections_legacy: u64,
+    pub collections_managed_other: u64,
+    pub collections_invalid: u64,
+    pub managed_key_refs: BTreeMap<String, u64>,
+    pub provider_key_check: String,
+}
+
+impl KeyWrapInventory {
+    pub fn migration_complete(&self) -> bool {
+        self.collections_invalid == 0
+            && self.collections_total == self.collections_active
+            && self.provider_key_check == active_key_label(&self.active_key_ref)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct KeyRewrapOptions {
+    pub dry_run: bool,
+    pub finalize_key_check: bool,
+    pub max_rows: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeyRewrapReport {
+    pub dry_run: bool,
+    pub scanned: u64,
+    pub would_rewrap: u64,
+    pub rewrapped: u64,
+    pub already_active: u64,
+    pub concurrent_changes: u64,
+    pub key_check_finalized: bool,
+    pub migration_complete: bool,
+    pub before: KeyWrapInventory,
+    pub after: KeyWrapInventory,
+}
+
+pub struct HostedKeyAdmin {
+    pool: PgPool,
+    crypto: ProviderCrypto,
+}
+
+impl HostedKeyAdmin {
+    pub async fn connect(database_url: &str, crypto: ProviderCrypto) -> ApiResult<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(database_url)
+            .await?;
+        hosted_migrator().run(&pool).await.map_err(|error| {
+            tracing::error!(%error, "hosted key administration migration check failed");
+            ApiError::internal("The hosted provider database migration check failed.")
+        })?;
+        let key_check: Vec<u8> = sqlx::query_scalar(
+            "SELECT key_check FROM hosted_provider_metadata WHERE singleton = true",
+        )
+        .fetch_one(&pool)
+        .await?;
+        crypto.verify_key_check(&key_check).await?;
+        Ok(Self { pool, crypto })
+    }
+
+    pub async fn inspect(&self) -> ApiResult<KeyWrapInventory> {
+        let key_check: Vec<u8> = sqlx::query_scalar(
+            "SELECT key_check FROM hosted_provider_metadata WHERE singleton = true",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let mut inventory = empty_inventory(self.crypto.active_key_ref(), &key_check);
+        let mut rows = sqlx::query_scalar::<_, Vec<u8>>(
+            "SELECT wrapped_data_key FROM hosted_provider_collections",
+        )
+        .fetch(&self.pool);
+        while let Some(value) = rows.try_next().await? {
+            add_to_inventory(&mut inventory, &value);
+        }
+        Ok(inventory)
+    }
+
+    pub async fn rewrap(&self, options: KeyRewrapOptions) -> ApiResult<KeyRewrapReport> {
+        if options.max_rows == 0 || options.max_rows > 1_000_000 {
+            return Err(ApiError::bad_request(
+                "invalid_rewrap_limit",
+                "The hosted key rewrap row limit must be between 1 and 1000000.",
+            ));
+        }
+        if options.dry_run && options.finalize_key_check {
+            return Err(ApiError::bad_request(
+                "invalid_rewrap_options",
+                "A dry run cannot finalize the provider key check.",
+            ));
+        }
+        let before = self.inspect().await?;
+        if before.collections_invalid > 0 {
+            return Err(ApiError::internal(
+                "Stored key envelopes are invalid; rewrap refused before mutation.",
+            ));
+        }
+        let mut cursor: Option<Uuid> = None;
+        let mut scanned = 0;
+        let mut would_rewrap = 0;
+        let mut rewrapped = 0;
+        let mut already_active = 0;
+        let mut concurrent_changes = 0;
+        while scanned < options.max_rows {
+            let mut transaction = self.pool.begin().await?;
+            let row = sqlx::query(
+                r#"SELECT id, wrapped_data_key
+                   FROM hosted_provider_collections
+                   WHERE ($1::uuid IS NULL OR id > $1)
+                   ORDER BY id
+                   LIMIT 1
+                   FOR UPDATE SKIP LOCKED"#,
+            )
+            .bind(cursor)
+            .fetch_optional(&mut *transaction)
+            .await?;
+            let Some(row) = row else {
+                transaction.commit().await?;
+                break;
+            };
+            let collection_id: Uuid = row.get("id");
+            let original: Vec<u8> = row.get("wrapped_data_key");
+            cursor = Some(collection_id);
+            scanned += 1;
+            match KeyWrappingRuntime::inspect(&original) {
+                Ok(KeyWrapInspection::AwsKmsV1 { key_ref })
+                    if key_ref == self.crypto.active_key_ref() =>
+                {
+                    already_active += 1;
+                    if options.dry_run {
+                        self.crypto
+                            .unwrap_data_key(&original, collection_id)
+                            .await?;
+                        transaction.rollback().await?;
+                    } else {
+                        transaction.commit().await?;
+                    }
+                    continue;
+                }
+                Ok(_) => {}
+                Err(_) => {
+                    transaction.rollback().await?;
+                    return Err(ApiError::internal(
+                        "A stored key envelope became invalid during rewrap.",
+                    ));
+                }
+            }
+            let data_key = self
+                .crypto
+                .unwrap_data_key(&original, collection_id)
+                .await?;
+            let replacement = self.crypto.wrap_data_key(&data_key, collection_id).await?;
+            if options.dry_run {
+                would_rewrap += 1;
+                transaction.rollback().await?;
+                continue;
+            }
+            let updated = sqlx::query(
+                "UPDATE hosted_provider_collections SET wrapped_data_key = $2, updated_at = now() WHERE id = $1 AND wrapped_data_key = $3",
+            )
+            .bind(collection_id)
+            .bind(replacement)
+            .bind(original)
+            .execute(&mut *transaction)
+            .await?;
+            if updated.rows_affected() == 1 {
+                rewrapped += 1;
+            } else {
+                concurrent_changes += 1;
+            }
+            transaction.commit().await?;
+        }
+
+        let mut after = self.inspect().await?;
+        let all_collections_active =
+            after.collections_invalid == 0 && after.collections_total == after.collections_active;
+        let mut key_check_finalized = false;
+        if options.finalize_key_check {
+            if !all_collections_active {
+                return Err(ApiError::conflict(
+                    "key_rewrap_incomplete",
+                    "The provider key check cannot change while any collection uses another wrapper.",
+                ));
+            }
+            let replacement = self.crypto.create_key_check().await?;
+            sqlx::query(
+                "UPDATE hosted_provider_metadata SET key_check = $1 WHERE singleton = true",
+            )
+            .bind(&replacement)
+            .execute(&self.pool)
+            .await?;
+            self.crypto.verify_key_check(&replacement).await?;
+            key_check_finalized = true;
+            after = self.inspect().await?;
+        }
+        Ok(KeyRewrapReport {
+            dry_run: options.dry_run,
+            scanned,
+            would_rewrap,
+            rewrapped,
+            already_active,
+            concurrent_changes,
+            key_check_finalized,
+            migration_complete: after.migration_complete(),
+            before,
+            after,
+        })
+    }
+}
+
+#[cfg(test)]
+fn summarize_inventory<'a>(
+    active_key_ref: &str,
+    collections: impl Iterator<Item = &'a [u8]>,
+    key_check: &[u8],
+) -> KeyWrapInventory {
+    let mut inventory = empty_inventory(active_key_ref, key_check);
+    for value in collections {
+        add_to_inventory(&mut inventory, value);
+    }
+    inventory
+}
+
+fn empty_inventory(active_key_ref: &str, key_check: &[u8]) -> KeyWrapInventory {
+    KeyWrapInventory {
+        active_key_ref: active_key_ref.to_string(),
+        collections_total: 0,
+        collections_active: 0,
+        collections_legacy: 0,
+        collections_managed_other: 0,
+        collections_invalid: 0,
+        managed_key_refs: BTreeMap::new(),
+        provider_key_check: inspection_label(key_check),
+    }
+}
+
+fn add_to_inventory(inventory: &mut KeyWrapInventory, value: &[u8]) {
+    inventory.collections_total += 1;
+    match KeyWrappingRuntime::inspect(value) {
+        Ok(KeyWrapInspection::LocalAes256GcmV1) => inventory.collections_legacy += 1,
+        Ok(KeyWrapInspection::AwsKmsV1 { key_ref }) => {
+            *inventory
+                .managed_key_refs
+                .entry(key_ref.clone())
+                .or_insert(0) += 1;
+            if key_ref == inventory.active_key_ref {
+                inventory.collections_active += 1;
+            } else {
+                inventory.collections_managed_other += 1;
+            }
+        }
+        Err(_) => inventory.collections_invalid += 1,
+    }
+}
+
+fn inspection_label(value: &[u8]) -> String {
+    match KeyWrappingRuntime::inspect(value) {
+        Ok(KeyWrapInspection::LocalAes256GcmV1) => "local-aes-256-gcm-v1".to_string(),
+        Ok(KeyWrapInspection::AwsKmsV1 { key_ref }) => format!("aws-kms-v1:{key_ref}"),
+        Err(error) => format!("invalid:{}", error_kind_label(error.kind)),
+    }
+}
+
+fn active_key_label(active_key_ref: &str) -> String {
+    if active_key_ref == "local-aes-256-gcm-v1" {
+        active_key_ref.to_string()
+    } else {
+        format!("aws-kms-v1:{active_key_ref}")
+    }
+}
+
+fn error_kind_label(kind: KeyWrapErrorKind) -> &'static str {
+    match kind {
+        KeyWrapErrorKind::AccessDenied => "access_denied",
+        KeyWrapErrorKind::Configuration => "configuration",
+        KeyWrapErrorKind::Disabled => "disabled",
+        KeyWrapErrorKind::InvalidCiphertext => "invalid_ciphertext",
+        KeyWrapErrorKind::InvalidEnvelope => "invalid_envelope",
+        KeyWrapErrorKind::InvalidResponse => "invalid_response",
+        KeyWrapErrorKind::Throttled => "throttled",
+        KeyWrapErrorKind::Timeout => "timeout",
+        KeyWrapErrorKind::Unavailable => "unavailable",
+        KeyWrapErrorKind::UnsupportedEnvelope => "unsupported_envelope",
+        KeyWrapErrorKind::WrongKey => "wrong_key",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{KeyWrappingBackend, KeyWrappingConfig, LegacyKeyWrapper};
+    use std::time::Duration;
+
+    #[test]
+    fn inventory_counts_invalid_and_legacy_values_without_identifiers() {
+        let inventory = summarize_inventory(
+            "arn:aws:kms:test:key/mrk-active",
+            [vec![1, 2, 3], vec![9, 9, 9]].iter().map(Vec::as_slice),
+            &[1, 2, 3],
+        );
+        assert_eq!(inventory.collections_total, 2);
+        assert_eq!(inventory.collections_legacy, 1);
+        assert_eq!(inventory.collections_invalid, 1);
+        assert_eq!(inventory.provider_key_check, "local-aes-256-gcm-v1");
+        let serialized = serde_json::to_string(&inventory).unwrap();
+        assert!(!serialized.contains("collection_id"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires MDBASE_TEST_KEY_ADMIN_DATABASE_URL, MDBASE_TEST_KMS_KEY_ID, and AWS credentials"]
+    async fn live_key_admin_rewraps_a_legacy_database_to_aws_kms() {
+        let database_url = std::env::var("MDBASE_TEST_KEY_ADMIN_DATABASE_URL").unwrap();
+        let kms_key_id = std::env::var("MDBASE_TEST_KMS_KEY_ID").unwrap();
+        let legacy_value = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let collection_id = Uuid::parse_str("01933333-3333-7333-8333-333333333333").unwrap();
+        let data_key = [0x43_u8; 32];
+
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        hosted_migrator().run(&pool).await.unwrap();
+        let legacy = ProviderCrypto::with_key_wrapping(
+            KeyWrappingRuntime::legacy(LegacyKeyWrapper::from_base64(legacy_value).unwrap()),
+            "staging",
+        )
+        .unwrap();
+        let key_check = legacy.create_key_check().await.unwrap();
+        let wrapped_data_key = legacy
+            .wrap_data_key(&data_key, collection_id)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO hosted_provider_metadata (singleton, key_check) VALUES (true, $1)",
+        )
+        .bind(key_check)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r#"INSERT INTO hosted_provider_collections
+               (id, template, spec_version, max_records, max_content_bytes,
+                max_document_bytes, max_replicas, resource_revision,
+                wrapped_data_key, resources_ciphertext)
+               VALUES ($1, 'mdbase', '0.3', 100, 1000000, 100000, 10,
+                       'test-resource-revision', $2, $3)"#,
+        )
+        .bind(collection_id)
+        .bind(wrapped_data_key)
+        .bind(vec![0_u8; 32])
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+
+        let migrating_crypto = managed_crypto(&kms_key_id, Some(legacy_value.to_string())).await;
+        let admin = HostedKeyAdmin::connect(&database_url, migrating_crypto)
+            .await
+            .unwrap();
+        let before = admin.inspect().await.unwrap();
+        assert_eq!(before.collections_legacy, 1);
+        assert!(!before.migration_complete());
+        let dry_run = admin
+            .rewrap(KeyRewrapOptions {
+                dry_run: true,
+                finalize_key_check: false,
+                max_rows: 10,
+            })
+            .await
+            .unwrap();
+        assert_eq!(dry_run.scanned, 1);
+        assert_eq!(dry_run.would_rewrap, 1);
+        assert_eq!(dry_run.rewrapped, 0);
+        let report = admin
+            .rewrap(KeyRewrapOptions {
+                dry_run: false,
+                finalize_key_check: true,
+                max_rows: 10,
+            })
+            .await
+            .unwrap();
+        assert_eq!(report.rewrapped, 1);
+        assert_eq!(report.would_rewrap, 0);
+        assert!(report.key_check_finalized);
+        assert!(report.migration_complete);
+        drop(admin);
+
+        let kms_only_crypto = managed_crypto(&kms_key_id, None).await;
+        let kms_only_admin = HostedKeyAdmin::connect(&database_url, kms_only_crypto.clone())
+            .await
+            .unwrap();
+        assert!(kms_only_admin.inspect().await.unwrap().migration_complete());
+        let repeated = kms_only_admin
+            .rewrap(KeyRewrapOptions {
+                dry_run: false,
+                finalize_key_check: true,
+                max_rows: 10,
+            })
+            .await
+            .unwrap();
+        assert_eq!(repeated.rewrapped, 0);
+        assert_eq!(repeated.already_active, 1);
+        assert!(repeated.migration_complete);
+        let stored: Vec<u8> = sqlx::query_scalar(
+            "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1",
+        )
+        .bind(collection_id)
+        .fetch_one(&kms_only_admin.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            kms_only_crypto
+                .unwrap_data_key(&stored, collection_id)
+                .await
+                .unwrap()
+                .as_ref(),
+            &data_key
+        );
+    }
+
+    async fn managed_crypto(key_id: &str, legacy_master_key: Option<String>) -> ProviderCrypto {
+        let runtime = KeyWrappingConfig {
+            backend: KeyWrappingBackend::AwsKms,
+            environment: "staging".to_string(),
+            legacy_master_key,
+            kms_key_id: Some(key_id.to_string()),
+            kms_region: Some("ap-southeast-1".to_string()),
+            kms_max_attempts: 3,
+            kms_timeout: Duration::from_secs(10),
+            cache_entries: 0,
+            cache_ttl: Duration::ZERO,
+        }
+        .build()
+        .await
+        .unwrap();
+        ProviderCrypto::with_key_wrapping(runtime, "staging").unwrap()
+    }
+}

--- a/crates/connect-hosted-provider/src/key_wrapping/aws.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/aws.rs
@@ -1,0 +1,258 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use aws_config::{retry::RetryConfig, BehaviorVersion};
+use aws_sdk_kms::{primitives::Blob, Client};
+use aws_smithy_types::{error::metadata::ProvideErrorMetadata, timeout::TimeoutConfig};
+use aws_types::region::Region;
+use zeroize::Zeroizing;
+
+use super::{KeyWrapContext, KeyWrapError, KeyWrapErrorKind, ManagedCiphertext, ManagedKeyService};
+
+#[derive(Clone)]
+pub struct AwsKmsKeyWrapper {
+    client: Client,
+    active_key_id: Arc<str>,
+    environment: Arc<str>,
+    operation_timeout: Duration,
+}
+
+impl AwsKmsKeyWrapper {
+    pub async fn from_default_chain(
+        region: impl Into<String>,
+        active_key_id: impl Into<String>,
+        environment: impl Into<String>,
+        max_attempts: u32,
+        operation_timeout: Duration,
+    ) -> Result<Self, KeyWrapError> {
+        let region = region.into();
+        let active_key_id = active_key_id.into();
+        let environment = environment.into();
+        validate_configuration(
+            &region,
+            &active_key_id,
+            &environment,
+            max_attempts,
+            operation_timeout,
+        )?;
+        let timeout_config = TimeoutConfig::builder()
+            .operation_timeout(operation_timeout)
+            .build();
+        let config = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(region))
+            .retry_config(RetryConfig::standard().with_max_attempts(max_attempts))
+            .timeout_config(timeout_config)
+            .load()
+            .await;
+        Ok(Self {
+            client: Client::new(&config),
+            active_key_id: active_key_id.into(),
+            environment: environment.into(),
+            operation_timeout,
+        })
+    }
+
+    fn ensure_context(&self, context: &KeyWrapContext) -> Result<(), KeyWrapError> {
+        if context.environment() != self.environment.as_ref() {
+            return Err(KeyWrapError::configuration(
+                "The KMS wrapping context does not match the configured environment.",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ManagedKeyService for AwsKmsKeyWrapper {
+    fn active_key_ref(&self) -> &str {
+        &self.active_key_id
+    }
+
+    async fn encrypt(
+        &self,
+        plaintext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<ManagedCiphertext, KeyWrapError> {
+        self.ensure_context(context)?;
+        let operation = self
+            .client
+            .encrypt()
+            .key_id(self.active_key_id.as_ref())
+            .plaintext(Blob::new(plaintext))
+            .set_encryption_context(Some(context.encryption_context().into_iter().collect()));
+        let response = tokio::time::timeout(self.operation_timeout, operation.send())
+            .await
+            .map_err(|_| KeyWrapError::timeout())?
+            .map_err(|error| classify_service_error(error.as_service_error()))?;
+        let ciphertext = response
+            .ciphertext_blob()
+            .ok_or_else(KeyWrapError::invalid_response)?
+            .as_ref()
+            .to_vec();
+        let key_ref = response
+            .key_id()
+            .ok_or_else(KeyWrapError::invalid_response)?
+            .to_string();
+        validate_kms_key_ref(&key_ref)?;
+        Ok(ManagedCiphertext {
+            key_ref,
+            ciphertext,
+        })
+    }
+
+    async fn decrypt(
+        &self,
+        key_ref: &str,
+        ciphertext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Zeroizing<Vec<u8>>, KeyWrapError> {
+        self.ensure_context(context)?;
+        validate_kms_key_ref(key_ref)?;
+        let operation = self
+            .client
+            .decrypt()
+            .ciphertext_blob(Blob::new(ciphertext))
+            .set_encryption_context(Some(context.encryption_context().into_iter().collect()));
+        let response = tokio::time::timeout(self.operation_timeout, operation.send())
+            .await
+            .map_err(|_| KeyWrapError::timeout())?
+            .map_err(|error| classify_service_error(error.as_service_error()))?;
+        let actual_key_ref = response
+            .key_id()
+            .ok_or_else(KeyWrapError::invalid_response)?;
+        if !same_kms_key(key_ref, actual_key_ref) {
+            return Err(KeyWrapError::new(
+                KeyWrapErrorKind::WrongKey,
+                "AWS KMS returned plaintext from an unexpected key.",
+            ));
+        }
+        let plaintext = response
+            .plaintext()
+            .ok_or_else(KeyWrapError::invalid_response)?;
+        Ok(Zeroizing::new(plaintext.as_ref().to_vec()))
+    }
+}
+
+fn validate_configuration(
+    region: &str,
+    active_key_id: &str,
+    environment: &str,
+    max_attempts: u32,
+    operation_timeout: Duration,
+) -> Result<(), KeyWrapError> {
+    if region.trim().is_empty()
+        || active_key_id.trim().is_empty()
+        || !matches!(environment, "staging" | "production" | "test")
+        || !(1..=10).contains(&max_attempts)
+        || operation_timeout.is_zero()
+        || operation_timeout > Duration::from_secs(60)
+    {
+        return Err(KeyWrapError::configuration(
+            "The AWS KMS wrapping configuration is invalid.",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_kms_key_ref(value: &str) -> Result<(), KeyWrapError> {
+    let Some((prefix, resource)) = value.rsplit_once(":key/") else {
+        return Err(KeyWrapError::invalid_response());
+    };
+    if !prefix.starts_with("arn:")
+        || resource.is_empty()
+        || !resource
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err(KeyWrapError::invalid_response());
+    }
+    Ok(())
+}
+
+fn same_kms_key(expected: &str, actual: &str) -> bool {
+    if expected == actual {
+        return true;
+    }
+    let expected_resource = expected.rsplit_once(":key/").map(|(_, value)| value);
+    let actual_resource = actual.rsplit_once(":key/").map(|(_, value)| value);
+    matches!(
+        (expected_resource, actual_resource),
+        (Some(expected), Some(actual)) if expected.starts_with("mrk-") && expected == actual
+    )
+}
+
+fn classify_service_error(error: Option<&impl ProvideErrorMetadata>) -> KeyWrapError {
+    match error.and_then(ProvideErrorMetadata::code) {
+        Some("AccessDeniedException") => KeyWrapError::new(
+            KeyWrapErrorKind::AccessDenied,
+            "AWS KMS denied the key operation.",
+        ),
+        Some("DisabledException" | "KMSInvalidStateException") => KeyWrapError::new(
+            KeyWrapErrorKind::Disabled,
+            "The AWS KMS key is not enabled for this operation.",
+        ),
+        Some("InvalidCiphertextException") => KeyWrapError::new(
+            KeyWrapErrorKind::InvalidCiphertext,
+            "AWS KMS rejected the wrapped key ciphertext or context.",
+        ),
+        Some("IncorrectKeyException" | "NotFoundException") => KeyWrapError::new(
+            KeyWrapErrorKind::WrongKey,
+            "The AWS KMS key referenced by the envelope is unavailable.",
+        ),
+        Some("ThrottlingException" | "LimitExceededException") => KeyWrapError::new(
+            KeyWrapErrorKind::Throttled,
+            "AWS KMS throttled the key operation.",
+        ),
+        Some("DependencyTimeoutException") => KeyWrapError::timeout(),
+        Some("KeyUnavailableException" | "KMSInternalException") => KeyWrapError::new(
+            KeyWrapErrorKind::Unavailable,
+            "AWS KMS is temporarily unavailable.",
+        ),
+        _ => KeyWrapError::new(
+            KeyWrapErrorKind::Unavailable,
+            "The AWS KMS key operation failed.",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_the_same_multi_region_key_across_regions() {
+        assert!(same_kms_key(
+            "arn:aws:kms:ap-southeast-1:445617516211:key/mrk-one",
+            "arn:aws:kms:ap-southeast-2:445617516211:key/mrk-one"
+        ));
+        assert!(!same_kms_key(
+            "arn:aws:kms:ap-southeast-1:445617516211:key/mrk-one",
+            "arn:aws:kms:ap-southeast-2:445617516211:key/mrk-two"
+        ));
+        assert!(!same_kms_key(
+            "arn:aws:kms:ap-southeast-1:445617516211:key/one",
+            "arn:aws:kms:ap-southeast-2:445617516211:key/one"
+        ));
+    }
+
+    #[test]
+    fn rejects_unsafe_configuration() {
+        assert!(validate_configuration("", "key", "staging", 3, Duration::from_secs(5)).is_err());
+        assert!(validate_configuration(
+            "ap-southeast-1",
+            "key",
+            "development",
+            3,
+            Duration::from_secs(5)
+        )
+        .is_err());
+        assert!(validate_configuration(
+            "ap-southeast-1",
+            "key",
+            "staging",
+            0,
+            Duration::from_secs(5)
+        )
+        .is_err());
+    }
+}

--- a/crates/connect-hosted-provider/src/key_wrapping/aws.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/aws.rs
@@ -2,7 +2,11 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use aws_config::{retry::RetryConfig, BehaviorVersion};
-use aws_sdk_kms::{primitives::Blob, Client};
+use aws_sdk_kms::{
+    primitives::Blob,
+    types::{KeySpec, KeyState, KeyUsageType},
+    Client,
+};
 use aws_smithy_types::{error::metadata::ProvideErrorMetadata, timeout::TimeoutConfig};
 use aws_types::region::Region;
 use zeroize::Zeroizing;
@@ -44,9 +48,35 @@ impl AwsKmsKeyWrapper {
             .timeout_config(timeout_config)
             .load()
             .await;
+        let client = Client::new(&config);
+        let response = tokio::time::timeout(
+            operation_timeout,
+            client.describe_key().key_id(&active_key_id).send(),
+        )
+        .await
+        .map_err(|_| KeyWrapError::timeout())?
+        .map_err(|error| classify_service_error(error.as_service_error()))?;
+        let metadata = response
+            .key_metadata()
+            .ok_or_else(KeyWrapError::invalid_response)?;
+        if !metadata.enabled()
+            || metadata.key_state() != Some(&KeyState::Enabled)
+            || metadata.key_usage() != Some(&KeyUsageType::EncryptDecrypt)
+            || metadata.key_spec() != Some(&KeySpec::SymmetricDefault)
+        {
+            return Err(KeyWrapError::new(
+                KeyWrapErrorKind::Disabled,
+                "The configured AWS KMS key is not an enabled symmetric encryption key.",
+            ));
+        }
+        let active_key_ref = metadata
+            .arn()
+            .ok_or_else(KeyWrapError::invalid_response)?
+            .to_string();
+        validate_kms_key_ref(&active_key_ref)?;
         Ok(Self {
-            client: Client::new(&config),
-            active_key_id: active_key_id.into(),
+            client,
+            active_key_id: active_key_ref.into(),
             environment: environment.into(),
             operation_timeout,
         })

--- a/crates/connect-hosted-provider/src/key_wrapping/cache.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/cache.rs
@@ -1,0 +1,215 @@
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct DataKeyCacheKey {
+    environment: String,
+    collection_id: Uuid,
+    envelope_digest: [u8; 32],
+}
+
+impl DataKeyCacheKey {
+    pub fn new(environment: &str, collection_id: Uuid, envelope_digest: [u8; 32]) -> Self {
+        Self {
+            environment: environment.to_string(),
+            collection_id,
+            envelope_digest,
+        }
+    }
+}
+
+struct CacheEntry {
+    key: Zeroizing<[u8; 32]>,
+    expires_at: Instant,
+    last_used: u64,
+}
+
+struct CacheState {
+    entries: HashMap<DataKeyCacheKey, CacheEntry>,
+    max_entries: usize,
+    ttl: Duration,
+    clock: u64,
+}
+
+impl CacheState {
+    fn get(&mut self, cache_key: &DataKeyCacheKey, now: Instant) -> Option<Zeroizing<[u8; 32]>> {
+        self.remove_expired(now);
+        self.clock = self.clock.wrapping_add(1);
+        let entry = self.entries.get_mut(cache_key)?;
+        entry.last_used = self.clock;
+        Some(Zeroizing::new(*entry.key))
+    }
+
+    fn insert(&mut self, cache_key: DataKeyCacheKey, key: &[u8; 32], now: Instant) {
+        if self.max_entries == 0 || self.ttl.is_zero() {
+            return;
+        }
+        self.remove_expired(now);
+        self.clock = self.clock.wrapping_add(1);
+        if !self.entries.contains_key(&cache_key) && self.entries.len() >= self.max_entries {
+            if let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(cache_key, _)| cache_key.clone())
+            {
+                self.entries.remove(&oldest);
+            }
+        }
+        self.entries.insert(
+            cache_key,
+            CacheEntry {
+                key: Zeroizing::new(*key),
+                expires_at: now + self.ttl,
+                last_used: self.clock,
+            },
+        );
+    }
+
+    fn remove_expired(&mut self, now: Instant) {
+        self.entries.retain(|_, entry| entry.expires_at > now);
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct DataKeyCache {
+    state: Arc<Mutex<CacheState>>,
+    gates: Arc<Mutex<HashMap<DataKeyCacheKey, Arc<Mutex<()>>>>>,
+    enabled: bool,
+}
+
+impl DataKeyCache {
+    pub fn new(max_entries: usize, ttl: Duration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(CacheState {
+                entries: HashMap::new(),
+                max_entries,
+                ttl,
+                clock: 0,
+            })),
+            gates: Arc::new(Mutex::new(HashMap::new())),
+            enabled: max_entries > 0 && !ttl.is_zero(),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub async fn get(&self, cache_key: &DataKeyCacheKey) -> Option<Zeroizing<[u8; 32]>> {
+        self.state.lock().await.get(cache_key, Instant::now())
+    }
+
+    pub async fn insert(&self, cache_key: DataKeyCacheKey, key: &[u8; 32]) {
+        self.state
+            .lock()
+            .await
+            .insert(cache_key, key, Instant::now());
+    }
+
+    pub async fn lock(&self, cache_key: &DataKeyCacheKey) -> DataKeyGate {
+        let gate = self
+            .gates
+            .lock()
+            .await
+            .entry(cache_key.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let guard = gate.clone().lock_owned().await;
+        DataKeyGate {
+            cache: self.clone(),
+            cache_key: cache_key.clone(),
+            gate: Some(gate),
+            guard: Some(guard),
+        }
+    }
+}
+
+pub(super) struct DataKeyGate {
+    cache: DataKeyCache,
+    cache_key: DataKeyCacheKey,
+    gate: Option<Arc<Mutex<()>>>,
+    guard: Option<OwnedMutexGuard<()>>,
+}
+
+impl Drop for DataKeyGate {
+    fn drop(&mut self) {
+        self.guard.take();
+        let cache = self.cache.clone();
+        let cache_key = self.cache_key.clone();
+        let Some(gate) = self.gate.take() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let mut gates = cache.gates.lock().await;
+            if Arc::strong_count(&gate) == 2
+                && gates
+                    .get(&cache_key)
+                    .is_some_and(|candidate| Arc::ptr_eq(candidate, &gate))
+            {
+                gates.remove(&cache_key);
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_key(value: u8) -> DataKeyCacheKey {
+        DataKeyCacheKey::new("staging", Uuid::from_u128(u128::from(value)), [value; 32])
+    }
+
+    #[test]
+    fn state_expires_and_evicts_least_recently_used_keys() {
+        let start = Instant::now();
+        let mut state = CacheState {
+            entries: HashMap::new(),
+            max_entries: 2,
+            ttl: Duration::from_secs(30),
+            clock: 0,
+        };
+        state.insert(cache_key(1), &[1; 32], start);
+        state.insert(cache_key(2), &[2; 32], start);
+        assert!(state.get(&cache_key(1), start).is_some());
+        state.insert(cache_key(3), &[3; 32], start);
+        assert!(state.get(&cache_key(1), start).is_some());
+        assert!(state.get(&cache_key(2), start).is_none());
+        assert!(state.get(&cache_key(3), start).is_some());
+        assert!(state
+            .get(&cache_key(1), start + Duration::from_secs(31))
+            .is_none());
+    }
+
+    #[test]
+    fn disabled_cache_never_retains_key_material() {
+        let now = Instant::now();
+        let mut state = CacheState {
+            entries: HashMap::new(),
+            max_entries: 0,
+            ttl: Duration::from_secs(30),
+            clock: 0,
+        };
+        state.insert(cache_key(1), &[1; 32], now);
+        assert!(state.get(&cache_key(1), now).is_none());
+    }
+
+    #[tokio::test]
+    async fn completed_singleflight_gates_are_removed() {
+        let cache = DataKeyCache::new(2, Duration::from_secs(30));
+        let key = cache_key(1);
+        let gate = cache.lock(&key).await;
+        assert_eq!(cache.gates.lock().await.len(), 1);
+        drop(gate);
+        tokio::task::yield_now().await;
+        assert!(cache.gates.lock().await.is_empty());
+    }
+}

--- a/crates/connect-hosted-provider/src/key_wrapping/envelope.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/envelope.rs
@@ -1,0 +1,148 @@
+use super::{KeyWrapError, KeyWrapInspection};
+
+const MAGIC: &[u8; 4] = b"MDBK";
+const ENVELOPE_VERSION: u8 = 1;
+const AWS_KMS_SCHEME: u8 = 1;
+const HEADER_BYTES: usize = 12;
+const MAX_KEY_REF_BYTES: usize = 2_048;
+const MAX_CIPHERTEXT_BYTES: usize = 8_192;
+
+#[derive(Debug)]
+pub(super) struct ManagedEnvelope<'a> {
+    pub key_ref: &'a str,
+    pub ciphertext: &'a [u8],
+}
+
+pub(super) fn encode_aws_kms(key_ref: &str, ciphertext: &[u8]) -> Result<Vec<u8>, KeyWrapError> {
+    validate_key_ref(key_ref)?;
+    if ciphertext.is_empty() || ciphertext.len() > MAX_CIPHERTEXT_BYTES {
+        return Err(KeyWrapError::invalid_envelope());
+    }
+    let key_ref_len = u16::try_from(key_ref.len()).map_err(|_| KeyWrapError::invalid_envelope())?;
+    let ciphertext_len =
+        u32::try_from(ciphertext.len()).map_err(|_| KeyWrapError::invalid_envelope())?;
+    let mut output = Vec::with_capacity(HEADER_BYTES + key_ref.len() + ciphertext.len());
+    output.extend_from_slice(MAGIC);
+    output.push(ENVELOPE_VERSION);
+    output.push(AWS_KMS_SCHEME);
+    output.extend_from_slice(&key_ref_len.to_be_bytes());
+    output.extend_from_slice(&ciphertext_len.to_be_bytes());
+    output.extend_from_slice(key_ref.as_bytes());
+    output.extend_from_slice(ciphertext);
+    Ok(output)
+}
+
+pub(super) fn parse_managed(value: &[u8]) -> Result<ManagedEnvelope<'_>, KeyWrapError> {
+    if value.len() < HEADER_BYTES || &value[..MAGIC.len()] != MAGIC {
+        return Err(KeyWrapError::invalid_envelope());
+    }
+    if value[4] != ENVELOPE_VERSION || value[5] != AWS_KMS_SCHEME {
+        return Err(KeyWrapError::unsupported_envelope());
+    }
+    let key_ref_len = usize::from(u16::from_be_bytes([value[6], value[7]]));
+    let ciphertext_len = usize::try_from(u32::from_be_bytes([
+        value[8], value[9], value[10], value[11],
+    ]))
+    .map_err(|_| KeyWrapError::invalid_envelope())?;
+    if key_ref_len == 0
+        || key_ref_len > MAX_KEY_REF_BYTES
+        || ciphertext_len == 0
+        || ciphertext_len > MAX_CIPHERTEXT_BYTES
+        || value.len() != HEADER_BYTES + key_ref_len + ciphertext_len
+    {
+        return Err(KeyWrapError::invalid_envelope());
+    }
+    let key_ref_end = HEADER_BYTES + key_ref_len;
+    let key_ref = std::str::from_utf8(&value[HEADER_BYTES..key_ref_end])
+        .map_err(|_| KeyWrapError::invalid_envelope())?;
+    validate_key_ref(key_ref)?;
+    Ok(ManagedEnvelope {
+        key_ref,
+        ciphertext: &value[key_ref_end..],
+    })
+}
+
+pub(super) fn inspect(value: &[u8]) -> Result<KeyWrapInspection, KeyWrapError> {
+    if value.first() == Some(&1) && !value.starts_with(MAGIC) {
+        return Ok(KeyWrapInspection::LocalAes256GcmV1);
+    }
+    let envelope = parse_managed(value)?;
+    Ok(KeyWrapInspection::AwsKmsV1 {
+        key_ref: envelope.key_ref.to_string(),
+    })
+}
+
+fn validate_key_ref(value: &str) -> Result<(), KeyWrapError> {
+    if value.is_empty()
+        || value.len() > MAX_KEY_REF_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() && byte != b'"' && byte != b'\\')
+    {
+        return Err(KeyWrapError::invalid_envelope());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_a_bounded_binary_envelope() {
+        let encoded = encode_aws_kms(
+            "arn:aws:kms:ap-southeast-1:445617516211:key/mrk-example",
+            &[7; 64],
+        )
+        .unwrap();
+        let parsed = parse_managed(&encoded).unwrap();
+        assert_eq!(
+            parsed.key_ref,
+            "arn:aws:kms:ap-southeast-1:445617516211:key/mrk-example"
+        );
+        assert_eq!(parsed.ciphertext, &[7; 64]);
+    }
+
+    #[test]
+    fn rejects_truncation_trailing_data_and_unknown_versions() {
+        let encoded = encode_aws_kms("arn:aws:kms:test:key/mrk-one", &[8; 32]).unwrap();
+        for length in 0..encoded.len() {
+            assert!(parse_managed(&encoded[..length]).is_err());
+        }
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert!(parse_managed(&trailing).is_err());
+        let mut unknown_version = encoded.clone();
+        unknown_version[4] = 2;
+        assert_eq!(
+            parse_managed(&unknown_version).unwrap_err().kind,
+            super::super::KeyWrapErrorKind::UnsupportedEnvelope
+        );
+        let mut unknown_scheme = encoded;
+        unknown_scheme[5] = 2;
+        assert_eq!(
+            parse_managed(&unknown_scheme).unwrap_err().kind,
+            super::super::KeyWrapErrorKind::UnsupportedEnvelope
+        );
+    }
+
+    #[test]
+    fn rejects_unbounded_or_ambiguous_fields() {
+        assert!(encode_aws_kms("", &[1]).is_err());
+        assert!(encode_aws_kms(&"a".repeat(MAX_KEY_REF_BYTES + 1), &[1]).is_err());
+        assert!(encode_aws_kms("arn:aws:kms:test:key/one", &[]).is_err());
+        assert!(
+            encode_aws_kms("arn:aws:kms:test:key/one", &[1; MAX_CIPHERTEXT_BYTES + 1]).is_err()
+        );
+        assert!(encode_aws_kms("arn:aws:kms:test:key/line\nbreak", &[1]).is_err());
+    }
+
+    #[test]
+    fn distinguishes_only_the_exact_legacy_version_prefix() {
+        assert_eq!(
+            inspect(&[1, 2, 3]).unwrap(),
+            KeyWrapInspection::LocalAes256GcmV1
+        );
+        assert!(inspect(&[2, 2, 3]).is_err());
+    }
+}

--- a/crates/connect-hosted-provider/src/key_wrapping/mod.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/mod.rs
@@ -1,0 +1,359 @@
+mod aws;
+mod envelope;
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
+use serde::Serialize;
+use thiserror::Error;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::symmetric_crypto::{decrypt, encrypt};
+
+pub use aws::AwsKmsKeyWrapper;
+
+const KEY_BYTES: usize = 32;
+const KEY_CHECK_AAD: &[u8] = b"provider-key-check-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyWrapErrorKind {
+    AccessDenied,
+    Configuration,
+    Disabled,
+    InvalidCiphertext,
+    InvalidEnvelope,
+    InvalidResponse,
+    Throttled,
+    Timeout,
+    Unavailable,
+    UnsupportedEnvelope,
+    WrongKey,
+}
+
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct KeyWrapError {
+    pub kind: KeyWrapErrorKind,
+    message: &'static str,
+}
+
+impl KeyWrapError {
+    pub(crate) fn new(kind: KeyWrapErrorKind, message: &'static str) -> Self {
+        Self { kind, message }
+    }
+
+    fn configuration(message: &'static str) -> Self {
+        Self::new(KeyWrapErrorKind::Configuration, message)
+    }
+
+    fn invalid_envelope() -> Self {
+        Self::new(
+            KeyWrapErrorKind::InvalidEnvelope,
+            "The hosted key-wrapping envelope is invalid.",
+        )
+    }
+
+    fn unsupported_envelope() -> Self {
+        Self::new(
+            KeyWrapErrorKind::UnsupportedEnvelope,
+            "The hosted key-wrapping envelope version or scheme is unsupported.",
+        )
+    }
+
+    fn invalid_response() -> Self {
+        Self::new(
+            KeyWrapErrorKind::InvalidResponse,
+            "The managed key service returned an invalid response.",
+        )
+    }
+
+    fn timeout() -> Self {
+        Self::new(
+            KeyWrapErrorKind::Timeout,
+            "The managed key service operation timed out.",
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyWrapInspection {
+    LocalAes256GcmV1,
+    AwsKmsV1 { key_ref: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyWrapPurpose {
+    CollectionDataKey,
+    ProviderKeyCheck,
+}
+
+#[derive(Debug, Clone)]
+pub struct KeyWrapContext {
+    environment: String,
+    purpose: KeyWrapPurpose,
+    collection_id: Option<Uuid>,
+    legacy_aad: Vec<u8>,
+}
+
+impl KeyWrapContext {
+    pub fn collection(
+        environment: impl Into<String>,
+        collection_id: Uuid,
+    ) -> Result<Self, KeyWrapError> {
+        let environment = validate_environment(environment.into())?;
+        Ok(Self {
+            environment,
+            purpose: KeyWrapPurpose::CollectionDataKey,
+            collection_id: Some(collection_id),
+            legacy_aad: canonical_aad(("collection_key", collection_id))?,
+        })
+    }
+
+    pub fn provider_key_check(environment: impl Into<String>) -> Result<Self, KeyWrapError> {
+        Ok(Self {
+            environment: validate_environment(environment.into())?,
+            purpose: KeyWrapPurpose::ProviderKeyCheck,
+            collection_id: None,
+            legacy_aad: KEY_CHECK_AAD.to_vec(),
+        })
+    }
+
+    pub fn environment(&self) -> &str {
+        &self.environment
+    }
+
+    fn encryption_context(&self) -> BTreeMap<String, String> {
+        let mut context = BTreeMap::from([
+            ("mdbase:service".to_string(), "hosted-provider".to_string()),
+            ("mdbase:environment".to_string(), self.environment.clone()),
+            (
+                "mdbase:purpose".to_string(),
+                match self.purpose {
+                    KeyWrapPurpose::CollectionDataKey => "collection-data-key",
+                    KeyWrapPurpose::ProviderKeyCheck => "provider-key-check",
+                }
+                .to_string(),
+            ),
+            ("mdbase:envelope-version".to_string(), "1".to_string()),
+        ]);
+        if let Some(collection_id) = self.collection_id {
+            context.insert(
+                "mdbase:collection-id".to_string(),
+                collection_id.to_string(),
+            );
+        }
+        context
+    }
+}
+
+#[derive(Clone)]
+pub struct LegacyKeyWrapper {
+    key: [u8; KEY_BYTES],
+}
+
+impl LegacyKeyWrapper {
+    pub fn from_base64(value: &str) -> Result<Self, KeyWrapError> {
+        let decoded = general_purpose::URL_SAFE_NO_PAD
+            .decode(value)
+            .or_else(|_| general_purpose::STANDARD.decode(value))
+            .map_err(|_| KeyWrapError::configuration("The legacy provider key is invalid."))?;
+        let key = decoded
+            .try_into()
+            .map_err(|_| KeyWrapError::configuration("The legacy provider key is invalid."))?;
+        Ok(Self { key })
+    }
+
+    fn wrap(&self, plaintext: &[u8], context: &KeyWrapContext) -> Result<Vec<u8>, KeyWrapError> {
+        encrypt(&self.key, plaintext, &context.legacy_aad).map_err(|_| {
+            KeyWrapError::new(
+                KeyWrapErrorKind::Unavailable,
+                "The legacy provider key could not wrap key material.",
+            )
+        })
+    }
+
+    fn unwrap(
+        &self,
+        ciphertext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Zeroizing<Vec<u8>>, KeyWrapError> {
+        decrypt(&self.key, ciphertext, &context.legacy_aad)
+            .map(Zeroizing::new)
+            .map_err(|_| {
+                KeyWrapError::new(
+                    KeyWrapErrorKind::InvalidCiphertext,
+                    "The legacy wrapped key failed authentication.",
+                )
+            })
+    }
+}
+
+pub(crate) struct ManagedCiphertext {
+    key_ref: String,
+    ciphertext: Vec<u8>,
+}
+
+#[async_trait]
+pub(crate) trait ManagedKeyService: Send + Sync {
+    fn active_key_ref(&self) -> &str;
+
+    async fn encrypt(
+        &self,
+        plaintext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<ManagedCiphertext, KeyWrapError>;
+
+    async fn decrypt(
+        &self,
+        key_ref: &str,
+        ciphertext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Zeroizing<Vec<u8>>, KeyWrapError>;
+}
+
+#[derive(Clone)]
+enum ActiveKeyWriter {
+    Legacy(LegacyKeyWrapper),
+    Managed(Arc<dyn ManagedKeyService>),
+}
+
+#[derive(Clone)]
+pub struct KeyWrappingRuntime {
+    active: ActiveKeyWriter,
+    legacy_reader: Option<LegacyKeyWrapper>,
+    managed_reader: Option<Arc<dyn ManagedKeyService>>,
+}
+
+impl KeyWrappingRuntime {
+    pub fn legacy(wrapper: LegacyKeyWrapper) -> Self {
+        Self {
+            active: ActiveKeyWriter::Legacy(wrapper.clone()),
+            legacy_reader: Some(wrapper),
+            managed_reader: None,
+        }
+    }
+
+    pub fn aws_kms(wrapper: AwsKmsKeyWrapper, legacy_reader: Option<LegacyKeyWrapper>) -> Self {
+        let managed: Arc<dyn ManagedKeyService> = Arc::new(wrapper);
+        Self {
+            active: ActiveKeyWriter::Managed(managed.clone()),
+            legacy_reader,
+            managed_reader: Some(managed),
+        }
+    }
+
+    #[cfg(test)]
+    fn managed_for_test(
+        managed: Arc<dyn ManagedKeyService>,
+        legacy_reader: Option<LegacyKeyWrapper>,
+    ) -> Self {
+        Self {
+            active: ActiveKeyWriter::Managed(managed.clone()),
+            legacy_reader,
+            managed_reader: Some(managed),
+        }
+    }
+
+    pub fn active_key_ref(&self) -> &str {
+        match &self.active {
+            ActiveKeyWriter::Legacy(_) => "local-aes-256-gcm-v1",
+            ActiveKeyWriter::Managed(wrapper) => wrapper.active_key_ref(),
+        }
+    }
+
+    pub fn inspect(value: &[u8]) -> Result<KeyWrapInspection, KeyWrapError> {
+        envelope::inspect(value)
+    }
+
+    pub async fn wrap_data_key(
+        &self,
+        data_key: &[u8; KEY_BYTES],
+        context: &KeyWrapContext,
+    ) -> Result<Vec<u8>, KeyWrapError> {
+        self.wrap_bytes(data_key, context).await
+    }
+
+    pub async fn unwrap_data_key(
+        &self,
+        wrapped: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Zeroizing<[u8; KEY_BYTES]>, KeyWrapError> {
+        let plaintext = self.unwrap_bytes(wrapped, context).await?;
+        if plaintext.len() != KEY_BYTES {
+            return Err(KeyWrapError::new(
+                KeyWrapErrorKind::InvalidCiphertext,
+                "The unwrapped collection data key has an invalid length.",
+            ));
+        }
+        let mut key = [0_u8; KEY_BYTES];
+        key.copy_from_slice(&plaintext);
+        Ok(Zeroizing::new(key))
+    }
+
+    pub async fn wrap_bytes(
+        &self,
+        plaintext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Vec<u8>, KeyWrapError> {
+        match &self.active {
+            ActiveKeyWriter::Legacy(wrapper) => wrapper.wrap(plaintext, context),
+            ActiveKeyWriter::Managed(wrapper) => {
+                let wrapped = wrapper.encrypt(plaintext, context).await?;
+                envelope::encode_aws_kms(&wrapped.key_ref, &wrapped.ciphertext)
+            }
+        }
+    }
+
+    pub async fn unwrap_bytes(
+        &self,
+        wrapped: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Zeroizing<Vec<u8>>, KeyWrapError> {
+        match Self::inspect(wrapped)? {
+            KeyWrapInspection::LocalAes256GcmV1 => self
+                .legacy_reader
+                .as_ref()
+                .ok_or_else(|| {
+                    KeyWrapError::configuration(
+                        "Stored keys require the legacy provider key reader.",
+                    )
+                })?
+                .unwrap(wrapped, context),
+            KeyWrapInspection::AwsKmsV1 { .. } => {
+                let envelope = envelope::parse_managed(wrapped)?;
+                self.managed_reader
+                    .as_ref()
+                    .ok_or_else(|| {
+                        KeyWrapError::configuration("Stored keys require the AWS KMS reader.")
+                    })?
+                    .decrypt(envelope.key_ref, envelope.ciphertext, context)
+                    .await
+            }
+        }
+    }
+}
+
+fn validate_environment(value: String) -> Result<String, KeyWrapError> {
+    if value.is_empty()
+        || value.len() > 32
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(KeyWrapError::configuration(
+            "The key-wrapping environment is invalid.",
+        ));
+    }
+    Ok(value)
+}
+
+fn canonical_aad(value: impl Serialize) -> Result<Vec<u8>, KeyWrapError> {
+    serde_json::to_vec(&value).map_err(|_| {
+        KeyWrapError::configuration("The legacy key-wrapping identity could not serialize.")
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/connect-hosted-provider/src/key_wrapping/mod.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/mod.rs
@@ -1,16 +1,19 @@
 mod aws;
+mod cache;
 mod envelope;
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use uuid::Uuid;
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::symmetric_crypto::{decrypt, encrypt};
+use cache::{DataKeyCache, DataKeyCacheKey};
 
 pub use aws::AwsKmsKeyWrapper;
 
@@ -84,6 +87,60 @@ pub enum KeyWrapInspection {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyWrappingBackend {
+    Local,
+    AwsKms,
+}
+
+pub struct KeyWrappingConfig {
+    pub backend: KeyWrappingBackend,
+    pub environment: String,
+    pub legacy_master_key: Option<String>,
+    pub kms_key_id: Option<String>,
+    pub kms_region: Option<String>,
+    pub kms_max_attempts: u32,
+    pub kms_timeout: Duration,
+    pub cache_entries: usize,
+    pub cache_ttl: Duration,
+}
+
+impl KeyWrappingConfig {
+    pub async fn build(self) -> Result<KeyWrappingRuntime, KeyWrapError> {
+        let legacy_master_key = self.legacy_master_key.map(Zeroizing::new);
+        let legacy = legacy_master_key
+            .as_deref()
+            .map(|value| LegacyKeyWrapper::from_base64(value.as_str()))
+            .transpose()?;
+        let runtime = match self.backend {
+            KeyWrappingBackend::Local => KeyWrappingRuntime::legacy(legacy.ok_or_else(|| {
+                KeyWrapError::configuration(
+                    "The legacy provider key is required for local key wrapping.",
+                )
+            })?),
+            KeyWrappingBackend::AwsKms => {
+                if !matches!(self.environment.as_str(), "staging" | "production") {
+                    return Err(KeyWrapError::configuration(
+                        "The AWS KMS environment must be staging or production.",
+                    ));
+                }
+                let key_id = required_setting(self.kms_key_id, "AWS KMS key ID")?;
+                let region = required_setting(self.kms_region, "AWS KMS region")?;
+                let kms = AwsKmsKeyWrapper::from_default_chain(
+                    region,
+                    key_id,
+                    self.environment,
+                    self.kms_max_attempts,
+                    self.kms_timeout,
+                )
+                .await?;
+                KeyWrappingRuntime::aws_kms(kms, legacy)
+            }
+        };
+        runtime.with_data_key_cache(self.cache_entries, self.cache_ttl)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KeyWrapPurpose {
     CollectionDataKey,
     ProviderKeyCheck,
@@ -148,7 +205,7 @@ impl KeyWrapContext {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct LegacyKeyWrapper {
     key: [u8; KEY_BYTES],
 }
@@ -224,6 +281,7 @@ pub struct KeyWrappingRuntime {
     active: ActiveKeyWriter,
     legacy_reader: Option<LegacyKeyWrapper>,
     managed_reader: Option<Arc<dyn ManagedKeyService>>,
+    data_key_cache: DataKeyCache,
 }
 
 impl KeyWrappingRuntime {
@@ -232,6 +290,7 @@ impl KeyWrappingRuntime {
             active: ActiveKeyWriter::Legacy(wrapper.clone()),
             legacy_reader: Some(wrapper),
             managed_reader: None,
+            data_key_cache: DataKeyCache::new(0, Duration::ZERO),
         }
     }
 
@@ -241,6 +300,7 @@ impl KeyWrappingRuntime {
             active: ActiveKeyWriter::Managed(managed.clone()),
             legacy_reader,
             managed_reader: Some(managed),
+            data_key_cache: DataKeyCache::new(1_024, Duration::from_secs(300)),
         }
     }
 
@@ -253,7 +313,22 @@ impl KeyWrappingRuntime {
             active: ActiveKeyWriter::Managed(managed.clone()),
             legacy_reader,
             managed_reader: Some(managed),
+            data_key_cache: DataKeyCache::new(0, Duration::ZERO),
         }
+    }
+
+    pub fn with_data_key_cache(
+        mut self,
+        max_entries: usize,
+        ttl: Duration,
+    ) -> Result<Self, KeyWrapError> {
+        if max_entries > 100_000 || ttl > Duration::from_secs(24 * 60 * 60) {
+            return Err(KeyWrapError::configuration(
+                "The hosted data-key cache configuration is invalid.",
+            ));
+        }
+        self.data_key_cache = DataKeyCache::new(max_entries, ttl);
+        Ok(self)
     }
 
     pub fn active_key_ref(&self) -> &str {
@@ -272,7 +347,11 @@ impl KeyWrappingRuntime {
         data_key: &[u8; KEY_BYTES],
         context: &KeyWrapContext,
     ) -> Result<Vec<u8>, KeyWrapError> {
-        self.wrap_bytes(data_key, context).await
+        let wrapped = self.wrap_bytes(data_key, context).await?;
+        if let Some(cache_key) = data_key_cache_key(context, &wrapped) {
+            self.data_key_cache.insert(cache_key, data_key).await;
+        }
+        Ok(wrapped)
     }
 
     pub async fn unwrap_data_key(
@@ -280,6 +359,26 @@ impl KeyWrappingRuntime {
         wrapped: &[u8],
         context: &KeyWrapContext,
     ) -> Result<Zeroizing<[u8; KEY_BYTES]>, KeyWrapError> {
+        let cache_key = self
+            .data_key_cache
+            .is_enabled()
+            .then(|| data_key_cache_key(context, wrapped))
+            .flatten();
+        if let Some(cache_key) = &cache_key {
+            if let Some(key) = self.data_key_cache.get(cache_key).await {
+                return Ok(key);
+            }
+        }
+        let _gate = if let Some(cache_key) = &cache_key {
+            Some(self.data_key_cache.lock(cache_key).await)
+        } else {
+            None
+        };
+        if let Some(cache_key) = &cache_key {
+            if let Some(key) = self.data_key_cache.get(cache_key).await {
+                return Ok(key);
+            }
+        }
         let plaintext = self.unwrap_bytes(wrapped, context).await?;
         if plaintext.len() != KEY_BYTES {
             return Err(KeyWrapError::new(
@@ -289,6 +388,9 @@ impl KeyWrappingRuntime {
         }
         let mut key = [0_u8; KEY_BYTES];
         key.copy_from_slice(&plaintext);
+        if let Some(cache_key) = cache_key {
+            self.data_key_cache.insert(cache_key, &key).await;
+        }
         Ok(Zeroizing::new(key))
     }
 
@@ -349,10 +451,33 @@ fn validate_environment(value: String) -> Result<String, KeyWrapError> {
     Ok(value)
 }
 
+fn data_key_cache_key(context: &KeyWrapContext, wrapped: &[u8]) -> Option<DataKeyCacheKey> {
+    if context.purpose != KeyWrapPurpose::CollectionDataKey {
+        return None;
+    }
+    Some(DataKeyCacheKey::new(
+        &context.environment,
+        context.collection_id?,
+        Sha256::digest(wrapped).into(),
+    ))
+}
+
 fn canonical_aad(value: impl Serialize) -> Result<Vec<u8>, KeyWrapError> {
     serde_json::to_vec(&value).map_err(|_| {
         KeyWrapError::configuration("The legacy key-wrapping identity could not serialize.")
     })
+}
+
+fn required_setting(value: Option<String>, name: &'static str) -> Result<String, KeyWrapError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            KeyWrapError::configuration(match name {
+                "AWS KMS key ID" => "The AWS KMS key ID is required.",
+                "AWS KMS region" => "The AWS KMS region is required.",
+                _ => "A managed key setting is required.",
+            })
+        })
 }
 
 #[cfg(test)]

--- a/crates/connect-hosted-provider/src/key_wrapping/tests.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/tests.rs
@@ -223,10 +223,106 @@ async fn rejects_wrong_context_and_invalid_unwrapped_lengths() {
     );
 }
 
+#[tokio::test]
+async fn coalesces_concurrent_cache_misses_and_keys_cache_entries_by_envelope_digest() {
+    let service = Arc::new(FakeManagedService::healthy());
+    let writer = KeyWrappingRuntime::managed_for_test(service.clone(), None);
+    let wrapped = writer
+        .wrap_data_key(&[0x21; KEY_BYTES], &context())
+        .await
+        .unwrap();
+    let reader = KeyWrappingRuntime::managed_for_test(service.clone(), None)
+        .with_data_key_cache(8, std::time::Duration::from_secs(60))
+        .unwrap();
+    let mut tasks = Vec::new();
+    for _ in 0..24 {
+        let reader = reader.clone();
+        let wrapped = wrapped.clone();
+        tasks.push(tokio::spawn(async move {
+            reader.unwrap_data_key(&wrapped, &context()).await.unwrap()
+        }));
+    }
+    for task in tasks {
+        assert_eq!(task.await.unwrap().as_ref(), &[0x21; KEY_BYTES]);
+    }
+    assert_eq!(service.contexts.lock().unwrap().len(), 2);
+
+    let mut changed = wrapped;
+    *changed.last_mut().unwrap() ^= 1;
+    assert_ne!(
+        reader
+            .unwrap_data_key(&changed, &context())
+            .await
+            .unwrap()
+            .as_ref(),
+        &[0x21; KEY_BYTES]
+    );
+    assert_eq!(service.contexts.lock().unwrap().len(), 3);
+}
+
 #[test]
 fn key_check_context_never_contains_a_collection_identifier() {
     let context = KeyWrapContext::provider_key_check("production").unwrap();
     let values = context.encryption_context();
     assert_eq!(values["mdbase:purpose"], "provider-key-check");
     assert!(!values.contains_key("mdbase:collection-id"));
+}
+
+#[tokio::test]
+#[ignore = "requires MDBASE_TEST_KMS_KEY_ID, MDBASE_TEST_KMS_RECOVERY_KEY_ID, and AWS credentials"]
+async fn live_aws_kms_primary_and_recovery_replica_round_trip() {
+    let key_id = std::env::var("MDBASE_TEST_KMS_KEY_ID").unwrap();
+    let recovery_key_id = std::env::var("MDBASE_TEST_KMS_RECOVERY_KEY_ID").unwrap();
+    let primary = AwsKmsKeyWrapper::from_default_chain(
+        "ap-southeast-1",
+        key_id,
+        "staging",
+        3,
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
+    let recovery = AwsKmsKeyWrapper::from_default_chain(
+        "ap-southeast-2",
+        recovery_key_id,
+        "staging",
+        3,
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
+    let primary = KeyWrappingRuntime::aws_kms(primary, None);
+    let recovery = KeyWrappingRuntime::aws_kms(recovery, None);
+    let context = context();
+    let data_key = [0x37; KEY_BYTES];
+    let wrapped = primary.wrap_data_key(&data_key, &context).await.unwrap();
+    assert_eq!(
+        primary
+            .unwrap_data_key(&wrapped, &context)
+            .await
+            .unwrap()
+            .as_ref(),
+        &data_key
+    );
+    assert_eq!(
+        recovery
+            .unwrap_data_key(&wrapped, &context)
+            .await
+            .unwrap()
+            .as_ref(),
+        &data_key
+    );
+    let wrong_context = KeyWrapContext::collection(
+        "staging",
+        Uuid::parse_str("01999999-9999-7999-8999-999999999999").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        primary
+            .unwrap_data_key(&wrapped, &wrong_context)
+            .await
+            .unwrap_err()
+            .kind,
+        KeyWrapErrorKind::InvalidCiphertext
+    );
 }

--- a/crates/connect-hosted-provider/src/key_wrapping/tests.rs
+++ b/crates/connect-hosted-provider/src/key_wrapping/tests.rs
@@ -1,0 +1,232 @@
+use std::sync::{Arc, Mutex};
+
+use super::*;
+
+const MANAGED_KEY: &str = "arn:aws:kms:ap-southeast-1:445617516211:key/mrk-test";
+
+#[derive(Clone)]
+struct FakeManagedService {
+    active_key_ref: &'static str,
+    failure: Arc<Mutex<Option<KeyWrapErrorKind>>>,
+    contexts: Arc<Mutex<Vec<BTreeMap<String, String>>>>,
+}
+
+impl FakeManagedService {
+    fn healthy() -> Self {
+        Self {
+            active_key_ref: MANAGED_KEY,
+            failure: Arc::new(Mutex::new(None)),
+            contexts: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn fail_with(&self, kind: KeyWrapErrorKind) {
+        *self.failure.lock().unwrap() = Some(kind);
+    }
+
+    fn maybe_fail(&self) -> Result<(), KeyWrapError> {
+        if let Some(kind) = self.failure.lock().unwrap().take() {
+            return Err(KeyWrapError::new(kind, "Synthetic managed key failure."));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ManagedKeyService for FakeManagedService {
+    fn active_key_ref(&self) -> &str {
+        self.active_key_ref
+    }
+
+    async fn encrypt(
+        &self,
+        plaintext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<ManagedCiphertext, KeyWrapError> {
+        self.maybe_fail()?;
+        self.contexts
+            .lock()
+            .unwrap()
+            .push(context.encryption_context());
+        Ok(ManagedCiphertext {
+            key_ref: self.active_key_ref.to_string(),
+            ciphertext: plaintext.iter().map(|byte| byte ^ 0x5a).collect(),
+        })
+    }
+
+    async fn decrypt(
+        &self,
+        key_ref: &str,
+        ciphertext: &[u8],
+        context: &KeyWrapContext,
+    ) -> Result<Zeroizing<Vec<u8>>, KeyWrapError> {
+        self.maybe_fail()?;
+        if key_ref != self.active_key_ref {
+            return Err(KeyWrapError::new(
+                KeyWrapErrorKind::WrongKey,
+                "Synthetic key mismatch.",
+            ));
+        }
+        self.contexts
+            .lock()
+            .unwrap()
+            .push(context.encryption_context());
+        Ok(Zeroizing::new(
+            ciphertext.iter().map(|byte| byte ^ 0x5a).collect(),
+        ))
+    }
+}
+
+fn context() -> KeyWrapContext {
+    KeyWrapContext::collection(
+        "staging",
+        Uuid::parse_str("01911111-1111-7111-8111-111111111111").unwrap(),
+    )
+    .unwrap()
+}
+
+fn legacy() -> LegacyKeyWrapper {
+    LegacyKeyWrapper::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap()
+}
+
+#[tokio::test]
+async fn writes_managed_envelopes_and_reads_them_with_exact_context() {
+    let service = Arc::new(FakeManagedService::healthy());
+    let runtime = KeyWrappingRuntime::managed_for_test(service.clone(), Some(legacy()));
+    let data_key = [9_u8; KEY_BYTES];
+    let wrapped = runtime.wrap_data_key(&data_key, &context()).await.unwrap();
+    assert_eq!(
+        KeyWrappingRuntime::inspect(&wrapped).unwrap(),
+        KeyWrapInspection::AwsKmsV1 {
+            key_ref: MANAGED_KEY.to_string()
+        }
+    );
+    assert_eq!(
+        runtime
+            .unwrap_data_key(&wrapped, &context())
+            .await
+            .unwrap()
+            .as_ref(),
+        &data_key
+    );
+    let contexts = service.contexts.lock().unwrap();
+    assert_eq!(contexts.len(), 2);
+    assert_eq!(contexts[0], contexts[1]);
+    assert_eq!(contexts[0]["mdbase:environment"], "staging");
+    assert_eq!(contexts[0]["mdbase:purpose"], "collection-data-key");
+    assert_eq!(
+        contexts[0]["mdbase:collection-id"],
+        "01911111-1111-7111-8111-111111111111"
+    );
+}
+
+#[tokio::test]
+async fn managed_writer_can_migrate_exact_legacy_envelopes() {
+    let legacy_runtime = KeyWrappingRuntime::legacy(legacy());
+    let data_key = [3_u8; KEY_BYTES];
+    let legacy_wrapped = legacy_runtime
+        .wrap_data_key(&data_key, &context())
+        .await
+        .unwrap();
+    let managed = KeyWrappingRuntime::managed_for_test(
+        Arc::new(FakeManagedService::healthy()),
+        Some(legacy()),
+    );
+    assert_eq!(
+        managed
+            .unwrap_data_key(&legacy_wrapped, &context())
+            .await
+            .unwrap()
+            .as_ref(),
+        &data_key
+    );
+    let rewrapped = managed.wrap_data_key(&data_key, &context()).await.unwrap();
+    assert!(matches!(
+        KeyWrappingRuntime::inspect(&rewrapped).unwrap(),
+        KeyWrapInspection::AwsKmsV1 { .. }
+    ));
+}
+
+#[tokio::test]
+async fn fails_closed_without_the_reader_required_by_stored_state() {
+    let legacy_runtime = KeyWrappingRuntime::legacy(legacy());
+    let wrapped = legacy_runtime
+        .wrap_data_key(&[4; KEY_BYTES], &context())
+        .await
+        .unwrap();
+    let managed =
+        KeyWrappingRuntime::managed_for_test(Arc::new(FakeManagedService::healthy()), None);
+    assert_eq!(
+        managed
+            .unwrap_data_key(&wrapped, &context())
+            .await
+            .unwrap_err()
+            .kind,
+        KeyWrapErrorKind::Configuration
+    );
+}
+
+#[tokio::test]
+async fn preserves_managed_failure_categories_without_key_material() {
+    let service = Arc::new(FakeManagedService::healthy());
+    let runtime = KeyWrappingRuntime::managed_for_test(service.clone(), None);
+    for kind in [
+        KeyWrapErrorKind::AccessDenied,
+        KeyWrapErrorKind::Disabled,
+        KeyWrapErrorKind::InvalidCiphertext,
+        KeyWrapErrorKind::Throttled,
+        KeyWrapErrorKind::Timeout,
+        KeyWrapErrorKind::Unavailable,
+    ] {
+        service.fail_with(kind);
+        let error = runtime
+            .wrap_data_key(&[8; KEY_BYTES], &context())
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind, kind);
+        assert!(!error.to_string().contains(MANAGED_KEY));
+        assert!(!error.to_string().contains("080808"));
+    }
+}
+
+#[tokio::test]
+async fn rejects_wrong_context_and_invalid_unwrapped_lengths() {
+    let legacy_runtime = KeyWrappingRuntime::legacy(legacy());
+    let wrapped = legacy_runtime
+        .wrap_data_key(&[2; KEY_BYTES], &context())
+        .await
+        .unwrap();
+    let other = KeyWrapContext::collection(
+        "staging",
+        Uuid::parse_str("01922222-2222-7222-8222-222222222222").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        legacy_runtime
+            .unwrap_data_key(&wrapped, &other)
+            .await
+            .unwrap_err()
+            .kind,
+        KeyWrapErrorKind::InvalidCiphertext
+    );
+
+    let service = Arc::new(FakeManagedService::healthy());
+    let runtime = KeyWrappingRuntime::managed_for_test(service, None);
+    let short = runtime.wrap_bytes(&[1, 2, 3], &context()).await.unwrap();
+    assert_eq!(
+        runtime
+            .unwrap_data_key(&short, &context())
+            .await
+            .unwrap_err()
+            .kind,
+        KeyWrapErrorKind::InvalidCiphertext
+    );
+}
+
+#[test]
+fn key_check_context_never_contains_a_collection_identifier() {
+    let context = KeyWrapContext::provider_key_check("production").unwrap();
+    let values = context.encryption_context();
+    assert_eq!(values["mdbase:purpose"], "provider-key-check");
+    assert!(!values.contains_key("mdbase:collection-id"));
+}

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -2,6 +2,7 @@ mod blob_store;
 mod crypto;
 mod error;
 mod http;
+mod key_admin;
 mod key_wrapping;
 mod notifications;
 mod provider;
@@ -15,9 +16,10 @@ pub use blob_store::{
 pub use crypto::ProviderCrypto;
 pub use error::{ApiError, ApiResult};
 pub use http::{app, AppState};
+pub use key_admin::{HostedKeyAdmin, KeyRewrapOptions, KeyRewrapReport, KeyWrapInventory};
 pub use key_wrapping::{
     AwsKmsKeyWrapper, KeyWrapContext, KeyWrapError, KeyWrapErrorKind, KeyWrapInspection,
-    KeyWrappingRuntime, LegacyKeyWrapper,
+    KeyWrappingBackend, KeyWrappingConfig, KeyWrappingRuntime, LegacyKeyWrapper,
 };
 pub use notifications::{HostedNotificationConfig, HostedNotificationRuntime};
 pub use provider::{

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -2,8 +2,10 @@ mod blob_store;
 mod crypto;
 mod error;
 mod http;
+mod key_wrapping;
 mod notifications;
 mod provider;
+mod symmetric_crypto;
 mod template;
 mod workspace;
 
@@ -13,6 +15,10 @@ pub use blob_store::{
 pub use crypto::ProviderCrypto;
 pub use error::{ApiError, ApiResult};
 pub use http::{app, AppState};
+pub use key_wrapping::{
+    AwsKmsKeyWrapper, KeyWrapContext, KeyWrapError, KeyWrapErrorKind, KeyWrapInspection,
+    KeyWrappingRuntime, LegacyKeyWrapper,
+};
 pub use notifications::{HostedNotificationConfig, HostedNotificationRuntime};
 pub use provider::{
     HostedProvider, NotificationRecoveryStatus, PrepareAuthorityImport, PrepareAuthorityTransfer,

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -1,9 +1,9 @@
 use std::{net::IpAddr, sync::Arc, time::Duration};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use mdbase_connect_hosted_provider::{
-    app, AppState, HostedNotificationConfig, HostedProvider, ProviderCrypto, ProviderLimits,
-    R2BlobStore, R2Config,
+    app, AppState, HostedNotificationConfig, HostedProvider, KeyWrappingBackend, KeyWrappingConfig,
+    ProviderCrypto, ProviderLimits, R2BlobStore, R2Config,
 };
 use tokio::{net::TcpListener, signal};
 use tracing_subscriber::EnvFilter;
@@ -11,12 +11,47 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Parser)]
 #[command(name = "mdbase-connect-hosted-provider")]
 struct Arguments {
-    #[arg(long, env = "DATABASE_URL")]
-    database_url: String,
-    #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN")]
-    internal_token: String,
-    #[arg(long, env = "MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY")]
-    master_key: String,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KEY_WRAPPER",
+        value_enum,
+        default_value = "local"
+    )]
+    key_wrapper: KeyWrapperBackend,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KEY_ENVIRONMENT",
+        default_value = "local"
+    )]
+    key_environment: String,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_KMS_KEY_ID")]
+    kms_key_id: Option<String>,
+    #[arg(long, env = "MDBASE_CONNECT_HOSTED_KMS_REGION")]
+    kms_region: Option<String>,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KMS_MAX_ATTEMPTS",
+        default_value_t = 3
+    )]
+    kms_max_attempts: u32,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KMS_TIMEOUT_SECONDS",
+        default_value_t = 5
+    )]
+    kms_timeout_seconds: u64,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KEY_CACHE_ENTRIES",
+        default_value_t = 1_024
+    )]
+    key_cache_entries: usize,
+    #[arg(
+        long,
+        env = "MDBASE_CONNECT_HOSTED_KEY_CACHE_TTL_SECONDS",
+        default_value_t = 300
+    )]
+    key_cache_ttl_seconds: u64,
     #[arg(long, env = "MDBASE_CONNECT_CONTROL_PLANE_URL")]
     control_plane_url: Option<String>,
     #[arg(long, env = "HOST", default_value = "127.0.0.1")]
@@ -93,10 +128,6 @@ struct Arguments {
     r2_endpoint: String,
     #[arg(long, env = "MDBASE_CONNECT_R2_BUCKET")]
     r2_bucket: String,
-    #[arg(long, env = "MDBASE_CONNECT_R2_ACCESS_KEY_ID")]
-    r2_access_key_id: String,
-    #[arg(long, env = "MDBASE_CONNECT_R2_SECRET_ACCESS_KEY")]
-    r2_secret_access_key: String,
     #[arg(
         long,
         env = "MDBASE_CONNECT_R2_MULTIPART_PART_BYTES",
@@ -123,9 +154,37 @@ struct Arguments {
     allow_insecure_r2: bool,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum KeyWrapperBackend {
+    Local,
+    AwsKms,
+}
+
+struct RuntimeSecrets {
+    database_url: String,
+    internal_token: String,
+    master_key: Option<String>,
+    r2_access_key_id: String,
+    r2_secret_access_key: String,
+}
+
+impl RuntimeSecrets {
+    fn from_environment() -> Result<Self, std::io::Error> {
+        Ok(Self {
+            database_url: required_environment("DATABASE_URL")?,
+            internal_token: required_environment("MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN")?,
+            master_key: optional_environment("MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY")?,
+            r2_access_key_id: required_environment("MDBASE_CONNECT_R2_ACCESS_KEY_ID")?,
+            r2_secret_access_key: required_environment("MDBASE_CONNECT_R2_SECRET_ACCESS_KEY")?,
+        })
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let arguments = Arguments::parse();
+    let mut secrets = RuntimeSecrets::from_environment()?;
     if arguments.maintenance_interval_seconds == 0 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -147,7 +206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_target(false)
         .init();
 
-    let crypto = ProviderCrypto::from_base64(&arguments.master_key)?;
+    let crypto = provider_crypto(&arguments, secrets.master_key.take()).await?;
     let limits = ProviderLimits {
         max_records_per_collection: arguments.max_records_per_collection,
         max_bytes_per_collection: arguments.max_bytes_per_collection,
@@ -163,14 +222,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .control_plane_url
             .map(|control_plane_url| HostedNotificationConfig {
                 control_plane_url,
-                internal_token: arguments.internal_token.clone(),
+                internal_token: secrets.internal_token.clone(),
             });
     let r2_config = if arguments.allow_insecure_r2 {
         R2Config::new_insecure_loopback(
             arguments.r2_endpoint,
             arguments.r2_bucket,
-            arguments.r2_access_key_id,
-            arguments.r2_secret_access_key,
+            secrets.r2_access_key_id,
+            secrets.r2_secret_access_key,
             arguments.r2_multipart_part_bytes,
             arguments.r2_download_part_bytes,
             Duration::from_secs(arguments.r2_presign_ttl_seconds),
@@ -179,8 +238,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         R2Config::new(
             arguments.r2_endpoint,
             arguments.r2_bucket,
-            arguments.r2_access_key_id,
-            arguments.r2_secret_access_key,
+            secrets.r2_access_key_id,
+            secrets.r2_secret_access_key,
             arguments.r2_multipart_part_bytes,
             arguments.r2_download_part_bytes,
             Duration::from_secs(arguments.r2_presign_ttl_seconds),
@@ -188,14 +247,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let blob_store = Arc::new(R2BlobStore::new(r2_config));
     let provider = HostedProvider::connect(
-        &arguments.database_url,
+        &secrets.database_url,
         crypto,
         limits,
         blob_store,
         notification_config,
     )
     .await?;
-    let state = AppState::new(provider.clone(), &arguments.internal_token)?;
+    let state = AppState::new(provider.clone(), &secrets.internal_token)?;
     let maintenance = tokio::spawn(maintain_history(
         provider.clone(),
         arguments.retain_changes,
@@ -219,6 +278,51 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = notification_recovery.await;
     result?;
     Ok(())
+}
+
+async fn provider_crypto(
+    arguments: &Arguments,
+    legacy_master_key: Option<String>,
+) -> Result<ProviderCrypto, Box<dyn std::error::Error>> {
+    let environment = arguments.key_environment.clone();
+    let runtime = KeyWrappingConfig {
+        backend: match arguments.key_wrapper {
+            KeyWrapperBackend::Local => KeyWrappingBackend::Local,
+            KeyWrapperBackend::AwsKms => KeyWrappingBackend::AwsKms,
+        },
+        environment: environment.clone(),
+        legacy_master_key,
+        kms_key_id: arguments.kms_key_id.clone(),
+        kms_region: arguments.kms_region.clone(),
+        kms_max_attempts: arguments.kms_max_attempts,
+        kms_timeout: Duration::from_secs(arguments.kms_timeout_seconds),
+        cache_entries: arguments.key_cache_entries,
+        cache_ttl: Duration::from_secs(arguments.key_cache_ttl_seconds),
+    }
+    .build()
+    .await?;
+    Ok(ProviderCrypto::with_key_wrapping(runtime, environment)?)
+}
+
+fn required_environment(name: &'static str) -> Result<String, std::io::Error> {
+    optional_environment(name)?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("required environment variable {name} is missing or empty"),
+        )
+    })
+}
+
+fn optional_environment(name: &'static str) -> Result<Option<String>, std::io::Error> {
+    match std::env::var(name) {
+        Ok(value) if value.trim().is_empty() => Ok(None),
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("environment variable {name} is not valid Unicode"),
+        )),
+    }
 }
 
 async fn maintain_history(provider: HostedProvider, retain_changes: u64, period: Duration) {

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -85,8 +85,26 @@ use policy::*;
 
 const SNAPSHOT_PAGE_SIZE: i64 = 200;
 const DATABASE_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+const KEY_READINESS_SUCCESS_TTL: Duration = Duration::from_secs(60);
+const KEY_READINESS_FAILURE_TTL: Duration = Duration::from_secs(5);
 type WorkingSetSlot = Arc<Mutex<Option<CachedCollection>>>;
 type WorkingSetRegistry = Arc<Mutex<HashMap<Uuid, WorkingSetSlot>>>;
+
+struct KeyReadinessState {
+    last_checked: Instant,
+    healthy: bool,
+}
+
+impl KeyReadinessState {
+    fn should_probe(&self, now: Instant) -> bool {
+        let ttl = if self.healthy {
+            KEY_READINESS_SUCCESS_TTL
+        } else {
+            KEY_READINESS_FAILURE_TTL
+        };
+        now.saturating_duration_since(self.last_checked) >= ttl
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ProviderLimits {
@@ -142,6 +160,7 @@ impl Default for ProviderLimits {
 pub struct HostedProvider {
     pool: PgPool,
     crypto: ProviderCrypto,
+    key_readiness: Arc<Mutex<KeyReadinessState>>,
     limits: ProviderLimits,
     working_sets: WorkingSetRegistry,
     notifications: Option<HostedNotificationRuntime>,
@@ -370,7 +389,7 @@ fn validate_contract_setup_targets(
     Ok(())
 }
 
-fn hosted_migrator() -> sqlx::migrate::Migrator {
+pub(crate) fn hosted_migrator() -> sqlx::migrate::Migrator {
     let mut migrator = sqlx::migrate!("./migrations");
     migrator.set_ignore_missing(true);
     migrator

--- a/crates/connect-hosted-provider/src/provider/authority_import_files.rs
+++ b/crates/connect-hosted-provider/src/provider/authority_import_files.rs
@@ -51,7 +51,7 @@ impl HostedProvider {
                 "A finalized authority import cannot accept file uploads.",
             ));
         }
-        let data_key = self.authority_import_data_key(&row)?;
+        let data_key = self.authority_import_data_key(&row).await?;
         let manifest = self.authority_import_manifest(&row, &data_key, import_id)?;
         let file = manifest
             .files
@@ -189,7 +189,7 @@ impl HostedProvider {
         let mut transaction = self.pool.begin().await?;
         let row = authority_import_row(&mut transaction, import_id).await?;
         authorize_authority_import(&row, token)?;
-        let data_key = self.authority_import_data_key(&row)?;
+        let data_key = self.authority_import_data_key(&row).await?;
         let transfer = self
             .load_import_file_transfer(&mut transaction, request.transfer_id, &data_key)
             .await?
@@ -261,7 +261,7 @@ impl HostedProvider {
         let mut transaction = self.pool.begin().await?;
         let row = authority_import_row(&mut transaction, import_id).await?;
         authorize_authority_import(&row, token)?;
-        let data_key = self.authority_import_data_key(&row)?;
+        let data_key = self.authority_import_data_key(&row).await?;
         let mut transfer = self
             .load_import_file_transfer(&mut transaction, request.transfer_id, &data_key)
             .await?
@@ -311,12 +311,14 @@ impl HostedProvider {
         Ok(import_file_receipt(&transfer))
     }
 
-    fn authority_import_data_key(&self, row: &PgRow) -> ApiResult<[u8; 32]> {
+    async fn authority_import_data_key(
+        &self,
+        row: &PgRow,
+    ) -> ApiResult<zeroize::Zeroizing<[u8; 32]>> {
         let collection_id: Uuid = row.get("collection_id");
-        self.crypto.unwrap_data_key(
-            &row.get::<Vec<u8>, _>("wrapped_data_key"),
-            &collection_key_aad(collection_id),
-        )
+        self.crypto
+            .unwrap_data_key(&row.get::<Vec<u8>, _>("wrapped_data_key"), collection_id)
+            .await
     }
 
     fn authority_import_manifest(

--- a/crates/connect-hosted-provider/src/provider/authority_imports.rs
+++ b/crates/connect-hosted-provider/src/provider/authority_imports.rs
@@ -276,9 +276,7 @@ impl HostedProvider {
         }
         let collection_id = row.get::<Uuid, _>("collection_id");
         let wrapped: Vec<u8> = row.get("wrapped_data_key");
-        let data_key = self
-            .crypto
-            .unwrap_data_key(&wrapped, &collection_key_aad(collection_id))?;
+        let data_key = self.crypto.unwrap_data_key(&wrapped, collection_id).await?;
         let previous_digest: Option<String> = row.get("manifest_digest");
         let previous_revision: Option<String> = row.get("source_revision");
         let manifest_changed = previous_digest.as_deref() != Some(&manifest.manifest_digest)
@@ -381,9 +379,7 @@ impl HostedProvider {
         }
         let collection_id = row.get::<Uuid, _>("collection_id");
         let wrapped: Vec<u8> = row.get("wrapped_data_key");
-        let data_key = self
-            .crypto
-            .unwrap_data_key(&wrapped, &collection_key_aad(collection_id))?;
+        let data_key = self.crypto.unwrap_data_key(&wrapped, collection_id).await?;
         sqlx::query(
             "DELETE FROM hosted_provider_authority_import_records
              WHERE import_id = $1 AND page = $2",
@@ -436,15 +432,13 @@ impl HostedProvider {
         authorize_authority_import(&row, token)?;
         if authority_import_state(&row, "import_state")? == ProviderAuthorityImportState::Uploaded {
             let mut result = provider_authority_import(&row)?;
-            result.contracts = authority_import_contracts(self, &row)?;
+            result.contracts = authority_import_contracts(self, &row).await?;
             transaction.commit().await?;
             return Ok(result);
         }
         let collection_id = row.get::<Uuid, _>("collection_id");
         let wrapped: Vec<u8> = row.get("wrapped_data_key");
-        let data_key = self
-            .crypto
-            .unwrap_data_key(&wrapped, &collection_key_aad(collection_id))?;
+        let data_key = self.crypto.unwrap_data_key(&wrapped, collection_id).await?;
         let manifest_ciphertext: Vec<u8> = row
             .get::<Option<Vec<u8>>, _>("manifest_ciphertext")
             .ok_or_else(|| {
@@ -830,7 +824,7 @@ impl HostedProvider {
                 ));
             }
             let mut result = provider_authority_import(&row)?;
-            result.contracts = authority_import_contracts(self, &row)?;
+            result.contracts = authority_import_contracts(self, &row).await?;
             transaction.commit().await?;
             return Ok(result);
         }
@@ -871,7 +865,7 @@ impl HostedProvider {
         .fetch_one(&mut *transaction)
         .await?;
         let mut result = provider_authority_import(&saved)?;
-        result.contracts = authority_import_contracts(self, &row)?;
+        result.contracts = authority_import_contracts(self, &row).await?;
         transaction.commit().await?;
         Ok(result)
     }

--- a/crates/connect-hosted-provider/src/provider/authority_snapshots.rs
+++ b/crates/connect-hosted-provider/src/provider/authority_snapshots.rs
@@ -74,7 +74,7 @@ pub(super) fn provider_authority_import(row: &PgRow) -> ApiResult<ProviderAuthor
     })
 }
 
-pub(super) fn authority_import_contracts(
+pub(super) async fn authority_import_contracts(
     provider: &HostedProvider,
     row: &PgRow,
 ) -> ApiResult<Vec<CollectionContractDescriptor>> {
@@ -82,7 +82,8 @@ pub(super) fn authority_import_contracts(
     let wrapped_data_key: Vec<u8> = row.get("wrapped_data_key");
     let data_key = provider
         .crypto
-        .unwrap_data_key(&wrapped_data_key, &collection_key_aad(collection_id))?;
+        .unwrap_data_key(&wrapped_data_key, collection_id)
+        .await?;
     let manifest_ciphertext: Option<Vec<u8>> = row.get("manifest_ciphertext");
     let manifest: AuthorityImportManifest = provider.crypto.decrypt_json(
         &data_key,

--- a/crates/connect-hosted-provider/src/provider/authority_transfers.rs
+++ b/crates/connect-hosted-provider/src/provider/authority_transfers.rs
@@ -90,7 +90,9 @@ impl HostedProvider {
         let next_epoch = current_epoch
             .checked_add(1)
             .ok_or_else(|| ApiError::internal("The collection authority epoch is exhausted."))?;
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let resources =
             load_resource_documents(&mut transaction, &self.crypto, &data_key, collection_id)
                 .await?;

--- a/crates/connect-hosted-provider/src/provider/collections.rs
+++ b/crates/connect-hosted-provider/src/provider/collections.rs
@@ -62,9 +62,7 @@ impl HostedProvider {
         }
         let (resources, documents) = template::resources(template_name)?;
         let data_key = self.crypto.generate_data_key();
-        let wrapped_data_key = self
-            .crypto
-            .wrap_data_key(&data_key, &collection_key_aad(collection_id))?;
+        let wrapped_data_key = self.crypto.wrap_data_key(&data_key, collection_id).await?;
         let resources_ciphertext =
             self.crypto
                 .encrypt_json(&data_key, &resources, &resources_aad(collection_id))?;

--- a/crates/connect-hosted-provider/src/provider/crypto_state.rs
+++ b/crates/connect-hosted-provider/src/provider/crypto_state.rs
@@ -10,10 +10,6 @@ pub(super) fn optional_encrypted_record(
         .transpose()
 }
 
-pub(super) fn collection_key_aad(collection_id: Uuid) -> Vec<u8> {
-    aad(("collection_key", collection_id))
-}
-
 pub(super) fn resources_aad(collection_id: Uuid) -> Vec<u8> {
     aad(("resources", collection_id))
 }

--- a/crates/connect-hosted-provider/src/provider/files/lifecycle.rs
+++ b/crates/connect-hosted-provider/src/provider/files/lifecycle.rs
@@ -66,7 +66,9 @@ impl HostedProvider {
             request_origin,
         )?;
         let collection = lock_file_collection(&mut transaction, collection_id).await?;
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let mutation = FileMutationIdentity {
             data_key: &data_key,
             collection_id,
@@ -235,7 +237,9 @@ impl HostedProvider {
             request_origin,
         )?;
         let collection = lock_file_collection(&mut transaction, collection_id).await?;
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let mutation = FileMutationIdentity {
             data_key: &data_key,
             collection_id,

--- a/crates/connect-hosted-provider/src/provider/files/persistence.rs
+++ b/crates/connect-hosted-provider/src/provider/files/persistence.rs
@@ -21,7 +21,10 @@ impl HostedProvider {
         replica_from_row(row)
     }
 
-    pub(super) async fn load_collection_key(&self, collection_id: Uuid) -> ApiResult<[u8; 32]> {
+    pub(super) async fn load_collection_key(
+        &self,
+        collection_id: Uuid,
+    ) -> ApiResult<zeroize::Zeroizing<[u8; 32]>> {
         let wrapped: Vec<u8> = sqlx::query_scalar(
             "SELECT wrapped_data_key FROM hosted_provider_collections WHERE id = $1 AND state = 'active'",
         )
@@ -29,7 +32,7 @@ impl HostedProvider {
         .fetch_optional(&self.pool)
         .await?
         .ok_or_else(hosted_collection_not_found)?;
-        self.collection_key(collection_id, &wrapped)
+        self.collection_key(collection_id, &wrapped).await
     }
 
     pub(super) async fn load_current_file(

--- a/crates/connect-hosted-provider/src/provider/files/upload.rs
+++ b/crates/connect-hosted-provider/src/provider/files/upload.rs
@@ -35,7 +35,9 @@ impl HostedProvider {
                 "The file exceeds this hosted collection's per-file limit.",
             ));
         }
-        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, row.get("wrapped_data_key"))
+            .await?;
         if let Some(existing) = self
             .load_upload_transfer(collection_id, request.transfer_id, &data_key)
             .await?
@@ -709,8 +711,9 @@ impl HostedProvider {
         .fetch_optional(&mut *transaction)
         .await?
         .ok_or_else(hosted_collection_not_found)?;
-        let data_key =
-            self.collection_key(transfer.collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(transfer.collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let locked_transfer = sqlx::query(
             "SELECT state, receipt_ciphertext FROM hosted_provider_file_transfers WHERE id = $1 FOR UPDATE",
         )

--- a/crates/connect-hosted-provider/src/provider/lifecycle.rs
+++ b/crates/connect-hosted-provider/src/provider/lifecycle.rs
@@ -29,6 +29,10 @@ impl HostedProvider {
                             let provider = Self {
                                 pool,
                                 crypto,
+                                key_readiness: Arc::new(Mutex::new(KeyReadinessState {
+                                    last_checked: Instant::now(),
+                                    healthy: true,
+                                })),
                                 limits,
                                 working_sets: Arc::new(Mutex::new(HashMap::new())),
                                 notifications,
@@ -98,6 +102,7 @@ impl HostedProvider {
     pub async fn ready(&self) -> ApiResult<NotificationRecoveryStatus> {
         sqlx::query("SELECT 1").execute(&self.pool).await?;
         self.blob_store.ready().await?;
+        self.verify_key_readiness().await?;
         let status = self.notification_recovery.read().await.clone();
         if status.configured && status.recovery != "ok" {
             return Err(ApiError::new(
@@ -107,6 +112,33 @@ impl HostedProvider {
             ));
         }
         Ok(status)
+    }
+
+    async fn verify_key_readiness(&self) -> ApiResult<()> {
+        // Serialize probes so a burst of health requests performs at most one KMS
+        // decrypt. A short failure cache prevents an unavailable key service from
+        // being amplified by the platform's readiness polling.
+        let mut readiness = self.key_readiness.lock().await;
+        if !readiness.should_probe(Instant::now()) {
+            return if readiness.healthy {
+                Ok(())
+            } else {
+                Err(key_readiness_unavailable())
+            };
+        }
+
+        match verify_stored_database_key(&self.pool, &self.crypto).await {
+            Ok(()) => {
+                readiness.last_checked = Instant::now();
+                readiness.healthy = true;
+                Ok(())
+            }
+            Err(error) => {
+                readiness.last_checked = Instant::now();
+                readiness.healthy = false;
+                Err(error)
+            }
+        }
     }
 
     pub async fn upsert_notification_grant(
@@ -152,5 +184,33 @@ impl HostedProvider {
                 Err(error)
             }
         }
+    }
+}
+
+fn key_readiness_unavailable() -> ApiError {
+    ApiError::new(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "key_readiness_unavailable",
+        "The hosted provider cannot currently verify its configured key hierarchy.",
+    )
+}
+
+#[cfg(test)]
+mod key_readiness_tests {
+    use super::*;
+
+    #[test]
+    fn successful_and_failed_checks_have_bounded_probe_intervals() {
+        let start = Instant::now();
+        let mut state = KeyReadinessState {
+            last_checked: start,
+            healthy: true,
+        };
+        assert!(!state.should_probe(start + KEY_READINESS_SUCCESS_TTL - Duration::from_millis(1)));
+        assert!(state.should_probe(start + KEY_READINESS_SUCCESS_TTL));
+
+        state.healthy = false;
+        assert!(!state.should_probe(start + KEY_READINESS_FAILURE_TTL - Duration::from_millis(1)));
+        assert!(state.should_probe(start + KEY_READINESS_FAILURE_TTL));
     }
 }

--- a/crates/connect-hosted-provider/src/provider/mutations.rs
+++ b/crates/connect-hosted-provider/src/provider/mutations.rs
@@ -78,7 +78,9 @@ impl HostedProvider {
                 "Hosted collection not found.",
             )
         })?;
-        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        let data_key = self
+            .collection_key(collection_id, &wrapped_data_key)
+            .await?;
         if let Some(row) = sqlx::query(
             "SELECT mutation_hash, receipt_ciphertext FROM hosted_provider_mutation_receipts WHERE replica_id = $1 AND mutation_id = $2",
         )

--- a/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
@@ -373,7 +373,9 @@ impl HostedProvider {
                 "Hosted collection not found.",
             )
         })?;
-        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, row.get("wrapped_data_key"))
+            .await?;
         self.crypto.decrypt_json(
             &data_key,
             row.get("resources_ciphertext"),

--- a/crates/connect-hosted-provider/src/provider/operation_reads.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_reads.rs
@@ -19,7 +19,9 @@ impl HostedProvider {
                 "Hosted collection not found.",
             )
         })?;
-        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, row.get("wrapped_data_key"))
+            .await?;
         let resources: SyncCollectionResources = self.crypto.decrypt_json(
             &data_key,
             row.get("resources_ciphertext"),
@@ -128,7 +130,9 @@ impl HostedProvider {
         .await?;
         let mut has_more =
             record_rows.len() > limit as usize || resource_rows.len() > limit as usize;
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let mut events = Vec::new();
         for row in record_rows {
             let sequence = number(row.get::<i64, _>("sequence"), "change sequence")?;
@@ -220,7 +224,9 @@ impl HostedProvider {
             )
         })?;
         let head = number(collection.get::<i64, _>("head"), "collection head")?;
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let working_set = self.working_set(collection_id).await;
         let mut cached = working_set.lock().await;
         if cached
@@ -315,7 +321,9 @@ impl HostedProvider {
             ));
         }
         let wrapped_data_key: Vec<u8> = row.get("wrapped_data_key");
-        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        let data_key = self
+            .collection_key(collection_id, &wrapped_data_key)
+            .await?;
         if let Some(ciphertext) = row.get::<Option<Vec<u8>>, _>("response_ciphertext") {
             let response = self.crypto.decrypt_json(
                 &data_key,

--- a/crates/connect-hosted-provider/src/provider/operation_records.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_records.rs
@@ -41,7 +41,9 @@ impl HostedProvider {
                 "Hosted collection not found.",
             )
         })?;
-        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        let data_key = self
+            .collection_key(collection_id, &wrapped_data_key)
+            .await?;
         let request_hash = operation_request_hash(operation, request_input)?;
         if let Some(row) = sqlx::query(
             r#"SELECT operation, request_hash, prepared_mutation_ciphertext
@@ -225,7 +227,9 @@ impl HostedProvider {
         .bind(collection_id)
         .fetch_one(&self.pool)
         .await?;
-        let data_key = self.collection_key(collection_id, &wrapped_data_key)?;
+        let data_key = self
+            .collection_key(collection_id, &wrapped_data_key)
+            .await?;
         let request_hash = operation_request_hash(operation, input)?;
         let response_ciphertext = self.crypto.encrypt_json(
             &data_key,

--- a/crates/connect-hosted-provider/src/provider/operation_types.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_types.rs
@@ -37,7 +37,9 @@ impl HostedProvider {
                 "The type definition exceeds the hosted document size limit.",
             ));
         }
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let working_set = self.working_set(collection_id).await;
         let mut cached = working_set.lock().await;
         if cached
@@ -252,7 +254,9 @@ impl HostedProvider {
                 "A type pack resource exceeds the hosted document size limit.",
             ));
         }
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let working_set = self.working_set(collection_id).await;
         let mut cached = working_set.lock().await;
         if cached

--- a/crates/connect-hosted-provider/src/provider/operation_views.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_views.rs
@@ -37,7 +37,9 @@ impl HostedProvider {
                 "The saved-view source exceeds the hosted document size limit.",
             ));
         }
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         let working_set = self.working_set(collection_id).await;
         let mut cached = working_set.lock().await;
         if cached

--- a/crates/connect-hosted-provider/src/provider/persistence.rs
+++ b/crates/connect-hosted-provider/src/provider/persistence.rs
@@ -10,6 +10,7 @@ pub(super) async fn verify_database_key(
 ) -> Result<(), DatabaseKeyError> {
     let candidate = crypto
         .create_key_check()
+        .await
         .map_err(DatabaseKeyError::Invalid)?;
     sqlx::query(
         r#"INSERT INTO hosted_provider_metadata (singleton, key_check)
@@ -26,7 +27,19 @@ pub(super) async fn verify_database_key(
             .map_err(DatabaseKeyError::Database)?;
     crypto
         .verify_key_check(&key_check)
+        .await
         .map_err(DatabaseKeyError::Invalid)
+}
+
+pub(super) async fn verify_stored_database_key(
+    pool: &PgPool,
+    crypto: &ProviderCrypto,
+) -> ApiResult<()> {
+    let key_check: Vec<u8> =
+        sqlx::query_scalar("SELECT key_check FROM hosted_provider_metadata WHERE singleton = true")
+            .fetch_one(pool)
+            .await?;
+    crypto.verify_key_check(&key_check).await
 }
 
 pub(super) async fn authenticate_in(

--- a/crates/connect-hosted-provider/src/provider/provider_state.rs
+++ b/crates/connect-hosted-provider/src/provider/provider_state.rs
@@ -1,13 +1,12 @@
 use super::*;
 
 impl HostedProvider {
-    pub(super) fn collection_key(
+    pub(super) async fn collection_key(
         &self,
         collection_id: Uuid,
         wrapped: &[u8],
-    ) -> ApiResult<[u8; 32]> {
-        self.crypto
-            .unwrap_data_key(wrapped, &collection_key_aad(collection_id))
+    ) -> ApiResult<zeroize::Zeroizing<[u8; 32]>> {
+        self.crypto.unwrap_data_key(wrapped, collection_id).await
     }
 
     pub(super) async fn working_set(&self, collection_id: Uuid) -> WorkingSetSlot {

--- a/crates/connect-hosted-provider/src/provider/sync_reads.rs
+++ b/crates/connect-hosted-provider/src/provider/sync_reads.rs
@@ -41,7 +41,9 @@ impl HostedProvider {
         let head = number(row.get::<i64, _>("head"), "collection head")?;
         let retained_after = number(row.get::<i64, _>("retained_after"), "retained cursor")?;
         let resource_revision: String = row.get("resource_revision");
-        let data_key = self.collection_key(collection_id, row.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, row.get("wrapped_data_key"))
+            .await?;
         let mut resources: SyncCollectionResources = self.crypto.decrypt_json(
             &data_key,
             row.get("resources_ciphertext"),
@@ -140,7 +142,9 @@ impl HostedProvider {
                 "The replica scope changed; open a new sync session.",
             ));
         }
-        let data_key = self.collection_key(collection_id, lease.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, lease.get("wrapped_data_key"))
+            .await?;
         let rows = sqlx::query(
             r#"SELECT record_id, revision, types, sequence, payload_ciphertext
                FROM (
@@ -264,7 +268,9 @@ impl HostedProvider {
                 "The replica scope changed; open a new sync session.",
             ));
         }
-        let data_key = self.collection_key(collection_id, lease.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, lease.get("wrapped_data_key"))
+            .await?;
         let rows = sqlx::query(
             r#"SELECT file_id, revision, size, object_key, payload_ciphertext, sequence
                FROM (
@@ -379,7 +385,9 @@ impl HostedProvider {
             collection.get::<i64, _>("retained_after"),
             "retained cursor",
         )?;
-        let data_key = self.collection_key(collection_id, collection.get("wrapped_data_key"))?;
+        let data_key = self
+            .collection_key(collection_id, collection.get("wrapped_data_key"))
+            .await?;
         if after < retained_after {
             return Ok(SyncChangesPage {
                 protocol_version: SYNC_PROTOCOL_VERSION,

--- a/crates/connect-hosted-provider/src/symmetric_crypto.rs
+++ b/crates/connect-hosted-provider/src/symmetric_crypto.rs
@@ -1,0 +1,55 @@
+use aes_gcm::{
+    aead::{Aead, KeyInit, Payload},
+    Aes256Gcm, Nonce,
+};
+use rand_core::{OsRng, RngCore};
+
+use crate::error::{ApiError, ApiResult};
+
+const ENVELOPE_VERSION: u8 = 1;
+const NONCE_BYTES: usize = 12;
+
+pub(crate) fn encrypt(key: &[u8; 32], plaintext: &[u8], aad: &[u8]) -> ApiResult<Vec<u8>> {
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
+    let mut nonce = [0_u8; NONCE_BYTES];
+    OsRng.fill_bytes(&mut nonce);
+    let nonce = Nonce::from(nonce);
+    let ciphertext = cipher
+        .encrypt(
+            &nonce,
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|_| ApiError::internal("The hosted value could not be encrypted."))?;
+    let mut envelope = Vec::with_capacity(1 + NONCE_BYTES + ciphertext.len());
+    envelope.push(ENVELOPE_VERSION);
+    envelope.extend_from_slice(&nonce);
+    envelope.extend_from_slice(&ciphertext);
+    Ok(envelope)
+}
+
+pub(crate) fn decrypt(key: &[u8; 32], envelope: &[u8], aad: &[u8]) -> ApiResult<Vec<u8>> {
+    if envelope.len() <= 1 + NONCE_BYTES || envelope[0] != ENVELOPE_VERSION {
+        return Err(ApiError::internal(
+            "The hosted ciphertext envelope is invalid.",
+        ));
+    }
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|_| ApiError::internal("The hosted encryption key is invalid."))?;
+    let nonce_bytes: [u8; NONCE_BYTES] = envelope[1..1 + NONCE_BYTES]
+        .try_into()
+        .map_err(|_| ApiError::internal("The hosted ciphertext envelope is invalid."))?;
+    let nonce = Nonce::from(nonce_bytes);
+    cipher
+        .decrypt(
+            &nonce,
+            Payload {
+                msg: &envelope[1 + NONCE_BYTES..],
+                aad,
+            },
+        )
+        .map_err(|_| ApiError::internal("The hosted ciphertext failed authentication."))
+}

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -641,23 +641,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.15",
- "http 0.2.12",
+ "h2",
  "http 1.4.2",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.11.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -830,7 +824,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1892,25 +1886,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
@@ -2104,30 +2079,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
@@ -2136,7 +2087,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -2150,32 +2101,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.2",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.9",
 ]
@@ -2192,12 +2128,12 @@ dependencies = [
  "futures-util",
  "http 1.4.2",
  "http-body 1.1.0",
- "hyper 1.11.0",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3333,8 +3269,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.42",
- "socket2 0.6.5",
+ "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3354,7 +3290,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -3372,7 +3308,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3552,22 +3488,22 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
@@ -3646,18 +3582,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
@@ -3666,7 +3590,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3691,16 +3615,6 @@ checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3756,16 +3670,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sec1"
@@ -4051,16 +3955,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -4131,7 +4025,7 @@ dependencies = [
  "log",
  "memchr",
  "percent-encoding",
- "rustls 0.23.42",
+ "rustls",
  "rustls-native-certs",
  "serde",
  "serde_json",
@@ -4461,7 +4355,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4479,21 +4373,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.42",
+ "rustls",
  "tokio",
 ]
 
@@ -4516,10 +4400,10 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -4713,7 +4597,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
- "rustls 0.23.42",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.7",
  "thiserror",

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -290,6 +290,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.2",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-credential-types"
 version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +364,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -353,6 +383,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-kms"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217276b3d948ec05b2726d66b2c9013567ca42751052c287ec45800ee81799c9"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,8 +420,8 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -389,6 +444,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-sso"
+version = "1.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sigv4"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,7 +527,7 @@ checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -432,7 +563,7 @@ version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -456,6 +587,27 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -512,6 +664,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
 version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
@@ -531,13 +692,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
 name = "aws-smithy-runtime"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1255,7 +1426,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1365,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2026,7 +2197,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2554,8 +2725,12 @@ version = "0.1.0-beta.23"
 dependencies = [
  "aes-gcm",
  "async-trait",
+ "aws-config",
  "aws-credential-types",
+ "aws-sdk-kms",
  "aws-sdk-s3",
+ "aws-smithy-types",
+ "aws-types",
  "axum",
  "base64",
  "chrono",
@@ -2584,6 +2759,7 @@ dependencies = [
  "unicode-normalization",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2782,7 +2958,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,7 +3334,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -3196,9 +3372,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3465,7 +3641,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3890,7 +4066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4183,10 +4359,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4633,6 +4809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,7 +5024,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -27,6 +27,7 @@ RUN apt-get update \
  && useradd --create-home --uid 10001 mdbase
 
 COPY --from=build /build/mdbase-connect/target/release/mdbase-connect-hosted-provider /usr/local/bin/
+COPY --from=build /build/mdbase-connect/target/release/mdbase-hosted-key-admin /usr/local/bin/
 
 ENV HOST=0.0.0.0 \
     PORT=8790 \

--- a/docs/decisions/0003-managed-provider-key-wrapping.md
+++ b/docs/decisions/0003-managed-provider-key-wrapping.md
@@ -1,0 +1,176 @@
+# ADR 0003: Managed hosted-provider key wrapping
+
+- Status: accepted
+- Date: 2026-08-02
+
+## Context
+
+Each hosted collection has a random 256-bit data-encryption key (DEK). The DEK
+encrypts collection resources, records, history, operation receipts, and file
+metadata. The current provider wraps every DEK with one 256-bit deployment
+master key supplied through Render. PostgreSQL contains only wrapped DEKs and
+ciphertext, but the deployment key cannot be rotated without rewriting every
+collection and a lost key makes a restored database unreadable.
+
+The managed service needs online rotation, an auditable use boundary, explicit
+recovery behavior, and an idempotent migration from the existing local wrapper.
+KMS must never receive record payloads or local-collection data.
+
+## Decision
+
+### Separate content encryption from key wrapping
+
+`ProviderCrypto` continues to perform local authenticated content encryption.
+Key wrapping is an asynchronous interface with two implementations:
+
+- `local-aes-256-gcm-v1`, retained only to read and migrate existing values;
+- `aws-kms-v1`, the managed-service writer and normal reader.
+
+The active writer is configured explicitly. A deployment may have both readers
+during migration, but it has exactly one active writer. A KMS deployment fails
+closed if its KMS key ID, region, credentials, or legacy fallback required by
+stored rows is missing.
+
+### Self-describing wrap envelope
+
+New wrapped values use a bounded, versioned binary envelope containing:
+
+- a fixed mdbase key-envelope marker and envelope version;
+- the wrapping scheme;
+- the immutable KMS key ARN returned by KMS, never only an alias;
+- the KMS ciphertext blob.
+
+Existing AES-GCM envelopes are recognized only by their exact legacy format.
+Unknown markers, versions, schemes, duplicate fields, oversized fields, and
+malformed base64 are rejected. The envelope is not secret; it contains no
+plaintext DEK or credential. Keeping the key reference with the ciphertext
+makes inventory and recovery deterministic without adding wrapping columns to
+every query that reads `wrapped_data_key`.
+
+### KMS operation and context
+
+The provider generates each DEK locally with the operating-system CSPRNG and
+calls KMS `Encrypt`. Unwrap calls KMS `Decrypt` and supplies the complete
+encryption context. Rotation tooling may use `ReEncrypt` only when both source
+and destination contexts are preserved exactly; otherwise it decrypts a DEK in
+bounded memory and immediately wraps it with the active writer.
+
+The authenticated KMS encryption context contains:
+
+- `mdbase:service = hosted-provider`;
+- `mdbase:environment = staging` or `production`;
+- `mdbase:purpose = collection-data-key` or `provider-key-check`;
+- `mdbase:collection-id = <UUID>` for collection keys;
+- `mdbase:envelope-version = 1`.
+
+The same canonical purpose/collection identity remains authenticated by the
+legacy wrapper's associated data. A ciphertext cannot be moved between
+environments, purposes, or collections and still decrypt.
+
+KMS calls have an explicit operation timeout, use the AWS SDK's bounded retry
+policy, and map access denial, disabled/not-found keys, invalid ciphertext,
+throttling, timeout, and unavailable-service failures to stable internal error
+categories. Errors and tracing may include operation, environment, scheme, and
+key ARN, but never plaintext keys, ciphertext blobs, credentials, record data,
+or collection contents.
+
+### Key hierarchy and identities
+
+The managed account owns separate customer-managed keys and aliases:
+
+- `alias/mdbase/hosted-provider/staging`;
+- `alias/mdbase/hosted-provider/production`.
+
+Singapore (`ap-southeast-1`) is primary because the Render services run there.
+Keys are created as multi-Region-capable so a deliberately provisioned Sydney
+(`ap-southeast-2`) replica can recover matching ciphertext. Staging receives a
+replica for the recovery drill; production does not rely on one until its
+policy and drill have been reviewed.
+
+Human administration uses the MFA-backed IAM Identity Center role. Render uses
+separate staging and production IAM workload users because Render currently has
+no native AWS workload-identity federation and IAM Roles Anywhere would add a
+CA, workload certificate, and credential helper to this small deployment. Each
+user can use only its environment's key and exact encryption context. Access
+keys are created outside infrastructure state, stored only in the matching
+Render environment, and rotated with two overlapping keys. IAM Roles Anywhere
+remains the preferred later replacement when its PKI lifecycle is justified.
+
+### Provider key check and cache
+
+The database provider-key check is wrapped by the same active wrapper and uses
+the dedicated `provider-key-check` context. During migration the provider can
+verify a legacy check with the legacy reader while writing KMS collection
+envelopes. The migration switches the check only after inventory proves all
+collection DEKs use the active managed key.
+
+Successful DEK unwraps are cached only in process memory by collection ID,
+envelope digest, and key reference. The cache is bounded by entry count and
+time, never serialized, zeroizes evicted key bytes, and is discarded on restart.
+The envelope digest prevents a stale cached DEK from surviving a database
+rewrap. Administrative rewrap clears the affected entry.
+
+### Migration and rotation
+
+The administrative tool has read-only `inspect` and mutating `rewrap` modes.
+It reports counts by envelope version/scheme/key reference and never prints
+collection IDs, ciphertext, or plaintext keys. Rewrap:
+
+1. locks one collection row with `FOR UPDATE SKIP LOCKED`;
+2. unwraps using the envelope-selected reader and exact context;
+3. wraps using the configured active writer;
+4. updates only when the original envelope still matches;
+5. commits that row before continuing;
+6. records aggregate success, skipped, concurrent-change, and failure counts.
+
+The command is idempotent, accepts a batch limit, supports dry-run, and can
+resume after interruption. It refuses to migrate the provider-key check or
+declare completion while any active/importing/deleting collection requires a
+different reader. Legacy key access is removed only after a cold restart and a
+full semantic staging exercise prove the inventory is entirely managed.
+
+Alias rotation is deliberately not treated as DEK rotation. Moving an alias
+changes only new writes. Existing envelopes retain the immutable old key ARN
+until the rewrap tool migrates them. The old key is disabled only for a bounded
+drill after inventory reaches zero, then retained according to the recovery
+policy; deletion is never part of an online rotation.
+
+## Failure and recovery behavior
+
+- New collection creation fails without writing partial collection state when
+  KMS wrapping fails.
+- A cache miss fails closed when KMS cannot decrypt; cached DEKs may serve only
+  until their short configured TTL and never make readiness claim KMS healthy.
+- Readiness performs a bounded managed key-check decrypt, so a cold deployment
+  cannot become ready solely from a warm cache.
+- Wrong environment/context, revoked credentials, a disabled key, and a
+  different multi-Region key all fail authentication.
+- Database recovery uses the exact key ARN in each envelope. A recovery-region
+  replica is accepted only when it shares the same multi-Region key ID and the
+  recovery deployment supplies the original encryption context.
+- Key deletion has a 30-day waiting period and is prohibited while any retained
+  backup manifest references the key.
+
+## Verification
+
+The implementation requires:
+
+- deterministic envelope parsing and legacy compatibility tests;
+- fake-wrapper tests for denied, throttled, timed-out, disabled, missing,
+  malformed, wrong-context, partial-migration, concurrency, and cache cases;
+- database migration and idempotent rewrap tests;
+- actual staging KMS encrypt/decrypt, audit, alias rotation, full rewrap,
+  disabled-old-key, credential rotation, cold restart, and hosted semantic
+  exercises;
+- an isolated recovery using the Sydney replica and restored database/object
+  set before the production key hierarchy is considered complete.
+
+## Consequences
+
+The provider gains an asynchronous dependency at DEK wrap/unwrap boundaries
+and a small bounded memory cache. This is more complex than one local master
+key, but it makes key identity, rotation, audit, and recovery explicit. KMS cost
+is proportional to cache misses and collection creation/rotation rather than
+record operations. The existing Render master key remains a temporary migration
+secret and is removed from each environment only after live evidence proves no
+stored envelope needs it.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,6 +1,7 @@
 # Encryption architecture
 
-Status: encrypted relay and standard hosted encryption implemented
+Status: encrypted relay, first-contact trust, standard hosted encryption, and
+managed hosted key wrapping implemented
 
 ## Purpose
 
@@ -44,15 +45,21 @@ downgrade behavior. Connector identity material lives in the operating-system
 credential store. Existing owner-only `relay-identity.key` installations are
 migrated into that store, read back for identity verification, and only then
 have the legacy file removed. Verifying first contact and auditing logs remain
-public-release gates.
+public-release gates. First contact now uses a signed application authorization
+request, stable application-installation identity, and an independently derived
+short authentication string. Portal approval still chooses the collection and
+permissions; the local connector separately accepts or rejects the exact new
+installation before it stores the grant.
 
 The hosted provider encrypts canonical records, retained versions, change
 payloads, mutation receipts, and collection resources with AES-256-GCM under a
-random per-collection data key. It wraps that key with the provider deployment
-master key and authenticates ciphertext identity as associated data. PostgreSQL
-retains the wrapped key, ciphertext, and the explicit metadata listed below.
-Key-service integration, online key rotation, and restore drills remain release
-operations work; private/zero-knowledge hosting is not implemented.
+random per-collection data key. A versioned wrapping boundary supports the
+legacy local deployment key and AWS KMS envelopes carrying the immutable key
+ARN. Exact KMS encryption context binds each wrapped key to its environment,
+purpose, and collection. PostgreSQL retains only the wrapped key, ciphertext,
+and the explicit metadata listed below. Live staging activation, rotation, and
+isolated restore drills remain release operations work;
+private/zero-knowledge hosting is not implemented.
 
 Local Markdown files are also plaintext from mdbase's perspective. Operating
 system full-disk encryption, encrypted home directories, and device access
@@ -142,33 +149,33 @@ removes the connector's active grant key and blocks relay routing. Losing an
 application key requires authorization again; it never puts the underlying
 local collection at risk.
 
-### Active control-plane attacks
+### First-contact authentication
 
 Server-mediated public-key discovery protects against passive observation,
 payload logging, database disclosure, and an honest-but-curious control plane.
-An actively malicious control plane could try to replace public keys during the
-first authorization and become a man in the middle.
+The signed authorization request additionally prevents the server from
+silently substituting application installation or per-grant keys.
 
-The protocol should make that boundary explicit. Increasing levels of active
-server resistance are possible:
+For the first grant from an application installation to a local connector, the
+application and connector derive the same short authentication string from
+their independently held keys and the exact first-contact transcript. The
+application shows its value through the SDK while the connector shows its
+value locally through the desktop or headless CLI. The connector stores trust
+only after the user confirms an exact match. A mismatch, expired request,
+changed installation key, changed connector key, replayed request, or absent
+local confirmation fails closed. Later grants may reuse the exact trusted
+installation identity; changing its key material requires first contact again.
 
-1. **Grant binding and key continuity.** The connector signs the approved key
-   binding, and applications pin the connector identity after first use. Later
-   substitutions become visible.
-2. **Key transparency.** Connector identity changes appear in an append-only,
-   auditable account log.
-3. **User verification.** A short authentication string or QR flow confirms a
-   first connection through a path outside the relay.
+This comparison is separate from portal consent. The portal remains the only
+place that selects a collection and permissions, and connector trust endpoints
+cannot create or broaden a grant. Hosted-only grants do not cross a local
+connector and therefore do not require local first-contact approval.
 
-The SDK now enforces connector key continuity within a grant: refresh and
-policy rotation may change the scope epoch and key ID, but a different
-connector identity, agreement key, application key, or grant ID fails closed
-and requires explicit reauthorization. This detects substitution after the
-first approved binding; it does not authenticate first contact.
-
-The first public release should choose and document one of these levels after a
-focused threat-model review. It must not describe server-mediated first contact
-as protection against an actively malicious server.
+The comparison resists an active control plane only when the user compares the
+application and connector displays through independently trusted surfaces. A
+compromised application or connector display remains within that endpoint's
+trust boundary. Append-only key transparency is a possible later defense and
+is not part of the current claim.
 
 ### Encrypted envelope
 
@@ -253,11 +260,13 @@ encryption below. Deployment verification and restore drills are release gates.
 
 ### Collection envelope encryption
 
-Each hosted collection receives a random 256-bit data-encryption key. A
-deployment master key supplied to the Rust provider wraps that collection key.
-PostgreSQL stores the wrapped collection key and encrypted content. Provider
-startup verifies the supplied master key against an authenticated database key
-check and refuses a mismatched key.
+Each hosted collection receives a random 256-bit data-encryption key. The Rust
+provider wraps that collection key through one explicitly selected writer:
+the legacy local AES-256-GCM wrapper or the managed AWS KMS wrapper. PostgreSQL
+stores a bounded self-describing envelope with the wrapping scheme and, for
+KMS, the immutable key ARN returned by AWS. Provider startup resolves aliases,
+checks the enabled symmetric key, and verifies an authenticated database key
+check before reporting readiness.
 
 AES-256-GCM envelopes carry a random 96-bit nonce. Associated data binds each
 envelope to its purpose and identity: collection resources to the collection;
@@ -270,10 +279,14 @@ The provider decrypts records to evaluate authorized operations through
 and durable caches. Memory clearing has platform limits, so operational
 isolation remains part of the protection.
 
-The current provider does not support live master-key or collection-key
-rotation. Backup restoration must use the original provider master key. A
-versioned key-service integration, rotation procedure, and restore drill remain
-release operations work.
+The aggregate-only key administration tool inspects envelope counts and
+rewraps one locked collection at a time. It is resumable, idempotent, supports
+a real-operation dry run, and finalizes the provider key-check only after every
+active collection uses the configured immutable KMS key. Alias movement affects
+new writes only; existing envelopes continue to name their old key until they
+are rewrapped. A bounded old-key disablement drill and an isolated restore must
+pass before legacy access is retired. The accepted design and exact context are
+documented in [ADR 0003](./decisions/0003-managed-provider-key-wrapping.md).
 
 ### Hosted metadata
 
@@ -396,8 +409,9 @@ Keys have distinct lifecycles:
 - per-grant application keys are created during authorization, rotated on
   reauthorization or policy change, and discarded on disconnect or revocation;
 - standard hosted collection keys are generated by the provider and wrapped by
-  its deployment master key. Versioned rotation and a formally exercised key
-  destruction procedure remain to be implemented;
+  a versioned local or AWS KMS key envelope. Rotation rewrites only these small
+  DEK envelopes, retains immutable old-key references for backups, and removes
+  legacy reader access only after cold-start and recovery evidence;
 - private hosted collection keys are generated and wrapped on user devices,
   shared only with approved device/application keys, and covered by an explicit
   recovery procedure.
@@ -415,20 +429,26 @@ and decrypted recovery material never enter audit events.
 - browser non-extractable keys, atomic counters, encrypted operations, binding
   refresh, and fail-closed behavior;
 - opaque relay routing and cross-runtime end-to-end coverage;
-- per-collection hosted data keys wrapped by a deployment master key;
+- signed authorization, stable installation identity, independently displayed
+  first-contact codes, exact local trust persistence, and desktop/headless
+  acceptance, rejection, and revocation;
+- per-collection hosted data keys and authenticated content envelopes;
+- versioned local and AWS KMS wrappers, exact-context KMS envelopes, bounded
+  zeroizing DEK cache, stored-key readiness checks, and aggregate-only
+  inspect/rewrap/finalization tooling;
 - authenticated encryption for hosted documents, resources, retained versions,
   change images, and mutation receipts;
 - keyed record-path lookup without plaintext record paths in PostgreSQL; and
 - ciphertext tamper, wrong-key, two-provider race, sync, and operation tests.
 
-### Next: security review and key operations
+### Next: live key and recovery operations
 
 - native application key storage for a future non-browser SDK;
-- first-contact connector identity verification or key transparency;
 - independent protocol review and systematic log, trace, and crash-path audit;
-- move hosted key wrapping to a versioned managed-key boundary;
-- implement and exercise rotation, restore, deletion, and key-service outage
-  procedures; and
+- activate managed wrapping in staging, rewrap legacy envelopes, rotate to a
+  second KMS key, and prove cold operation with the old runtime key disabled;
+- exercise database, object, KMS-replica, retained-old-key, and credential-loss
+  recovery in an isolated environment; and
 - verify managed volume and backup encryption in the production environment.
 
 ### Later: private hosted prototype
@@ -462,12 +482,14 @@ The relay-only encryption milestone is complete when:
 
 ## Decisions still open
 
-- first-contact authentication against an actively malicious control plane;
+- append-only connector/application key transparency beyond explicit
+  first-contact comparison;
 - relay key rotation intervals and message limits;
 - visible relay metadata, including whether operation names remain visible;
 - any future plaintext metadata or query-index leakage for standard hosted
   collections;
-- hosted key-service availability, rotation, and disaster-recovery procedure;
+- production hosted key retention and recovery-region policy after the staging
+  drills establish measured recovery time and dependencies;
 - private-hosted recovery and contract-scoped key distribution.
 
 The relay guarantee can be implemented independently of hosted sync. Hosted

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -66,6 +66,43 @@ Canonical documents and retained content are encrypted with a per-collection
 data key. Type labels, identifiers, revisions, sequences, sizes, deletion state,
 and keyed path tokens may remain visible as documented routing metadata.
 
+## Managed key wrapping
+
+Hosted deployments select the data-key writer with
+`MDBASE_CONNECT_HOSTED_KEY_WRAPPER`. `local` requires
+`MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY`; `aws-kms` requires
+`MDBASE_CONNECT_HOSTED_KEY_ENVIRONMENT`, `MDBASE_CONNECT_HOSTED_KMS_KEY_ID`,
+and `MDBASE_CONNECT_HOSTED_KMS_REGION`. AWS credentials come from the standard
+SDK credential chain. The database URL, provider internal token, legacy master
+key, and R2 credentials are environment-only settings rather than command-line
+arguments so they do not enter shell history or process listings.
+
+The service resolves a configured KMS alias to an immutable enabled symmetric
+key ARN at startup. Its least-privilege identity needs `DescribeKey`, plus only
+`Encrypt` and `Decrypt` on that environment's key under the exact encryption
+context in [ADR 0003](decisions/0003-managed-provider-key-wrapping.md). `/ready`
+re-verifies the stored provider key-check at a bounded interval; a short failed
+probe cache prevents health polling from amplifying a KMS outage.
+
+The release image also contains `mdbase-hosted-key-admin`. It accepts database
+and legacy-key secrets only from `DATABASE_URL` and
+`MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY`. With the same non-secret KMS
+configuration as the provider, the migration sequence is:
+
+```bash
+mdbase-hosted-key-admin inspect
+mdbase-hosted-key-admin rewrap --dry-run
+mdbase-hosted-key-admin rewrap --finalize-key-check
+mdbase-hosted-key-admin inspect
+```
+
+Inspection streams aggregate envelope counts and never emits collection IDs,
+ciphertexts, or plaintext keys. Dry-run performs real exact-context decrypt and
+wrap operations but rolls back every row. Rewrap locks and commits one row at a
+time, is resumable and idempotent, and refuses to finalize the key-check until
+every collection uses the active key ARN. Keep the legacy key configured until
+a KMS-only cold restart and semantic staging exercise pass.
+
 Hosted collection files use a separate object data plane. PostgreSQL retains
 encrypted paths and descriptors, capabilities, transfer journals, exact
 idempotent receipts, revision history, quotas, and the shared record/file

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -979,9 +979,17 @@ try {
     provider.url,
     controlDatabase
   );
-  await connectCommand(desktopProfile, [
-    "mirror", "remove", desktopMirror.replica_id, "--yes"
-  ]);
+  await waitFor(async () => {
+    try {
+      await connectCommand(desktopProfile, [
+        "mirror", "remove", desktopMirror.replica_id, "--yes"
+      ]);
+      return true;
+    } catch (error) {
+      if (error?.stderr?.includes('"code":"mirror_busy"')) return false;
+      throw error;
+    }
+  }, "Daemon-managed mirror remained busy during removal", 400);
   assert.deepEqual(await connectCommand(desktopProfile, ["mirror", "list"]), []);
   await stopConnectDaemon(desktopProfile, desktopDaemon);
 
@@ -2187,7 +2195,6 @@ schema:
 
   process.stdout.write("mdbase PostgreSQL hosted provider e2e passed\n");
 } finally {
-  delete globalThis.location;
   if (notificationCallbackServer) {
     await new Promise((resolveClose) => notificationCallbackServer.close(resolveClose));
   }
@@ -3681,7 +3688,15 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie) {
       name: /Add Workout Inline E2E’s starter type/
     })).toBeChecked();
     await page.getByRole("button", { name: "Set up and allow Workout Inline E2E" }).click();
-    await expect(page.getByText("Access approved", { exact: true })).toBeVisible();
+    const outcome = await Promise.race([
+      page.getByText("Access approved", { exact: true })
+        .waitFor({ state: "visible" })
+        .then(() => "approved"),
+      page.locator(".message.error").waitFor({ state: "visible" }).then(() => "error")
+    ]);
+    if (outcome === "error") {
+      throw new Error(`Inline hosted authorization failed: ${await page.locator(".message.error").innerText()}`);
+    }
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## Summary

- introduce a versioned hosted-key wrapping boundary with legacy local and AWS KMS implementations
- bind every KMS operation to exact environment, purpose, and collection encryption context and persist immutable KMS key ARNs in bounded envelopes
- add readiness checks, a bounded zeroizing DEK cache with singleflight, and aggregate-only inspect/rewrap/finalize tooling
- exercise managed migration and primary/recovery multi-region behavior with ignored live tests and a disposable Docker test binary
- document the accepted architecture and current operational state

## Security properties

- the provider fails closed when stored envelopes need an unavailable reader or when its stored key check cannot be authenticated
- aliases select only the writer; old envelopes retain immutable key identity and cannot be silently redirected
- KMS context contains no record paths or payload data
- administrative output is aggregate-only and rewraps one locked collection at a time
- the old AWS TLS connector is removed rather than carrying a second native TLS stack

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Node 24: `pnpm typecheck`
- Node 24: `pnpm test`
- Node 24: `pnpm e2e`
- Node 24: `pnpm e2e:provider`

Live staging activation and the two-key rotation/recovery drill follow after this change is released as an immutable image.