### PR TITLE
Prepare v0.1.0-beta.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "clap",
  "directories",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "chrono",
  "directories",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "async-trait",
  "axum",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/config/release-readiness.json
+++ b/config/release-readiness.json
@@ -5,9 +5,12 @@
       "id": "first-contact-trust-decision",
       "title": "First-contact connector trust decision",
       "owner": "Product and security owners",
-      "status": "required",
-      "evidence": [],
-      "notes": "Ship an explicit user-verifiable trust decision or equivalent transparency mechanism for a connector first seen by an application."
+      "status": "complete",
+      "evidence": [
+        "https://github.com/mdbase-dev/mdbase-connect/pull/154",
+        "https://github.com/mdbase-dev/mdbase-connect/actions/runs/30750841856"
+      ],
+      "notes": "A signed authorization request and independently derived authentication string now require exact local confirmation on desktop or the headless CLI, separately from portal consent. Cross-runtime, real-browser, Electron, restart, mismatch, revocation, and policy tests passed in the recorded CI run."
     },
     {
       "id": "managed-key-service-and-rotation-drill",

--- a/crates/connect-protocol/src/tests.rs
+++ b/crates/connect-protocol/src/tests.rs
@@ -471,7 +471,7 @@ fn rust_relay_messages_match_the_canonical_wire_schema() {
     for message in [
         RelayMessage::RelayHello {
             protocol_version: CONTROL_PROTOCOL_VERSION,
-            connector_version: "0.1.0-beta.23".to_string(),
+            connector_version: "0.1.0-beta.24".to_string(),
             capabilities: RELAY_CAPABILITIES
                 .iter()
                 .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "clap",
  "directories",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "chrono",
  "directories",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "async-trait",
  "axum",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.23"
+version = "0.1.0-beta.24"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -114,9 +114,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.23
-git tag -a v0.1.0-beta.23 -m "mdbase connect 0.1.0-beta.23"
-git push origin v0.1.0-beta.23
+pnpm version:check v0.1.0-beta.24
+git tag -a v0.1.0-beta.24 -m "mdbase connect 0.1.0-beta.24"
+git push origin v0.1.0-beta.24
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -662,7 +662,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.23",
+    connector_version: "0.1.0-beta.24",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.23" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.24" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.23",
+  "version": "0.1.0-beta.24",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- mark the implemented first-contact trust gate complete with the merged PR and full CI run as durable evidence
- bump the Rust workspace, JavaScript packages, fixtures, lockfiles, MCP advertisement, and release documentation to `0.1.0-beta.24`

This release carries the merged signed first-contact flow and managed hosted KMS boundary. The KMS, full recovery, and desktop-signing stable gates remain open until their live evidence exists.

## Verification

- Node 24: `pnpm version:check v0.1.0-beta.24`
- Node 24: `pnpm check:release-readiness`
- `cargo test -p mdbase-connect-protocol`
- Node 24: protocol package test suite
- `git diff --check`

The immediately preceding feature commit passed the full Server CI matrix before merge; this PR will repeat that matrix against the exact beta version.