### PR TITLE
Fence hosted backups from blob deletion

### DIFF
--- a/crates/connect-hosted-provider/migrations/0022_backup_holds.sql
+++ b/crates/connect-hosted-provider/migrations/0022_backup_holds.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS hosted_provider_backup_holds (
+  id uuid PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  CONSTRAINT hosted_provider_backup_holds_expiry_check CHECK (
+    expires_at > created_at
+    AND expires_at <= created_at + interval '6 hours'
+  )
+);
+
+CREATE INDEX IF NOT EXISTS hosted_provider_backup_holds_expiry_idx
+  ON hosted_provider_backup_holds (expires_at);

--- a/crates/connect-hosted-provider/src/backup_admin.rs
+++ b/crates/connect-hosted-provider/src/backup_admin.rs
@@ -27,6 +27,14 @@ pub struct BackupHoldInventory {
     pub latest_expiry: Option<DateTime<Utc>>,
 }
 
+#[derive(sqlx::FromRow)]
+struct BackupHoldInventoryRow {
+    observed_at: DateTime<Utc>,
+    active_holds: i64,
+    earliest_expiry: Option<DateTime<Utc>>,
+    latest_expiry: Option<DateTime<Utc>>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct BackupHoldRelease {
     pub released: bool,
@@ -90,13 +98,11 @@ impl HostedBackupAdmin {
         let mut transaction = self.pool.begin().await?;
         lock_exclusive(&mut transaction).await?;
         remove_expired(&mut transaction).await?;
-        let (observed_at, active_holds, earliest_expiry, latest_expiry): (
-            DateTime<Utc>,
-            i64,
-            Option<DateTime<Utc>>,
-            Option<DateTime<Utc>>,
-        ) = sqlx::query_as(
-            r#"SELECT now(), count(*), min(expires_at), max(expires_at)
+        let row: BackupHoldInventoryRow = sqlx::query_as(
+            r#"SELECT now() AS observed_at,
+                      count(*) AS active_holds,
+                      min(expires_at) AS earliest_expiry,
+                      max(expires_at) AS latest_expiry
                FROM hosted_provider_backup_holds
                WHERE expires_at > now()"#,
         )
@@ -104,11 +110,11 @@ impl HostedBackupAdmin {
         .await?;
         transaction.commit().await?;
         Ok(BackupHoldInventory {
-            observed_at,
-            active_holds: u64::try_from(active_holds)
+            observed_at: row.observed_at,
+            active_holds: u64::try_from(row.active_holds)
                 .map_err(|_| ApiError::internal("The active backup hold count is invalid."))?,
-            earliest_expiry,
-            latest_expiry,
+            earliest_expiry: row.earliest_expiry,
+            latest_expiry: row.latest_expiry,
         })
     }
 }

--- a/crates/connect-hosted-provider/src/backup_admin.rs
+++ b/crates/connect-hosted-provider/src/backup_admin.rs
@@ -1,0 +1,177 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::{postgres::PgPoolOptions, PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    provider::hosted_migrator,
+};
+
+const MINIMUM_HOLD_SECONDS: u64 = 60;
+const MAXIMUM_HOLD_SECONDS: u64 = 6 * 60 * 60;
+const BACKUP_DELETION_LOCK: i64 = 0x4d44_4241_5345_424b;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BackupHold {
+    pub hold_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BackupHoldInventory {
+    pub observed_at: DateTime<Utc>,
+    pub active_holds: u64,
+    pub earliest_expiry: Option<DateTime<Utc>>,
+    pub latest_expiry: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BackupHoldRelease {
+    pub released: bool,
+}
+
+pub struct HostedBackupAdmin {
+    pool: PgPool,
+}
+
+impl HostedBackupAdmin {
+    pub async fn connect(database_url: &str) -> ApiResult<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(database_url)
+            .await?;
+        hosted_migrator().run(&pool).await.map_err(|error| {
+            tracing::error!(%error, "hosted backup administration migration check failed");
+            ApiError::internal("The hosted provider database migration check failed.")
+        })?;
+        Ok(Self { pool })
+    }
+
+    pub async fn acquire(&self, ttl_seconds: u64) -> ApiResult<BackupHold> {
+        validate_ttl(ttl_seconds)?;
+        let mut transaction = self.pool.begin().await?;
+        lock_exclusive(&mut transaction).await?;
+        remove_expired(&mut transaction).await?;
+        let hold_id = Uuid::now_v7();
+        let (created_at, expires_at): (DateTime<Utc>, DateTime<Utc>) = sqlx::query_as(
+            r#"INSERT INTO hosted_provider_backup_holds (id, expires_at)
+               VALUES ($1, now() + ($2 * interval '1 second'))
+               RETURNING created_at, expires_at"#,
+        )
+        .bind(hold_id)
+        .bind(i64::try_from(ttl_seconds).map_err(|_| invalid_ttl())?)
+        .fetch_one(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(BackupHold {
+            hold_id,
+            created_at,
+            expires_at,
+        })
+    }
+
+    pub async fn release(&self, hold_id: Uuid) -> ApiResult<BackupHoldRelease> {
+        let mut transaction = self.pool.begin().await?;
+        lock_exclusive(&mut transaction).await?;
+        remove_expired(&mut transaction).await?;
+        let released = sqlx::query("DELETE FROM hosted_provider_backup_holds WHERE id = $1")
+            .bind(hold_id)
+            .execute(&mut *transaction)
+            .await?
+            .rows_affected()
+            == 1;
+        transaction.commit().await?;
+        Ok(BackupHoldRelease { released })
+    }
+
+    pub async fn inspect(&self) -> ApiResult<BackupHoldInventory> {
+        let mut transaction = self.pool.begin().await?;
+        lock_exclusive(&mut transaction).await?;
+        remove_expired(&mut transaction).await?;
+        let (observed_at, active_holds, earliest_expiry, latest_expiry): (
+            DateTime<Utc>,
+            i64,
+            Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+        ) = sqlx::query_as(
+            r#"SELECT now(), count(*), min(expires_at), max(expires_at)
+               FROM hosted_provider_backup_holds
+               WHERE expires_at > now()"#,
+        )
+        .fetch_one(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(BackupHoldInventory {
+            observed_at,
+            active_holds: u64::try_from(active_holds)
+                .map_err(|_| ApiError::internal("The active backup hold count is invalid."))?,
+            earliest_expiry,
+            latest_expiry,
+        })
+    }
+}
+
+pub(crate) async fn lock_blob_deletion(
+    transaction: &mut Transaction<'_, Postgres>,
+) -> ApiResult<bool> {
+    sqlx::query("SELECT pg_advisory_xact_lock_shared($1)")
+        .bind(BACKUP_DELETION_LOCK)
+        .execute(&mut **transaction)
+        .await?;
+    let active: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM hosted_provider_backup_holds WHERE expires_at > now())",
+    )
+    .fetch_one(&mut **transaction)
+    .await?;
+    Ok(active)
+}
+
+async fn lock_exclusive(transaction: &mut Transaction<'_, Postgres>) -> ApiResult<()> {
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(BACKUP_DELETION_LOCK)
+        .execute(&mut **transaction)
+        .await?;
+    Ok(())
+}
+
+async fn remove_expired(transaction: &mut Transaction<'_, Postgres>) -> ApiResult<()> {
+    sqlx::query("DELETE FROM hosted_provider_backup_holds WHERE expires_at <= now()")
+        .execute(&mut **transaction)
+        .await?;
+    Ok(())
+}
+
+fn validate_ttl(ttl_seconds: u64) -> ApiResult<()> {
+    if !(MINIMUM_HOLD_SECONDS..=MAXIMUM_HOLD_SECONDS).contains(&ttl_seconds) {
+        return Err(invalid_ttl());
+    }
+    Ok(())
+}
+
+fn invalid_ttl() -> ApiError {
+    ApiError::bad_request(
+        "invalid_backup_hold_ttl",
+        "The backup hold TTL must be between 60 and 21600 seconds.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backup_hold_ttl_is_strictly_bounded() {
+        assert_eq!(
+            validate_ttl(59).unwrap_err().code,
+            "invalid_backup_hold_ttl"
+        );
+        validate_ttl(60).unwrap();
+        validate_ttl(21_600).unwrap();
+        assert_eq!(
+            validate_ttl(21_601).unwrap_err().code,
+            "invalid_backup_hold_ttl"
+        );
+    }
+}

--- a/crates/connect-hosted-provider/src/bin/mdbase-hosted-backup-admin.rs
+++ b/crates/connect-hosted-provider/src/bin/mdbase-hosted-backup-admin.rs
@@ -1,0 +1,119 @@
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+use mdbase_connect_hosted_provider::{ApiError, HostedBackupAdmin};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Parser)]
+#[command(name = "mdbase-hosted-backup-admin")]
+#[command(about = "Coordinate a bounded hosted database and object backup hold")]
+struct Arguments {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Inspect,
+    Acquire {
+        #[arg(long, default_value_t = 14_400)]
+        ttl_seconds: u64,
+    },
+    Release {
+        #[arg(long)]
+        hold_id: Uuid,
+    },
+}
+
+#[derive(Serialize)]
+struct Success<T: Serialize> {
+    ok: bool,
+    result: T,
+}
+
+#[derive(Serialize)]
+struct Failure<'a> {
+    ok: bool,
+    error: FailureBody<'a>,
+}
+
+#[derive(Serialize)]
+struct FailureBody<'a> {
+    code: &'a str,
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run(Arguments::parse()).await {
+        Ok(value) => {
+            println!(
+                "{}",
+                serde_json::to_string(&value).expect("admin result serializes")
+            );
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!(
+                "{}",
+                serde_json::to_string(&Failure {
+                    ok: false,
+                    error: FailureBody {
+                        code: error.code(),
+                        message: error.to_string(),
+                    },
+                })
+                .expect("admin error serializes")
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(arguments: Arguments) -> Result<serde_json::Value, AdminError> {
+    let database_url = required_environment("DATABASE_URL")?;
+    let admin = HostedBackupAdmin::connect(&database_url).await?;
+    match arguments.command {
+        Command::Inspect => Ok(serde_json::to_value(Success {
+            ok: true,
+            result: admin.inspect().await?,
+        })?),
+        Command::Acquire { ttl_seconds } => Ok(serde_json::to_value(Success {
+            ok: true,
+            result: admin.acquire(ttl_seconds).await?,
+        })?),
+        Command::Release { hold_id } => Ok(serde_json::to_value(Success {
+            ok: true,
+            result: admin.release(hold_id).await?,
+        })?),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum AdminError {
+    #[error("Required environment configuration is missing or invalid: {0}.")]
+    Environment(&'static str),
+    #[error("{0}")]
+    Provider(#[from] ApiError),
+    #[error("The backup administration result could not serialize.")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl AdminError {
+    fn code(&self) -> &'static str {
+        match self {
+            Self::Environment(_) => "environment_configuration_error",
+            Self::Provider(error) => error.code,
+            Self::Serialization(_) => "serialization_error",
+        }
+    }
+}
+
+fn required_environment(name: &'static str) -> Result<String, AdminError> {
+    match std::env::var(name) {
+        Ok(value) if !value.trim().is_empty() => Ok(value),
+        Ok(_) | Err(std::env::VarError::NotPresent) => Err(AdminError::Environment(name)),
+        Err(std::env::VarError::NotUnicode(_)) => Err(AdminError::Environment(name)),
+    }
+}

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -1,3 +1,4 @@
+mod backup_admin;
 mod blob_store;
 mod crypto;
 mod error;
@@ -10,6 +11,7 @@ mod symmetric_crypto;
 mod template;
 mod workspace;
 
+pub use backup_admin::{BackupHold, BackupHoldInventory, BackupHoldRelease, HostedBackupAdmin};
 pub use blob_store::{
     BlobByteStream, BlobStore, BlobStreamError, PresignedPart, R2BlobStore, R2Config, UploadedPart,
 };

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -34,6 +34,7 @@ use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::{
+    backup_admin::lock_blob_deletion,
     blob_store::BlobStore,
     crypto::ProviderCrypto,
     error::{ApiError, ApiResult},

--- a/crates/connect-hosted-provider/src/provider/compaction.rs
+++ b/crates/connect-hosted-provider/src/provider/compaction.rs
@@ -207,6 +207,10 @@ impl HostedProvider {
         for row in rows {
             let key: String = row.get("object_key");
             let mut transaction = self.pool.begin().await?;
+            if lock_blob_deletion(&mut transaction).await? {
+                transaction.commit().await?;
+                break;
+            }
             let claimed = sqlx::query_scalar::<_, String>(
                 "SELECT object_key FROM hosted_provider_blob_deletions WHERE object_key = $1 FOR UPDATE",
             )

--- a/crates/connect-hosted-provider/tests/file_lifecycle_adversarial.rs
+++ b/crates/connect-hosted-provider/tests/file_lifecycle_adversarial.rs
@@ -1,6 +1,8 @@
 mod support;
 
-use mdbase_connect_hosted_provider::HostedProvider;
+use std::sync::Arc;
+
+use mdbase_connect_hosted_provider::{HostedBackupAdmin, HostedProvider};
 use sqlx::Executor;
 use support::{
     assert_storage_consistent, wait_for_database_condition, wait_for_query_blocked, CopyCheckpoint,
@@ -27,8 +29,101 @@ async fn adversarial_file_lifecycle_scenarios() {
     commit_wins_maintenance_loses(&database_url).await;
     maintenance_recovers_abandoned_open_upload(&database_url).await;
     maintenance_retries_object_deletion_after_outage(&database_url).await;
+    backup_hold_fences_in_flight_and_future_deletions(&database_url).await;
     duplicate_commit_is_idempotent(&database_url).await;
     duplicate_commit_across_providers_is_idempotent(&database_url).await;
+}
+
+async fn backup_hold_fences_in_flight_and_future_deletions(database_url: &str) {
+    let fixture = FileLifecycleFixture::new(database_url).await;
+    let in_flight_key = format!("v1/blobs/{}/backup-race", fixture.collection_id);
+    fixture.blobs.put(&in_flight_key, b"already queued").await;
+    enqueue_test_deletion(&fixture, &in_flight_key).await;
+    fixture.blobs.arm_delete().await;
+
+    let provider = fixture.provider.clone();
+    let deletion = tokio::spawn(async move { provider.delete_pending_blobs(10).await });
+    fixture.blobs.wait_for_delete().await;
+
+    let admin = Arc::new(
+        HostedBackupAdmin::connect(database_url)
+            .await
+            .expect("backup admin connects"),
+    );
+    let acquiring_admin = Arc::clone(&admin);
+    let mut acquire = tokio::spawn(async move { acquiring_admin.acquire(600).await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(150), &mut acquire)
+            .await
+            .is_err(),
+        "hold acquisition waits for an in-flight object deletion"
+    );
+
+    fixture.blobs.release_delete().await;
+    assert_eq!(
+        deletion
+            .await
+            .expect("deletion task joins")
+            .expect("queued deletion succeeds"),
+        1
+    );
+    assert!(!fixture.blobs.contains(&in_flight_key).await);
+    let hold = acquire
+        .await
+        .expect("hold task joins")
+        .expect("hold is acquired after deletion finishes");
+
+    let held_key = format!("v1/blobs/{}/held", fixture.collection_id);
+    fixture.blobs.put(&held_key, b"must survive the hold").await;
+    enqueue_test_deletion(&fixture, &held_key).await;
+    assert_eq!(
+        fixture
+            .provider
+            .delete_pending_blobs(10)
+            .await
+            .expect("maintenance observes the hold"),
+        0
+    );
+    assert!(fixture.blobs.contains(&held_key).await);
+    assert_eq!(
+        admin.inspect().await.expect("hold inventory").active_holds,
+        1
+    );
+    assert!(
+        !admin
+            .release(Uuid::now_v7())
+            .await
+            .expect("unknown release is idempotent")
+            .released
+    );
+    assert!(
+        admin
+            .release(hold.hold_id)
+            .await
+            .expect("hold releases")
+            .released
+    );
+    assert_eq!(
+        fixture
+            .provider
+            .delete_pending_blobs(10)
+            .await
+            .expect("maintenance resumes after release"),
+        1
+    );
+    assert!(!fixture.blobs.contains(&held_key).await);
+}
+
+async fn enqueue_test_deletion(fixture: &FileLifecycleFixture, key: &str) {
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_blob_deletions
+             (object_key, byte_length, reason)
+           VALUES ($1, 0, 'backup_hold_test')"#,
+    )
+    .bind(key)
+    .execute(&fixture.pool)
+    .await
+    .expect("test deletion is queued");
 }
 
 async fn commit_wins_abort_loses(database_url: &str) {

--- a/crates/connect-hosted-provider/tests/support/blob_store.rs
+++ b/crates/connect-hosted-provider/tests/support/blob_store.rs
@@ -86,6 +86,7 @@ impl CopyGate {
 pub struct ControlledBlobStore {
     objects: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
     copy_gate: Arc<CopyGate>,
+    delete_gate: Arc<CopyGate>,
     delete_failures_remaining: Arc<Mutex<u32>>,
 }
 
@@ -116,6 +117,18 @@ impl ControlledBlobStore {
 
     pub async fn fail_next_delete(&self) {
         *self.delete_failures_remaining.lock().await += 1;
+    }
+
+    pub async fn arm_delete(&self) {
+        self.delete_gate.arm(CopyCheckpoint::BeforePublish).await;
+    }
+
+    pub async fn wait_for_delete(&self) {
+        self.delete_gate.wait_until_reached().await;
+    }
+
+    pub async fn release_delete(&self) {
+        self.delete_gate.release().await;
     }
 }
 
@@ -230,6 +243,9 @@ impl BlobStore for ControlledBlobStore {
             return Err(ApiError::internal("injected object deletion failure"));
         }
         drop(failures);
+        self.delete_gate
+            .checkpoint(CopyCheckpoint::BeforePublish)
+            .await;
         self.objects.lock().await.remove(key);
         Ok(())
     }

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -28,6 +28,7 @@ RUN apt-get update \
 
 COPY --from=build /build/mdbase-connect/target/release/mdbase-connect-hosted-provider /usr/local/bin/
 COPY --from=build /build/mdbase-connect/target/release/mdbase-hosted-key-admin /usr/local/bin/
+COPY --from=build /build/mdbase-connect/target/release/mdbase-hosted-backup-admin /usr/local/bin/
 
 ENV HOST=0.0.0.0 \
     PORT=8790 \

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -60,7 +60,10 @@ The production schema is normalized around these relations:
 - `hosted_replicas`: mode, contract/type scope, scope epoch, acknowledgement,
   credential state, and revocation;
 - `hosted_snapshot_leases`: bounded leases pinning an authority sequence and
-  resource revision while pages are downloaded.
+  resource revision while pages are downloaded; and
+- `hosted_provider_backup_holds`: short-lived administrative leases fencing
+  deletion of committed objects while a database export and object manifest
+  are captured.
 
 Canonical documents and retained content are encrypted with a per-collection
 data key. Type labels, identifiers, revisions, sequences, sizes, deletion state,
@@ -161,6 +164,33 @@ ordinary file transfers. It persists object-deletion intent before contacting
 R2, resumes interrupted multipart cleanup, and drains deletions only after
 rechecking that no durable file metadata references the object.
 
+## Consistent backup boundary
+
+The release image contains `mdbase-hosted-backup-admin` for coordinating a
+logical PostgreSQL export with the committed R2 objects named by that export:
+
+```bash
+mdbase-hosted-backup-admin acquire --ttl-seconds 14400
+mdbase-hosted-backup-admin inspect
+mdbase-hosted-backup-admin release --hold-id <uuid>
+```
+
+Acquisition takes a database advisory lock exclusively, so it waits for an R2
+deletion already in progress before creating the lease. Every queued committed
+object deletion takes the same lock in shared transaction mode, discards no
+object while any unexpired hold exists, and keeps its durable deletion intent
+for a later maintenance pass. The shared lock remains held through the object
+store call, closing the check/delete race across provider instances.
+
+Holds are limited to 60 seconds through six hours and expire in PostgreSQL if
+the backup worker disappears. Multiple holds compose safely: deletion resumes
+only after all of them are released or expired. Administrative output contains
+only hold IDs, timestamps, and aggregate counts. A backup must acquire the hold
+before exporting PostgreSQL, derive its committed-object manifest from that
+export, durably publish the database and every referenced object, and write its
+completion marker before releasing the hold. Disposable multipart and import
+staging objects are outside this recovery set.
+
 ## Mirrors and authority transfer
 
 Application caches and filesystem mirrors are replicas. Receive-only mirrors
@@ -198,7 +228,6 @@ path may not silently regress them.
 ## Deliberate non-goals for the first hosted release
 
 - multi-owner collaboration;
-- attachments and object storage;
 - billing;
 - private/zero-knowledge hosted collections;
 - peer-to-peer or multi-authority merging;


### PR DESCRIPTION
## Summary

- add a bounded PostgreSQL-backed backup hold with exact acquire, inspect, and release administration
- fence every committed-object deletion with a shared transaction advisory lock and active-hold check
- keep the shared lock through the object-store delete so acquisition cannot race an already-running deletion across provider instances
- expire abandoned holds after at most six hours and keep queued deletion intent intact while held
- include the aggregate-only `mdbase-hosted-backup-admin` in the immutable provider image

## Recovery boundary

A recovery workflow acquires the hold before exporting PostgreSQL, derives its committed-object manifest from that export, publishes the database and every referenced object plus a completion marker, then releases the exact hold. Disposable staging objects are outside the recovery set.

## Verification

- `cargo fmt --all -- --check`
- strict hosted-provider Clippy
- hosted-provider unit tests
- real PostgreSQL adversarial file lifecycle E2E

The adversarial suite pauses a deletion inside the object store, proves hold acquisition waits for it, proves a later queued object survives maintenance during the hold, checks idempotent wrong-ID release, and proves deletion resumes only after exact release.