### PR TITLE
Publish canonical headless CLI archives

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -308,6 +308,32 @@ jobs:
           fi
           test -n "$(find release-artifacts -type f -print -quit)"
 
+      - name: Stage canonical headless CLI and daemon
+        shell: bash
+        run: |
+          binary="target/release/mdbase"
+          filename_mode=standard
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            binary="target/release/mdbase.exe"
+            filename_mode=unsigned-preview
+          elif [ "${{ matrix.platform }}" = "macos" ]; then
+            app_path="$(find apps/desktop/out -type d -name 'mdbase connect.app' -print -quit)"
+            test -n "$app_path"
+            binary="$app_path/Contents/Resources/mdbase"
+            if [ "$MACOS_RELEASE_MODE" = "signed" ]; then
+              codesign --verify --strict --verbose=2 "$binary"
+            else
+              filename_mode=unsigned-preview
+            fi
+          fi
+          node scripts/package-headless-cli.mjs \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --version "${{ steps.version.outputs.value }}" \
+            --binary "$binary" \
+            --output-directory release-artifacts \
+            --filename-mode "$filename_mode"
+
       - name: Sign and verify release artifact provenance
         shell: bash
         run: |
@@ -485,6 +511,91 @@ jobs:
             --notes "Files containing **UNSIGNED** are preview builds, not trusted platform releases. Windows will show Unknown Publisher or SmartScreen warnings. macOS will require a manual Privacy & Security override and has not been notarized. Checksums and GitHub OIDC-backed Sigstore bundles establish build provenance but do not replace platform signing." \
             --prerelease \
             --title "mdbase connect $GITHUB_REF_NAME"
+
+  headless-package-smoke:
+    if: github.event_name != 'push'
+    name: ${{ matrix.label }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Headless macOS Apple Silicon smoke test
+            os: macos-15
+            platform: macos
+            arch: arm64
+          - label: Headless macOS Intel smoke test
+            os: macos-15-intel
+            platform: macos
+            arch: x64
+          - label: Headless Windows smoke test
+            os: windows-2025
+            platform: windows
+            arch: x64
+          - label: Headless Linux smoke test
+            os: ubuntu-24.04
+            platform: linux
+            arch: x64
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: mdbase-connect
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: mdbase-connect
+
+      - id: mdbase_revision
+        shell: bash
+        run: echo "revision=$(tr -d '\r\n' < deploy/docker/mdbase-rs-revision)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: callumalpass/mdbase-rs
+          ref: ${{ steps.mdbase_revision.outputs.revision }}
+          path: mdbase-rs
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Install Rust
+        shell: bash
+        run: |
+          rustup toolchain install 1.94.0 --profile minimal
+          rustup override set 1.94.0
+
+      - name: Build and exercise the standalone release
+        shell: bash
+        run: |
+          cargo build --locked --release -p mdbase-cli
+          binary=target/release/mdbase
+          filename_mode=standard
+          executable_name=mdbase
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            binary=target/release/mdbase.exe
+            executable_name=mdbase.exe
+            filename_mode=unsigned-preview
+          elif [ "${{ matrix.platform }}" = "macos" ]; then
+            filename_mode=unsigned-preview
+          fi
+          version="$(node -p "require('./package.json').version")"
+          node scripts/package-headless-cli.mjs \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --version "$version" \
+            --binary "$binary" \
+            --output-directory headless-artifacts \
+            --filename-mode "$filename_mode"
+          archive="$(find headless-artifacts -type f -name '*.tar.gz' -print -quit)"
+          test -n "$archive"
+          mkdir headless-extracted
+          tar -xzf "$archive" -C headless-extracted
+          packaged_binary="$(find headless-extracted -type f -name "$executable_name" -print -quit)"
+          test -n "$packaged_binary"
+          "$packaged_binary" --help >/dev/null
+          "$packaged_binary" connect daemon run --help >/dev/null
 
   windows-package-smoke:
     if: github.event_name != 'push'

--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ in the [Security policy](SECURITY.md) for suspected vulnerabilities.
 
 ## Command line
 
-The desktop app includes the unified `mdbase` CLI and background daemon. Direct
-collection commands are top-level; identity, authorization, mirroring, and
-daemon administration live under `mdbase connect`.
+The desktop app includes the unified `mdbase` CLI and background daemon. The
+same native executable is also published as a standalone headless archive for
+Linux, macOS, and Windows. Direct collection commands are top-level; identity,
+authorization, mirroring, and daemon administration live under
+`mdbase connect`.
 
 ```bash
 mdbase --root /path/to/notes query --types task
@@ -152,7 +154,8 @@ mdbase connect status
 
 Human-readable output is the default. Connect administration commands support
 `--json` for automation. See the [unified CLI guide](docs/unified-cli.md) for
-the full command model.
+the full command model and the [headless installation guide](docs/headless.md)
+for verified standalone installation and service operation.
 
 ## Self-hosting
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -1,0 +1,59 @@
+# Headless mdbase installation
+
+The standalone `mdbase` archive contains the same native CLI and local
+authorization daemon that ships inside the matching mdbase connect desktop
+release. It does not contain Electron and does not introduce a second trust or
+collection implementation.
+
+## Verify before installing
+
+Download the archive, its entry in the platform `SHA256SUMS` file, and the
+adjacent `.sigstore.json` bundle from the same GitHub release. Verify the
+checksum and Sigstore identity before extracting it. The expected certificate
+identity is the tag-bound workflow:
+
+```text
+https://github.com/mdbase-dev/mdbase-connect/.github/workflows/desktop-release.yml@refs/tags/VERSION
+```
+
+Sigstore proves which repository workflow produced the bytes. It does not
+replace Apple notarization or Windows Authenticode. An artifact whose filename
+contains `UNSIGNED` is a preview and may trigger an operating-system warning.
+
+## Install and run
+
+On Linux or macOS, extract the archive and install the executable at a stable
+path on `PATH`, for example:
+
+```bash
+install -m 0755 mdbase ~/.local/bin/mdbase
+mdbase connect daemon install
+mdbase connect daemon status
+```
+
+On Windows, extract `mdbase.exe` to a stable per-user directory, add that
+directory to `PATH`, then run the same `mdbase connect daemon install` and
+`status` commands from PowerShell.
+
+`daemon install` copies the exact invoking executable into mdbase's private
+runtime directory and registers the per-user service. Run it again after
+installing an upgrade. For containers, SSH sessions, or supervisors that should
+own the process lifecycle, use the canonical foreground entry point instead:
+
+```bash
+mdbase --state-dir /secure/persistent/state connect daemon run
+```
+
+The daemon is the final authorization boundary for local collections. Portal
+approval still selects the collection and permissions; first contact is then
+confirmed locally, including in a fully headless session:
+
+```bash
+mdbase --json connect trust list
+mdbase --json connect trust show REQUEST_ID
+mdbase --json connect trust accept REQUEST_ID --code AUTHENTICATION_STRING
+```
+
+Do not expose the local control socket or named pipe over a network. Back up the
+state directory and OS credential store according to the recovery guidance for
+your platform.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -39,8 +39,10 @@ pnpm --filter @mdbase/connect-desktop package
 ```
 
 The package command compiles the release daemon/CLI, creates the platform
-Electron bundle, and verifies that `app.asar` and the `mdbase`
-executable are both present.
+Electron bundle, and verifies that `app.asar` and the `mdbase` executable are
+both present. The release workflow also smoke-tests that exact native
+executable's CLI and foreground-daemon entry points, then publishes it as a
+standalone headless archive with the same tag-bound provenance and checksums.
 Run the packaged application once with a fresh user-data directory and complete
 pairing, collection registration, encrypted application authorization, one write,
 pause/resume, and revocation.
@@ -66,12 +68,21 @@ whose filenames contain `UNSIGNED`. They are preview artifacts, not the
 canonical Windows installation channel. Windows will show Unknown Publisher or
 SmartScreen warnings for them. Checksums and GitHub OIDC-backed Sigstore bundles
 prove which workflow produced the files, but do not provide Authenticode trust.
+The standalone Windows headless archive follows the same `UNSIGNED` rule until
+an Authenticode publisher path is configured.
 
 Before company-backed publisher accounts are available, beta releases may also
 contain macOS DMG and ZIP files whose names contain `UNSIGNED`. They are neither
 Developer ID signed nor notarized and require a manual Gatekeeper override.
 Their bundled warning, checksums, and Sigstore bundles describe the exact
 trust boundary.
+
+Standalone macOS headless archives use the `mdbase` executable copied from the
+packaged application. A trusted archive is published only when that nested
+binary passes strict code-signature verification; otherwise its filename
+contains `UNSIGNED`. Linux headless archives are native release binaries with
+workflow identity, checksums, and Sigstore bundles. See
+[`headless.md`](headless.md) for the installation and daemon lifecycle.
 
 The `Desktop Release` workflow builds, verifies, signs, and publishes the
 installers for a version tag. To enable trusted macOS output, configure these

--- a/scripts/lib/package-headless-cli.test.mjs
+++ b/scripts/lib/package-headless-cli.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { packageHeadlessCli } from "../package-headless-cli.mjs";
+
+test("packages the verified canonical CLI for each release filename mode", async () => {
+  const root = await mkdtemp(join(tmpdir(), "mdbase-headless-test-"));
+  try {
+    const repositoryRoot = join(root, "repo");
+    const outputDirectory = join(root, "output");
+    await mkdir(join(repositoryRoot, "docs"), { recursive: true });
+    await writeFile(join(repositoryRoot, "LICENSE"), "test license\n");
+    await writeFile(join(repositoryRoot, "docs", "headless.md"), "install safely\n");
+    const binary = join(root, "mdbase");
+    await writeFile(binary, `#!/usr/bin/env bash
+case "$*" in
+  --help|"connect daemon run --help") exit 0 ;;
+  *) exit 1 ;;
+esac
+`);
+    await chmod(binary, 0o755);
+
+    const packaged = await packageHeadlessCli({
+      platform: "linux",
+      arch: "x64",
+      version: "0.1.0-beta.25",
+      binary,
+      outputDirectory,
+      repositoryRoot
+    });
+    assert.equal(packaged.artifactName, "mdbase-cli-0.1.0-beta.25-linux-x64.tar.gz");
+    const listing = spawnSync("tar", ["-tzf", packaged.artifactPath], { encoding: "utf8" });
+    assert.equal(listing.status, 0);
+    assert.match(listing.stdout, /mdbase-0\.1\.0-beta\.25-linux-x64\/mdbase$/m);
+    assert.match(listing.stdout, /README\.md$/m);
+    assert.match(listing.stdout, /LICENSE$/m);
+
+    const unsigned = await packageHeadlessCli({
+      platform: "windows",
+      arch: "x64",
+      version: "0.1.0-beta.25",
+      binary,
+      outputDirectory,
+      filenameMode: "unsigned-preview",
+      repositoryRoot
+    });
+    assert.equal(
+      unsigned.artifactName,
+      "mdbase-cli-0.1.0-beta.25-windows-x64-UNSIGNED.tar.gz"
+    );
+    assert.ok((await readFile(unsigned.artifactPath)).length > 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects ambiguous or unsupported release identities", async () => {
+  await assert.rejects(
+    packageHeadlessCli({
+      platform: "freebsd",
+      arch: "x64",
+      version: "0.1.0-beta.25",
+      binary: "/missing",
+      outputDirectory: "/missing"
+    }),
+    /Unsupported headless platform/
+  );
+});

--- a/scripts/package-headless-cli.mjs
+++ b/scripts/package-headless-cli.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { constants } from "node:fs";
+import {
+  access,
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  rm,
+  stat
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const platforms = new Set(["linux", "macos", "windows"]);
+const filenameModes = new Set(["standard", "unsigned-preview"]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: "pipe",
+    timeout: 30_000
+  });
+  if (result.error || result.status !== 0) {
+    fail(`Command failed while packaging the headless CLI: ${basename(command)} ${args.join(" ")}`);
+  }
+}
+
+export async function packageHeadlessCli({
+  platform,
+  arch,
+  version,
+  binary,
+  outputDirectory,
+  filenameMode = "standard",
+  repositoryRoot = resolve(import.meta.dirname, "..")
+}) {
+  if (!platforms.has(platform)) {
+    fail(`Unsupported headless platform: ${platform}`);
+  }
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(arch)) {
+    fail(`Invalid headless architecture: ${arch}`);
+  }
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?$/.test(version)) {
+    fail(`Invalid headless release version: ${version}`);
+  }
+  if (!filenameModes.has(filenameMode)) {
+    fail(`Unsupported headless filename mode: ${filenameMode}`);
+  }
+
+  const binaryPath = resolve(binary);
+  await access(binaryPath, constants.R_OK | constants.X_OK);
+  run(binaryPath, ["--help"]);
+  run(binaryPath, ["connect", "daemon", "run", "--help"]);
+
+  const outputPath = resolve(outputDirectory);
+  await mkdir(outputPath, { recursive: true });
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "mdbase-headless-release-"));
+  try {
+    const packageName = `mdbase-${version}-${platform}-${arch}`;
+    const packageDirectory = join(temporaryRoot, packageName);
+    await mkdir(packageDirectory);
+    const executableName = platform === "windows" ? "mdbase.exe" : "mdbase";
+    const packagedBinary = join(packageDirectory, executableName);
+    await copyFile(binaryPath, packagedBinary);
+    await chmod(packagedBinary, 0o755);
+    await copyFile(join(repositoryRoot, "LICENSE"), join(packageDirectory, "LICENSE"));
+    await copyFile(
+      join(repositoryRoot, "docs", "headless.md"),
+      join(packageDirectory, "README.md")
+    );
+
+    const unsignedSuffix = filenameMode === "unsigned-preview" ? "-UNSIGNED" : "";
+    const artifactName = `mdbase-cli-${version}-${platform}-${arch}${unsignedSuffix}.tar.gz`;
+    const artifactPath = join(outputPath, artifactName);
+    try {
+      await access(artifactPath, constants.F_OK);
+      fail(`Refusing to overwrite an existing headless artifact: ${artifactName}`);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+    run("tar", ["-czf", artifactPath, "-C", temporaryRoot, packageName]);
+    const artifact = await stat(artifactPath);
+    if (!artifact.isFile() || artifact.size === 0) {
+      fail("The headless CLI archive is empty.");
+    }
+    return { artifactName, artifactPath, packageName };
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+function parseArguments(args) {
+  const values = {};
+  const known = new Set([
+    "platform",
+    "arch",
+    "version",
+    "binary",
+    "output-directory",
+    "filename-mode"
+  ]);
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!name?.startsWith("--") || value === undefined) {
+      fail("Headless packaging arguments must be --name VALUE pairs.");
+    }
+    const key = name.slice(2);
+    if (!known.has(key) || Object.hasOwn(values, key)) {
+      fail(`Unknown or duplicate headless packaging argument: ${name}`);
+    }
+    values[key] = value;
+  }
+  const required = ["platform", "arch", "version", "binary", "output-directory"];
+  for (const name of required) {
+    if (!values[name]) {
+      fail(`Missing required argument: --${name}`);
+    }
+  }
+  return {
+    platform: values.platform,
+    arch: values.arch,
+    version: values.version,
+    binary: values.binary,
+    outputDirectory: values["output-directory"],
+    filenameMode: values["filename-mode"] ?? "standard"
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  packageHeadlessCli(parseArguments(process.argv.slice(2)))
+    .then(({ artifactName }) => process.stdout.write(`${artifactName}\n`))
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/package-headless-cli.mjs
+++ b/scripts/package-headless-cli.mjs
@@ -22,14 +22,18 @@ function fail(message) {
   throw new Error(message);
 }
 
-function run(command, args) {
+function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     encoding: "utf8",
     stdio: "pipe",
-    timeout: 30_000
+    timeout: 30_000,
+    ...options
   });
   if (result.error || result.status !== 0) {
-    fail(`Command failed while packaging the headless CLI: ${basename(command)} ${args.join(" ")}`);
+    const detail = result.error?.message ?? result.stderr?.trim() ?? `exit ${result.status}`;
+    fail(
+      `Command failed while packaging the headless CLI: ${basename(command)} ${args.join(" ")} (${detail})`
+    );
   }
 }
 
@@ -88,7 +92,12 @@ export async function packageHeadlessCli({
         throw error;
       }
     }
-    run("tar", ["-czf", artifactPath, "-C", temporaryRoot, packageName]);
+    // Keep native Windows drive-qualified paths away from bsdtar's command line;
+    // some builds interpret the colon as remote-archive syntax. Create the archive
+    // beside the package using simple relative names, then copy it atomically.
+    const temporaryArtifact = join(temporaryRoot, artifactName);
+    run("tar", ["-czf", artifactName, packageName], { cwd: temporaryRoot });
+    await copyFile(temporaryArtifact, artifactPath, constants.COPYFILE_EXCL);
     const artifact = await stat(artifactPath);
     if (!artifact.isFile() || artifact.size === 0) {
       fail("The headless CLI archive is empty.");


### PR DESCRIPTION
## Summary
- publish the exact native `mdbase` CLI/daemon beside each desktop platform release
- verify CLI and foreground-daemon entry points before packaging
- preserve platform trust labels: macOS must pass signature verification, Windows and unsigned macOS remain explicit previews
- attach the existing tag-bound Sigstore provenance and checksum chain
- document verified installation, service lifecycle, and headless first-contact commands

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p mdbase-cli`
- real optimized Linux binary packaged, extracted, and executed
- Node 24 `pnpm typecheck` and `pnpm test`
- packager unit tests cover archive content, naming, validation, and preview labels
- PR workflow builds and exercises all four native platform/architecture archives