### PR TITLE
Support temporary R2 credentials

### DIFF
--- a/crates/connect-hosted-provider/src/blob_store.rs
+++ b/crates/connect-hosted-provider/src/blob_store.rs
@@ -30,6 +30,7 @@ pub struct R2Config {
     pub bucket: String,
     pub access_key_id: String,
     pub secret_access_key: String,
+    pub session_token: Option<String>,
     pub multipart_part_bytes: u64,
     pub download_part_bytes: u64,
     pub presign_ttl: Duration,
@@ -51,6 +52,7 @@ impl R2Config {
             bucket: bucket.into(),
             access_key_id: access_key_id.into(),
             secret_access_key: secret_access_key.into(),
+            session_token: None,
             multipart_part_bytes,
             download_part_bytes,
             presign_ttl,
@@ -74,6 +76,7 @@ impl R2Config {
             bucket: bucket.into(),
             access_key_id: access_key_id.into(),
             secret_access_key: secret_access_key.into(),
+            session_token: None,
             multipart_part_bytes,
             download_part_bytes,
             presign_ttl,
@@ -82,6 +85,12 @@ impl R2Config {
         config.validate()?;
         config.endpoint = config.endpoint.trim_end_matches('/').to_string();
         Ok(config)
+    }
+
+    pub fn with_session_token(mut self, session_token: Option<String>) -> ApiResult<Self> {
+        self.session_token = session_token;
+        self.validate()?;
+        Ok(self)
     }
 
     fn validate(&self) -> ApiResult<()> {
@@ -101,6 +110,10 @@ impl R2Config {
             || self.bucket.len() > 255
             || self.access_key_id.trim().is_empty()
             || self.secret_access_key.trim().is_empty()
+            || self
+                .session_token
+                .as_ref()
+                .is_some_and(|token| token.trim().is_empty())
             || !(MIN_MULTIPART_PART_BYTES..=MAX_MULTIPART_PART_BYTES)
                 .contains(&self.multipart_part_bytes)
             || !(MIN_DOWNLOAD_PART_BYTES..=MAX_DOWNLOAD_PART_BYTES)
@@ -139,7 +152,7 @@ impl R2BlobStore {
         let credentials = Credentials::new(
             config.access_key_id.clone(),
             config.secret_access_key.clone(),
-            None,
+            config.session_token.clone(),
             None,
             "mdbase-connect-r2",
         );
@@ -604,10 +617,16 @@ mod tests {
             8 * 1024 * 1024,
             Duration::from_secs(900),
         )
+        .unwrap()
+        .with_session_token(Some("temporary-session".to_string()))
         .unwrap();
         let store = R2BlobStore::new(valid);
         assert_eq!(store.upload_part_size(), 8 * 1024 * 1024);
         assert_eq!(store.download_part_size(), 8 * 1024 * 1024);
+        assert_eq!(
+            store.config.session_token.as_deref(),
+            Some("temporary-session")
+        );
 
         for invalid in [
             R2Config::new(
@@ -668,6 +687,18 @@ mod tests {
             8 * 1024 * 1024,
             Duration::from_secs(900),
         )
+        .is_err());
+        assert!(R2Config::new(
+            "https://account.r2.cloudflarestorage.com",
+            "bucket",
+            "access",
+            "secret",
+            8 * 1024 * 1024,
+            8 * 1024 * 1024,
+            Duration::from_secs(900),
+        )
+        .unwrap()
+        .with_session_token(Some("   ".to_string()))
         .is_err());
     }
 

--- a/crates/connect-hosted-provider/src/blob_store.rs
+++ b/crates/connect-hosted-provider/src/blob_store.rs
@@ -10,6 +10,7 @@ use futures_util::{stream, Stream};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::pin::Pin;
 use std::time::Duration;
 use url::Url;
@@ -24,7 +25,7 @@ pub type BlobStreamError = Box<dyn std::error::Error + Send + Sync>;
 pub type BlobByteStream =
     Pin<Box<dyn Stream<Item = Result<Bytes, BlobStreamError>> + Send + 'static>>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct R2Config {
     pub endpoint: String,
     pub bucket: String,
@@ -35,6 +36,26 @@ pub struct R2Config {
     pub download_part_bytes: u64,
     pub presign_ttl: Duration,
     allow_insecure_loopback: bool,
+}
+
+impl fmt::Debug for R2Config {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("R2Config")
+            .field("endpoint", &self.endpoint)
+            .field("bucket", &self.bucket)
+            .field("access_key_id", &"[redacted]")
+            .field("secret_access_key", &"[redacted]")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "[redacted]"),
+            )
+            .field("multipart_part_bytes", &self.multipart_part_bytes)
+            .field("download_part_bytes", &self.download_part_bytes)
+            .field("presign_ttl", &self.presign_ttl)
+            .field("allow_insecure_loopback", &self.allow_insecure_loopback)
+            .finish()
+    }
 }
 
 impl R2Config {
@@ -728,6 +749,11 @@ mod tests {
         assert!(url.query_pairs().any(|(name, value)| {
             name.eq_ignore_ascii_case("X-Amz-Security-Token") && value == "temporary-session"
         }));
+        let debug = format!("{:?}", store.config);
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains("temporary-access"));
+        assert!(!debug.contains("temporary-secret"));
+        assert!(!debug.contains("temporary-session"));
     }
 
     #[test]

--- a/crates/connect-hosted-provider/src/blob_store.rs
+++ b/crates/connect-hosted-provider/src/blob_store.rs
@@ -702,6 +702,34 @@ mod tests {
         .is_err());
     }
 
+    #[tokio::test]
+    async fn temporary_session_token_is_bound_to_presigned_requests() {
+        let config = R2Config::new(
+            "https://account.r2.cloudflarestorage.com",
+            "private-bucket",
+            "temporary-access",
+            "temporary-secret",
+            8 * 1024 * 1024,
+            8 * 1024 * 1024,
+            Duration::from_secs(900),
+        )
+        .unwrap()
+        .with_session_token(Some("temporary-session".to_string()))
+        .unwrap();
+        let store = R2BlobStore::new(config);
+        let request = store
+            .presign_put(
+                "v1/staging/01922222-2222-7222-8222-222222222222/01933333-3333-7333-8333-333333333333",
+                5,
+            )
+            .await
+            .unwrap();
+        let url = Url::parse(&request.url).unwrap();
+        assert!(url.query_pairs().any(|(name, value)| {
+            name.eq_ignore_ascii_case("X-Amz-Security-Token") && value == "temporary-session"
+        }));
+    }
+
     #[test]
     fn opaque_object_keys_cannot_escape_the_provider_prefix() {
         for invalid in ["", "/absolute", "v1/../secret", "v1/white space"] {

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -167,6 +167,7 @@ struct RuntimeSecrets {
     master_key: Option<String>,
     r2_access_key_id: String,
     r2_secret_access_key: String,
+    r2_session_token: Option<String>,
 }
 
 impl RuntimeSecrets {
@@ -177,6 +178,7 @@ impl RuntimeSecrets {
             master_key: optional_environment("MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY")?,
             r2_access_key_id: required_environment("MDBASE_CONNECT_R2_ACCESS_KEY_ID")?,
             r2_secret_access_key: required_environment("MDBASE_CONNECT_R2_SECRET_ACCESS_KEY")?,
+            r2_session_token: optional_environment("MDBASE_CONNECT_R2_SESSION_TOKEN")?,
         })
     }
 }
@@ -244,7 +246,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             arguments.r2_download_part_bytes,
             Duration::from_secs(arguments.r2_presign_ttl_seconds),
         )?
-    };
+    }
+    .with_session_token(secrets.r2_session_token)?;
     let blob_store = Arc::new(R2BlobStore::new(r2_config));
     let provider = HostedProvider::connect(
         &secrets.database_url,

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -78,7 +78,10 @@ Hosted deployments select the data-key writer with
 and `MDBASE_CONNECT_HOSTED_KMS_REGION`. AWS credentials come from the standard
 SDK credential chain. The database URL, provider internal token, legacy master
 key, and R2 credentials are environment-only settings rather than command-line
-arguments so they do not enter shell history or process listings.
+arguments so they do not enter shell history or process listings. The R2
+credential may include `MDBASE_CONNECT_R2_SESSION_TOKEN` when an S3-compatible
+provider issues short-lived credentials; omitting it preserves ordinary
+long-lived bucket credentials.
 
 The service resolves a configured KMS alias to an immutable enabled symmetric
 key ARN at startup. Its least-privilege identity needs `DescribeKey`, plus only


### PR DESCRIPTION
## Summary

- accept an optional R2 session token through the hosted-provider secret boundary
- pass short-lived S3 credentials into the AWS SDK without changing permanent credential behavior
- validate empty session tokens fail closed and document the environment setting
- redact all R2 credential material from `R2Config` diagnostics

## Validation

- hosted-provider suite: 59 passed, 2 live-only ignored
- presigning regression proves `X-Amz-Security-Token` is bound to temporary requests
- diagnostic regression proves access key, secret key, and session token are redacted
- strict hosted-provider Clippy
- full Rust workspace with the repository's isolated test-secret backend
- Node 24 typecheck, unit, and E2E suites

This enables the recovery tooling to use Cloudflare's expiring bucket-scoped credentials.
