### PR TITLE
Prepare v0.1.0-beta.25

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,5 +1,5 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.19
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:2e9a07c8e17f9f470ca102ac4fc6e13bff6e5c0441bed4ca9f8d67e4a86a0f14
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:aeb491bed5dcee1c43c358186bb86615868ea687b81d6eea06fe5a60198d3935
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.24
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:6fd07d1c4b896db67233698325d478823cd40b7c6686f7907766fd048b6a187f
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:d394bc97bcb41b91827d63bd9fc3ae0b445de56ad055b41e50fa164487b0d9e6

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -252,6 +252,11 @@ jobs:
       CANDIDATE_IMAGE: mdbase-connect-hosted-provider:upgrade-candidate
       PROVIDER_INTERNAL_TOKEN: previous-provider-upgrade-internal-token
       PROVIDER_MASTER_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      MDBASE_CONNECT_R2_ENDPOINT: http://127.0.0.1:9000
+      MDBASE_CONNECT_R2_BUCKET: upgrade-canary
+      MDBASE_CONNECT_R2_ACCESS_KEY_ID: upgrade-canary
+      MDBASE_CONNECT_R2_SECRET_ACCESS_KEY: upgrade-canary-secret
+      MDBASE_CONNECT_ALLOW_INSECURE_R2: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -262,6 +267,28 @@ jobs:
           --tag "$CANDIDATE_IMAGE"
           .
 
+      - name: Start test-only R2 readiness stub
+        run: |
+          node --input-type=module --eval '
+            import { createServer } from "node:http";
+            createServer((_request, response) => {
+              response.writeHead(200);
+              response.end();
+            }).listen(9000, "127.0.0.1");
+          ' >"$RUNNER_TEMP/mdbase-upgrade-r2.log" 2>&1 &
+          r2_pid=$!
+          echo "$r2_pid" >"$RUNNER_TEMP/mdbase-upgrade-r2.pid"
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:9000 >/dev/null; then
+              exit 0
+            fi
+            if ! kill -0 "$r2_pid" >/dev/null 2>&1 || [ "$attempt" = 30 ]; then
+              cat "$RUNNER_TEMP/mdbase-upgrade-r2.log"
+              exit 1
+            fi
+            sleep 1
+          done
+
       - name: Create the previous provider schema
         run: |
           . .github/previous-release.env
@@ -271,6 +298,11 @@ jobs:
             --env DATABASE_URL \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
+            --env MDBASE_CONNECT_R2_ENDPOINT \
+            --env MDBASE_CONNECT_R2_BUCKET \
+            --env MDBASE_CONNECT_R2_ACCESS_KEY_ID \
+            --env MDBASE_CONNECT_R2_SECRET_ACCESS_KEY \
+            --env MDBASE_CONNECT_ALLOW_INSECURE_R2 \
             "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE" >/dev/null
           for attempt in {1..30}; do
             if curl --fail --silent http://127.0.0.1:8790/ready >/dev/null; then
@@ -334,6 +366,11 @@ jobs:
             --env DATABASE_URL \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
+            --env MDBASE_CONNECT_R2_ENDPOINT \
+            --env MDBASE_CONNECT_R2_BUCKET \
+            --env MDBASE_CONNECT_R2_ACCESS_KEY_ID \
+            --env MDBASE_CONNECT_R2_SECRET_ACCESS_KEY \
+            --env MDBASE_CONNECT_ALLOW_INSECURE_R2 \
             "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE" >/dev/null
           for attempt in {1..30}; do
             if curl --fail --silent http://127.0.0.1:8790/ready >/dev/null; then
@@ -365,16 +402,7 @@ jobs:
 
       - name: Require candidate migration and recovery readiness
         run: |
-          node --input-type=module --eval '
-            import { createServer } from "node:http";
-            createServer((_request, response) => {
-              response.writeHead(200);
-              response.end();
-            }).listen(9000, "127.0.0.1");
-          ' >/tmp/mdbase-upgrade-r2.log 2>&1 &
-          r2_pid=$!
           cleanup() {
-            kill "$r2_pid" >/dev/null 2>&1 || true
             docker logs mdbase-provider-upgrade-candidate || true
             docker rm --force mdbase-provider-upgrade-candidate >/dev/null 2>&1 || true
           }
@@ -385,11 +413,11 @@ jobs:
             --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
             --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
             --env MDBASE_CONNECT_CONTROL_PLANE_URL=http://127.0.0.1:9 \
-            --env MDBASE_CONNECT_R2_ENDPOINT=http://127.0.0.1:9000 \
-            --env MDBASE_CONNECT_R2_BUCKET=upgrade-canary \
-            --env MDBASE_CONNECT_R2_ACCESS_KEY_ID=upgrade-canary \
-            --env MDBASE_CONNECT_R2_SECRET_ACCESS_KEY=upgrade-canary-secret \
-            --env MDBASE_CONNECT_ALLOW_INSECURE_R2=true \
+            --env MDBASE_CONNECT_R2_ENDPOINT \
+            --env MDBASE_CONNECT_R2_BUCKET \
+            --env MDBASE_CONNECT_R2_ACCESS_KEY_ID \
+            --env MDBASE_CONNECT_R2_SECRET_ACCESS_KEY \
+            --env MDBASE_CONNECT_ALLOW_INSECURE_R2 \
             "$CANDIDATE_IMAGE" >/dev/null
 
           for attempt in {1..30}; do
@@ -424,6 +452,14 @@ jobs:
                        WHERE grant_id = '22222222-2222-4222-8222-222222222222'")
           echo "Migrated notification contract: $contract"
           [[ "$contract" == "mdbase.runtime.timer.fired|1.0.0" ]]
+
+      - name: Stop test-only R2 readiness stub
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/mdbase-upgrade-r2.pid" ]; then
+            r2_pid=$(<"$RUNNER_TEMP/mdbase-upgrade-r2.pid")
+            kill "$r2_pid" >/dev/null 2>&1 || true
+          fi
 
   hosted-provider:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -316,15 +316,13 @@ jobs:
           done
           docker rm --force mdbase-provider-previous >/dev/null
 
-      - name: Seed the persisted beta notification shape
+      - name: Seed the persisted previous release notification shape
         run: |
           docker run --rm --interactive --network host \
             --env PGPASSWORD=previous-provider-upgrade \
             postgres:18-alpine \
             psql --host 127.0.0.1 --username mdbase --dbname mdbase_provider_upgrade \
             --set ON_ERROR_STOP=1 <<'SQL'
-          DELETE FROM _sqlx_migrations WHERE version = 15;
-
           INSERT INTO hosted_provider_collections
             (id, template, spec_version, max_records, max_content_bytes,
              max_document_bytes, max_replicas, resource_revision,
@@ -350,7 +348,7 @@ jobs:
               "scope":{"contracts":[],"access":"full_collection"},
               "notification_criteria":[{
                 "id":"task.reminder",
-                "event":{"id":"timer.fired","version":1},
+                "event":{"id":"mdbase.runtime.timer.fired","version":"1.0.0"},
                 "presentation":{"title":"Task reminder"}
               }],
               "created_at":"2026-07-29T00:00:00Z"
@@ -358,7 +356,7 @@ jobs:
           );
           SQL
 
-      - name: Apply the previous release migration
+      - name: Reopen persisted state with the previous release
         run: |
           . .github/previous-release.env
           docker run --detach --name mdbase-provider-previous-migration \
@@ -397,10 +395,10 @@ jobs:
                        )
                        FROM hosted_provider_notification_grants
                        WHERE grant_id = '22222222-2222-4222-8222-222222222222'")
-          echo "Previous release partial migration: $previous_contract"
-          [[ "$previous_contract" == "timer.fired|1.0.0" ]]
+          echo "Previous release notification contract: $previous_contract"
+          [[ "$previous_contract" == "mdbase.runtime.timer.fired|1.0.0" ]]
 
-      - name: Require candidate migration and recovery readiness
+      - name: Require candidate recovery readiness
         run: |
           cleanup() {
             docker logs mdbase-provider-upgrade-candidate || true
@@ -450,7 +448,7 @@ jobs:
                        )
                        FROM hosted_provider_notification_grants
                        WHERE grant_id = '22222222-2222-4222-8222-222222222222'")
-          echo "Migrated notification contract: $contract"
+          echo "Recovered notification contract: $contract"
           [[ "$contract" == "mdbase.runtime.timer.fired|1.0.0" ]]
 
       - name: Stop test-only R2 readiness stub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "clap",
  "directories",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "chrono",
  "directories",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "async-trait",
  "axum",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-protocol/src/tests.rs
+++ b/crates/connect-protocol/src/tests.rs
@@ -471,7 +471,7 @@ fn rust_relay_messages_match_the_canonical_wire_schema() {
     for message in [
         RelayMessage::RelayHello {
             protocol_version: CONTROL_PROTOCOL_VERSION,
-            connector_version: "0.1.0-beta.24".to_string(),
+            connector_version: "0.1.0-beta.25".to_string(),
             capabilities: RELAY_CAPABILITIES
                 .iter()
                 .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "clap",
  "directories",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "chrono",
  "directories",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "async-trait",
  "axum",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.24"
+version = "0.1.0-beta.25"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -125,9 +125,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.24
-git tag -a v0.1.0-beta.24 -m "mdbase connect 0.1.0-beta.24"
-git push origin v0.1.0-beta.24
+pnpm version:check v0.1.0-beta.25
+git tag -a v0.1.0-beta.25 -m "mdbase connect 0.1.0-beta.25"
+git push origin v0.1.0-beta.25
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -662,7 +662,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.24",
+    connector_version: "0.1.0-beta.25",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.24" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.25" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.24",
+  "version": "0.1.0-beta.25",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- advance every Rust and JavaScript package plus release documentation to `0.1.0-beta.25`
- exercise previous-release compatibility against the actual beta.24 server and hosted-provider images instead of the stale beta.19 fixture
- bind those previous images to the annotated beta.24 tag commit and the exact signed staging release state
- supply beta.24’s required R2 configuration through a job-scoped test-only readiness stub
- seed the notification contract state beta.24 can actually persist, then require both beta.24 reopen and candidate recovery before readiness

## Why

The temporary R2 session-token support needs a new immutable release identity before recovery acceptance can deploy it to staging. Beta tags are immutable, so the already-published beta.24 identity cannot be reused.

Advancing the previous-release pin also exposed stale CI assumptions: beta.24 requires R2 at startup and already records notification migrations 15 and 16. The compatibility job now models that real release boundary instead of manufacturing a post-migration legacy row.

## Validation

- Node 24 `pnpm version:check v0.1.0-beta.25`
- Node 24 beta release-readiness validation (two intentionally open stable gates)
- Node 24 complete `pnpm test`
- Rust format check and versioned relay-schema test
- beta.24 annotated tag commit and previous server/provider digests match the verified staging release state
- actionlint and Ruby YAML parsing for the modified workflow
- immutable beta.24 provider reached readiness with the test-only R2 boundary locally
- `git diff --check`

The full replacement PR matrix is running.