### PR TITLE
Harden cross-platform release preflight tests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -7,7 +7,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/desktop-release.yml"
+      - "apps/editor/**"
       - "apps/desktop/**"
+      - "packages/**"
+      - "scripts/lib/package-headless-cli.test.mjs"
+      - "scripts/package-headless-cli.mjs"
       - "scripts/configure-windows-store-package.ps1"
       - "scripts/verify-windows-packages.ps1"
       - "pnpm-lock.yaml"
@@ -596,6 +600,45 @@ jobs:
           test -n "$packaged_binary"
           "$packaged_binary" --help >/dev/null
           "$packaged_binary" connect daemon run --help >/dev/null
+
+  cross-platform-release-tests:
+    if: github.event_name != 'push'
+    name: ${{ matrix.label }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Windows release regression tests
+            os: windows-2025
+          - label: macOS Intel release regression tests
+            os: macos-15-intel
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: mdbase-connect
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: mdbase-connect
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.15.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: mdbase-connect/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages
+      - name: Exercise headless release packaging
+        run: node --test scripts/lib/package-headless-cli.test.mjs
+      - name: Exercise editor release tests
+        run: pnpm --filter mdbase-editor test
 
   windows-package-smoke:
     if: github.event_name != 'push'

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -253,6 +253,7 @@ describe("mdbase editor", () => {
 
     await screen.findByRole("heading", { name: "Writing" });
     const folders = screen.getByRole("group", { name: "Folders" });
+    await waitFor(() => expect(folders).toHaveAttribute("aria-busy", "false"));
     expect(within(folders).queryByRole("button", { name: /^Show notes in Projects\/Alpha,/ })).not.toBeInTheDocument();
     const disclosure = within(folders).getByRole("button", { name: "Expand Projects" });
     await user.click(disclosure);
@@ -294,6 +295,7 @@ describe("mdbase editor", () => {
 
     await screen.findByRole("heading", { name: "Writing" });
     const tags = screen.getByRole("group", { name: "Tags" });
+    await waitFor(() => expect(tags).toHaveAttribute("aria-busy", "false"));
     await user.click(within(tags).getByRole("button", { name: "Tags" }));
     fireEvent.contextMenu(within(tags).getByRole("button", { name: /^Show notes tagged #ideas,/ }), {
       clientX: 60,

--- a/apps/editor/src/test-setup.ts
+++ b/apps/editor/src/test-setup.ts
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterEach, beforeEach, vi } from "vitest";
+
+configure({ asyncUtilTimeout: 5_000 });
 
 afterEach(() => {
   cleanup();

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],
     restoreMocks: true,
+    testTimeout: 15_000,
     include: ["src/**/*.test.{ts,tsx}"]
   }
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "pnpm -r build",
-    "build:packages": "pnpm --filter './packages/**' -r --if-present build",
+    "build:packages": "pnpm --filter \"./packages/**\" -r --if-present build",
     "check:architecture": "node scripts/check-architecture.mjs",
     "check:release-readiness": "node scripts/check-release-readiness.mjs",
     "generate:problems": "node scripts/generate-connect-problems.mjs",

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -2693,6 +2693,12 @@ async function authorityPromotionCliE2E(
   const recovered = await connectCommand(profile, ["mirror", "list"]);
   assert.equal(recovered.length, 1);
   assert.equal(recovered[0].replica_id, mirror.replica_id);
+  await waitFor(async () => {
+    const [status] = await connectCommand(profile, ["mirror", "list"]);
+    return status?.replica_id === mirror.replica_id
+      && status.syncing === false
+      && status.state === "up_to_date";
+  }, "Recovered promotion mirror did not become idle", 400);
 
   const promotion = spawn(connectBinary, connectArguments(profile, [
     "--json", "mirror", "promote", mirror.replica_id, "--no-open"

--- a/scripts/lib/package-headless-cli.test.mjs
+++ b/scripts/lib/package-headless-cli.test.mjs
@@ -8,20 +8,35 @@ import { packageHeadlessCli } from "../package-headless-cli.mjs";
 
 test("packages the verified canonical CLI for each release filename mode", async () => {
   const root = await mkdtemp(join(tmpdir(), "mdbase-headless-test-"));
+  const originalWorkingDirectory = process.cwd();
+  let changedWorkingDirectory = false;
   try {
     const repositoryRoot = join(root, "repo");
     const outputDirectory = join(root, "output");
     await mkdir(join(repositoryRoot, "docs"), { recursive: true });
     await writeFile(join(repositoryRoot, "LICENSE"), "test license\n");
     await writeFile(join(repositoryRoot, "docs", "headless.md"), "install safely\n");
-    const binary = join(root, "mdbase");
-    await writeFile(binary, `#!/usr/bin/env bash
+    let binary;
+    if (process.platform === "win32") {
+      // Use a real host-native executable on Windows. The adjacent extensionless
+      // script lets node accept the CLI's multi-word help invocation without
+      // weakening the production packager's native-binary verification.
+      await writeFile(join(root, "connect"), `
+if (process.argv.slice(2).join(" ") !== "daemon run --help") process.exit(1);
+`);
+      process.chdir(root);
+      changedWorkingDirectory = true;
+      binary = process.execPath;
+    } else {
+      binary = join(root, "mdbase");
+      await writeFile(binary, `#!/usr/bin/env bash
 case "$*" in
   --help|"connect daemon run --help") exit 0 ;;
   *) exit 1 ;;
 esac
 `);
-    await chmod(binary, 0o755);
+      await chmod(binary, 0o755);
+    }
 
     const packaged = await packageHeadlessCli({
       platform: "linux",
@@ -53,6 +68,7 @@ esac
     );
     assert.ok((await readFile(unsigned.artifactPath)).length > 0);
   } finally {
+    if (changedWorkingDirectory) process.chdir(originalWorkingDirectory);
     await rm(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- use a host-native executable fixture for the headless CLI packager on Windows without weakening production binary verification
- give editor async assertions and whole tests explicit budgets suitable for the slower macOS Intel release runner
- trigger Desktop Release preflight for editor, shared-package, and headless-packager changes
- run the exact regression suites on Windows and Intel macOS before the next release tag

## Failure evidence
- beta.25 Desktop Release run 30781450634 failed deterministically because Windows tried to execute the test fixture’s extensionless Bash script
- the macOS Intel job’s first editor failure was the default 5-second test timeout; later async failures followed, while the same suite passed on Apple Silicon, Linux, Server CI, and locally

## Local validation
- Node 24 headless packager tests
- editor 245-test suite
- full Node 24 typecheck
- full Node 24 unit suite

## Live CI validation
- Desktop Release pull-request run 30783608502: four real headless archive smokes, Windows Store packaging, and dedicated Windows/Intel regression jobs (in progress)
