### PR TITLE
Prepare beta26 recovery release

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,5 +1,5 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.24
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:6fd07d1c4b896db67233698325d478823cd40b7c6686f7907766fd048b6a187f
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:d394bc97bcb41b91827d63bd9fc3ae0b445de56ad055b41e50fa164487b0d9e6
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.25
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:9f37cd050755346134a9bb1ac4056138e37d16881bb796ed3db2f1a3db6a8710
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:f095b09a4821b3a244326c3a35dae4bac011d4fb0b03001407dfe7e7248747ba

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "clap",
  "directories",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "chrono",
  "directories",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "async-trait",
  "axum",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -280,6 +280,7 @@ pub struct CollectionRegistry {
     db_path: PathBuf,
     providers: Arc<Mutex<HashMap<Uuid, Arc<FilesystemProvider>>>>,
     file_reconciles: Arc<Mutex<HashMap<Uuid, Arc<Mutex<()>>>>>,
+    encrypted_request_writes: Arc<Mutex<()>>,
 }
 
 /// Filesystem state that must be synchronized after a successful operation.

--- a/crates/connect-core/src/registry/database.rs
+++ b/crates/connect-core/src/registry/database.rs
@@ -10,6 +10,7 @@ impl CollectionRegistry {
             db_path: state_dir.as_ref().join("connector.sqlite"),
             providers: Arc::new(Mutex::new(HashMap::new())),
             file_reconciles: Arc::new(Mutex::new(HashMap::new())),
+            encrypted_request_writes: Arc::new(Mutex::new(())),
         };
         registry.migrate()?;
         registry.recover_file_transfers()?;

--- a/crates/connect-core/src/registry/encrypted_requests.rs
+++ b/crates/connect-core/src/registry/encrypted_requests.rs
@@ -30,6 +30,14 @@ impl CollectionRegistry {
         request_id: Uuid,
         request_fingerprint: &str,
     ) -> Result<EncryptedRequestClaim, ConnectError> {
+        // SQLite permits one writer at a time. Keep the small replay-ledger transactions ordered
+        // within this connector process so bursts of authenticated operations cannot turn normal
+        // writer contention into a false security rejection. Collection operations themselves stay
+        // concurrent, and SQLite remains the cross-process serialization boundary.
+        let _write_guard = self
+            .encrypted_request_writes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut connection = self.connection()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let state = transaction
@@ -129,6 +137,10 @@ impl CollectionRegistry {
         request_fingerprint: &str,
         response_envelope: &str,
     ) -> Result<(), ConnectError> {
+        let _write_guard = self
+            .encrypted_request_writes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let updated = self.connection()?.execute(
             "UPDATE grant_crypto_requests SET response_envelope = ?5
              WHERE grant_id = ?1 AND key_id = ?2 AND request_id = ?3

--- a/crates/connect-core/src/registry/tests/security_state.rs
+++ b/crates/connect-core/src/registry/tests/security_state.rs
@@ -149,6 +149,49 @@ fn encrypted_replay_window_survives_restart_allows_reordering_and_serializes_dup
 }
 
 #[test]
+fn encrypted_replay_ledger_accepts_a_full_concurrent_request_burst() {
+    const REQUESTS: usize = 32;
+
+    let state = tempdir().unwrap();
+    let registry = Arc::new(CollectionRegistry::open(state.path()).unwrap());
+    let grant_id = Uuid::new_v4();
+    let barrier = Arc::new(Barrier::new(REQUESTS));
+    let threads = (0..REQUESTS)
+        .map(|index| {
+            let registry = registry.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                let counter = u64::try_from(index + 1).unwrap();
+                let request_id = Uuid::new_v4();
+                let fingerprint = format!("fingerprint-{counter}");
+                barrier.wait();
+                let claim = registry.claim_encrypted_request(
+                    grant_id,
+                    "burst-key",
+                    counter,
+                    request_id,
+                    &fingerprint,
+                )?;
+                registry.complete_encrypted_request(
+                    grant_id,
+                    "burst-key",
+                    request_id,
+                    &fingerprint,
+                    r#"{"ciphertext":"response"}"#,
+                )?;
+                Ok::<_, ConnectError>(claim)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let claims = threads
+        .into_iter()
+        .map(|thread| thread.join().unwrap().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(claims, vec![EncryptedRequestClaim::Fresh; REQUESTS]);
+}
+
+#[test]
 fn development_registry_upgrade_adds_origin_receipts_and_a_safe_reorder_floor() {
     let state = tempdir().unwrap();
     let path = state.path().join("connector.sqlite");

--- a/crates/connect-protocol/src/tests.rs
+++ b/crates/connect-protocol/src/tests.rs
@@ -471,7 +471,7 @@ fn rust_relay_messages_match_the_canonical_wire_schema() {
     for message in [
         RelayMessage::RelayHello {
             protocol_version: CONTROL_PROTOCOL_VERSION,
-            connector_version: "0.1.0-beta.25".to_string(),
+            connector_version: "0.1.0-beta.26".to_string(),
             capabilities: RELAY_CAPABILITIES
                 .iter()
                 .map(|value| (*value).to_string())

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "clap",
  "directories",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "chrono",
  "directories",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "async-trait",
  "axum",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.25"
+version = "0.1.0-beta.26"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -125,9 +125,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.25
-git tag -a v0.1.0-beta.25 -m "mdbase connect 0.1.0-beta.25"
-git push origin v0.1.0-beta.25
+pnpm version:check v0.1.0-beta.26
+git tag -a v0.1.0-beta.26 -m "mdbase connect 0.1.0-beta.26"
+git push origin v0.1.0-beta.26
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -662,7 +662,7 @@ test("relay request and response discriminators reject malformed wire messages",
   const hello = {
     type: "relay_hello",
     protocol_version: 1,
-    connector_version: "0.1.0-beta.25",
+    connector_version: "0.1.0-beta.26",
     capabilities: [
       "authorization-activation",
       "encrypted-relay",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/lib/package-headless-cli.test.mjs
+++ b/scripts/lib/package-headless-cli.test.mjs
@@ -41,22 +41,22 @@ esac
     const packaged = await packageHeadlessCli({
       platform: "linux",
       arch: "x64",
-      version: "0.1.0-beta.25",
+      version: "0.1.0-beta.26",
       binary,
       outputDirectory,
       repositoryRoot
     });
-    assert.equal(packaged.artifactName, "mdbase-cli-0.1.0-beta.25-linux-x64.tar.gz");
+    assert.equal(packaged.artifactName, "mdbase-cli-0.1.0-beta.26-linux-x64.tar.gz");
     const listing = spawnSync("tar", ["-tzf", packaged.artifactPath], { encoding: "utf8" });
     assert.equal(listing.status, 0);
-    assert.match(listing.stdout, /mdbase-0\.1\.0-beta\.25-linux-x64\/mdbase$/m);
+    assert.match(listing.stdout, /mdbase-0\.1\.0-beta\.26-linux-x64\/mdbase$/m);
     assert.match(listing.stdout, /README\.md$/m);
     assert.match(listing.stdout, /LICENSE$/m);
 
     const unsigned = await packageHeadlessCli({
       platform: "windows",
       arch: "x64",
-      version: "0.1.0-beta.25",
+      version: "0.1.0-beta.26",
       binary,
       outputDirectory,
       filenameMode: "unsigned-preview",
@@ -64,7 +64,7 @@ esac
     });
     assert.equal(
       unsigned.artifactName,
-      "mdbase-cli-0.1.0-beta.25-windows-x64-UNSIGNED.tar.gz"
+      "mdbase-cli-0.1.0-beta.26-windows-x64-UNSIGNED.tar.gz"
     );
     assert.ok((await readFile(unsigned.artifactPath)).length > 0);
   } finally {
@@ -78,7 +78,7 @@ test("rejects ambiguous or unsupported release identities", async () => {
     packageHeadlessCli({
       platform: "freebsd",
       arch: "x64",
-      version: "0.1.0-beta.25",
+      version: "0.1.0-beta.26",
       binary: "/missing",
       outputDirectory: "/missing"
     }),

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.25" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.26" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.25",
+  "version": "0.1.0-beta.26",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- advances the Rust workspace, JavaScript packages, MCP identity, protocol fixtures, and release examples to 0.1.0-beta.26
- pins beta25 as the exact previous-release compatibility target using immutable server and hosted-provider image digests
- keeps the hosted-provider Docker lockfile synchronized with the workspace lockfile
- serializes the connector's short encrypted replay-ledger writes while preserving concurrent collection operations
- adds a synchronized 32-request regression test for authenticated counter reordering and durable receipts

## Why

Beta26 contains the path-scoped R2 readiness correction needed to run the isolated recovery drill with a least-privilege temporary Cloudflare credential. A fresh exact release image and archive are required because the retained beta25 provider image predates that correction.

Windows CI also exposed SQLite writer contention in the encrypted replay ledger under a full 32-request burst. A transient lock error was being treated as a security rejection. The ledger now has an explicit in-process single-writer boundary; authentication, replay-window checks, durable receipts, and the actual operation concurrency are unchanged.

## Impact

Production remains pinned to beta23. Staging will only be updated after the protected build publishes signed beta26 images. The replay-ledger change affects only short local registry writes and prevents valid concurrent requests from receiving false rejections.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- new 32-thread replay-ledger regression test
- loopback concurrent-request regression repeated 20 consecutive times
- `pnpm version:check v0.1.0-beta.26`
- `pnpm check:release-readiness`
- `pnpm typecheck`, `pnpm test`, and `pnpm e2e` under Node 24
- focused Rust and TypeScript protocol, MCP, and headless packaging tests
- workspace and hosted-provider lockfile byte comparison
