### PR TITLE
Complete the encrypted recovery release gate

### DIFF
--- a/config/release-readiness.json
+++ b/config/release-readiness.json
@@ -30,9 +30,15 @@
       "id": "backup-encryption-and-restore-drill",
       "title": "Encrypted backup and restore drill",
       "owner": "Service operations owner",
-      "status": "required",
-      "evidence": [],
-      "notes": "Verify encrypted database and volume backups, restoration, key recovery, recovery objectives, and deletion behavior in the managed environment."
+      "status": "complete",
+      "evidence": [
+        "https://github.com/mdbase-dev/mdbase-cloud-ops/actions/runs/30795956568",
+        "https://github.com/mdbase-dev/mdbase-cloud-ops/pull/56",
+        "https://github.com/mdbase-dev/mdbase-cloud-ops/pull/75",
+        "https://github.com/mdbase-dev/mdbase-cloud-ops/pull/76",
+        "https://github.com/mdbase-dev/mdbase-cloud-ops/pull/77"
+      ],
+      "notes": "The beta26 staging drill independently verified the signed governance-retained archive, clean-restored all three PostgreSQL databases, restored and digest-checked non-empty provider-managed R2 data, decrypted every hosted collection key through the Sydney KMS replica, cold-started the exact archived provider image, exercised restored and synthetic record/file semantics, measured recovery-point age and elapsed recovery time, proved provider-driven deletion, and cleanup-verified both source and isolated targets."
     },
     {
       "id": "platform-signing-and-notarization",

--- a/config/security-audit-package.json
+++ b/config/security-audit-package.json
@@ -286,10 +286,6 @@
       "description": "The relay broker is a single managed service; tested recovery is automatic reconnect after broker restoration, not uninterrupted high availability."
     },
     {
-      "id": "complete-recovery-drill-pending",
-      "description": "The isolated full database, object, KMS-replica, retained-key, and clean-environment recovery drill remains open."
-    },
-    {
       "id": "platform-signing-pending",
       "description": "Canonical platform signing and notarization are not yet configured."
     },

--- a/docs/decisions/0003-managed-provider-key-wrapping.md
+++ b/docs/decisions/0003-managed-provider-key-wrapping.md
@@ -165,6 +165,12 @@ The implementation requires:
 - an isolated recovery using the Sydney replica and restored database/object
   set before the production key hierarchy is considered complete.
 
+The final requirement passed in staging on 2026-08-03 against the exact beta26
+provider image and a non-empty retained object set. The private operations
+evidence records the signed archive identity, all three PostgreSQL restores,
+Sydney KMS decrypt coverage, semantic file/collection checks, measured recovery
+objectives, failed attempts, corrective commits, and exact cleanup.
+
 ## Consequences
 
 The provider gains an asynchronous dependency at DEK wrap/unwrap boundaries

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -57,9 +57,10 @@ random per-collection data key. A versioned wrapping boundary supports the
 legacy local deployment key and AWS KMS envelopes carrying the immutable key
 ARN. Exact KMS encryption context binds each wrapped key to its environment,
 purpose, and collection. PostgreSQL retains only the wrapped key, ciphertext,
-and the explicit metadata listed below. Live staging activation and a complete
-V1-to-V2 rotation drill have passed; the isolated full recovery drill remains
-release operations work. Private/zero-knowledge hosting is not implemented.
+and the explicit metadata listed below. Live staging activation, a complete
+V1-to-V2 rotation drill, and an isolated Sydney-replica recovery of the exact
+beta26 database/object set have passed. Private/zero-knowledge hosting is not
+implemented.
 
 Local Markdown files are also plaintext from mdbase's perspective. Operating
 system full-disk encryption, encrypted home directories, and device access

--- a/docs/security-audit-package.md
+++ b/docs/security-audit-package.md
@@ -137,8 +137,7 @@ items are:
 - future native SDK key storage still needs platform-keystore integration;
 - Render uses narrowly scoped, rotated static AWS credentials rather than
   workload identity federation;
-- full isolated recovery and platform signing/notarization remain open release
-  gates; and
+- platform signing/notarization remains an open release gate; and
 - recovery administration currently depends on one operator.
 
 An assessor should prioritize authorization-ceiling confusion, substituted-key

--- a/scripts/lib/security-audit-package.test.mjs
+++ b/scripts/lib/security-audit-package.test.mjs
@@ -24,7 +24,6 @@ const requiredLimitationIds = [
   "no-key-transparency",
   "render-static-aws-credentials",
   "single-relay-broker",
-  "complete-recovery-drill-pending",
   "platform-signing-pending",
   "single-operator-recovery"
 ];


### PR DESCRIPTION
## Summary
- mark encrypted backup/recovery complete with immutable archive, automation, corrective, and durable-evidence references
- remove the now-closed recovery limitation from the internal audit package
- update KMS/encryption documentation with the live beta26 Sydney-replica result
- preserve platform signing as the sole open stable-release gate and retain independent-audit/single-operator limitations

## Evidence
- archive workflow: https://github.com/mdbase-dev/mdbase-cloud-ops/actions/runs/30795956568
- semantic recovery automation: https://github.com/mdbase-dev/mdbase-cloud-ops/pull/56
- live-discovered corrections: https://github.com/mdbase-dev/mdbase-cloud-ops/pull/75 and https://github.com/mdbase-dev/mdbase-cloud-ops/pull/76
- structured evidence: https://github.com/mdbase-dev/mdbase-cloud-ops/pull/77

## Verification
- Node 24 release-readiness and security-audit package tests (10/10)
- `pnpm check:release-readiness` reports only platform signing open
- JSON and diff validation

Production was not mutated.