### PR TITLE
Prepare beta27 signed desktop release

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,5 +1,5 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.25
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:9f37cd050755346134a9bb1ac4056138e37d16881bb796ed3db2f1a3db6a8710
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:f095b09a4821b3a244326c3a35dae4bac011d4fb0b03001407dfe7e7248747ba
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.26
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:8d9b745b04c13ae2c3029677122e56efde18cb558a3fbeef0ff757ef1cce8180
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:81e30f69073cca54b5a47f633cd027c0ffd6e178bb447fe14fbb7bd3969a3475

--- a/scripts/lib/package-headless-cli.test.mjs
+++ b/scripts/lib/package-headless-cli.test.mjs
@@ -41,22 +41,22 @@ esac
     const packaged = await packageHeadlessCli({
       platform: "linux",
       arch: "x64",
-      version: "0.1.0-beta.26",
+      version: "0.1.0-beta.27",
       binary,
       outputDirectory,
       repositoryRoot
     });
-    assert.equal(packaged.artifactName, "mdbase-cli-0.1.0-beta.26-linux-x64.tar.gz");
+    assert.equal(packaged.artifactName, "mdbase-cli-0.1.0-beta.27-linux-x64.tar.gz");
     const listing = spawnSync("tar", ["-tzf", packaged.artifactPath], { encoding: "utf8" });
     assert.equal(listing.status, 0);
-    assert.match(listing.stdout, /mdbase-0\.1\.0-beta\.26-linux-x64\/mdbase$/m);
+    assert.match(listing.stdout, /mdbase-0\.1\.0-beta\.27-linux-x64\/mdbase$/m);
     assert.match(listing.stdout, /README\.md$/m);
     assert.match(listing.stdout, /LICENSE$/m);
 
     const unsigned = await packageHeadlessCli({
       platform: "windows",
       arch: "x64",
-      version: "0.1.0-beta.26",
+      version: "0.1.0-beta.27",
       binary,
       outputDirectory,
       filenameMode: "unsigned-preview",
@@ -64,7 +64,7 @@ esac
     });
     assert.equal(
       unsigned.artifactName,
-      "mdbase-cli-0.1.0-beta.26-windows-x64-UNSIGNED.tar.gz"
+      "mdbase-cli-0.1.0-beta.27-windows-x64-UNSIGNED.tar.gz"
     );
     assert.ok((await readFile(unsigned.artifactPath)).length > 0);
   } finally {
@@ -78,7 +78,7 @@ test("rejects ambiguous or unsupported release identities", async () => {
     packageHeadlessCli({
       platform: "freebsd",
       arch: "x64",
-      version: "0.1.0-beta.26",
+      version: "0.1.0-beta.27",
       binary: "/missing",
       outputDirectory: "/missing"
     }),


### PR DESCRIPTION
## What changed

- advance the previous-release upgrade fixtures from beta.25 to the published beta.26 image digests
- align the headless packaging test fixtures with the existing beta.27 workspace version

## Why

This prepares the already-versioned beta.27 commit for its first Developer ID-signed and Apple-notarized desktop release. The upgrade gates must test against the immediately preceding immutable release, and the packaging fixture must assert the version being published.

## Validation

- `node --test scripts/lib/package-headless-cli.test.mjs`
- `pnpm version:check v0.1.0-beta.27`
- `pnpm check:release-readiness`
- `git diff --check`
