### PR TITLE
Fail fast on unbootstrapped npm packages

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -45,6 +45,9 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Verify trusted-publisher bootstrap
+        run: pnpm check:npm-bootstrap
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm version:check
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,6 +57,25 @@ the status without evidence is itself rejected.
 
 ## Signing and publication
 
+### First publication of a new npm package
+
+npm trusted publishing cannot create a package. Before tagging a release that
+adds a public package, a scope owner must bootstrap that package once:
+
+1. Run the full local package verification above and pack the package from the
+   exact reviewed commit.
+2. Authenticate interactively with `npm login` and publish that audited tarball
+   with `npm publish <tarball> --access public --tag next`.
+3. Configure `publish-npm.yml` in `mdbase-dev/mdbase-connect` as the package's
+   GitHub Actions trusted publisher, restricted to the `npm` environment and
+   the `npm publish` operation.
+4. Run `pnpm check:npm-bootstrap` before creating the release tag.
+
+The tag workflow runs the same check before publishing anything. This keeps a
+missing first-time bootstrap from leaving a release partially published. All
+subsequent publications use short-lived GitHub OIDC credentials and provenance;
+do not add a long-lived npm publication token to the repository.
+
 Canonical public artifacts use each platform's trust channel:
 
 - macOS: Developer ID signing and Apple notarization;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm -r build",
     "build:packages": "pnpm --filter \"./packages/**\" -r --if-present build",
     "check:architecture": "node scripts/check-architecture.mjs",
+    "check:npm-bootstrap": "node scripts/check-npm-package-bootstrap.mjs",
     "check:release-readiness": "node scripts/check-release-readiness.mjs",
     "generate:problems": "node scripts/generate-connect-problems.mjs",
     "check:problems": "node scripts/generate-connect-problems.mjs --check",

--- a/scripts/check-npm-package-bootstrap.mjs
+++ b/scripts/check-npm-package-bootstrap.mjs
@@ -1,0 +1,53 @@
+import { pathToFileURL } from "node:url";
+
+import { publicPackages } from "./public-packages.mjs";
+
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
+
+export async function findUnbootstrappedPackages({
+  fetchImpl = globalThis.fetch,
+  registry = process.env.npm_config_registry ?? DEFAULT_REGISTRY,
+} = {}) {
+  if (typeof fetchImpl !== "function") throw new Error("fetch is unavailable");
+
+  const packages = await publicPackages();
+  const results = await Promise.all(
+    packages.map(async ({ name }) => {
+      const response = await fetchImpl(packageMetadataUrl(registry, name), {
+        headers: { accept: "application/json" },
+      });
+      if (response.ok) return undefined;
+      if (response.status === 404) return name;
+      throw new Error(
+        `npm registry lookup for ${name} returned HTTP ${response.status}`,
+      );
+    }),
+  );
+  return results.filter(Boolean);
+}
+
+export function packageMetadataUrl(registry, packageName) {
+  const registryUrl = new URL(registry.endsWith("/") ? registry : `${registry}/`);
+  return new URL(encodeURIComponent(packageName), registryUrl).href;
+}
+
+async function main() {
+  const missing = await findUnbootstrappedPackages();
+  if (missing.length === 0) {
+    process.stdout.write("Every public npm package is bootstrapped.\n");
+    return;
+  }
+
+  process.stderr.write(
+    [
+      "::error::Public npm packages must exist before trusted publishing can release them.",
+      ...missing.map((name) => `- ${name}`),
+      "Publish each package once with an interactive scope-owner session, configure publish-npm.yml as its trusted publisher, and rerun this check before creating a release tag.",
+      "See docs/releasing.md for the exact bootstrap procedure.",
+      "",
+    ].join("\n"),
+  );
+  process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) await main();

--- a/scripts/lib/check-npm-package-bootstrap.test.mjs
+++ b/scripts/lib/check-npm-package-bootstrap.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  findUnbootstrappedPackages,
+  packageMetadataUrl,
+} from "../check-npm-package-bootstrap.mjs";
+
+test("encodes scoped package metadata URLs", () => {
+  assert.equal(
+    packageMetadataUrl(
+      "https://registry.example.test/custom",
+      "@mdbase-dev/connect-testing",
+    ),
+    "https://registry.example.test/custom/%40mdbase-dev%2Fconnect-testing",
+  );
+});
+
+test("reports every public package absent from the registry", async () => {
+  const requested = [];
+  const missing = await findUnbootstrappedPackages({
+    registry: "https://registry.example.test/",
+    fetchImpl: async (url) => {
+      requested.push(url);
+      return {
+        ok: !url.includes("connect-testing"),
+        status: url.includes("connect-testing") ? 404 : 200,
+      };
+    },
+  });
+
+  assert.deepEqual(missing, ["@mdbase-dev/connect-testing"]);
+  assert.equal(requested.length, 7);
+});
+
+test("fails closed when the registry cannot answer authoritatively", async () => {
+  await assert.rejects(
+    findUnbootstrappedPackages({
+      fetchImpl: async () => ({ ok: false, status: 503 }),
+    }),
+    /npm registry lookup .* HTTP 503/,
+  );
+});


### PR DESCRIPTION
## Outcome

Prevents a newly added npm package from leaving a tagged release partially published.

- checks the full centralized public-package inventory against the configured npm registry before packing or publishing anything
- reports every package that still needs its one-time interactive bootstrap
- fails closed on non-authoritative registry errors
- documents the exact bootstrap and trusted-publisher procedure without introducing long-lived publication tokens

## Verification

- `fnm exec --using=24 pnpm exec node --test scripts/lib/*.test.mjs` (38/38)
- `fnm exec --using=24 pnpm check:architecture`
- live preflight correctly identifies only `@mdbase-dev/connect-testing` as unbootstrapped
- `git diff --check`

This follow-up addresses the production release issue discovered while publishing v0.1.0-beta.28.