### PR TITLE
Make editor manifest validation portable

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -635,6 +635,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:packages
+      - name: Exercise the complete editor release build
+        run: pnpm --filter mdbase-editor build
       - name: Exercise headless release packaging
         run: node --test scripts/lib/package-headless-cli.test.mjs
       - name: Exercise editor release tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "clap",
  "directories",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "chrono",
  "directories",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -15,7 +15,7 @@
     "preview": "vite preview --host 127.0.0.1",
     "icons": "node scripts/write-phosphor-icon-names.mjs",
     "manifest": "node scripts/write-manifest.mjs",
-    "manifest:validate": "mdbase-connect-dev validate-manifest public/.well-known/mdbase-app.json"
+    "manifest:validate": "node ../../packages/devkit/dist/cli.js validate-manifest public/.well-known/mdbase-app.json"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "clap",
  "directories",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "chrono",
  "directories",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.29"
+version = "0.1.0-beta.30"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.29
-git tag -a v0.1.0-beta.29 -m "mdbase connect 0.1.0-beta.29"
-git push origin v0.1.0-beta.29
+pnpm version:check v0.1.0-beta.30
+git tag -a v0.1.0-beta.30 -m "mdbase connect 0.1.0-beta.30"
+git push origin v0.1.0-beta.30
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.29" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.30" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.29",
+  "version": "0.1.0-beta.30",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Outcome

- invokes the Editor manifest validator through Node so clean pnpm installs do not depend on a platform-specific workspace bin shim
- exercises the complete Editor production build on Windows and Intel macOS pull-request CI
- advances the release train to beta.30 because beta.29's Windows desktop artifact could not be built

## Root cause

pnpm installs workspace links before `@mdbase-dev/connect-dev/dist/cli.js` exists. It warns that it cannot create the command shim. Unix builds could still resolve a direct executable link after the package was compiled; Windows had no generated command and failed with `mdbase-connect-dev is not recognized` during the tagged release. Pull-request release checks built packages and ran Editor tests, but did not run the Editor production build, so the tagged workflow was the first exact exercise of this path.

## Verification

- clean install reproduced the missing-shim warning
- package build followed by the complete Editor production build succeeds through the portable entrypoint
- release version consistency for v0.1.0-beta.30
- all workspace builds and TypeScript checks
- all Node and browser-independent workspace tests
- all seven public package consumer audits
- Rust formatting and the complete workspace test suite
