### PR TITLE
Make collection operations a canonical contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "clap",
  "directories",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "chrono",
  "directories",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "clap",
  "directories",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "chrono",
  "directories",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.30"
+version = "0.1.0-beta.31"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.30
-git tag -a v0.1.0-beta.30 -m "mdbase connect 0.1.0-beta.30"
-git push origin v0.1.0-beta.30
+pnpm version:check v0.1.0-beta.31
+git tag -a v0.1.0-beta.31 -m "mdbase connect 0.1.0-beta.31"
+git push origin v0.1.0-beta.31
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/src/operations.ts
+++ b/packages/protocol/src/operations.ts
@@ -1,26 +1,48 @@
-export type CollectionOperation =
-  | "describe"
-  | "changes"
-  | "read"
-  | "query"
-  | "list_views"
-  | "execute_view"
-  | "read_view_source"
-  | "create_view_source"
-  | "update_view_source"
-  | "delete_view_source"
-  | "validate"
-  | "create"
-  | "update"
-  | "delete"
-  | "rename"
-  | "read_type"
-  | "create_type"
-  | "update_type"
-  | "assess_type_pack"
-  | "apply_type_pack"
-  | "list_timers"
-  | "put_timer"
-  | "cancel_timer"
-  | "reconcile_timers"
-  | "sync";
+/**
+ * The executable collection-operation contract. Runtime parsers, capability
+ * compilation, and public types must all consume this value; do not maintain a
+ * second operation allow-list at an SDK or service boundary.
+ */
+export const COLLECTION_OPERATIONS = [
+  "describe",
+  "changes",
+  "read",
+  "query",
+  "list_views",
+  "execute_view",
+  "read_view_source",
+  "create_view_source",
+  "update_view_source",
+  "delete_view_source",
+  "validate",
+  "create",
+  "update",
+  "delete",
+  "rename",
+  "read_type",
+  "create_type",
+  "update_type",
+  "assess_type_pack",
+  "apply_type_pack",
+  "list_timers",
+  "put_timer",
+  "cancel_timer",
+  "reconcile_timers",
+  "sync"
+] as const;
+
+export type CollectionOperation = typeof COLLECTION_OPERATIONS[number];
+
+const COLLECTION_OPERATION_SET: ReadonlySet<string> = new Set(
+  COLLECTION_OPERATIONS
+);
+
+export function isCollectionOperation(value: string): value is CollectionOperation {
+  return COLLECTION_OPERATION_SET.has(value);
+}
+
+export function areCollectionOperations(
+  values: readonly string[]
+): values is readonly CollectionOperation[] {
+  return values.every(isCollectionOperation);
+}

--- a/packages/protocol/test/schema.test.mjs
+++ b/packages/protocol/test/schema.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
+import { COLLECTION_OPERATIONS } from "../dist/operations.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const schema = JSON.parse(readFileSync(resolve(here, "../schemas/connect-protocol.v1.schema.json"), "utf8"));
@@ -48,6 +49,13 @@ test("all canonical schemas compile as strict JSON Schema 2020-12", () => {
   assert.ok(validator(interopSchema.$id));
   assert.ok(validator(syncSchema.$id));
   assert.ok(validator(problemSchema.$id));
+});
+
+test("the protocol schema exposes the executable collection operation contract", () => {
+  assert.deepEqual(
+    schema.$defs.operation.enum,
+    [...COLLECTION_OPERATIONS]
+  );
 });
 
 test("file capabilities use an explicit namespace and scope", () => {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.30" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.31" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.30",
+  "version": "0.1.0-beta.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -537,6 +537,37 @@ describe("mdbase connect server", () => {
     const applicationId = discovered.json().application.id as string;
     const applicationManifestDigest =
       discovered.json().application.manifest_digest as string;
+    const definitionManager = applicationManifestFixture({
+      contracts: [],
+      access: "full_collection",
+      capabilities: {
+        contract_version: 1,
+        required: ["definitions.type-pack.apply"]
+      }
+    }, "Definition Manager");
+    definitionManager.manifest.id = "dev.mdbase.definition-manager";
+    definitionManager.manifest.redirect_uris = [definitionManager.redirectUri];
+    const registeredDefinitionManager = await app.inject({
+      method: "POST",
+      url: "/v1/apps/register",
+      payload: { manifest: definitionManager.manifest }
+    });
+    expect(
+      registeredDefinitionManager.statusCode,
+      registeredDefinitionManager.body
+    ).toBe(200);
+    const semanticAuthorization = await postWebAuthorization(app, {
+      applicationId: registeredDefinitionManager.json().application.id,
+      applicationManifestDigest:
+        registeredDefinitionManager.json().application.manifest_digest,
+      redirectUri: definitionManager.redirectUri,
+      verifier: "semantic-capability-verifier-that-is-long-enough-0001",
+      state: "semantic-capability",
+      operations: ["assess_type_pack", "apply_type_pack"],
+      collectionId
+    });
+    expect(semanticAuthorization.statusCode, semanticAuthorization.body).toBe(200);
+
     const invalidEncryption = await app.inject({
       method: "GET",
       url: `/oauth/authorize?client_id=${applicationId}&redirect_uri=${encodeURIComponent(manifestServer.redirectUri)}&code_challenge=${"a".repeat(43)}&code_challenge_method=S256&relay_protocol=3&application_agreement_public_key=${"A".repeat(87)}`,

--- a/services/server/src/collection-access.ts
+++ b/services/server/src/collection-access.ts
@@ -1,6 +1,7 @@
-import type {
-  CollectionOperation,
-  GrantScope
+import {
+  COLLECTION_OPERATIONS,
+  type CollectionOperation,
+  type GrantScope
 } from "@mdbase-dev/connect-protocol";
 import type { DatabaseQueryable } from "./db.js";
 import {
@@ -9,32 +10,7 @@ import {
   type CollectionLocator
 } from "./collection-catalog.js";
 
-export const COLLECTION_OPERATIONS = [
-  "describe",
-  "changes",
-  "read",
-  "query",
-  "validate",
-  "list_views",
-  "execute_view",
-  "read_view_source",
-  "create_view_source",
-  "update_view_source",
-  "delete_view_source",
-  "create",
-  "update",
-  "delete",
-  "rename",
-  "read_type",
-  "create_type",
-  "update_type",
-  "apply_type_pack",
-  "list_timers",
-  "put_timer",
-  "cancel_timer",
-  "reconcile_timers",
-  "sync"
-] as const satisfies readonly CollectionOperation[];
+export { COLLECTION_OPERATIONS };
 
 export type CollectionAction =
   | "collection.discover"

--- a/services/server/src/collection-operation-policy.ts
+++ b/services/server/src/collection-operation-policy.ts
@@ -1,0 +1,94 @@
+import type { CollectionOperation } from "@mdbase-dev/connect-protocol";
+
+interface CollectionOperationPolicy {
+  requiresFullCollection: boolean;
+  requiresPortableProfile: boolean;
+  requiresWriteReplica: boolean;
+}
+
+/**
+ * Server-side policy for every executable collection operation. Keeping this
+ * exhaustive makes a new protocol operation a compile-time decision at each
+ * authorization and replica boundary instead of an easy-to-miss allow-list
+ * update.
+ */
+const COLLECTION_OPERATION_POLICIES = {
+  describe: policy(),
+  changes: policy(),
+  read: policy(),
+  query: policy({ requiresPortableProfile: true }),
+  list_views: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true
+  }),
+  execute_view: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true
+  }),
+  read_view_source: policy(),
+  create_view_source: policy({ requiresWriteReplica: true }),
+  update_view_source: policy({ requiresWriteReplica: true }),
+  delete_view_source: policy({ requiresWriteReplica: true }),
+  validate: policy({ requiresFullCollection: true }),
+  create: policy({ requiresWriteReplica: true }),
+  update: policy({ requiresWriteReplica: true }),
+  delete: policy({ requiresWriteReplica: true }),
+  rename: policy({ requiresWriteReplica: true }),
+  read_type: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true
+  }),
+  create_type: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true,
+    requiresWriteReplica: true
+  }),
+  update_type: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true,
+    requiresWriteReplica: true
+  }),
+  assess_type_pack: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true
+  }),
+  apply_type_pack: policy({
+    requiresFullCollection: true,
+    requiresPortableProfile: true,
+    requiresWriteReplica: true
+  }),
+  list_timers: policy(),
+  put_timer: policy({ requiresWriteReplica: true }),
+  cancel_timer: policy({ requiresWriteReplica: true }),
+  reconcile_timers: policy({ requiresWriteReplica: true }),
+  sync: policy()
+} as const satisfies Record<CollectionOperation, CollectionOperationPolicy>;
+
+export function requiresFullCollectionAccess(
+  operation: CollectionOperation
+): boolean {
+  return COLLECTION_OPERATION_POLICIES[operation].requiresFullCollection;
+}
+
+export function requiresPortableProfile(
+  operation: CollectionOperation
+): boolean {
+  return COLLECTION_OPERATION_POLICIES[operation].requiresPortableProfile;
+}
+
+export function requiresWriteReplica(
+  operation: CollectionOperation
+): boolean {
+  return COLLECTION_OPERATION_POLICIES[operation].requiresWriteReplica;
+}
+
+function policy(
+  overrides: Partial<CollectionOperationPolicy> = {}
+): CollectionOperationPolicy {
+  return {
+    requiresFullCollection: false,
+    requiresPortableProfile: false,
+    requiresWriteReplica: false,
+    ...overrides
+  };
+}

--- a/services/server/src/features/grants/policy.test.ts
+++ b/services/server/src/features/grants/policy.test.ts
@@ -28,4 +28,11 @@ describe("application capability policy", () => {
       }
     })).toBe(false);
   });
+
+  it("fails closed when persisted grants contain a non-protocol operation", () => {
+    expect(operationsAllowedByRequirements(
+      ["read", "future_unclassified_operation"],
+      requirements
+    )).toBe(false);
+  });
 });

--- a/services/server/src/features/grants/policy.ts
+++ b/services/server/src/features/grants/policy.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { operationsForApplicationCapabilities } from "@mdbase-dev/connect-protocol";
+import {
+  areCollectionOperations,
+  isCollectionOperation,
+  operationsForApplicationCapabilities
+} from "@mdbase-dev/connect-protocol";
 import type {
   ApplicationProvisions,
   ApplicationRequirements,
-  CollectionOperation,
   CollectionContractDescriptor,
   ContractRequirement,
   GrantEncryption,
@@ -13,28 +16,10 @@ import type {
 import type { DatabasePool } from "../../database-types.js";
 import { typesForContracts } from "../../hosted.js";
 import { RequestValidationError } from "../../platform/http-errors.js";
-
-const FULL_COLLECTION_OPERATIONS = new Set([
-  "validate",
-  "list_views",
-  "execute_view",
-  "read_type",
-  "create_type",
-  "update_type",
-  "assess_type_pack",
-  "apply_type_pack"
-]);
-
-const PORTABLE_PROFILE_OPERATIONS = new Set([
-  "query",
-  "list_views",
-  "execute_view",
-  "read_type",
-  "create_type",
-  "update_type",
-  "assess_type_pack",
-  "apply_type_pack"
-]);
+import {
+  requiresFullCollectionAccess,
+  requiresPortableProfile
+} from "../../collection-operation-policy.js";
 
 export function scopeForRequirements(
   requirements: ApplicationRequirements | null | undefined,
@@ -60,21 +45,24 @@ export function collectionSupportsOperations(
   specVersion: string,
   operations: readonly string[]
 ): boolean {
+  if (!areCollectionOperations(operations)) return false;
   return /^0\.3(?:\.|$)/.test(specVersion)
-    || operations.every(
-      (operation) => !PORTABLE_PROFILE_OPERATIONS.has(operation)
-    );
+    || operations.every((operation) => !requiresPortableProfile(operation));
 }
 
 export function assertCollectionSupportsOperations(
   specVersion: string,
   operations: readonly string[]
 ): void {
-  const unsupported = operations.find(
-    (operation) =>
-      PORTABLE_PROFILE_OPERATIONS.has(operation)
-      && !/^0\.3(?:\.|$)/.test(specVersion)
-  );
+  const validOperations = areCollectionOperations(operations);
+  const unsupported = validOperations
+    ? operations.find((operation) =>
+        requiresPortableProfile(operation)
+          && !/^0\.3(?:\.|$)/.test(specVersion)
+      )
+    : operations.find((operation) =>
+        !isCollectionOperation(operation)
+      );
   if (unsupported) {
     throw new RequestValidationError(
       `This collection uses mdbase ${specVersion} and does not support the ${unsupported} operation.`
@@ -86,14 +74,15 @@ export function operationsAllowedByRequirements(
   operations: readonly string[],
   requirements: ApplicationRequirements | null | undefined
 ): boolean {
+  if (!areCollectionOperations(operations)) return false;
   if (
     requirements?.access !== "full_collection"
-    && operations.some((operation) => FULL_COLLECTION_OPERATIONS.has(operation))
+    && operations.some(requiresFullCollectionAccess)
   ) return false;
   const declared = requirements?.capabilities;
   if (!declared) return true;
   const allowed = new Set(operationsForApplicationCapabilities(declared));
-  return operations.every((operation) => allowed.has(operation as CollectionOperation));
+  return operations.every((operation) => allowed.has(operation));
 }
 
 export function assertOperationsAllowedByRequirements(

--- a/services/server/src/grant-planner.test.ts
+++ b/services/server/src/grant-planner.test.ts
@@ -4,6 +4,7 @@ import type {
   CollectionOperation,
   GrantScope
 } from "@mdbase-dev/connect-protocol";
+import { operationsForApplicationCapabilities } from "@mdbase-dev/connect-protocol";
 import {
   ownerAccess,
   type CollectionAccessContext
@@ -29,6 +30,31 @@ const owner = ownerAccess({
 }, "owner");
 
 describe("planCollectionGrant", () => {
+  it("plans every operation compiled for type-pack application sessions", () => {
+    const capabilities = {
+      contract_version: 1 as const,
+      required: ["definitions.type-pack.apply"] as const
+    };
+    const operations = operationsForApplicationCapabilities(capabilities);
+    const result = planCollectionGrant({
+      requestedOperations: operations,
+      applicationOperationCeiling: operations,
+      requirements: {
+        contracts: [],
+        access: "full_collection",
+        capabilities
+      },
+      availableContracts: [],
+      access: owner
+    });
+
+    expect(result).toEqual({
+      operations: ["assess_type_pack", "apply_type_pack"],
+      scope: { access: "full_collection", contracts: [] },
+      replicaMode: "read_write"
+    });
+  });
+
   it("intersects application, request, and human access ceilings", () => {
     const result = planCollectionGrant({
       requestedOperations: ["read", "update"],

--- a/services/server/src/grant-planner.ts
+++ b/services/server/src/grant-planner.ts
@@ -7,32 +7,10 @@ import type {
 } from "@mdbase-dev/connect-protocol";
 import { FILE_PROTOCOL_VERSION } from "@mdbase-dev/connect-protocol";
 import type { CollectionAccessContext } from "./collection-access.js";
-
-const FULL_COLLECTION_OPERATIONS = new Set<CollectionOperation>([
-  "validate",
-  "list_views",
-  "execute_view",
-  "read_type",
-  "create_type",
-  "update_type",
-  "apply_type_pack"
-]);
-
-const WRITE_OPERATIONS = new Set<CollectionOperation>([
-  "create",
-  "update",
-  "delete",
-  "rename",
-  "create_type",
-  "update_type",
-  "apply_type_pack",
-  "create_view_source",
-  "update_view_source",
-  "delete_view_source",
-  "put_timer",
-  "cancel_timer",
-  "reconcile_timers"
-]);
+import {
+  requiresFullCollectionAccess,
+  requiresWriteReplica
+} from "./collection-operation-policy.js";
 
 const WRITE_FILE_ACTIONS = new Set(["add", "replace", "move", "delete"]);
 
@@ -91,7 +69,7 @@ export function planCollectionGrant(input: {
   }
   if (
     input.requirements.access !== "full_collection"
-    && operations.some((operation) => FULL_COLLECTION_OPERATIONS.has(operation))
+    && operations.some(requiresFullCollectionAccess)
   ) {
     throw new GrantPlanningError(
       "Saved views, collection-wide validation, and type definitions require the application manifest to request full collection access."
@@ -107,7 +85,7 @@ export function planCollectionGrant(input: {
   return {
     operations,
     scope,
-    replicaMode: operations.some((operation) => WRITE_OPERATIONS.has(operation))
+    replicaMode: operations.some(requiresWriteReplica)
       || fileRequirement?.actions.some((action) => WRITE_FILE_ACTIONS.has(action))
       ? "read_write"
       : "read_only",


### PR DESCRIPTION
## What changed

- make the protocol package's executable collection-operation tuple the runtime and type-level source of truth
- have every server Zod operation parser consume that canonical tuple
- classify every operation in one exhaustive server policy table for full-collection scope, portable-profile support, and write-replica behavior
- fail closed when persisted grants contain a non-protocol operation
- cover semantic `definitions.type-pack.apply` compilation through a real signed application authorization request
- release the correction as `0.1.0-beta.31`

## Root cause

`assess_type_pack` was part of the public `CollectionOperation` type and was emitted by the semantic capability compiler, but the server maintained a separate handwritten runtime allow-list that omitted it. TypeScript's prior `satisfies readonly CollectionOperation[]` check verified that listed values were valid; it could not prove that every operation was listed. TaskNotes and Editor therefore produced correct signed requests which the server rejected before authorization.

The operation tuple is now canonical and the server policy table is exhaustive. A future operation cannot be added without being accepted by runtime parsers and explicitly classified at the authorization/replica boundaries.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm version:check v0.1.0-beta.31`
- `pnpm check:architecture`
- `pnpm check:npm-bootstrap`
- `pnpm check:release-readiness`
- `pnpm check:problems`
- `pnpm package:audit`
- `pnpm audit:dependencies`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `git diff --check`

The final server suite is 254/254 green, including the signed semantic-capability regression and fail-closed persisted-operation coverage.
