### PR TITLE
Enable Obsidian Base views in hosted collections

### DIFF
--- a/crates/connect-hosted-provider/src/template.rs
+++ b/crates/connect-hosted-provider/src/template.rs
@@ -3,6 +3,19 @@ use sha2::{Digest, Sha256};
 
 use crate::error::{ApiError, ApiResult};
 
+const MDBASE_TEMPLATE_REVISION: &str = "mdbase-template:2";
+const MDBASE_CONFIGURATION: &str = r#"spec_version: 0.3.0
+settings:
+  types_folder: _types
+  default_validation: error
+x-obsidian:
+  bases:
+    include:
+      - views/**/*.base
+    create_folder: views
+    default_for_new_views: true
+"#;
+
 #[derive(Debug, Clone)]
 pub struct ResourceDocument {
     pub path: &'static str,
@@ -22,11 +35,9 @@ pub fn resources(template: &str) -> ApiResult<(SyncCollectionResources, Vec<Reso
 }
 
 fn mdbase() -> (SyncCollectionResources, Vec<ResourceDocument>) {
-    const CONFIGURATION: &str =
-        "spec_version: 0.3.0\nsettings:\n  types_folder: _types\n  default_validation: error\n";
     (
         SyncCollectionResources {
-            revision: "mdbase-template:1".to_string(),
+            revision: MDBASE_TEMPLATE_REVISION.to_string(),
             spec_version: "0.3.0".to_string(),
             types: Vec::new(),
             contracts: Vec::new(),
@@ -35,8 +46,11 @@ fn mdbase() -> (SyncCollectionResources, Vec<ResourceDocument>) {
         vec![ResourceDocument {
             path: "mdbase.yaml",
             kind: "configuration",
-            revision: format!("sha256:{:x}", Sha256::digest(CONFIGURATION.as_bytes())),
-            document: CONFIGURATION,
+            revision: format!(
+                "sha256:{:x}",
+                Sha256::digest(MDBASE_CONFIGURATION.as_bytes())
+            ),
+            document: MDBASE_CONFIGURATION,
         }],
     )
 }
@@ -46,9 +60,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn generic_mdbase_template_has_no_application_contracts() {
+    fn generic_mdbase_template_enables_portable_base_views_without_app_contracts() {
         let (resources, documents) = resources("mdbase").unwrap();
-        assert_eq!(resources.revision, "mdbase-template:1");
+        assert_eq!(resources.revision, MDBASE_TEMPLATE_REVISION);
         assert!(resources.types.is_empty());
         assert!(resources.contracts.is_empty());
         assert_eq!(documents.len(), 1);
@@ -58,5 +72,12 @@ mod tests {
             format!("sha256:{:x}", Sha256::digest(documents[0].document))
         );
         assert!(documents[0].document.contains("spec_version: 0.3.0"));
+        assert!(documents[0]
+            .document
+            .contains("include:\n      - views/**/*.base"));
+        assert!(documents[0].document.contains("create_folder: views"));
+        assert!(documents[0]
+            .document
+            .contains("default_for_new_views: true"));
     }
 }

--- a/crates/connect-hosted-provider/src/workspace.rs
+++ b/crates/connect-hosted-provider/src/workspace.rs
@@ -983,4 +983,69 @@ views:
             .unwrap();
         assert!(deleted.valid, "{:?}", deleted.diagnostics);
     }
+
+    #[test]
+    fn hosted_template_creates_executes_updates_and_deletes_obsidian_base_views() {
+        let workspace = WorkingSet::materialize(resources(), []).unwrap();
+        let document = "views:\n  - type: tasknotesTaskList\n    name: Focused work\n";
+        let created = workspace
+            .view_source_operation(
+                "create_view_source",
+                &json!({
+                    "format": "obsidian.base",
+                    "name": "Focused work",
+                    "document": document,
+                }),
+            )
+            .unwrap();
+        assert!(created.valid, "{:?}", created.diagnostics);
+        assert_eq!(created.result["path"], "views/focused-work.base");
+        assert_eq!(created.result["format"], "obsidian.base");
+
+        let listed = workspace.read_operation("list_views", &json!({})).unwrap();
+        assert!(listed.valid, "{:?}", listed.diagnostics);
+        assert_eq!(listed.result["meta"]["total_count"], 1);
+        assert_eq!(
+            listed.result["views"][0]["source"]["path"],
+            "views/focused-work.base"
+        );
+
+        let executed = workspace
+            .read_operation(
+                "execute_view",
+                &json!({
+                    "path": "views/focused-work.base",
+                    "view": "focused-work",
+                }),
+            )
+            .unwrap();
+        assert!(executed.valid, "{:?}", executed.diagnostics);
+        assert_eq!(executed.result["meta"]["total_count"], 0);
+
+        let updated_document = document.replace("Focused work", "Deep work");
+        let updated = workspace
+            .view_source_operation(
+                "update_view_source",
+                &json!({
+                    "path": "views/focused-work.base",
+                    "if_revision": created.result["revision"],
+                    "document": updated_document,
+                }),
+            )
+            .unwrap();
+        assert!(updated.valid, "{:?}", updated.diagnostics);
+
+        let deleted = workspace
+            .view_source_operation(
+                "delete_view_source",
+                &json!({
+                    "path": "views/focused-work.base",
+                    "if_revision": updated.result["revision"],
+                }),
+            )
+            .unwrap();
+        assert!(deleted.valid, "{:?}", deleted.diagnostics);
+        let listed = workspace.read_operation("list_views", &json!({})).unwrap();
+        assert_eq!(listed.result["meta"]["total_count"], 0);
+    }
 }

--- a/crates/connect-hosted-provider/src/workspace.rs
+++ b/crates/connect-hosted-provider/src/workspace.rs
@@ -569,6 +569,9 @@ fn safe_relative(relative: &str) -> ApiResult<()> {
 mod contract_setup_tests;
 
 #[cfg(test)]
+mod obsidian_base_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -982,70 +985,5 @@ views:
             )
             .unwrap();
         assert!(deleted.valid, "{:?}", deleted.diagnostics);
-    }
-
-    #[test]
-    fn hosted_template_creates_executes_updates_and_deletes_obsidian_base_views() {
-        let workspace = WorkingSet::materialize(resources(), []).unwrap();
-        let document = "views:\n  - type: tasknotesTaskList\n    name: Focused work\n";
-        let created = workspace
-            .view_source_operation(
-                "create_view_source",
-                &json!({
-                    "format": "obsidian.base",
-                    "name": "Focused work",
-                    "document": document,
-                }),
-            )
-            .unwrap();
-        assert!(created.valid, "{:?}", created.diagnostics);
-        assert_eq!(created.result["path"], "views/focused-work.base");
-        assert_eq!(created.result["format"], "obsidian.base");
-
-        let listed = workspace.read_operation("list_views", &json!({})).unwrap();
-        assert!(listed.valid, "{:?}", listed.diagnostics);
-        assert_eq!(listed.result["meta"]["total_count"], 1);
-        assert_eq!(
-            listed.result["views"][0]["source"]["path"],
-            "views/focused-work.base"
-        );
-
-        let executed = workspace
-            .read_operation(
-                "execute_view",
-                &json!({
-                    "path": "views/focused-work.base",
-                    "view": "focused-work",
-                }),
-            )
-            .unwrap();
-        assert!(executed.valid, "{:?}", executed.diagnostics);
-        assert_eq!(executed.result["meta"]["total_count"], 0);
-
-        let updated_document = document.replace("Focused work", "Deep work");
-        let updated = workspace
-            .view_source_operation(
-                "update_view_source",
-                &json!({
-                    "path": "views/focused-work.base",
-                    "if_revision": created.result["revision"],
-                    "document": updated_document,
-                }),
-            )
-            .unwrap();
-        assert!(updated.valid, "{:?}", updated.diagnostics);
-
-        let deleted = workspace
-            .view_source_operation(
-                "delete_view_source",
-                &json!({
-                    "path": "views/focused-work.base",
-                    "if_revision": updated.result["revision"],
-                }),
-            )
-            .unwrap();
-        assert!(deleted.valid, "{:?}", deleted.diagnostics);
-        let listed = workspace.read_operation("list_views", &json!({})).unwrap();
-        assert_eq!(listed.result["meta"]["total_count"], 0);
     }
 }

--- a/crates/connect-hosted-provider/src/workspace/obsidian_base_tests.rs
+++ b/crates/connect-hosted-provider/src/workspace/obsidian_base_tests.rs
@@ -1,0 +1,67 @@
+use serde_json::json;
+
+use super::{tests::resources, WorkingSet};
+
+#[test]
+fn hosted_template_creates_executes_updates_and_deletes_obsidian_base_views() {
+    let workspace = WorkingSet::materialize(resources(), []).unwrap();
+    let document = "views:\n  - type: tasknotesTaskList\n    name: Focused work\n";
+    let created = workspace
+        .view_source_operation(
+            "create_view_source",
+            &json!({
+                "format": "obsidian.base",
+                "name": "Focused work",
+                "document": document,
+            }),
+        )
+        .unwrap();
+    assert!(created.valid, "{:?}", created.diagnostics);
+    assert_eq!(created.result["path"], "views/focused-work.base");
+    assert_eq!(created.result["format"], "obsidian.base");
+
+    let listed = workspace.read_operation("list_views", &json!({})).unwrap();
+    assert!(listed.valid, "{:?}", listed.diagnostics);
+    assert_eq!(listed.result["meta"]["total_count"], 1);
+    assert_eq!(
+        listed.result["views"][0]["source"]["path"],
+        "views/focused-work.base"
+    );
+
+    let executed = workspace
+        .read_operation(
+            "execute_view",
+            &json!({
+                "path": "views/focused-work.base",
+                "view": "focused-work",
+            }),
+        )
+        .unwrap();
+    assert!(executed.valid, "{:?}", executed.diagnostics);
+    assert_eq!(executed.result["meta"]["total_count"], 0);
+
+    let updated = workspace
+        .view_source_operation(
+            "update_view_source",
+            &json!({
+                "path": "views/focused-work.base",
+                "if_revision": created.result["revision"],
+                "document": document.replace("Focused work", "Deep work"),
+            }),
+        )
+        .unwrap();
+    assert!(updated.valid, "{:?}", updated.diagnostics);
+
+    let deleted = workspace
+        .view_source_operation(
+            "delete_view_source",
+            &json!({
+                "path": "views/focused-work.base",
+                "if_revision": updated.result["revision"],
+            }),
+        )
+        .unwrap();
+    assert!(deleted.valid, "{:?}", deleted.diagnostics);
+    let listed = workspace.read_operation("list_views", &json!({})).unwrap();
+    assert_eq!(listed.result["meta"]["total_count"], 0);
+}

--- a/services/server/src/hosted.test.ts
+++ b/services/server/src/hosted.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createDatabase, type DatabasePool } from "./db.js";
 import {
   hostedContracts,
+  hostedResources,
   HostedAuthorityRegistry
 } from "./hosted.js";
 
@@ -12,6 +13,18 @@ afterEach(async () => database?.end());
 describe("hosted collection profiles", () => {
   it("keeps generic mdbase collections independent of application contracts", () => {
     expect(hostedContracts("mdbase")).toEqual([]);
+  });
+
+  it("enables Obsidian Base view sources in every new hosted collection", () => {
+    const resources = hostedResources("mdbase");
+    expect(resources.revision).toBe("mdbase-template:2");
+    expect(resources.documents[0]!.document).toContain(
+      "include:\n      - views/**/*.base"
+    );
+    expect(resources.documents[0]!.document).toContain("create_folder: views");
+    expect(resources.documents[0]!.document).toContain(
+      "default_for_new_views: true"
+    );
   });
 });
 

--- a/services/server/src/hosted.ts
+++ b/services/server/src/hosted.ts
@@ -445,10 +445,19 @@ export function typesForContracts(
 }
 
 export function mdbaseResources(): SyncCollectionResources {
-  const configuration =
-    "spec_version: 0.3.0\nsettings:\n  types_folder: _types\n  default_validation: error\n";
+  const configuration = `spec_version: 0.3.0
+settings:
+  types_folder: _types
+  default_validation: error
+x-obsidian:
+  bases:
+    include:
+      - views/**/*.base
+    create_folder: views
+    default_for_new_views: true
+`;
   return {
-    revision: "mdbase-template:1",
+    revision: "mdbase-template:2",
     spec_version: "0.3.0",
     types: [],
     contracts: [],


### PR DESCRIPTION
## Summary

- configure new hosted collections to accept Obsidian Base sources under views/**/*.base
- default generated views to the views folder and bump the hosted template revision
- keep the Rust provider and legacy TypeScript template synchronized
- cover the complete hosted view lifecycle in a dedicated test module

## Why

TaskNotes creates Obsidian Base view sources, but generic hosted collections did not declare an x-obsidian.bases.include path. The backend therefore rejected otherwise valid views. New hosted collections now provide that capability as a collection-level invariant.

No migration is included because the affected collections are pre-release test data and can be recreated.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- cargo test -p mdbase-connect-hosted-provider hosted_template_creates_executes_updates_and_deletes_obsidian_base_views
- pnpm typecheck
- pnpm test
- pnpm check:architecture
- git diff --check