### PR TITLE
Fix packed browser fixture serialization

### DIFF
--- a/.ops/tasks/Beta hardening 09 - candidate and consumer migrations.md
+++ b/.ops/tasks/Beta hardening 09 - candidate and consumer migrations.md
@@ -9,8 +9,8 @@ phase: 6
 depends_on: [Beta hardening 06 - management correctness, Beta hardening 07 - public SDK surface]
 tags: [beta, packaging, consumers, editor, workouts, pickle, tasknotes]
 created_at: 2026-08-04T17:48:28+10:00
-updated_at: 2026-08-05T11:53:42+10:00
-progress_summary: Candidate 62513b927384 passed the complete Server, Desktop release, Editor, and image-publish workflows, but exact packed-artifact consumer validation rejected it before tagging or deployment. The packed testing package serialized a browser fixture that closed over an imported grant-encryption constant, and Editor's external authority harness retained stale operation-transport-v1 assertions. The testing boundary now carries grant encryption v1 explicitly in its serialized seed with a real serialization/IndexedDB/WebCrypto regression. A replacement immutable main commit, exact repack, all four repins, and every downstream gate remain required. Production is untouched.
+updated_at: 2026-08-05T11:59:45+10:00
+progress_summary: Candidate 62513b927384 passed complete CI and signed image publication, but exact packed-artifact validation rejected it before tagging or deployment. Connect PR #185 carries grant encryption v1 explicitly in the Playwright-serialized seed with a serialization/IndexedDB/WebCrypto regression. Exact 7f689ed697f2 tarballs pass Editor authorization recovery, both remote-authority flows, and the full 45-test browser matrix; Editor commit ae6aad7 uses the canonical operation-transport constant. Replacement CI, one immutable main commit, exact repack, four repins, and every downstream gate remain required. Production is untouched.
 type: task
 ---
 
@@ -241,3 +241,12 @@ and their required product gates are rerun.
   serializes the function into an isolated realm and executes the connector
   path through IndexedDB and WebCrypto; package test, typecheck, and build pass
   under Node 24.13.0.
+- Draft Connect PR `mdbase-dev/mdbase-connect#185` packages committed source
+  `7f689ed697f2`. The packed Testing output resolves the imported constant while
+  constructing the seed and reads only `seed.grantEncryptionProtocolVersion`
+  inside the serialized callback.
+- Editor commit `ae6aad7` replaces only operation request/response envelope
+  literals with `OPERATION_TRANSPORT_PROTOCOL_VERSION`; independent file and
+  encryption v1 fixtures remain unchanged. Exact `7f689ed697f2` artifacts pass
+  the focused authorization/remote-authority run 3/3 and the complete browser
+  matrix 45/45, including 10,000-note performance and accessibility.

--- a/.ops/tasks/Beta hardening 09 - candidate and consumer migrations.md
+++ b/.ops/tasks/Beta hardening 09 - candidate and consumer migrations.md
@@ -9,8 +9,8 @@ phase: 6
 depends_on: [Beta hardening 06 - management correctness, Beta hardening 07 - public SDK surface]
 tags: [beta, packaging, consumers, editor, workouts, pickle, tasknotes]
 created_at: 2026-08-04T17:48:28+10:00
-updated_at: 2026-08-05T11:04:54+10:00
-progress_summary: Reopened after the e1c candidate audit found that the documented independent compatibility axes were not enforced by the live wire. The correction and all discovered cross-version/system fixtures are complete locally. Replacement Server CI 30964684133 proves the relay, Windows durability, and beta.28 provider recovery corrections, then exposed the hosted provider's generic operation wrapper and notification grant projection; both now carry exact transport-v2/binding-v3 requirements while file/sync v1 remain independent. The complete hosted-provider E2E passes locally. One final replacement CI remains before the fresh immutable candidate and four consumer repins.
+updated_at: 2026-08-05T11:53:42+10:00
+progress_summary: Candidate 62513b927384 passed the complete Server, Desktop release, Editor, and image-publish workflows, but exact packed-artifact consumer validation rejected it before tagging or deployment. The packed testing package serialized a browser fixture that closed over an imported grant-encryption constant, and Editor's external authority harness retained stale operation-transport-v1 assertions. The testing boundary now carries grant encryption v1 explicitly in its serialized seed with a real serialization/IndexedDB/WebCrypto regression. A replacement immutable main commit, exact repack, all four repins, and every downstream gate remain required. Production is untouched.
 type: task
 ---
 
@@ -214,3 +214,30 @@ artifacts remain useful migration evidence but are not release candidates.
 The slice closes again only after one immutable post-correction Connect commit
 produces all six packages, all four consumer PRs pin exactly those artifacts,
 and their required product gates are rerun.
+
+## Rejected packed candidate `62513b927384`
+
+- Connect merge commit `62513b927384959600c66fb76b50d3bc90134e08`
+  passed Server CI `30965358301`, Desktop release CI `30965358308`, post-merge
+  Server CI `30966039505`, post-merge Editor CI `30966039504`, and signed image
+  publication `30966577643`.
+- All six packages were then built and packed from a clean detached worktree at
+  that exact commit. Artifact-manifest verification proved all four consumers
+  were temporarily pinned to one `0.1.0-beta.32-62513b927384` set.
+- Workouts passed 24 tests, typecheck, build, and 10 browser tests. Pickle passed
+  its full verify and 8 browser tests. TaskNotes passed its full 352-test verify;
+  its browser rerun was deferred after a concurrent local server occupied its
+  Playwright port.
+- Editor passed 240 unit tests, typecheck, and build. Its packed-artifact browser
+  run passed 42 tests but correctly failed authorization recovery because
+  Playwright serialized `writeSeed` without the imported
+  `GRANT_ENCRYPTION_PROTOCOL_VERSION` binding. Two remote-authority assertions
+  also still expected operation transport v1.
+- The release train stopped before a tag, consumer commit, staging deployment,
+  or production change. `62513b927384` is rejected evidence, not a release
+  candidate.
+- The Connect correction copies grant encryption v1 into the browser fixture
+  seed before crossing the Playwright evaluation boundary. Its regression
+  serializes the function into an isolated realm and executes the connector
+  path through IndexedDB and WebCrypto; package test, typecheck, and build pass
+  under Node 24.13.0.

--- a/.ops/tasks/SDK and authority beta hardening.md
+++ b/.ops/tasks/SDK and authority beta hardening.md
@@ -14,8 +14,8 @@ tags:
   - user-experience
   - consumers
 created_at: 2026-08-04T10:51:42+10:00
-updated_at: 2026-08-05T11:04:54+10:00
-progress_summary: Phases 0-5 remain green; the Phase 7 audit reopened Phase 6 because e1c documented independent compatibility axes without live enforcement. The live correction and all discovered system fixtures are now complete locally. Server CI 30964684133 proves relay, cross-platform durability, and beta.28 provider recovery, then exposed the hosted provider's stale generic operation wrapper and notification projection. Both now carry exact transport-v2/binding-v3 requirements while file/sync/encryption v1 remain independent; the complete hosted-provider E2E passes locally. One final replacement CI, a new immutable candidate, four exact-artifact repins, staging rollout, rollback, canaries, soak, and final audit remain. Production is untouched.
+updated_at: 2026-08-05T11:53:42+10:00
+progress_summary: Phases 0-5 remain green, while the Phase 7 audit keeps Phase 6 open until exact packed artifacts pass every consumer. Candidate 62513b927384 passed complete CI and signed image publication but packed Editor validation exposed a testing-package closure across Playwright's serialization boundary plus two stale external-harness transport assertions. The release train stopped before tagging or deployment. A serialized-seed regression and correction are green locally; a replacement main commit, six-package repack, four exact repins, staging rollout, rollback, canaries, soak, and final audit remain. Production is untouched.
 type: task
 ---
 

--- a/.ops/tasks/SDK and authority beta hardening.md
+++ b/.ops/tasks/SDK and authority beta hardening.md
@@ -14,8 +14,8 @@ tags:
   - user-experience
   - consumers
 created_at: 2026-08-04T10:51:42+10:00
-updated_at: 2026-08-05T11:53:42+10:00
-progress_summary: Phases 0-5 remain green, while the Phase 7 audit keeps Phase 6 open until exact packed artifacts pass every consumer. Candidate 62513b927384 passed complete CI and signed image publication but packed Editor validation exposed a testing-package closure across Playwright's serialization boundary plus two stale external-harness transport assertions. The release train stopped before tagging or deployment. A serialized-seed regression and correction are green locally; a replacement main commit, six-package repack, four exact repins, staging rollout, rollback, canaries, soak, and final audit remain. Production is untouched.
+updated_at: 2026-08-05T11:59:45+10:00
+progress_summary: Phases 0-5 remain green, while Phase 6 stays open until exact packed artifacts pass every consumer. Candidate 62513b927384 passed complete CI and signed image publication but packed Editor validation exposed a Playwright-serialization closure and stale harness assertions, stopping the train before tagging or deployment. Connect PR #185 and Editor ae6aad7 correct both boundaries; exact 7f689ed697f2 tarballs pass the full 45-test Editor browser matrix. Replacement CI, one immutable main commit, six-package repack, four exact repins, staging rollout, rollback, canaries, soak, and final audit remain. Production is untouched.
 type: task
 ---
 

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUUID, webcrypto } from "node:crypto";
 import {
   decryptRelayResponse,
   encryptRelayRequest,
@@ -14,13 +15,49 @@ class MemoryLocalStorage {
   removeItem(key: string) { this.values.delete(key); }
 }
 
-class FixturePage implements MdbaseTestPage {
+class SerializedFixturePage implements MdbaseTestPage {
   async evaluate<Result, Argument>(
     script: (argument: Argument) => Result | Promise<Result>,
     argument: Argument
   ): Promise<Result> {
-    return script(argument);
+    const serialized = Function(`"use strict"; return (${script.toString()});`)() as typeof script;
+    return serialized(argument);
   }
+}
+
+function fakeIndexedDb(): IDBFactory {
+  const database = {
+    objectStoreNames: { contains: () => false },
+    createObjectStore: vi.fn(),
+    transaction: () => {
+      const transaction = {
+        objectStore: () => ({ put: vi.fn(), delete: vi.fn() }),
+        error: null,
+        onerror: null as ((event: Event) => void) | null,
+        onabort: null as ((event: Event) => void) | null,
+        oncomplete: null as ((event: Event) => void) | null
+      };
+      queueMicrotask(() => transaction.oncomplete?.(new Event("complete")));
+      return transaction;
+    },
+    close: vi.fn()
+  };
+  return {
+    open: () => {
+      const request = {
+        result: database,
+        error: null,
+        onupgradeneeded: null as ((event: Event) => void) | null,
+        onerror: null as ((event: Event) => void) | null,
+        onsuccess: null as ((event: Event) => void) | null
+      };
+      queueMicrotask(() => {
+        request.onupgradeneeded?.(new Event("upgradeneeded"));
+        request.onsuccess?.(new Event("success"));
+      });
+      return request;
+    }
+  } as unknown as IDBFactory;
 }
 
 afterEach(() => vi.unstubAllGlobals());
@@ -30,7 +67,7 @@ describe("browser authorization fixture", () => {
     const storage = new MemoryLocalStorage();
     vi.stubGlobal("localStorage", storage);
     vi.stubGlobal("location", { origin: "https://tasks.example" });
-    const page = new FixturePage();
+    const page = new SerializedFixturePage();
     const controller = await installMdbaseBrowserFixture(page, {
       serverUrl: "https://connect.example/",
       application: {
@@ -75,6 +112,41 @@ describe("browser authorization fixture", () => {
     expect(JSON.parse(storage.getItem(tokenKey)!).expiresAt).toBeLessThan(Date.now());
     await controller.remove(page);
     expect(storage.getItem(tokenKey)).toBeNull();
+  });
+
+  it("serializes connector grant versions into the browser execution realm", async () => {
+    const storage = new MemoryLocalStorage();
+    vi.stubGlobal("localStorage", storage);
+    vi.stubGlobal("location", { origin: "https://tasks.example" });
+    vi.stubGlobal("indexedDB", fakeIndexedDb());
+    vi.stubGlobal("crypto", { subtle: webcrypto.subtle, randomUUID });
+
+    const controller = await installMdbaseBrowserFixture(new SerializedFixturePage(), {
+      serverUrl: "https://connect.example/",
+      application: {
+        manifest: {
+          manifest_version: 1,
+          id: "dev.example.tasks",
+          name: "Tasks",
+          homepage: "https://tasks.example/",
+          redirect_uris: ["https://tasks.example/callback"],
+          requirements: {
+            contracts: [],
+            capabilities: {
+              contract_version: 1,
+              required: ["collection.inspect", "records.read"],
+              optional: []
+            }
+          }
+        }
+      },
+      collection: { id: "collection-1", name: "Tasks" },
+      authority: { kind: "connector" }
+    });
+
+    expect(controller.relay).toBeDefined();
+    const tokenKey = [...storage.values.keys()].find((key) => key.includes(":token:"))!;
+    expect(JSON.parse(storage.getItem(tokenKey)!).encryption.protocol_version).toBe(1);
   });
 
   it("decrypts and responds through the production encrypted relay profile", async () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -81,6 +81,7 @@ interface BrowserFixtureSeed {
   authorityKind: MdbaseFixtureAuthority["kind"];
   connectorAgreementPublicKey?: string;
   directAccess?: "enabled" | "disabled";
+  grantEncryptionProtocolVersion: GrantEncryption["protocol_version"];
   token: Record<string, unknown>;
 }
 
@@ -138,6 +139,7 @@ function fixtureSeed(
     collectionId: options.collection.id,
     keyHandle: `fixture:${options.application.manifest.id}:${options.collection.id}`,
     authorityKind: options.authority.kind,
+    grantEncryptionProtocolVersion: GRANT_ENCRYPTION_PROTOCOL_VERSION,
     ...(connectorAgreementPublicKey ? { connectorAgreementPublicKey } : {}),
     ...(options.directAccess ? { directAccess: options.directAccess } : {}),
     token: {
@@ -249,7 +251,7 @@ async function writeSeed(seed: BrowserFixtureSeed): Promise<FixtureRelayBinding 
       }
       const grantId = crypto.randomUUID();
       const encryption: GrantEncryption = {
-        protocol_version: GRANT_ENCRYPTION_PROTOCOL_VERSION,
+        protocol_version: seed.grantEncryptionProtocolVersion,
         suite: "P256-HKDF-SHA256-AES256GCM",
         key_id: `fixture-${crypto.randomUUID()}`,
         scope_epoch: 1,


### PR DESCRIPTION
## Summary
- carry grant-encryption protocol version inside the Playwright-serialized browser seed
- execute testing-package browser callbacks in a serialized realm during unit tests
- add connector IndexedDB/WebCrypto regression coverage
- record why exact candidate 62513b927384 was rejected before tagging or deployment

## Verification
- Node 24.13.0: testing package test, typecheck, and build
- architecture check
- exact packed artifacts from 7f689ed697f2
- mdbase-editor authorization recovery and remote-authority focused tests: 3/3
- mdbase-editor full Playwright matrix: 45/45
- .ops validation: valid, zero issues
