### PR TITLE
Preserve hosted recovery telemetry in release images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "clap",
  "directories",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "chrono",
  "directories",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "clap",
  "directories",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "chrono",
  "directories",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.33"
+version = "0.1.0-beta.34"
 dependencies = [
  "chrono",
  "mdbase",

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -32,7 +32,7 @@ COPY --from=build /build/mdbase-connect/target/release/mdbase-hosted-backup-admi
 
 ENV HOST=0.0.0.0 \
     PORT=8790 \
-    RUST_LOG=mdbase_connect_hosted_provider=info,tower_http=debug \
+    RUST_LOG=mdbase_connect_hosted_provider=info,mdbase_connect::metrics=info,tower_http=debug \
     RENDER_GIT_COMMIT=${MDBASE_CONNECT_REVISION}
 
 EXPOSE 8790

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.33
-git tag -a v0.1.0-beta.33 -m "mdbase connect 0.1.0-beta.33"
-git push origin v0.1.0-beta.33
+pnpm version:check v0.1.0-beta.34
+git tag -a v0.1.0-beta.34 -m "mdbase connect 0.1.0-beta.34"
+git push origin v0.1.0-beta.34
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/lib/container-observability.test.mjs
+++ b/scripts/lib/container-observability.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("the hosted-provider image enables privacy-safe metrics by default", async () => {
+  const dockerfile = await readFile("deploy/docker/Dockerfile.hosted-provider", "utf8");
+  const rustLog = dockerfile.match(/RUST_LOG=([^ \\\n]+)/)?.[1];
+
+  assert.ok(rustLog, "the hosted-provider image must define RUST_LOG");
+  assert.match(
+    rustLog,
+    /(?:^|,)mdbase_connect::metrics=(?:info|debug|trace)(?:,|$)/,
+    "the hosted-provider image must not filter out release-gating privacy-safe metrics"
+  );
+});

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.33" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.34" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.33",
+  "version": "0.1.0-beta.34",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- enable the dedicated `mdbase_connect::metrics` target in the hosted-provider image default filter
- add a regression test that prevents release images from filtering out beta-gating telemetry
- advance the coherent workspace release identity to `0.1.0-beta.34`

## Release hold evidence

The beta.33 staging runtime was healthy and the Workouts declaration canary deployed successfully, but `bin/observe-beta-hardening` correctly held because no `mutation_journal_snapshot` was visible. Inspection of the immutable beta.33 image showed its baked `RUST_LOG` value allowed only `mdbase_connect_hosted_provider` and `tower_http`, while recovery telemetry deliberately uses the separate `mdbase_connect::metrics` target.

## Verification

- `fnm exec --using=24 pnpm test`
- `cargo check -p mdbase-connect-hosted-provider`
- `fnm exec --using=24 pnpm version:check v0.1.0-beta.34`
- `git diff --check`