### PR TITLE
Record beta.34 rollout evidence

### DIFF
--- a/.ops/tasks/Beta hardening 10 - rollout and beta gate.md
+++ b/.ops/tasks/Beta hardening 10 - rollout and beta gate.md
@@ -1,6 +1,6 @@
 ---
 title: Beta hardening 10 - rollout and beta gate
-status: in_progress
+status: done
 priority: critical
 owner: codex
 parent: SDK and authority beta hardening
@@ -9,8 +9,8 @@ phase: 7
 depends_on: [Beta hardening 09 - candidate and consumer migrations]
 tags: [beta, deployment, canary, observability, rollback]
 created_at: 2026-08-04T17:48:28+10:00
-updated_at: 2026-08-06T02:32:00+10:00
-progress_summary: Staging beta.34 is live from exact signed images after two verified automatic whole-train rollbacks. Workouts, Editor, Pickle, and TaskNotes passed in order with clean privacy-safe observation; all four live declarations, OAuth v4, R2 CORS, and the broker outage/recovery drill are green. The required 60-minute soak and production restore-tested checkpoint are running. Production remains beta.31 and the external-beta invitation gate remains closed.
+updated_at: 2026-08-06T03:28:00+10:00
+progress_summary: Complete. Staging and production run exact signed beta.34 images after restore-tested checkpoints and verified automatic whole-train rollback. Workouts, Editor, Pickle, and TaskNotes passed in order with clean observations; broker recovery, a 60-minute zero-failure soak, production acceptance, retained rollback evidence, and two clean post-promotion snapshots are green. The external-beta invitation gate is satisfied; no invitations were sent by this task.
 type: task
 ---
 
@@ -67,3 +67,27 @@ rollback target before activating any schema that it cannot reopen.
   soak. Production promotion is committed in cloud-ops main
   `2cd2987fadf09e81ab30a9354c0648f91aa4625d`, but deployment is held until the
   soak and production checkpoint workflow `31024842803` both succeed.
+
+## Production rollout and gate closure — 2026-08-06
+
+- Soak workflow `31024686507` passed its complete 3,600-second window with 110
+  samples, 660 endpoint checks, zero transient failures, and full signed
+  acceptance at both boundaries.
+- Production checkpoint workflow `31024842803` encrypted and restore-tested all
+  three databases and retained artifact
+  `encrypted-production-backups-31024842803` for the destructive prerelease
+  migration rollback boundary.
+- Promotion workflow `31029549943` deployed the exact staged beta.34 image set
+  from cloud-ops main `2cd2987fadf09e81ab30a9354c0648f91aa4625d`.
+  The three exact production reset waivers passed, prior live digests were
+  recorded, all four services reached live in dependency order, and rollback
+  artifact `production-deployment-state-31029549943` is retained.
+- Workflow and independent production acceptance passed exact image identity,
+  health/readiness, OAuth device and semantic web writes, all four public
+  declarations, R2 browser CORS, and entitlement reconciliation.
+- Two consecutive privacy-safe production journal snapshots show completed
+  state only, no unfinished age or failure events, and available pool capacity.
+
+All rollout, rollback, observation, documentation, and external-beta invitation
+criteria are satisfied. Invitations were deliberately left to the normal
+human-owned product process rather than being sent by this engineering task.

--- a/.ops/tasks/Beta hardening 10 - rollout and beta gate.md
+++ b/.ops/tasks/Beta hardening 10 - rollout and beta gate.md
@@ -9,8 +9,8 @@ phase: 7
 depends_on: [Beta hardening 09 - candidate and consumer migrations]
 tags: [beta, deployment, canary, observability, rollback]
 created_at: 2026-08-04T17:48:28+10:00
-updated_at: 2026-08-05T22:23:00+10:00
-progress_summary: Delivery slice 9 and both expanded successor tasks are complete. Phase 7 is ready to stage immutable beta.33 source 55b536aafa9a1ae1031171fa7e39ae99fa4530f0 with exact consumer heads Editor eb48e42, Workouts fa5684c, Pickle 5e3cbe0, and TaskNotes 6febc15. No deployment or database change has occurred. Next: exact artifact/image audit, recovery checkpoint, guarded staging activation, rollback exercise, ordered canaries, privacy-safe soak, final audit, and only then the external-beta invitation decision.
+updated_at: 2026-08-06T02:32:00+10:00
+progress_summary: Staging beta.34 is live from exact signed images after two verified automatic whole-train rollbacks. Workouts, Editor, Pickle, and TaskNotes passed in order with clean privacy-safe observation; all four live declarations, OAuth v4, R2 CORS, and the broker outage/recovery drill are green. The required 60-minute soak and production restore-tested checkpoint are running. Production remains beta.31 and the external-beta invitation gate remains closed.
 type: task
 ---
 
@@ -45,3 +45,25 @@ before any external-beta invitation.
 The next action is the single production-shaped deployment workflow requested
 by the user. Preserve the old stack and verified database checkpoint as the
 rollback target before activating any schema that it cannot reopen.
+
+## Staging rollout evidence — 2026-08-06
+
+- Staging activation uses beta.34 source
+  `ea56354739626c55f05a485cd707164740b2c391` and exact signed image digests.
+  beta.34 is a runtime-only correction that exposes the already-shipped
+  privacy-safe metrics; all consumers retain the exact beta.33 SDK artifacts.
+- Two earlier activations detected the missing snapshot evidence and restored
+  the complete beta.31 train automatically. The corrected activation passed
+  signed image identity, migrated readiness, OAuth v4, candidate manifests,
+  and browser CORS.
+- Workouts, Editor, Pickle, and TaskNotes were merged and deployed one at a
+  time. Each hold produced a clean journal/pool/boundary observation before the
+  next canary advanced; final deployed-manifest verification passes for all
+  four applications.
+- The broker drill observed the required HTTP 503 while Core NATS was
+  suspended, recovered stable readiness after resume, and reran the full signed
+  acceptance suite successfully.
+- Workflow `31024686507` is performing the mandatory 60-minute continuous
+  soak. Production promotion is committed in cloud-ops main
+  `2cd2987fadf09e81ab30a9354c0648f91aa4625d`, but deployment is held until the
+  soak and production checkpoint workflow `31024842803` both succeed.

--- a/.ops/tasks/SDK and authority beta hardening.md
+++ b/.ops/tasks/SDK and authority beta hardening.md
@@ -1,6 +1,6 @@
 ---
 title: SDK and authority beta hardening
-status: in_progress
+status: done
 priority: critical
 owner: codex
 tags:
@@ -14,8 +14,8 @@ tags:
   - user-experience
   - consumers
 created_at: 2026-08-04T10:51:42+10:00
-updated_at: 2026-08-06T02:32:00+10:00
-progress_summary: Phases 0-6 and both expanded successor tasks are complete. Immutable beta.33 packages from 9335459694ec0d1ad550f30bad9c8cd500666e41 are live in all four ordered consumers; beta.34 source ea56354739626c55f05a485cd707164740b2c391 is a runtime-only observability correction with no SDK or protocol change. Staging activation, restore-tested checkpoint, two automatic rollback exercises, Workouts/Editor/Pickle/TaskNotes canaries, fleet manifest verification, privacy-safe observations, and the broker recovery drill are green. The required 60-minute soak and production pre-migration checkpoint are running; production remains beta.31 and the external-beta gate remains closed.
+updated_at: 2026-08-06T03:28:00+10:00
+progress_summary: Complete. Phases 0-7 plus application-declared configuration provisioning and final SDK polish are shipped. All four consumers use exact beta.33 SDK artifacts; staging and production run exact signed beta.34 runtime images from ea56354739626c55f05a485cd707164740b2c391. Restore-tested checkpoints, automatic whole-train rollback, ordered canaries, broker recovery, 60-minute zero-failure soak, production promotion, independent acceptance, and post-promotion privacy-safe observations are green. Every external-beta invitation criterion is satisfied; invitations were not sent as part of this engineering program.
 type: task
 ---
 
@@ -602,3 +602,31 @@ public API redesign, a large file split, and a consumer migration in one review.
   Production remains on beta.31 while workflow `31024842803` creates the fresh
   encrypted, restore-tested pre-migration checkpoint. The external-beta gate is
   deliberately still closed.
+
+## Program completion — 2026-08-06
+
+- Soak workflow `31024686507` ran for 3,600 seconds with 110 samples, 660
+  endpoint checks, zero transient failures, and two complete signed acceptance
+  runs.
+- Production checkpoint workflow `31024842803` retained encrypted artifact
+  `encrypted-production-backups-31024842803`; every PostgreSQL 17/18 export was
+  restored into a clean matching-major database before encryption.
+- Cloud-ops main `2cd2987fadf09e81ab30a9354c0648f91aa4625d`
+  records the exact production beta.34 images and three reviewed prerelease
+  reset waivers. Promotion workflow `31029549943` used the exact confirmation
+  token, recorded the previous live image set, applied broker/provider/Connect/
+  MCP in dependency order, reconciled entitlements, passed production OAuth,
+  live declarations, R2 CORS, and synthetic acceptance, and retained rollback
+  artifact `production-deployment-state-31029549943`.
+- Independent post-promotion `bin/verify-production` passed. Two consecutive
+  privacy-safe production journal snapshots contain completed state only, no
+  unfinished operations or failure events, and available PostgreSQL pool
+  capacity.
+- The checked changelog, SDK/outcome/recovery documentation, contract matrix,
+  examples, package exports, platform preview warnings, and beta release notes
+  describe the shipped guarantees and limitations. Every beta invitation item
+  is backed by the phase exit gates and rollout evidence above.
+
+All Phase 0-7 gates and both added successor tasks are complete. External beta
+invitations may now begin through the product's normal human-owned invitation
+process; this program did not send invitations or contact users.

--- a/.ops/tasks/SDK and authority beta hardening.md
+++ b/.ops/tasks/SDK and authority beta hardening.md
@@ -14,8 +14,8 @@ tags:
   - user-experience
   - consumers
 created_at: 2026-08-04T10:51:42+10:00
-updated_at: 2026-08-05T22:23:00+10:00
-progress_summary: Phases 0-6 and both expanded successor tasks are complete on immutable beta.33 source 55b536aafa9a1ae1031171fa7e39ae99fa4530f0. Exact packages are SHA-512 verified in Editor eb48e42, Workouts fa5684c, Pickle 5e3cbe0, and TaskNotes 6febc15; all consumer, native, conformance, setup, and real-authority recovery gates are green. No staging or production deployment has occurred. Phase 7 is now the only remaining work: exact image audit and recovery checkpoint, one guarded activation, rollback proof, ordered canaries, privacy-safe soak, final audit, and the external-beta invitation decision.
+updated_at: 2026-08-06T02:32:00+10:00
+progress_summary: Phases 0-6 and both expanded successor tasks are complete. Immutable beta.33 packages from 9335459694ec0d1ad550f30bad9c8cd500666e41 are live in all four ordered consumers; beta.34 source ea56354739626c55f05a485cd707164740b2c391 is a runtime-only observability correction with no SDK or protocol change. Staging activation, restore-tested checkpoint, two automatic rollback exercises, Workouts/Editor/Pickle/TaskNotes canaries, fleet manifest verification, privacy-safe observations, and the broker recovery drill are green. The required 60-minute soak and production pre-migration checkpoint are running; production remains beta.31 and the external-beta gate remains closed.
 type: task
 ---
 
@@ -577,3 +577,28 @@ public API redesign, a large file split, and a consumer migration in one review.
   release-readiness/package verification, followed by one immutable artifact
   set across Editor, Workouts, Pickle Android, and TaskNotes, then one staged
   activation/canary/rollback/soak program.
+
+## Phase 7 staging evidence — 2026-08-06
+
+- Immutable beta.33 SDK packages and beta.34 runtime images are published from
+  exact source commits `9335459694ec0d1ad550f30bad9c8cd500666e41` and
+  `ea56354739626c55f05a485cd707164740b2c391`. beta.34 changes only the hosted
+  provider's privacy-safe metric filter; its protocol and minimum connector
+  version remain beta.33.
+- The staging database-only checkpoint is encrypted and restore-tested. Two
+  failed beta.33 activations automatically restored the complete beta.31 image
+  train, proving the rollback path before the corrected beta.34 activation.
+- Staging now runs the exact signed beta.34 relay, provider, Connect, and MCP
+  digests. Health/readiness, OAuth v4 writes, R2 CORS, and all four live
+  declarations pass exact release acceptance.
+- Canaries advanced strictly in order: Workouts, Editor, Pickle, then TaskNotes.
+  Every post-canary observation has zero unknown outcomes, request-ID conflicts,
+  metric failures, boundary failures, database timeouts, migration failures,
+  unfinished journal age, and persistent pool exhaustion.
+- The broker recovery drill suspended the sole staging Core NATS broker,
+  observed Connect readiness fail closed with HTTP 503, resumed the broker,
+  required stable recovery, and passed the complete signed staging suite.
+- The 60-minute revision-bound soak is running as workflow `31024686507`.
+  Production remains on beta.31 while workflow `31024842803` creates the fresh
+  encrypted, restore-tested pre-migration checkpoint. The external-beta gate is
+  deliberately still closed.


### PR DESCRIPTION
## Summary

- record exact beta.33 SDK and beta.34 runtime release identities
- capture staging checkpoints, automatic rollback, ordered canaries, privacy-safe observations, broker recovery, and the zero-failure soak
- record the restore-tested production checkpoint, exact production promotion, retained rollback state, independent acceptance, and post-promotion observation
- close Phase 7 and the parent Phase 0–7 program after every external-beta gate is satisfied

No invitations were sent; invitation execution remains with the normal human-owned product process.

## Validation

- `.ops`: `mdbase validate --json` reports no issues
- `.ops`: the query for tasks whose status is not `done` returns zero records
- `git diff --check` passes
- production and staging workflow evidence is linked by exact run ID in the task records