### PR TITLE
Fix hosted notification grants and release beta.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.1.0-beta.35
+
+Beta.35 is a production hotfix for application approval against hosted
+collections. It preserves beta.34's authority contracts and data formats.
+
+- Hosted notification grants now carry the exact declaration identity and
+  manifest digest already bound into the signed application authorization.
+  This fixes approval for applications such as TaskNotes that declare hosted
+  notification criteria.
+- Rust and TypeScript grant summaries now require the same application identity
+  fields, so an incomplete control-plane payload fails at build time.
+- Safe hosted-provider validation failures retain their HTTP 422 status and
+  structured problem instead of being reported as a generic storage failure.
+
 ## 0.1.0-beta.33
 
 Beta.33 is the single successor to the undeployed beta.32 candidate. It retains

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "clap",
  "directories",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "chrono",
  "directories",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "clap",
  "directories",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "chrono",
  "directories",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.34"
+version = "0.1.0-beta.35"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.34
-git tag -a v0.1.0-beta.34 -m "mdbase connect 0.1.0-beta.34"
-git push origin v0.1.0-beta.34
+pnpm version:check v0.1.0-beta.35
+git tag -a v0.1.0-beta.35 -m "mdbase connect 0.1.0-beta.35"
+git push origin v0.1.0-beta.35
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -288,6 +288,10 @@ export type MdbaseOperationResponse<Result = unknown> =
 export interface GrantPolicy {
   id: string;
   application_id: string;
+  /** Stable declaration identity bound into the exact application authorization. */
+  application_declaration_id: string;
+  /** Unprefixed SHA-256 digest of the exact approved application manifest. */
+  application_manifest_digest: string;
   collection_id: string;
   operations: CollectionOperation[];
   scope: GrantScope;

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.34" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.35" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.34",
+  "version": "0.1.0-beta.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/features/authorizations/approval-service.ts
+++ b/services/server/src/features/authorizations/approval-service.ts
@@ -285,6 +285,8 @@ export async function approvePortalAuthorization(
     grant = {
       id: grantId,
       application_id: pending.application_id,
+      application_declaration_id: applicationDeclarationId,
+      application_manifest_digest: applicationManifestDigest,
       collection_id: selected.local_id,
       operations: operations as GrantPolicy["operations"],
       scope,

--- a/services/server/src/features/grants/service.test.ts
+++ b/services/server/src/features/grants/service.test.ts
@@ -1,0 +1,99 @@
+import type {
+  ApplicationAuthorizationProof,
+  GrantSummary,
+  NotificationCriterion
+} from "@mdbase-dev/connect-protocol";
+import { describe, expect, it, vi } from "vitest";
+import type { DatabaseQueryable } from "../../db.js";
+import type { HostedProviderClient } from "../../hosted-provider.js";
+import { syncHostedNotificationGrant } from "./service.js";
+
+const collectionId = "00000000-0000-4000-8000-000000000001";
+const grantId = "00000000-0000-4000-8000-000000000002";
+const applicationId = "00000000-0000-4000-8000-000000000003";
+const applicationManifestDigest = "a".repeat(64);
+
+const notificationCriteria: NotificationCriterion[] = [{
+  id: "task.reminder",
+  event: {
+    id: "mdbase.runtime.timer.fired",
+    version: "1.0.0",
+    digest: `sha256:${"4".repeat(64)}`
+  },
+  presentation: {
+    title: "Task reminder",
+    body: "Open TaskNotes to view your task."
+  }
+}];
+
+const applicationAuthorization = {
+  binding: {
+    protocol_version: 4,
+    authorization_id: "00000000-0000-4000-8000-000000000004",
+    application_id: applicationId,
+    application_declaration_id: "dev.tasknotes.app",
+    application_manifest_digest: applicationManifestDigest,
+    application_installation_id: "installation",
+    installation_signing_public_key: "installation-key",
+    grant_agreement_public_key: "agreement-key",
+    grant_signing_public_key: "signing-key",
+    flow: "authorization_code",
+    authorization_nonce: "nonce",
+    issued_at: "2026-08-05T20:00:00.000Z",
+    expires_at: "2026-08-05T20:10:00.000Z",
+    redirect_uri: "https://app.tasknotes.dev/auth/mdbase/callback",
+    code_challenge: "challenge",
+    contracts: {
+      operation_transport_protocol: 2,
+      application_authorization_binding: 4,
+      semantic_capabilities_contract: 1,
+      durable_mutation_protocol: 1
+    },
+    requested_operations: ["query"]
+  },
+  signature: "signature"
+} satisfies ApplicationAuthorizationProof;
+
+describe("hosted notification grant synchronization", () => {
+  it("sends the exact approved application identity required by the provider", async () => {
+    const query = vi.fn(async () => ({
+      rows: [{
+        id: grantId,
+        application_id: applicationId,
+        application_name: "TaskNotes",
+        application_distribution: "web" as const,
+        application_homepage: "https://app.tasknotes.dev/",
+        application_project_url: null,
+        application_origin: "https://app.tasknotes.dev",
+        application_icon: "https://app.tasknotes.dev/icon.png",
+        collection_id: collectionId,
+        collection_name: "Tasks",
+        operations: ["query"],
+        scope: { contracts: [], access: "full_collection" as const },
+        notification_criteria: notificationCriteria,
+        file_capability: null,
+        created_at: new Date("2026-08-05T20:00:00.000Z"),
+        application_authorization: applicationAuthorization
+      }],
+      rowCount: 1
+    }));
+    const upsertNotificationGrant = vi.fn(async () => undefined);
+    const db = { query } as unknown as DatabaseQueryable;
+    const provider = { upsertNotificationGrant } as unknown as HostedProviderClient;
+
+    await syncHostedNotificationGrant(db, provider, grantId);
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining(
+      "a.distribution AS application_distribution"
+    ), [grantId]);
+    expect(upsertNotificationGrant).toHaveBeenCalledOnce();
+    expect(upsertNotificationGrant).toHaveBeenCalledWith(
+      collectionId,
+      expect.objectContaining({
+        application_declaration_id: "dev.tasknotes.app",
+        application_manifest_digest: applicationManifestDigest,
+        application_distribution: "web"
+      }) satisfies Partial<GrantSummary>
+    );
+  });
+});

--- a/services/server/src/features/grants/service.ts
+++ b/services/server/src/features/grants/service.ts
@@ -99,7 +99,9 @@ export async function syncHostedNotificationGrant(
     id: string;
     application_id: string;
     application_name: string;
+    application_distribution: "web" | "portable";
     application_homepage: string;
+    application_project_url: string | null;
     application_origin: string;
     application_icon: string | null;
     collection_id: string;
@@ -112,7 +114,9 @@ export async function syncHostedNotificationGrant(
     application_authorization: import("@mdbase-dev/connect-protocol").ApplicationAuthorizationProof;
   }>(
     `SELECT g.id, g.application_id, a.name AS application_name,
+            a.distribution AS application_distribution,
             a.homepage AS application_homepage,
+            a.project_url AS application_project_url,
             CASE WHEN g.application_origin = '' THEN a.homepage
                  ELSE g.application_origin END AS application_origin,
             a.icon AS application_icon,
@@ -136,11 +140,19 @@ export async function syncHostedNotificationGrant(
   const grant: GrantSummary = {
     id: row.id,
     application_id: row.application_id,
+    application_declaration_id:
+      row.application_authorization.binding.application_declaration_id,
+    application_manifest_digest:
+      row.application_authorization.binding.application_manifest_digest,
     collection_id: row.collection_id,
     operations: row.operations as GrantSummary["operations"],
     scope: row.scope,
     application_name: row.application_name,
+    application_distribution: row.application_distribution,
     application_homepage: row.application_homepage,
+    ...(row.application_project_url
+      ? { application_project_url: row.application_project_url }
+      : {}),
     application_origin: row.application_origin,
     ...(row.application_icon ? { application_icon: row.application_icon } : {}),
     collection_name: row.collection_name,

--- a/services/server/src/platform/error-handler.test.ts
+++ b/services/server/src/platform/error-handler.test.ts
@@ -1,0 +1,58 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it } from "vitest";
+import { HostedProviderResponseError } from "../hosted-provider.js";
+import { registerErrorHandler } from "./error-handler.js";
+
+const applications = [] as Array<ReturnType<typeof Fastify>>;
+
+afterEach(async () => {
+  while (applications.length) await applications.pop()?.close();
+});
+
+describe("hosted provider error boundary", () => {
+  it("preserves a safe provider validation response", async () => {
+    const app = Fastify();
+    applications.push(app);
+    registerErrorHandler(app);
+    app.get("/provider-validation", async () => {
+      throw new HostedProviderResponseError(
+        422,
+        "notification_runtime_invalid",
+        "The notification criterion is not supported."
+      );
+    });
+
+    const response = await app.inject({ method: "GET", url: "/provider-validation" });
+
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toEqual({
+      error: {
+        code: "notification_runtime_invalid",
+        message: "The notification criterion is not supported."
+      }
+    });
+  });
+
+  it("still hides provider server failures behind the storage boundary", async () => {
+    const app = Fastify();
+    applications.push(app);
+    registerErrorHandler(app);
+    app.get("/provider-failure", async () => {
+      throw new HostedProviderResponseError(
+        500,
+        "provider_database_failure",
+        "internal provider detail"
+      );
+    });
+
+    const response = await app.inject({ method: "GET", url: "/provider-failure" });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.json()).toEqual({
+      error: {
+        code: "hosted_provider_error",
+        message: "The hosted storage provider could not complete the request."
+      }
+    });
+  });
+});

--- a/services/server/src/platform/error-handler.ts
+++ b/services/server/src/platform/error-handler.ts
@@ -105,7 +105,7 @@ export function registerErrorHandler(app: FastifyInstance): void {
       return reply.code(denied ? 403 : 400).send(apiError(error.code, error.message));
     }
     if (error instanceof HostedProviderResponseError) {
-      if ([400, 404, 409, 429].includes(error.status)) {
+      if ([400, 404, 409, 422, 429].includes(error.status)) {
         return reply.code(error.status).send(apiError(error.code, error.message));
       }
       request.log.error(


### PR DESCRIPTION
## What changed

- Populate hosted notification grants with the exact application declaration identity and manifest digest already bound into the signed authorization.
- Align the TypeScript `GrantSummary` contract with the Rust provider contract.
- Preserve safe hosted-provider HTTP 422 validation responses instead of flattening them into a generic storage failure.
- Prepare the immutable `0.1.0-beta.35` hotfix release.

## Root cause

The beta.33 Rust provider added two required `GrantSummary` identity fields, but the TypeScript server-side grant shape and hosted notification projection were not updated. TaskNotes collection setup completed, then the provider rejected the incomplete notification-grant JSON with HTTP 422; Connect exposed that as a generic 502.

## User impact

TaskNotes and other applications with notification criteria can approve access to hosted collections again. Failed attempts are cleanup-safe and may be retried after promotion.

## Validation

- Focused notification-grant and provider-error regression tests: 3 passed
- Full Connect server suite: 283 passed
- Protocol tests/schema generation/typecheck: passed
- Server typecheck: passed
- Rust workspace clippy with warnings denied: passed
- Release version/readiness, architecture, dependency audit, and npm bootstrap checks: passed
