### PR TITLE
Simplify application access review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.0-beta.36
+
+Beta.36 simplifies the application access decision without changing the
+authorization protocol or collection semantics.
+
+- Requests with several compatible collections now require an explicit
+  collection choice before access can be reviewed.
+- The default review summarizes concrete capabilities and keeps delete and
+  collection-structure access visible while exact operations remain editable.
+- Mandatory type and configuration setup is described as a collection change;
+  expert identifiers and meaningful type-mapping choices remain available on
+  demand.
+- In-progress collection and permission choices survive a browser refresh for
+  the lifetime of the authorization request.
+
 ## 0.1.0-beta.35
 
 Beta.35 is a production hotfix for application approval against hosted

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "clap",
  "directories",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "chrono",
  "directories",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -221,7 +221,8 @@ try {
     .getByRole("heading", { name: "Docker fixture consumer" })
     .waitFor();
   await portalPage
-    .getByRole("radio", { name: /Docker fixture/ })
+    .locator(".selected-collection-summary")
+    .filter({ hasText: "Docker fixture" })
     .waitFor({ state: "attached", timeout: 15_000 });
   await portalPage
     .getByRole("button", { name: "Allow Docker fixture consumer" })

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/portal/src/authorization-permissions.tsx
+++ b/apps/portal/src/authorization-permissions.tsx
@@ -1,6 +1,45 @@
 import { groupAuthorizationOperations } from "@mdbase/connect-ui/access";
 import type { PendingAuthorization } from "./api";
 
+export function PermissionCapabilitySummary({
+  groups,
+  selected,
+  files
+}: {
+  groups: ReturnType<typeof groupAuthorizationOperations>;
+  selected: ReadonlySet<string>;
+  files?: PendingAuthorization["requirements"]["files"];
+}) {
+  const capabilities = groups.flatMap((group) => {
+    const selectedOperations = group.operations.filter((operation) => selected.has(operation.id));
+    return selectedOperations.length > 0 ? [{
+      id: group.id,
+      label: group.label,
+      description: group.description,
+      higherImpact: group.id === "delete" || group.id === "manage"
+    }] : [];
+  });
+  if (files) {
+    capabilities.push({
+      id: "files",
+      label: files.actions.includes("delete") ? "Manage and delete files" : "Work with files",
+      description: files.scope.kind === "collection"
+        ? "Use the requested file actions in every visible folder."
+        : `Use the requested file actions in ${files.scope.folders.join(", ")}.`,
+      higherImpact: files.actions.includes("delete")
+    });
+  }
+  return (
+    <ul className="permission-capabilities" aria-label="What this application can do">
+      {capabilities.map((capability) => <li className={capability.higherImpact ? "higher-impact" : undefined} key={capability.id}>
+        <span className="capability-mark" aria-hidden="true">{capability.higherImpact ? "!" : "\u2713"}</span>
+        <span><strong>{capability.label}</strong><small>{capability.description}</small></span>
+        {capability.higherImpact && <b>Higher impact</b>}
+      </li>)}
+    </ul>
+  );
+}
+
 export function PermissionChoices({
   groups,
   selected,
@@ -24,7 +63,7 @@ export function PermissionChoices({
   return (
     <details className="permission-review">
       <summary>
-        <span><strong>{selectedGroups.map((group) => group.label).join(" · ")}</strong><small>{selectedTotal} of {total} specific actions selected. Open details to narrow access.</small></span>
+        <span><strong>Review exact permissions</strong><small>{selectedTotal} of {total} requested actions selected{selectedGroups.length > 0 ? ` across ${selectedGroups.length} ${selectedGroups.length === 1 ? "capability" : "capabilities"}` : ""}.</small></span>
         <b>Details</b>
       </summary>
       <div className="permission-groups">{groups.map((group) => (
@@ -68,7 +107,7 @@ export function FilePermissionSummary({ files }: {
   return (
     <details className="permission-review file-permission-review">
       <summary>
-        <span><strong>Files</strong><small>{files.actions.length} requested {files.actions.length === 1 ? "action" : "actions"}. {scope}</small></span>
+        <span><strong>Review exact file permissions</strong><small>{files.actions.length} required {files.actions.length === 1 ? "action" : "actions"}. {scope}</small></span>
         <b>Details</b>
       </summary>
       <div className="permission-groups">

--- a/apps/portal/src/authorization-review-state.ts
+++ b/apps/portal/src/authorization-review-state.ts
@@ -1,0 +1,36 @@
+export interface StoredAuthorizationReview {
+  collectionId?: string;
+  operations?: string[];
+  reviewing?: boolean;
+}
+
+function storageKey(requestId: string): string {
+  return `mdbase:authorization-review:${requestId}`;
+}
+
+export function storedAuthorizationReview(requestId: string): StoredAuthorizationReview | null {
+  try {
+    const stored = sessionStorage.getItem(storageKey(requestId));
+    if (!stored) return null;
+    const value = JSON.parse(stored) as StoredAuthorizationReview;
+    return value && typeof value === "object" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveAuthorizationReview(requestId: string, value: StoredAuthorizationReview): void {
+  try {
+    sessionStorage.setItem(storageKey(requestId), JSON.stringify(value));
+  } catch {
+    // Authorization still works when browser storage is unavailable.
+  }
+}
+
+export function clearAuthorizationReview(requestId: string): void {
+  try {
+    sessionStorage.removeItem(storageKey(requestId));
+  } catch {
+    // Nothing else is required when browser storage is unavailable.
+  }
+}

--- a/apps/portal/src/authorization-view.tsx
+++ b/apps/portal/src/authorization-view.tsx
@@ -24,6 +24,11 @@ import {
 import { collectionCompatibility } from "./compatibility";
 import { configurationSetupSummary } from "./application-setup";
 import {
+  clearAuthorizationReview,
+  saveAuthorizationReview,
+  storedAuthorizationReview
+} from "./authorization-review-state";
+import {
   FilePermissionSummary,
   NotificationAccess,
   PermissionCapabilitySummary,
@@ -441,43 +446,6 @@ function initialSchemaValue(schema?: Record<string, unknown>): Record<string, un
       return "default" in value ? [[key, structuredClone(value.default)]] : [];
     }
   ));
-}
-
-interface StoredAuthorizationReview {
-  collectionId?: string;
-  operations?: string[];
-  reviewing?: boolean;
-}
-
-function authorizationReviewStorageKey(requestId: string): string {
-  return `mdbase:authorization-review:${requestId}`;
-}
-
-function storedAuthorizationReview(requestId: string): StoredAuthorizationReview | null {
-  try {
-    const stored = sessionStorage.getItem(authorizationReviewStorageKey(requestId));
-    if (!stored) return null;
-    const value = JSON.parse(stored) as StoredAuthorizationReview;
-    return value && typeof value === "object" ? value : null;
-  } catch {
-    return null;
-  }
-}
-
-function saveAuthorizationReview(requestId: string, value: StoredAuthorizationReview): void {
-  try {
-    sessionStorage.setItem(authorizationReviewStorageKey(requestId), JSON.stringify(value));
-  } catch {
-    // Authorization still works when browser storage is unavailable.
-  }
-}
-
-function clearAuthorizationReview(requestId: string): void {
-  try {
-    sessionStorage.removeItem(authorizationReviewStorageKey(requestId));
-  } catch {
-    // Nothing else is required when browser storage is unavailable.
-  }
 }
 
 export function ApprovalForm({

--- a/apps/portal/src/authorization-view.tsx
+++ b/apps/portal/src/authorization-view.tsx
@@ -26,6 +26,7 @@ import { configurationSetupSummary } from "./application-setup";
 import {
   FilePermissionSummary,
   NotificationAccess,
+  PermissionCapabilitySummary,
   PermissionChoices
 } from "./authorization-permissions";
 import {
@@ -34,7 +35,6 @@ import {
   initials,
   message,
   neededProvisions,
-  provisionNames,
   relativeTime,
   scopeDescription
 } from "./portal-model";
@@ -209,7 +209,7 @@ export function Authorization({ requestId }: { requestId: string }) {
             onReviewHere={() => continueInDesktop(false)}
           />
         ) : status === "pending" ? <>
-          <p>{authorization.application_name} is asking to use one collection. Choose where it can work and review what it can do.</p>
+          <p>{authorization.application_name} wants to use one collection.</p>
           {error && <div className="message error">{error}</div>}
           <ApprovalForm
             request={authorization}
@@ -239,19 +239,19 @@ export function RequestIdentity({ request, large = false }: { request: PendingAu
       <div>
         {large && <p className="eyebrow">Application access</p>}
         {large ? <h1>{request.application_name}</h1> : <strong>{request.application_name}</strong>}
-        <small>{request.distribution === "portable"
+        <small className="request-metadata">{request.distribution === "portable"
           ? `Downloaded HTML file${request.project_url ? ` · ${host(request.project_url)}` : ""}`
           : host(request.homepage)} · expires {relativeTime(request.expires_at)}</small>
         {request.distribution !== "portable" && (
-          <small>Only continue if you recognize this exact site. An approved application can use the selected data until you revoke it.</small>
+          <small className="request-guidance">Only continue if you recognize this exact site. An approved application can use the selected data until you revoke it.</small>
         )}
         {request.requirements.access === "full_collection" ? (
-          <small>Requests access to all record types in the selected collection.</small>
+          <small className="request-scope">Requests access to all record types in the selected collection.</small>
         ) : request.requirements.contracts.length > 0 && (
-          <small>{scopeDescription(request.requirements.contracts)}</small>
+          <small className="request-scope">{scopeDescription(request.requirements.contracts)}</small>
         )}
         {request.requirements.collection_kind === "hosted" && (
-          <small>Requires a collection hosted by mdbase</small>
+          <small className="request-scope">Requires a collection hosted by mdbase</small>
         )}
       </div>
     </div>
@@ -318,6 +318,7 @@ function ContractSetupEditor({
 }) {
   const suggestions = useMemo(() => suggestTypes(contract, types), [contract, types]);
   const canGuideExistingType = guidedBindingSupported(contract);
+  const canChooseExistingType = suggestions.length > 0 && canGuideExistingType;
   const selectedType = types.find((type) => type.name === value.typeName);
   const availableFields = selectedType ? typeFields(selectedType) : [];
   const fields = contractFields(contract);
@@ -333,26 +334,46 @@ function ContractSetupEditor({
     onChange({ ...value, typeName, fields: suggestion?.fields ?? {} });
   }
 
+  if (!canChooseExistingType) {
+    return (
+      <div className="contract-setup-consequence">
+        <span className="setup-change-mark" aria-hidden="true">+</span>
+        <div>
+          <strong>{applicationName} needs a {setupLabel(contract).toLocaleLowerCase()} type</strong>
+          <small>Allowing access adds a separate type supplied by {applicationName}. Existing records stay unchanged.</small>
+          <details className="contract-expert-details">
+            <summary>Expert details</summary>
+            <code>{contract.id} · {contract.version}</code>
+            {contract.description && <p>{contract.description}</p>}
+            {!canGuideExistingType && suggestions.length > 0 && <p>This application uses advanced behavior settings, so an existing type cannot be connected during approval.</p>}
+          </details>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="contract-setup-editor">
       <div className="contract-setup-heading">
         <div>
           <strong>Help {applicationName} understand {setupLabel(contract).toLocaleLowerCase()}</strong>
-          <small>{contract.description ?? "Choose whether to add the application’s starter type or use one of your existing types."}</small>
+          <small>{contract.description ?? `Choose whether to add a new ${setupLabel(contract).toLocaleLowerCase()} type or use one you already have.`}</small>
         </div>
-        <code>{contract.id} · {contract.version}</code>
+        <details className="contract-expert-details">
+          <summary>Expert details</summary>
+          <code>{contract.id} · {contract.version}</code>
+        </details>
       </div>
       <div className="contract-setup-mode" role="radiogroup" aria-label={`Setup for ${setupLabel(contract)}`}>
         <label className={value.mode === "starter" ? "selected" : undefined}>
           <input type="radio" name={`setup-${contract.id}-${contract.version}`} checked={value.mode === "starter"} disabled={disabled} onChange={() => onChange({ ...value, mode: "starter" })} />
-          <span><strong>Add {applicationName}’s starter type</strong><small>Create a separate type supplied by the application.</small></span>
+          <span><strong>Add a new {setupLabel(contract).toLocaleLowerCase()} type</strong><small>Create a separate type supplied by {applicationName}.</small></span>
         </label>
-        {suggestions.length > 0 && canGuideExistingType && <label className={value.mode === "existing" ? "selected" : undefined}>
+        <label className={value.mode === "existing" ? "selected" : undefined}>
           <input type="radio" name={`setup-${contract.id}-${contract.version}`} checked={value.mode === "existing"} disabled={disabled} onChange={() => onChange({ ...value, mode: "existing" })} />
           <span><strong>Use an existing type</strong><small>Keep your current records and explain which fields mean the same thing.</small></span>
-        </label>}
+        </label>
       </div>
-      {!canGuideExistingType && suggestions.length > 0 && <p className="field-note">This contract has advanced behavior settings. Add its starter type here, or connect an existing type later in mdbase editor.</p>}
       {value.mode === "existing" && canGuideExistingType && <div className="contract-mapping">
         <label className="contract-type-choice">
           <span>Existing type</span>
@@ -422,6 +443,43 @@ function initialSchemaValue(schema?: Record<string, unknown>): Record<string, un
   ));
 }
 
+interface StoredAuthorizationReview {
+  collectionId?: string;
+  operations?: string[];
+  reviewing?: boolean;
+}
+
+function authorizationReviewStorageKey(requestId: string): string {
+  return `mdbase:authorization-review:${requestId}`;
+}
+
+function storedAuthorizationReview(requestId: string): StoredAuthorizationReview | null {
+  try {
+    const stored = sessionStorage.getItem(authorizationReviewStorageKey(requestId));
+    if (!stored) return null;
+    const value = JSON.parse(stored) as StoredAuthorizationReview;
+    return value && typeof value === "object" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveAuthorizationReview(requestId: string, value: StoredAuthorizationReview): void {
+  try {
+    sessionStorage.setItem(authorizationReviewStorageKey(requestId), JSON.stringify(value));
+  } catch {
+    // Authorization still works when browser storage is unavailable.
+  }
+}
+
+function clearAuthorizationReview(requestId: string): void {
+  try {
+    sessionStorage.removeItem(authorizationReviewStorageKey(requestId));
+  } catch {
+    // Nothing else is required when browser storage is unavailable.
+  }
+}
+
 export function ApprovalForm({
   request,
   collections,
@@ -472,10 +530,22 @@ export function ApprovalForm({
     () => visibleChoices.filter((choice) => !choice.compatibility.compatible),
     [visibleChoices]
   );
-  const [collectionId, setCollectionId] = useState(
-    compatible[0]?.collection.id ?? ""
+  const savedReview = useMemo(() => storedAuthorizationReview(request.id), [request.id]);
+  const savedCollectionId = savedReview?.collectionId
+    && compatible.some((choice) => choice.collection.id === savedReview.collectionId)
+      ? savedReview.collectionId
+      : "";
+  const initialCollectionId = savedCollectionId
+    || (compatible.length === 1 ? compatible[0].collection.id : "");
+  const [collectionId, setCollectionId] = useState(initialCollectionId);
+  const [reviewing, setReviewing] = useState(
+    savedCollectionId ? savedReview?.reviewing === true : compatible.length === 1
   );
-  const [operations, setOperations] = useState(() => new Set(request.requested_operations));
+  const [operations, setOperations] = useState(() => new Set(
+    savedReview?.operations
+      ? savedReview.operations.filter((operation) => request.requested_operations.includes(operation))
+      : request.requested_operations
+  ));
   const [submitting, setSubmitting] = useState<"approved" | "denied" | "creating" | null>(null);
   const [creatingHosted, setCreatingHosted] = useState(false);
   const [collectionName, setCollectionName] = useState("");
@@ -519,12 +589,32 @@ export function ApprovalForm({
       count + group.operations.filter((operation) => operations.has(operation.id)).length,
     0
   );
+  const selectedPermissionGroups = permissionGroups.filter((group) =>
+    group.operations.some((operation) => operations.has(operation.id))
+  );
+  const higherImpactLabels = [
+    ...selectedPermissionGroups.flatMap((group) =>
+      group.id === "delete" || group.id === "manage" ? [group.label] : []
+    ),
+    ...(request.requirements.files?.actions.includes("delete") ? ["Delete files"] : []),
+    ...(hasSetup ? ["Changes collection setup"] : [])
+  ];
 
   useEffect(() => {
     if (!compatible.some((choice) => choice.collection.id === collectionId)) {
-      setCollectionId(compatible[0]?.collection.id ?? "");
+      const onlyCollectionId = compatible.length === 1 ? compatible[0].collection.id : "";
+      setCollectionId(onlyCollectionId);
+      setReviewing(Boolean(onlyCollectionId));
     }
   }, [collectionId, compatible]);
+
+  useEffect(() => {
+    saveAuthorizationReview(request.id, {
+      collectionId,
+      operations: [...operations],
+      reviewing
+    });
+  }, [collectionId, operations, request.id, reviewing]);
 
   useEffect(() => {
     setSetupChoices(Object.fromEntries(setupContracts.map((contract) => [
@@ -600,6 +690,7 @@ export function ApprovalForm({
           })
         } : {})
       });
+      clearAuthorizationReview(request.id);
       await onDecision(decision);
     } catch (decisionError) {
       if (preparingSetup) onSetupActivityChange?.(false);
@@ -634,6 +725,7 @@ export function ApprovalForm({
       setCreatedCollections((current) => [...current, collection]);
       onCollectionCreated(collection);
       setCollectionId(collection.id);
+      setReviewing(true);
       setCollectionName("");
       setCreatingHosted(false);
     } catch (creationError) {
@@ -655,14 +747,28 @@ export function ApprovalForm({
           ? `${host(request.project_url)} is a developer-supplied project link, not proof that the downloaded file came from that site.`
           : "A downloaded file has no website origin that mdbase can verify."}</p>
       </div>}
+      <div className="authorization-progress" aria-label="Application access review progress">
+        <span className={!reviewing ? "current" : "complete"}><b>1</b> Collection</span>
+        <span className={reviewing ? "current" : undefined}><b>2</b> Review access</span>
+      </div>
       <section className="approval-section">
         <div className="approval-section-intro">
-          <strong>Collection</strong>
-          <small>{request.collection_id
-            ? `${request.application_name} requested this specific collection.`
-            : `Choose where ${request.application_name} can work.`}</small>
+          <strong>{reviewing ? "Collection" : "Choose a collection"}</strong>
+          <small>{reviewing
+            ? `Where ${request.application_name} will work.`
+            : request.collection_id
+              ? `${request.application_name} requested this specific collection.`
+              : `Choose where ${request.application_name} can work.`}</small>
         </div>
         <div className="approval-section-content">
+          {reviewing && selected ? <div className="selected-collection-summary">
+            <div>
+              <span>Using</span>
+              <strong>{selected.display_name}</strong>
+              <small>{collectionLocations.get(selected.id)}</small>
+            </div>
+            {!request.collection_id && <button className="quiet-action" type="button" disabled={submitting !== null} onClick={() => setReviewing(false)}>Change</button>}
+          </div> : <>
           {compatible.length > 0 && <fieldset className="collection-choice-field">
             <legend>Collection and location</legend>
             <div className="collection-choice-list">
@@ -687,31 +793,38 @@ export function ApprovalForm({
               })}
             </div>
           </fieldset>}
-          {unavailable.length > 0 && <details className="collection-compatibility">
-            <summary>{compatible.length > 0
-              ? `${unavailable.length} other ${unavailable.length === 1 ? "collection is" : "collections are"} unavailable`
-              : `${unavailable.length} ${unavailable.length === 1 ? "collection is" : "collections are"} unavailable`}</summary>
-            <ul>{unavailable.map(({ collection, compatibility }) => <li key={collection.id}><span>{collection.display_name}</span><small>{compatibility.compatible ? "" : compatibility.detail}</small></li>)}</ul>
-          </details>}
-          {unavailableConnectors.length > 0 && <div className="field-note" role="status">
-            {unavailableConnectors.map((connector) => connector.reason === "paused"
-              ? `${connector.connector_name} has remote access paused.`
-              : `${connector.connector_name} is offline.`).join(" ")} Those local collections cannot be selected until their computer is available.
-          </div>}
-          {request.requirements.collection_kind !== "hosted"
-            && (compatible.length === 0 || unavailableConnectors.length > 0)
-            && <div className="desktop-collection-option">
-              <div>
-                <strong>Use a folder on this computer</strong>
-                <p>Open the desktop app to connect this computer, add a folder, and continue this same request.</p>
-              </div>
-              <a
-                className="button secondary link-button"
-                href={`mdbase-connect://authorize?request_id=${encodeURIComponent(request.id)}`}
-                onClick={onContinueInDesktop}
-              >Use a local folder</a>
-            </div>}
-          {canCreateHosted && !request.collection_id && (creatingHosted ? (
+          {compatible.length === 0 && <p className="field-note">{request.collection_id
+            ? "The collection requested by this application is not available."
+            : "No compatible collection is ready."}</p>}
+          {(unavailable.length > 0
+            || unavailableConnectors.length > 0
+            || (request.requirements.collection_kind !== "hosted" && !request.collection_id)
+            || (canCreateHosted && !request.collection_id)) && <details className="alternate-collection-options" open={compatible.length === 0 || creatingHosted ? true : undefined}>
+            <summary>{compatible.length > 0 ? "Need a different collection?" : "Choose another way"}</summary>
+            <div>
+              {unavailable.length > 0 && <div className="collection-compatibility">
+                <strong>{unavailable.length} {unavailable.length === 1 ? "collection is" : "collections are"} unavailable</strong>
+                <ul>{unavailable.map(({ collection, compatibility }) => <li key={collection.id}><span>{collection.display_name}</span><small>{compatibility.compatible ? "" : compatibility.detail}</small></li>)}</ul>
+              </div>}
+              {unavailableConnectors.length > 0 && <div className="field-note" role="status">
+                {unavailableConnectors.map((connector) => connector.reason === "paused"
+                  ? `${connector.connector_name} has remote access paused.`
+                  : `${connector.connector_name} is offline.`).join(" ")} Those local collections cannot be selected until their computer is available.
+              </div>}
+              {request.requirements.collection_kind !== "hosted"
+                && !request.collection_id
+                && <div className="desktop-collection-option">
+                  <div>
+                    <strong>Use a folder on this computer</strong>
+                    <p>Open the desktop app to connect this computer, add a folder, and continue this same request.</p>
+                  </div>
+                  <a
+                    className="button secondary link-button"
+                    href={`mdbase-connect://authorize?request_id=${encodeURIComponent(request.id)}`}
+                    onClick={onContinueInDesktop}
+                  >Use a local folder</a>
+                </div>}
+              {canCreateHosted && !request.collection_id && (creatingHosted ? (
             <form
               className="authorization-collection-create"
               id={`create-hosted-${request.id}`}
@@ -745,9 +858,8 @@ export function ApprovalForm({
                 </button>
               </div>
             </form>
-          ) : (
+              ) : (
             <div className="authorization-collection-action">
-              {compatible.length === 0 && <p className="field-note">No compatible collection is ready.</p>}
               <button
                 className="button secondary"
                 type="button"
@@ -759,23 +871,36 @@ export function ApprovalForm({
                 }}
               >Create hosted collection</button>
             </div>
-          ))}
-          {(!canCreateHosted || Boolean(request.collection_id)) && compatible.length === 0 && (
-            <p className="field-note">
-              {request.collection_id
-                ? "The collection requested by this application is not available."
-                : "No compatible collection is ready."}
-            </p>
-          )}
-          {setup.length > 0 && <p className="field-note">{setupTypes.length > 0
-            ? `Setup is required before access can become active. Add ${provisionNames(setup)}’s starter type below, or use an existing type.`
-            : `Setup is required before access can become active. Add ${provisionNames(setup)}’s starter type.`}</p>}
+              ))}
+            </div>
+          </details>}
+          <footer className="collection-step-actions">
+            <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
+            <button className="button primary" type="button" disabled={submitting !== null || !collectionId} onClick={() => setReviewing(true)}>Review access</button>
+          </footer>
+          </>}
         </div>
       </section>
-      {setupContracts.length > 0 && <section className="approval-section contract-setup-section">
+      {reviewing && <section className="approval-section">
         <div className="approval-section-intro">
-          <strong>Choose type setup</strong>
-          <small>Add a starter type, or match meanings in one you already use. Nothing changes until you approve and the collection validates.</small>
+          <strong>What it can do</strong>
+          <small>{permissionCount} requested actions across {permissionCategoryCount} {permissionCategoryCount === 1 ? "capability" : "capabilities"}.</small>
+        </div>
+        <div className="approval-section-content authorization-permissions">
+          <PermissionCapabilitySummary groups={permissionGroups} selected={operations} files={request.requirements.files} />
+          {permissionGroups.length > 0 && <PermissionChoices
+            groups={permissionGroups}
+            selected={operations}
+            disabled={submitting !== null}
+            onToggle={toggleOperation}
+          />}
+          {request.requirements.files && <FilePermissionSummary files={request.requirements.files} />}
+        </div>
+      </section>}
+      {reviewing && hasSetup && <section className="approval-section collection-changes-section">
+        <div className="approval-section-intro">
+          <strong>Collection changes</strong>
+          <small>These happen only after you allow access and the collection validates them.</small>
         </div>
         <div className="approval-section-content contract-setup-list">
           {setupContracts.map((contract) => {
@@ -791,14 +916,7 @@ export function ApprovalForm({
               onChange={(next) => setSetupChoices((current) => ({ ...current, [key]: next }))}
             />;
           })}
-        </div>
-      </section>}
-      {configurationSetup.length > 0 && <section className="approval-section configuration-setup-section">
-        <div className="approval-section-intro">
-          <strong>Review collection settings</strong>
-          <small>The application may add only these declared values under an extension setting. Existing and unrelated settings are preserved.</small>
-        </div>
-        <div className="approval-section-content configuration-setup-list">
+          {configurationSetup.length > 0 && <div className="configuration-setup-list">
           {configurationSetup.map((provision) => {
             const summary = configurationSetupSummary(provision);
             return <div className="configuration-setup-item" key={`${provision.requirement}:${provision.path}`}>
@@ -810,34 +928,22 @@ export function ApprovalForm({
               </div>
             </div>;
           })}
+          </div>}
         </div>
       </section>}
-      <section className="approval-section">
-        <div className="approval-section-intro">
-          <strong>Permissions</strong>
-          <small>{permissionCount} specific actions across {permissionCategoryCount} {permissionCategoryCount === 1 ? "category" : "categories"}.</small>
+      {reviewing && <NotificationAccess notifications={request.notifications} />}
+      {error && <div className="message error compact" role="alert">{error}</div>}
+      {reviewing && <footer className="approval-footer">
+        <div className="approval-receipt">
+          <strong>{request.application_name} · {selected?.display_name}</strong>
+          {higherImpactLabels.length > 0 && <span>{higherImpactLabels.join(" · ")}</span>}
+          <small>Access continues until you revoke it in mdbase connect.</small>
         </div>
-        <div className="authorization-permissions">
-          {permissionGroups.length > 0 && <PermissionChoices
-            groups={permissionGroups}
-            selected={operations}
-            disabled={submitting !== null}
-            onToggle={toggleOperation}
-          />}
-          {request.requirements.files && <FilePermissionSummary files={request.requirements.files} />}
-        </div>
-      </section>
-      <NotificationAccess notifications={request.notifications} />
-      {error && <div className="message error compact">{error}</div>}
-      <footer className="approval-footer">
-        <p>{selected
-          ? `${request.application_name} will work in ${selected.display_name} at ${selected.connector_name}. You can revoke access at any time in mdbase connect.`
-          : `Choose a compatible collection before allowing ${request.application_name}.`}</p>
         <div className="approval-actions">
           <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>
           <button className="button primary" type="button" disabled={submitting !== null || !collectionId || (selectedPermissionCount === 0 && !request.requirements.files) || !setupReady} onClick={() => void decide("approved")}>{submitting === "approved" ? (hasSetup ? "Setting up and allowing…" : "Approving…") : hasSetup ? `Set up and allow ${request.application_name}` : `Allow ${request.application_name}`}</button>
         </div>
-      </footer>
+      </footer>}
     </div>
   );
 }

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -931,11 +931,26 @@ h1 {
   min-width: 0;
 }
 
-.request-identity small {
+.request-identity .request-metadata {
   overflow: hidden;
   font-family: var(--mono);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.request-identity .request-guidance,
+.request-identity .request-scope {
+  overflow: visible;
+  max-width: 68ch;
+  font-family: inherit;
+  font-size: 0.74rem;
+  line-height: 1.5;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.request-identity .request-guidance {
+  color: var(--ink-soft);
 }
 
 .request-identity.large {
@@ -955,6 +970,53 @@ h1 {
   display: grid;
   margin-top: 1.1rem;
   border-top: 1px solid var(--line-strong);
+}
+
+.authorization-progress {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--line);
+}
+
+.authorization-progress > span {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.75rem;
+  color: var(--ink-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.authorization-progress > span + span {
+  padding-left: 1rem;
+  border-left: 1px solid var(--line);
+}
+
+.authorization-progress b {
+  display: grid;
+  width: 1.25rem;
+  height: 1.25rem;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+}
+
+.authorization-progress .current {
+  color: var(--ink);
+}
+
+.authorization-progress .current b {
+  border-color: var(--accent-dark);
+  color: var(--accent-dark);
+}
+
+.authorization-progress .complete b {
+  border-color: var(--connected);
+  color: var(--connected);
 }
 
 .portable-authorization-warning {
@@ -1017,6 +1079,62 @@ h1 {
   display: grid;
   gap: 0.65rem;
   min-width: 0;
+}
+
+.selected-collection-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 3.5rem;
+  padding: 0.45rem 0;
+}
+
+.selected-collection-summary > div,
+.approval-receipt {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.selected-collection-summary span,
+.selected-collection-summary small {
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+}
+
+.selected-collection-summary strong {
+  font-size: 0.84rem;
+}
+
+.alternate-collection-options {
+  min-width: 0;
+  margin-top: 0.2rem;
+  border-top: 1px solid var(--line);
+}
+
+.alternate-collection-options > summary {
+  padding: 0.8rem 0;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.alternate-collection-options > div {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0 0 0.8rem;
+}
+
+.collection-step-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  padding-top: 0.55rem;
+}
+
+.collection-step-actions .deny-button {
+  color: var(--danger);
 }
 
 .configuration-setup-list {
@@ -1277,6 +1395,71 @@ h1 {
 .contract-setup-editor:last-child {
   padding-bottom: 0;
   border-bottom: 0;
+}
+
+.contract-setup-consequence {
+  display: grid;
+  grid-template-columns: 1.35rem minmax(0, 1fr);
+  gap: 0.65rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.contract-setup-consequence:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.setup-change-mark {
+  display: grid;
+  width: 1.35rem;
+  height: 1.35rem;
+  place-items: center;
+  border: 1px solid color-mix(in oklch, var(--connected) 45%, var(--line));
+  border-radius: 50%;
+  color: var(--connected);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.contract-setup-consequence > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.contract-setup-consequence strong {
+  font-size: 0.8rem;
+}
+
+.contract-setup-consequence small {
+  color: var(--ink-muted);
+  font-size: 0.71rem;
+  line-height: 1.5;
+}
+
+.contract-expert-details {
+  color: var(--ink-muted);
+  font-size: 0.66rem;
+}
+
+.contract-expert-details summary {
+  width: fit-content;
+  margin-top: 0.2rem;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+
+.contract-expert-details code {
+  display: block;
+  margin-top: 0.4rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.contract-expert-details p {
+  margin: 0.35rem 0 0;
+  line-height: 1.45;
 }
 
 .contract-setup-heading {
@@ -1554,6 +1737,61 @@ select {
   display: grid;
 }
 
+.permission-capabilities {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+  list-style: none;
+}
+
+.permission-capabilities li {
+  display: grid;
+  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 3.4rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.permission-capabilities li > span:nth-child(2) {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.permission-capabilities strong {
+  font-size: 0.77rem;
+}
+
+.permission-capabilities small {
+  color: var(--ink-muted);
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+
+.permission-capabilities b {
+  color: var(--warning);
+  font-size: 0.64rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.capability-mark {
+  display: grid;
+  width: 1.2rem;
+  height: 1.2rem;
+  place-items: center;
+  color: var(--connected);
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.permission-capabilities .higher-impact .capability-mark {
+  color: var(--warning);
+}
+
 .authorization-permissions > .permission-review + .permission-review {
   border-top: 1px solid var(--line);
 }
@@ -1658,18 +1896,37 @@ select {
 }
 
 .approval-footer {
+  position: sticky;
+  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  padding: 1rem 0 0;
+  margin: 0 -0.75rem;
+  padding: 1rem 0.75rem;
+  border-top: 1px solid var(--line-strong);
+  background: color-mix(in oklch, var(--paper) 96%, transparent);
+  backdrop-filter: blur(10px);
 }
 
-.approval-footer > p {
+.approval-receipt {
   max-width: 48ch;
-  margin: 0;
+}
+
+.approval-receipt strong {
+  color: var(--ink);
+  font-size: 0.73rem;
+}
+
+.approval-receipt span {
+  color: var(--warning);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.approval-receipt small {
   color: var(--ink-muted);
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   line-height: 1.45;
 }
 
@@ -2239,12 +2496,34 @@ select {
   }
 
   .approval-footer {
-    align-items: flex-start;
-    flex-direction: column;
+    align-items: center;
+    flex-direction: row;
+    gap: 0.6rem;
+    margin-right: -0.5rem;
+    margin-left: -0.5rem;
+    padding: 0.75rem 0.5rem;
   }
 
   .approval-actions {
-    justify-content: flex-start;
+    flex: 1 0 auto;
+    justify-content: flex-end;
+    gap: 0.35rem;
+  }
+
+  .approval-actions .button {
+    padding: 0 0.7rem;
+  }
+
+  .approval-receipt {
+    max-width: 8.5rem;
+  }
+
+  .approval-receipt span {
+    line-height: 1.25;
+  }
+
+  .approval-receipt small {
+    display: none;
   }
 
   .center-page {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "clap",
  "directories",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "chrono",
  "directories",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.35"
+version = "0.1.0-beta.36"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/product-design/core-flows.md
+++ b/docs/product-design/core-flows.md
@@ -64,19 +64,30 @@ offer a retry rather than restarting silently.
 Goal: let the user make one informed decision about one application and one
 collection.
 
-The decision reads from identity to consequence:
+The decision adapts to the number of compatible collections. When one valid
+collection is available, open directly on the compact access review. When
+several are available, ask the user to choose one first and do not preselect an
+ambiguous target. Creation, desktop handoff, and unavailable collections stay
+under `Need a different collection?` until required.
+
+The review reads from identity to consequence:
 
 1. Application name, origin, and request expiry.
 2. Compatible collection and its authority.
-3. Requested operations, grouped in plain language.
-4. Contract-derived scope and any setup that approval will add.
+3. Requested capabilities, grouped in plain language. Delete and structural
+   access remain visible without opening exact permissions.
+4. Contract-derived scope and any collection changes that approval will add.
 5. Optional content-free notification rules.
 6. A sentence stating what the application will use and how long access lasts.
 7. `Deny` and `Allow [application]`.
 
-Start with all requested operations selected, then let the user narrow them.
-The collapsed state still shows `n of n selected`. An unavailable collection
-stays explainable, but cannot be selected.
+Start with all requested operations selected, then let the user narrow them
+under `Review exact permissions`. The collapsed state still shows `n of n
+selected`. Describe mandatory type or configuration setup as a consequence,
+not a choice. Show type mapping controls only when the collection offers a real
+existing-type alternative; keep contract identifiers under `Expert details`.
+An unavailable collection stays explainable, but cannot be selected. Preserve
+the in-progress collection and permission review for the browser session.
 
 Approval returns the user to the requesting application. Denial is a complete
 outcome, not an error.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.35
-git tag -a v0.1.0-beta.35 -m "mdbase connect 0.1.0-beta.35"
-git push origin v0.1.0-beta.35
+pnpm version:check v0.1.0-beta.36
+git tag -a v0.1.0-beta.36 -m "mdbase connect 0.1.0-beta.36"
+git push origin v0.1.0-beta.36
 ```
 
 The tag starts the only full desktop build. The four platform builders do not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/browser-accessibility.test.mjs
+++ b/scripts/browser-accessibility.test.mjs
@@ -272,7 +272,23 @@ async function auditPortalColdStartAuthorization() {
       await route.fulfill({
         json: {
           authorization,
-          collections: [],
+          collections: [{
+            id: "44444444-4444-4444-8444-444444444444",
+            kind: "local",
+            connector_name: "Home computer",
+            display_name: "Personal notes",
+            spec_version: "0.3.0",
+            contracts: [],
+            types: []
+          }, {
+            id: "55555555-5555-4555-8555-555555555555",
+            kind: "hosted",
+            connector_name: "Hosted by mdbase",
+            display_name: "Shared notes",
+            spec_version: "0.3.0",
+            contracts: [],
+            types: []
+          }],
           hosted_collections_available: true,
           unavailable_connectors: []
         }
@@ -287,13 +303,18 @@ async function auditPortalColdStartAuthorization() {
   });
   await page.goto(`${servers[0].origin}/authorize/${requestId}`);
   await page.getByRole("heading", { name: "Workout journal" }).waitFor();
+  const reviewAccess = page.getByRole("button", { name: "Review access" });
+  assert.equal(await reviewAccess.isDisabled(), true, "portal authorization: multiple collections require a deliberate choice");
+  assert.equal(await page.getByRole("radio").count(), 2, "portal authorization: compatible collections are visible");
+  assert.equal(await page.getByRole("radio", { checked: true }).count(), 0, "portal authorization: no ambiguous collection is preselected");
+  assert.equal(await page.getByText("Delete records", { exact: true }).count(), 0, "portal authorization: permissions wait until collection choice");
+  await page.getByText("Need a different collection?", { exact: true }).click();
   const localFolder = page.getByRole("link", { name: "Use a local folder" });
   assert.equal(
     await localFolder.getAttribute("href"),
     `mdbase-connect://authorize?request_id=${requestId}`,
     "portal authorization: desktop link preserves request ID"
   );
-  await expectText(page, "View and find records · Create and edit records · Delete records");
   await localFolder.evaluate((element) => {
     element.addEventListener("click", (event) => event.preventDefault(), { once: true });
   });
@@ -306,12 +327,24 @@ async function auditPortalColdStartAuthorization() {
   );
   await auditPage(page, "portal desktop continuation", { keyboard: true });
   await page.getByRole("button", { name: "Review in this browser" }).click();
+  await page.getByText("Need a different collection?", { exact: true }).click();
   await localFolder.waitFor();
   assert.equal(
     new URL(page.url()).searchParams.has("continue_in_desktop"),
     false,
     "portal authorization: browser review remains available"
   );
+  await page.getByRole("radio", { name: /Personal notes.*Home computer/ }).check();
+  await reviewAccess.click();
+  await page.getByText("View and find records", { exact: true }).first().waitFor();
+  await page.getByText("Create and edit records", { exact: true }).first().waitFor();
+  await page.getByText("Delete records", { exact: true }).first().waitFor();
+  await page.getByText("Higher impact", { exact: true }).first().waitFor();
+  await page.reload();
+  await page.getByText("Personal notes", { exact: true }).first().waitFor();
+  await page.getByText("Delete records", { exact: true }).first().waitFor();
+  assert.equal(await page.getByRole("button", { name: "Allow Workout journal" }).count(), 1, "portal authorization: review state survives refresh");
+  await auditPage(page, "portal application access review", { keyboard: true });
   assert.deepEqual(errors, []);
   await page.close();
 }

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -270,11 +270,7 @@ secret: connector scope test
   const collection = dashboard.collections[0];
 
   await onboardingPage.goto(`${serverUrl}/authorize/${authorizationId}`);
-  const collectionChoice = onboardingPage.locator(
-    `.collection-choice-list input[value="${collection.id}"]`
-  );
-  await collectionChoice.waitFor({ state: "visible" });
-  await collectionChoice.check();
+  await onboardingPage.getByText(collection.display_name, { exact: true }).waitFor();
   await onboardingPage.getByRole("button", { name: "Allow MVP Workout App" }).click();
   const callback = await finishSignedWebAuthorization(initialAuthorization);
   await onboardingContext.close();
@@ -573,13 +569,14 @@ implements:
     await setupPage.locator(
       `.collection-choice-list input[value="${collection.id}"]`
     ).click();
+    await setupPage.getByRole("button", { name: "Review access" }).click();
     const editor = setupPage.locator(".contract-setup-editor");
     await editor.getByText("Help Planning E2E understand planning item").waitFor();
     const setupOptions = await editor.locator(".contract-setup-mode > label").allTextContents();
-    if (!setupOptions[0]?.includes("Add Planning E2E’s starter type")) {
+    if (!setupOptions[0]?.includes("Add a new planning item type")) {
       throw new Error(`The default starter setup was not presented first: ${setupOptions}`);
     }
-    if (!await editor.getByLabel("Add Planning E2E’s starter type").isChecked()) {
+    if (!await editor.getByLabel("Add a new planning item type").isChecked()) {
       throw new Error("The approval UI did not default to the application-provided starter type.");
     }
     await editor.getByLabel("Use an existing type").check();
@@ -753,7 +750,8 @@ implements:
     await taskNotesPage.locator(
       `.collection-choice-list input[value="${collection.id}"]`
     ).click();
-    await taskNotesPage.getByText("Review collection settings").waitFor();
+    await taskNotesPage.getByRole("button", { name: "Review access" }).click();
+    await taskNotesPage.getByText("Collection changes").waitFor();
     await taskNotesPage.getByText("x-obsidian → bases → include").waitFor();
     await taskNotesPage.getByText("views/tasknotes/**/*.base").waitFor();
     await taskNotesPage.getByRole("button", {

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -3887,11 +3887,11 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, re
     await page.getByRole("button", { name: "Create hosted collection" }).click();
     await page.getByLabel("New collection name").fill("Workout records");
     await page.getByRole("button", { name: "Create collection" }).click();
-    const collection = page.getByRole("radio", {
-      name: /Workout records.*Hosted by mdbase.*Setup review/
-    });
-    await expect(collection).toBeVisible();
-    await expect(collection).toBeChecked();
+    const collection = page.locator(".selected-collection-summary");
+    await expect(collection).toContainText("Using");
+    await expect(collection).toContainText("Workout records");
+    await expect(collection).toContainText("Hosted by mdbase");
+    await expect(collection.getByRole("button", { name: "Change" })).toBeVisible();
     await expect(page.getByText(
       "Workout Inline E2E needs a workout type"
     )).toBeVisible();

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -3893,7 +3893,7 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, re
     await expect(collection).toContainText("Hosted by mdbase");
     await expect(collection.getByRole("button", { name: "Change" })).toBeVisible();
     await expect(page.getByText(
-      "Workout Inline E2E needs a workout type"
+      "Workout Inline E2E needs a record type"
     )).toBeVisible();
     await expect(page.getByText(
       "Allowing access adds a separate type supplied by Workout Inline E2E. Existing records stay unchanged."

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -3843,7 +3843,8 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     const page = await context.newPage();
     await page.goto(authorizationUrl);
     await expect(page.getByRole("heading", { name: "Hosted SDK E2E" })).toBeVisible();
-    await expect(page.getByText("Hosted SDK E2E is asking to use one collection. Choose where it can work and review what it can do.")).toBeVisible();
+    await expect(page.getByText("Hosted SDK E2E wants to use one collection.")).toBeVisible();
+    await page.getByText("Need a different collection?", { exact: true }).click();
     const collection = page.getByRole("radio", {
       name: /Hosted writing.*Hosted by mdbase/
     });
@@ -3851,6 +3852,7 @@ async function authorizeHostedApplication(authorizationUrl, cookie, collectionId
     await collection.check();
     await expect(collection).toBeChecked();
     await expect(page.getByRole("button", { name: "Create hosted collection" })).toBeVisible();
+    await page.getByRole("button", { name: "Review access" }).click();
     await page.getByRole("button", { name: "Allow Hosted SDK E2E" }).click();
     const outcome = await Promise.race([
       page.waitForURL((url) => authorizationCallbackMatches(url, redirectUri))
@@ -3891,11 +3893,11 @@ async function authorizeHostedApplicationByCreating(authorizationUrl, cookie, re
     await expect(collection).toBeVisible();
     await expect(collection).toBeChecked();
     await expect(page.getByText(
-      "Setup is required before access can become active. Add Workout’s starter type."
+      "Workout Inline E2E needs a workout type"
     )).toBeVisible();
-    await expect(page.getByRole("radio", {
-      name: /Add Workout Inline E2E’s starter type/
-    })).toBeChecked();
+    await expect(page.getByText(
+      "Allowing access adds a separate type supplied by Workout Inline E2E. Existing records stay unchanged."
+    )).toBeVisible();
     await page.getByRole("button", { name: "Set up and allow Workout Inline E2E" }).click();
     const outcome = await Promise.race([
       page.waitForURL((url) => authorizationCallbackMatches(url, redirectUri))

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.35" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.36" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.35",
+  "version": "0.1.0-beta.36",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- split application authorization into an adaptive collection step and compact access review
- require an explicit collection choice when multiple compatible collections exist
- surface destructive and structural capabilities before exact permission details
- describe mandatory collection setup as a consequence and move contract identifiers under expert details
- preserve in-progress review choices for the browser session
- add a compact sticky approval receipt and responsive mobile treatment
- update flow documentation and browser/system test expectations

## Why

The previous screen combined collection routing, creation, compatibility, schema setup, permissions, notifications, and consent in one uninterrupted form. This reduces cognitive load while keeping the exact authorization boundary available.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:accessibility`
- `pnpm e2e`
- desktop and mobile rendered-state review
