### PR TITLE
Retire the duplicate editor publisher

### DIFF
--- a/.github/workflows/editor-pages.yml
+++ b/.github/workflows/editor-pages.yml
@@ -1,8 +1,17 @@
-name: Editor CI and release
+name: Editor CI
 
 on:
   push:
     branches: [main]
+    paths:
+      - "apps/editor/**"
+      - "packages/client/**"
+      - "packages/management/**"
+      - "packages/protocol/**"
+      - "packages/ui/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/editor-pages.yml"
   pull_request:
     paths:
       - "apps/editor/**"
@@ -46,71 +55,3 @@ jobs:
           MDBASE_EDITOR_BASE_PATH: /
       - run: pnpm --filter mdbase-editor check:bundle
       - run: pnpm --filter mdbase-editor check:csp
-
-  deploy-cloudflare:
-    if: github.event_name != 'pull_request' && vars.CLOUDFLARE_PAGES_ENABLED == '1'
-    needs: test
-    runs-on: ubuntu-latest
-    environment:
-      name: cloudflare-pages
-      url: https://editor.mdbase.dev/
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11.15.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages
-      - name: Build editor
-        run: pnpm --filter mdbase-editor build
-        env:
-          MDBASE_EDITOR_ORIGIN: https://editor.mdbase.dev
-          MDBASE_EDITOR_BASE_PATH: /
-      - name: Verify editor manifest
-        run: node -e 'const manifest = require("./apps/editor/dist/.well-known/mdbase-app.json"); if (manifest.homepage !== "https://editor.mdbase.dev/" || manifest.redirect_uris?.[0] !== "https://editor.mdbase.dev/" || manifest.requirements?.access !== "full_collection") process.exit(1)'
-      - name: Deploy editor
-        run: npx --yes --package wrangler@4.114.0 wrangler pages deploy apps/editor/dist --project-name=mdbase-editor --branch=main
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  deploy-cloudflare-staging:
-    if: github.event_name != 'pull_request' && vars.CLOUDFLARE_PAGES_ENABLED == '1'
-    needs: [test, deploy-cloudflare]
-    runs-on: ubuntu-latest
-    environment:
-      name: cloudflare-pages-staging
-      url: https://editor-staging.mdbase.dev/
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11.15.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages
-      - name: Build staging editor
-        run: pnpm --filter mdbase-editor build
-        env:
-          MDBASE_EDITOR_ORIGIN: https://editor-staging.mdbase.dev
-          MDBASE_EDITOR_BASE_PATH: /
-          VITE_MDBASE_CONNECT_URL: https://connect-staging.mdbase.dev
-      - name: Deploy staging editor
-        run: npx --yes --package wrangler@4.114.0 wrangler pages deploy apps/editor/dist --project-name=mdbase-editor --branch=staging
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      - name: Attach staging domain
-        run: node apps/editor/scripts/ensure-pages-domain.mjs
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_PAGES_PROJECT: mdbase-editor
-          CLOUDFLARE_PAGES_DOMAIN: editor-staging.mdbase.dev

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -56,20 +56,10 @@ flows, type inspection, settings, responsive navigation, accessibility, and a
 
 ## Deployment
 
-The production application is configured for
-`https://editor.mdbase.dev/` on Cloudflare Pages. The independent
-`editor-pages.yml` workflow runs the complete verification and browser suites,
-rebuilds the application for its
-dedicated origin, then uploads `dist` with Wrangler. Create a Direct Upload
-Pages project named `mdbase-editor` with production branch `main`.
-
-Configure the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` GitHub
-repository secrets, then set the `CLOUDFLARE_PAGES_ENABLED` repository variable
-to `1`.
-
-The same workflow publishes a permanent staging build at
-`https://editor-staging.mdbase.dev/`. It uses the `staging` Pages branch,
-generates a manifest for the staging editor origin, and targets the same-site
-`https://connect-staging.mdbase.dev` control-plane origin. The Pages API attaches the
-custom domain idempotently; Cloudflare DNS must proxy
-`editor-staging.mdbase.dev` to `staging.mdbase-editor.pages.dev`.
+The canonical editor lives in the independent
+[`mdbase-dev/mdbase-editor`](https://github.com/mdbase-dev/mdbase-editor)
+repository. That repository alone publishes the production and staging
+Cloudflare Pages branches. The editor workflow here remains a compatibility CI
+check for Connect changes and must not deploy to the shared `mdbase-editor`
+Pages project; doing so would replace the canonical application with this
+embedded compatibility copy.


### PR DESCRIPTION
## What changed

- keep the embedded editor workflow as compatibility CI only
- stop production and staging Cloudflare Pages deployments from the Connect monorepo
- limit main-branch editor CI runs to relevant paths
- document mdbase-dev/mdbase-editor as the sole publisher

## Why

The Connect monorepo and the independent editor repository were both publishing to the same mdbase-editor Cloudflare Pages project. Every Connect main push could overwrite the canonical editor with the older embedded copy. That removed the live manifest file grants, so binary files disappeared from both the browser and transclusions.

## Validation

- inspected the latest successful deployment logs from both repositories
- verified the canonical Pages deployment contains collection-wide file capabilities
- reproduced that the custom domains were overwritten with the embedded manifest
- git diff --check