### PR TITLE
Bound desktop E2E teardown

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -230,3 +230,4 @@ jobs:
       # Electron runs natively with an isolated profile while the control
       # plane uses the same packaged Docker boundary as production.
       - run: node test/system/run.mjs --suite desktop --no-prepare
+        timeout-minutes: 20

--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -129,7 +129,7 @@ try {
   );
   const connectorToken = secrets.values.connector;
   assert.match(connectorToken, /^con_/);
-  await pairingApp.close();
+  await closeDesktop(pairingApp);
   pairingApp = undefined;
 
   phase("running the real connector against the disposable credential");
@@ -329,8 +329,8 @@ try {
       "stop"
     ]).catch(() => {});
   }
-  await connectedApp?.close().catch(() => {});
-  await pairingApp?.close().catch(() => {});
+  await closeDesktop(connectedApp);
+  await closeDesktop(pairingApp);
   await portalBrowser?.close().catch(() => {});
   await environment?.close().catch(() => {});
   if (editor) {
@@ -397,6 +397,31 @@ function launchDesktop(userData, connectorToken) {
         : {})
     }
   });
+}
+
+async function closeDesktop(application) {
+  if (!application) return;
+  const child = application.process();
+  let forceClose;
+  try {
+    await Promise.race([
+      application.close(),
+      new Promise((resolveClose) => {
+        forceClose = setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+          }
+          resolveClose();
+        }, 5_000);
+      })
+    ]);
+  } catch {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  } finally {
+    clearTimeout(forceClose);
+  }
 }
 
 async function jsonRequest(path, options = {}) {


### PR DESCRIPTION
## What changed

- bound Electron application shutdown with a five-second force-close fallback
- cap the desktop CI step at twenty minutes

## Why

A renderer assertion failure could enter unbounded Electron teardown, leaving the hosted-provider job running indefinitely and hiding the real assertion. The new boundary preserves the underlying failure while ensuring the job cleans up and reports it.

## Validation

- native Electron reproduction now reports the hidden renderer timeout and removes its Docker environment instead of hanging
- desktop unit tests: 53 passed
- architecture check passed
- Node syntax and git diff checks passed