### PR TITLE
Prevent stale editor asset cache poisoning

### DIFF
--- a/.github/workflows/editor-pages.yml
+++ b/.github/workflows/editor-pages.yml
@@ -83,6 +83,11 @@ jobs:
         env:
           MDBASE_MANIFEST_VERIFY_ATTEMPTS: 12
           MDBASE_MANIFEST_VERIFY_DELAY_MS: 5000
+      - name: Verify production assets
+        run: node apps/editor/scripts/verify-deployment-assets.mjs apps/editor/dist/assets https://editor.mdbase.dev/
+        env:
+          MDBASE_ASSET_VERIFY_ATTEMPTS: 12
+          MDBASE_ASSET_VERIFY_DELAY_MS: 5000
 
   deploy-cloudflare-staging:
     if: github.event_name != 'pull_request' && vars.CLOUDFLARE_PAGES_ENABLED == '1'
@@ -125,3 +130,8 @@ jobs:
         env:
           MDBASE_MANIFEST_VERIFY_ATTEMPTS: 12
           MDBASE_MANIFEST_VERIFY_DELAY_MS: 5000
+      - name: Verify staging assets
+        run: node apps/editor/scripts/verify-deployment-assets.mjs apps/editor/dist/assets https://editor-staging.mdbase.dev/
+        env:
+          MDBASE_ASSET_VERIFY_ATTEMPTS: 12
+          MDBASE_ASSET_VERIFY_DELAY_MS: 5000

--- a/apps/editor/public/_headers
+++ b/apps/editor/public/_headers
@@ -10,4 +10,4 @@
   Cache-Control: no-store
 
 /assets/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=0, must-revalidate

--- a/apps/editor/scripts/check-csp.mjs
+++ b/apps/editor/scripts/check-csp.mjs
@@ -9,6 +9,10 @@ const [headers, html] = await Promise.all([
 ]);
 const policy = headers.match(/^\s*Content-Security-Policy:\s*(.+)$/m)?.[1];
 if (!policy) throw new Error("public/_headers does not define a Content-Security-Policy.");
+const assetCache = headers.match(/^\/assets\/\*\s*\n\s*Cache-Control:\s*(.+)$/m)?.[1];
+if (!assetCache?.includes("must-revalidate") || assetCache.includes("immutable")) {
+  throw new Error("Built assets must revalidate so a transient Pages fallback cannot be cached as an immutable module.");
+}
 
 const scriptDirective = policy.split(";")
   .map((directive) => directive.trim())

--- a/apps/editor/scripts/verify-deployment-assets.mjs
+++ b/apps/editor/scripts/verify-deployment-assets.mjs
@@ -1,0 +1,45 @@
+import { readdir } from "node:fs/promises";
+
+const directory = process.argv[2];
+const origin = process.argv[3];
+if (!directory || !origin) {
+  throw new Error("Usage: node scripts/verify-deployment-assets.mjs <asset-directory> <origin>");
+}
+
+const files = (await readdir(directory, { withFileTypes: true }))
+  .filter((entry) => entry.isFile())
+  .map((entry) => entry.name);
+if (files.length === 0) throw new Error(`No deployment assets found in ${directory}.`);
+
+const attempts = positiveInteger(process.env.MDBASE_ASSET_VERIFY_ATTEMPTS, 1);
+const delayMs = nonNegativeInteger(process.env.MDBASE_ASSET_VERIFY_DELAY_MS, 0);
+let failure;
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  try {
+    await Promise.all(files.map(async (file) => {
+      const url = new URL(`assets/${file}`, origin);
+      url.searchParams.set("deployment-check", `${Date.now()}-${attempt}`);
+      const response = await fetch(url, { cache: "no-store" });
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!response.ok || contentType.includes("text/html")) {
+        throw new Error(`${file} returned HTTP ${response.status} with ${contentType || "no content type"}`);
+      }
+    }));
+    console.log(`Verified ${files.length} editor assets at ${origin}`);
+    process.exit(0);
+  } catch (error) {
+    failure = error;
+    if (attempt < attempts) await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+throw failure;
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function nonNegativeInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 
 const basePath = `/${(process.env.MDBASE_EDITOR_BASE_PATH ?? "/").replace(/^\/+|\/+$/g, "")}/`
   .replace(/^\/\/$/, "/");
+const buildId = (process.env.MDBASE_EDITOR_BUILD_ID ?? process.env.GITHUB_SHA ?? "local")
+  .slice(0, 12)
+  .replace(/[^a-zA-Z0-9_-]/gu, "-");
 
 export default defineConfig({
   base: basePath,
@@ -10,7 +13,13 @@ export default defineConfig({
   build: {
     target: "es2022",
     sourcemap: true,
-    reportCompressedSize: true
+    reportCompressedSize: true,
+    rolldownOptions: {
+      output: {
+        entryFileNames: `assets/[name]-[hash]-${buildId}.js`,
+        chunkFileNames: `assets/[name]-[hash]-${buildId}.js`
+      }
+    }
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- add the commit ID to every JavaScript asset filename so releases never reuse a poisoned module URL
- make asset responses revalidate instead of caching a transient Pages fallback as immutable for one year
- verify every deployed production and staging asset returns a non-HTML response before release completion

## Why
Production verification found one Cloudflare edge had cached the SPA HTML fallback at a newly deployed JavaScript URL during propagation. That produced the editor restart screen even though the asset later became available.

## Verification
- production build with build-specific chunk names
- typecheck and manifest validation
- bundle and CSP/header budgets
- deployment-manifest tests