### PR TITLE
Reject legacy mirror state before current-schema decoding

### DIFF
--- a/crates/connect-mirror/src/directory_storage.rs
+++ b/crates/connect-mirror/src/directory_storage.rs
@@ -87,18 +87,25 @@ impl DirectoryMirror {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => return Err(MirrorError::io("Could not read", &self.state_file, error)),
         };
+        let envelope =
+            serde_json::from_slice::<DurableMirrorStateEnvelope>(&value).map_err(|error| {
+                MirrorError::new(
+                    "invalid_mirror_state",
+                    format!("Mirror state is corrupt: {error}"),
+                )
+            })?;
+        if envelope.engine_version != MIRROR_ENGINE_VERSION {
+            return Err(MirrorError::new(
+                "mirror_state_upgrade_required",
+                "Rebuild this prerelease mirror with the plan-only sync engine.",
+            ));
+        }
         let mut state = serde_json::from_slice::<DurableMirrorState>(&value).map_err(|error| {
             MirrorError::new(
                 "invalid_mirror_state",
                 format!("Mirror state is corrupt: {error}"),
             )
         })?;
-        if state.engine_version != MIRROR_ENGINE_VERSION {
-            return Err(MirrorError::new(
-                "mirror_state_upgrade_required",
-                "Rebuild this prerelease mirror with the plan-only sync engine.",
-            ));
-        }
         if state.protocol_version != SYNC_PROTOCOL_VERSION
             || state.replica_id != self.replica_id
             || state.mode != self.mode

--- a/crates/connect-mirror/src/lib.rs
+++ b/crates/connect-mirror/src/lib.rs
@@ -236,6 +236,12 @@ pub struct MirrorFailure {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct DurableMirrorStateEnvelope {
+    #[serde(default)]
+    engine_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct DurableMirrorState {
     protocol_version: u32,
     #[serde(default)]

--- a/crates/connect-mirror/src/tests.rs
+++ b/crates/connect-mirror/src/tests.rs
@@ -1353,6 +1353,28 @@ async fn corrupt_durable_state_fails_closed_without_reinitializing() {
 }
 
 #[tokio::test]
+async fn legacy_state_is_rejected_by_its_version_before_current_schema_fields() {
+    let source = record("one.md", "One");
+    let (_temporary, mirror, _authority) = harness(SyncReplicaMode::ReadOnly, vec![source]);
+    mirror.sync().await.unwrap();
+
+    let mut state: serde_json::Value =
+        serde_json::from_slice(&fs::read(&mirror.state_file).unwrap()).unwrap();
+    state.as_object_mut().unwrap().remove("engine_version");
+    let first_record = state["records"]
+        .as_object_mut()
+        .unwrap()
+        .values_mut()
+        .next()
+        .unwrap();
+    first_record.as_object_mut().unwrap().remove("hash");
+    fs::write(&mirror.state_file, serde_json::to_vec(&state).unwrap()).unwrap();
+
+    let error = mirror.sync().await.unwrap_err();
+    assert_eq!(error.code, "mirror_state_upgrade_required");
+}
+
+#[tokio::test]
 async fn initialization_collision_changes_nothing() {
     let source = record("one.md", "One");
     let (_temporary, mirror, _authority) = harness(SyncReplicaMode::ReadOnly, vec![source]);


### PR DESCRIPTION
## Outcome

Makes the prerelease state reset deterministic: the Rust mirror loader reads a minimal engine-version envelope before deserializing the current durable-state schema. Legacy state now always returns `mirror_state_upgrade_required`, even when its nested records predate required exact-document fields.

Malformed current-version state still fails closed as `invalid_mirror_state`.

## Live reproduction

Upgrading a beta.36 daemon to beta.39 left two legacy mirrors. One reached the intended upgrade error; the other failed first on a missing nested `document` field, broke `mirror list` globally, and retried forever in the background.

## Verification

- regression for schema-incompatible legacy state
- existing corrupt/truncated-state regression
- all 54 `mdbase-connect-mirror` tests
- strict Clippy
- cargo fmt and diff checks