### PR TITLE
Isolate mirrors that require prerelease rebuild

### DIFF
--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -280,6 +280,7 @@ interface DesktopMirrorSummary {
     completed: number;
     total: number | null;
   };
+  error_code?: string;
   error?: string;
 }
 

--- a/apps/desktop/src/renderer/view-model.ts
+++ b/apps/desktop/src/renderer/view-model.ts
@@ -66,6 +66,9 @@ export function mirrorState(mirror: DesktopMirrorSummary | undefined): {
     };
   }
   if (mirror.syncing) return { dot: "connecting", label: "Synchronizing" };
+  if (mirror.error_code === "mirror_state_upgrade_required") {
+    return { dot: "danger", label: "Synced folder must be rebuilt" };
+  }
   if (mirror.error || mirror.state === "offline") return { dot: "danger", label: "Synced folder needs attention" };
   if (mirror.conflicts.length > 0) return { dot: "paused", label: "Conflicts need a decision" };
   if (mirror.local_issues.length > 0 || mirror.state === "attention") return { dot: "paused", label: "Local files need attention" };

--- a/crates/connect-agent/src/mirrors/commands.rs
+++ b/crates/connect-agent/src/mirrors/commands.rs
@@ -5,7 +5,7 @@ impl MirrorManager {
         let entries = self.entries();
         let mut summaries = Vec::with_capacity(entries.len());
         for entry in entries {
-            summaries.push(self.summary(&entry)?);
+            summaries.push(self.list_summary(&entry));
         }
         summaries.sort_by(|left, right| {
             left.name

--- a/crates/connect-agent/src/mirrors/runtime.rs
+++ b/crates/connect-agent/src/mirrors/runtime.rs
@@ -40,6 +40,7 @@ impl MirrorManager {
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut workers = JoinSet::new();
             let mut retries = HashMap::<Uuid, BackgroundRetry>::new();
+            let mut blocked = HashSet::<Uuid>::new();
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
@@ -57,9 +58,11 @@ impl MirrorManager {
                             .map(|entry| entry.replica_id)
                             .collect::<HashSet<_>>();
                         retries.retain(|replica_id, _| actionable.contains(replica_id));
+                        blocked.retain(|replica_id| actionable.contains(replica_id));
                         let now = Instant::now();
                         for entry in entries.into_iter().filter(|entry| {
                             actionable.contains(&entry.replica_id)
+                                && !blocked.contains(&entry.replica_id)
                                 && retries
                                     .get(&entry.replica_id)
                                     .is_none_or(|retry| retry.at <= now)
@@ -81,8 +84,19 @@ impl MirrorManager {
                         match completed {
                             Some(Ok((replica_id, Ok(())))) => {
                                 retries.remove(&replica_id);
+                                blocked.remove(&replica_id);
                             }
                             Some(Ok((_, Err(error)))) if error.code() == "mirror_sync_skipped" => {}
+                            Some(Ok((replica_id, Err(error)))) if terminal_background_error(&error) => {
+                                retries.remove(&replica_id);
+                                blocked.insert(replica_id);
+                                tracing::warn!(
+                                    replica_id = %replica_id,
+                                    code = error.code(),
+                                    error = %error,
+                                    "hosted mirror background sync requires operator action"
+                                );
+                            }
                             Some(Ok((replica_id, Err(error)))) => {
                                 let retry = retries.entry(replica_id).or_default();
                                 retry.failures = retry.failures.saturating_add(1);

--- a/crates/connect-agent/src/mirrors/support.rs
+++ b/crates/connect-agent/src/mirrors/support.rs
@@ -139,6 +139,10 @@ pub(super) fn background_retry_delay(replica_id: Uuid, failures: u32) -> Duratio
     Duration::from_millis(millis as u64)
 }
 
+pub(super) fn terminal_background_error(error: &ConnectError) -> bool {
+    error.code() == "mirror_state_upgrade_required"
+}
+
 pub(super) fn computer_name() -> String {
     std::env::var("HOSTNAME")
         .or_else(|_| std::env::var("COMPUTERNAME"))

--- a/crates/connect-agent/src/mirrors/synchronization.rs
+++ b/crates/connect-agent/src/mirrors/synchronization.rs
@@ -1,6 +1,11 @@
 use super::*;
 
 impl MirrorManager {
+    pub(super) fn list_summary(&self, entry: &MirrorRegistryEntry) -> MirrorSummary {
+        self.summary(entry)
+            .unwrap_or_else(|error| unavailable_summary(entry, error.code(), error.to_string()))
+    }
+
     pub(super) fn summary(
         &self,
         entry: &MirrorRegistryEntry,
@@ -62,6 +67,7 @@ impl MirrorManager {
                     }
                     .to_string(),
                 }),
+            error_code: error.as_ref().map(|_| "mirror_runtime_error".to_string()),
             error,
         })
     }
@@ -338,5 +344,41 @@ impl MirrorManager {
 
     pub(super) async fn revoke_remote(&self, replica_id: Uuid) -> Result<(), ConnectError> {
         self.cloud()?.revoke_hosted_replica(replica_id).await
+    }
+}
+
+pub(super) fn unavailable_summary(
+    entry: &MirrorRegistryEntry,
+    error_code: &str,
+    error: String,
+) -> MirrorSummary {
+    MirrorSummary {
+        collection_id: entry.collection_id,
+        replica_id: entry.replica_id,
+        name: entry.name.clone(),
+        mode: entry.mode,
+        selective_sync: entry.selective_sync.clone(),
+        path: entry.path.to_string_lossy().to_string(),
+        state: MirrorState::Offline,
+        pending: 0,
+        conflicts: Vec::new(),
+        local_issues: Vec::new(),
+        cursor: None,
+        last_synced_at: None,
+        syncing: false,
+        promotion_pending: entry.promotion.is_some(),
+        promotion: entry
+            .promotion
+            .as_ref()
+            .map(|checkpoint| MirrorPromotionSummary {
+                phase: match checkpoint.phase {
+                    MirrorPromotionPhase::Requested => "awaiting_approval",
+                    MirrorPromotionPhase::Prepared => "verifying",
+                    MirrorPromotionPhase::Registered => "activating",
+                }
+                .to_string(),
+            }),
+        error_code: Some(error_code.to_string()),
+        error: Some(error),
     }
 }

--- a/crates/connect-agent/src/mirrors/tests.rs
+++ b/crates/connect-agent/src/mirrors/tests.rs
@@ -65,3 +65,49 @@ fn background_retry_is_bounded_and_jittered() {
     assert!((Duration::from_secs(4 * 60)..=MAX_BACKGROUND_BACKOFF).contains(&saturated));
     assert_ne!(first, SYNC_INTERVAL);
 }
+
+#[test]
+fn prerelease_state_upgrade_blocks_background_retry() {
+    let upgrade = mirror_error(
+        "mirror_state_upgrade_required",
+        "Rebuild this prerelease mirror.",
+    );
+    let transient = mirror_error("mirror_transport_failed", "Try again.");
+
+    assert!(terminal_background_error(&upgrade));
+    assert!(!terminal_background_error(&transient));
+}
+
+#[test]
+fn unavailable_mirror_summary_is_structured_and_local_to_one_replica() {
+    let temporary = tempfile::tempdir().unwrap();
+    let entry = MirrorRegistryEntry {
+        collection_id: Uuid::new_v4(),
+        replica_id: Uuid::new_v4(),
+        name: "Legacy".to_string(),
+        mode: SyncReplicaMode::ReadWrite,
+        selective_sync: SelectiveSyncPolicy::default(),
+        path: temporary.path().join("legacy"),
+        sync_url: "https://sync.example/v1/authority".to_string(),
+        control_url: "https://connect.example".to_string(),
+        enrollment_id: Uuid::new_v4(),
+        access_token_expires_at: "2026-08-08T00:00:00Z".to_string(),
+        created_at: "2026-08-07T00:00:00Z".to_string(),
+        lifecycle: MirrorLifecycle::Active,
+        promotion: None,
+    };
+
+    let summary = synchronization::unavailable_summary(
+        &entry,
+        "mirror_state_upgrade_required",
+        "Rebuild this prerelease mirror.".to_string(),
+    );
+
+    assert_eq!(summary.replica_id, entry.replica_id);
+    assert_eq!(summary.state, MirrorState::Offline);
+    assert_eq!(
+        summary.error_code.as_deref(),
+        Some("mirror_state_upgrade_required")
+    );
+    assert_eq!(summary.pending, 0);
+}

--- a/crates/connect-protocol/src/sync.rs
+++ b/crates/connect-protocol/src/sync.rs
@@ -58,6 +58,8 @@ pub struct MirrorSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub promotion: Option<MirrorPromotionSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 


### PR DESCRIPTION
## Outcome

A permanently incompatible prerelease mirror no longer breaks `mirror list` for every replica or retries forever in the background.

- list results isolate status failures per replica
- summaries include a structured `error_code`
- `mirror_state_upgrade_required` becomes an operator-action terminal condition for that replica
- other transient errors retain bounded jittered retry
- desktop labels the condition as a required rebuild

## Live evidence

The upgraded beta.36 registry contains two incompatible replicas. Before this change, list failed globally and both were retried indefinitely. With this build, both are independently returned as offline with `error_code: mirror_state_upgrade_required`; exactly one operator-action warning is logged per replica and no retry occurs.

## Verification

- 38 daemon tests
- 36 protocol tests
- strict Clippy
- desktop TypeScript checks and all 53 desktop tests
- architecture check: 532 production files / 1,140 relative imports / 14 packages
- live two-entry legacy registry verification