### PR TITLE
Make idle sync a durable no-op

### DIFF
--- a/crates/connect-mirror/src/directory_plan.rs
+++ b/crates/connect-mirror/src/directory_plan.rs
@@ -89,6 +89,15 @@ impl DirectoryMirror {
                 }),
             ));
         }
+        if plan.actions.is_empty() {
+            return Ok(result(
+                "applied",
+                &plan,
+                self.status_from_state(inspection.prior),
+                0,
+                None,
+            ));
+        }
         let mut state = self.prepare_batch(inspection)?;
         self.apply_prepared(&mut state).await
     }

--- a/crates/connect-mirror/src/sync_planner.rs
+++ b/crates/connect-mirror/src/sync_planner.rs
@@ -200,30 +200,35 @@ pub fn plan_reconciliation(
     }
     drafts = order_local_path_transitions(drafts, &inspection.objects)?;
     drafts = order_remote_path_transitions(drafts, &inspection.objects)?;
-    let effect_keys = drafts
-        .iter()
-        .map(|draft| draft.key.clone())
-        .collect::<Vec<_>>();
-    drafts.push(Draft {
-        key: "checkpoint".into(),
-        dependency_keys: effect_keys,
-        action: SyncAction::AdvanceCheckpoint {
-            action_id: String::new(),
-            depends_on: Vec::new(),
-            reason: if inspection.kind == "incremental" {
-                SyncPlanReason::RemoteChange
-            } else if inspection.kind == "rebuild" {
-                SyncPlanReason::Rebuild
-            } else {
-                SyncPlanReason::Initial
+    let requires_checkpoint = !drafts.is_empty()
+        || inspection.kind != "incremental"
+        || inspection.boundary.checkpoint.cursor != Some(inspection.boundary.authority_cursor);
+    if requires_checkpoint {
+        let effect_keys = drafts
+            .iter()
+            .map(|draft| draft.key.clone())
+            .collect::<Vec<_>>();
+        drafts.push(Draft {
+            key: "checkpoint".into(),
+            dependency_keys: effect_keys,
+            action: SyncAction::AdvanceCheckpoint {
+                action_id: String::new(),
+                depends_on: Vec::new(),
+                reason: if inspection.kind == "incremental" {
+                    SyncPlanReason::RemoteChange
+                } else if inspection.kind == "rebuild" {
+                    SyncPlanReason::Rebuild
+                } else {
+                    SyncPlanReason::Initial
+                },
+                expected: inspection.boundary.checkpoint.clone(),
+                next: SyncCheckpoint {
+                    generation: inspection.boundary.checkpoint.generation + 1,
+                    cursor: Some(inspection.boundary.authority_cursor),
+                },
             },
-            expected: inspection.boundary.checkpoint.clone(),
-            next: SyncCheckpoint {
-                generation: inspection.boundary.checkpoint.generation + 1,
-                cursor: Some(inspection.boundary.authority_cursor),
-            },
-        },
-    });
+        });
+    }
     let mut ids = BTreeMap::new();
     for draft in &drafts {
         ids.insert(draft.key.clone(), draft_id(draft, &inspection.boundary)?);

--- a/crates/connect-mirror/src/tests.rs
+++ b/crates/connect-mirror/src/tests.rs
@@ -633,6 +633,40 @@ async fn metadata_only_mirror_checkpoints_file_changes_without_materializing() {
 }
 
 #[tokio::test]
+async fn exact_incremental_sync_is_a_stable_zero_write_no_op() {
+    let source = record("notes/one.md", "One");
+    let (_temporary, mirror, _authority) = harness(SyncReplicaMode::ReadOnly, vec![source]);
+    mirror.sync().await.unwrap();
+
+    let state_before = fs::read(&mirror.state_file).unwrap();
+    let modified_before = fs::metadata(&mirror.state_file)
+        .unwrap()
+        .modified()
+        .unwrap();
+    let generation_before = mirror.read_state().unwrap().unwrap().generation;
+    let plan_before = mirror.inspect().await.unwrap();
+    assert!(plan_before.actions.is_empty());
+
+    mirror.sync().await.unwrap();
+
+    assert_eq!(fs::read(&mirror.state_file).unwrap(), state_before);
+    assert_eq!(
+        fs::metadata(&mirror.state_file)
+            .unwrap()
+            .modified()
+            .unwrap(),
+        modified_before
+    );
+    assert_eq!(
+        mirror.read_state().unwrap().unwrap().generation,
+        generation_before
+    );
+    let plan_after = mirror.inspect().await.unwrap();
+    assert!(plan_after.actions.is_empty());
+    assert_eq!(plan_after.fingerprint, plan_before.fingerprint);
+}
+
+#[tokio::test]
 async fn initial_snapshot_materializes_only_selected_file_classes_and_folders() {
     let replica_id = Uuid::new_v4();
     let authority = FakeAuthority::new(replica_id, SyncReplicaMode::ReadOnly, Vec::new());
@@ -1099,7 +1133,7 @@ async fn changing_folder_exclusions_reconciles_markdown_without_deleting_authori
 }
 
 #[tokio::test]
-async fn successful_sync_prunes_only_unreferenced_complete_file_blobs() {
+async fn effectful_sync_prunes_only_unreferenced_complete_file_blobs() {
     let replica_id = Uuid::new_v4();
     let authority = FakeAuthority::new(replica_id, SyncReplicaMode::ReadOnly, Vec::new());
     let file = authority.put_file(
@@ -1111,7 +1145,7 @@ async fn successful_sync_prunes_only_unreferenced_complete_file_blobs() {
         file_classes: vec![FileMediaClass::Image],
         excluded_folders: Vec::new(),
     };
-    let (_temporary, mirror, _authority) = custom_harness_with_selective_sync(authority, policy);
+    let (_temporary, mirror, authority) = custom_harness_with_selective_sync(authority, policy);
     mirror.sync().await.unwrap();
     let cache = mirror.state_file.parent().unwrap().join("file-blobs");
     let retained = cache.join(file.content_digest.strip_prefix("sha256:").unwrap());
@@ -1119,6 +1153,7 @@ async fn successful_sync_prunes_only_unreferenced_complete_file_blobs() {
     let incomplete = cache.join(format!("{}.download.tmp", "11".repeat(32)));
     fs::write(&stale, b"unreferenced").unwrap();
     fs::write(&incomplete, b"incomplete").unwrap();
+    authority.emit_put(record("trigger.md", "Trigger cache maintenance"));
 
     mirror.sync().await.unwrap();
 

--- a/packages/sync/src/directory-mirror.ts
+++ b/packages/sync/src/directory-mirror.ts
@@ -163,6 +163,14 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
         { code, message: value.message }
       );
     }
+    if (plan.actions.length === 0) {
+      return mirrorApplyResult(
+        "applied",
+        plan,
+        checkpointMirrorStatus(inspection.prior, this.mode),
+        0
+      );
+    }
     if (
       inspection.prior
       && plan.actions.length === 1

--- a/packages/sync/src/mirror.test.ts
+++ b/packages/sync/src/mirror.test.ts
@@ -1238,7 +1238,7 @@ describe("platform-neutral directory mirror", () => {
     });
   });
 
-  it("checkpoints a 2,000-record no-op sync only once", async () => {
+  it("makes a 2,000-record no-op sync a zero-write operation", async () => {
     const hosted = new MemoryAuthority({ snapshotPageSize: 100 });
     hosted.seed(records(2_000));
     const replicaId = hosted.registerReplica({ name: "Large mobile vault", mode: "read_only" });
@@ -1253,10 +1253,17 @@ describe("platform-neutral directory mirror", () => {
     await mirror.sync();
     fileSystem.reads = 0;
     const writesBefore = stateStore.writes;
+    const stateBefore = await stateStore.read();
+    const planBefore = await mirror.inspect();
     await mirror.sync();
+    const stateAfter = await stateStore.read();
+    const planAfter = await mirror.inspect();
 
-    expect(fileSystem.reads).toBe(2_000);
+    expect(fileSystem.reads).toBe(6_000);
     expect(fileSystem.writes).toBe(2_000);
-    expect(stateStore.writes - writesBefore).toBe(1);
+    expect(stateStore.writes - writesBefore).toBe(0);
+    expect(stateAfter).toEqual(stateBefore);
+    expect(planBefore.actions).toEqual([]);
+    expect(planAfter.fingerprint).toBe(planBefore.fingerprint);
   });
 });

--- a/packages/sync/src/sync-planner.test.ts
+++ b/packages/sync/src/sync-planner.test.ts
@@ -92,6 +92,35 @@ function inspected(
 }
 
 describe("pure exact-document planner", () => {
+  it("emits a stable empty plan for an exact incremental inspection", () => {
+    const idle = summary([]);
+    idle.boundary.authority_cursor = idle.boundary.checkpoint.cursor!;
+
+    const first = planReconciliation(idle, digest);
+    const second = planReconciliation(structuredClone(idle), digest);
+
+    expect(first.actions).toEqual([]);
+    expect(first.summary).toEqual({
+      uploads: 0,
+      downloads: 0,
+      conflicts: 0,
+      blocking_issues: 0
+    });
+    expect(second.fingerprint).toBe(first.fingerprint);
+  });
+
+  it("checkpoints a cursor advance even when projection filters every effect", () => {
+    const plan = planReconciliation(summary([]), digest);
+
+    expect(plan.actions).toEqual([
+      expect.objectContaining({
+        command: "advance_checkpoint",
+        expected: { generation: 3, cursor: 11 },
+        next: { generation: 4, cursor: 19 }
+      })
+    ]);
+  });
+
   it("matches the shared cross-runtime canonical plan fixture", async () => {
     const identity = "22222222-2222-4222-8222-222222222222";
     const base = ref(identity, "notes/parity.md", "base");

--- a/packages/sync/src/sync-planner.ts
+++ b/packages/sync/src/sync-planner.ts
@@ -149,18 +149,23 @@ export function planReconciliation(
   }
   drafts = orderLocalPathTransitions(drafts, inspection.objects, digest);
   drafts = orderRemotePathTransitions(drafts, inspection.objects);
-  const effectKeys = drafts.map((draft) => draft.key);
-  drafts.push({
-    key: "checkpoint",
-    depends_on_keys: effectKeys,
-    command: "advance_checkpoint",
-    reason: inspection.kind === "incremental" ? "remote_change" : inspection.kind,
-    expected: inspection.boundary.checkpoint,
-    next: {
-      generation: inspection.boundary.checkpoint.generation + 1,
-      cursor: inspection.boundary.authority_cursor
-    }
-  } satisfies ActionDraft);
+  const requiresCheckpoint = drafts.length > 0
+    || inspection.kind !== "incremental"
+    || inspection.boundary.checkpoint.cursor !== inspection.boundary.authority_cursor;
+  if (requiresCheckpoint) {
+    const effectKeys = drafts.map((draft) => draft.key);
+    drafts.push({
+      key: "checkpoint",
+      depends_on_keys: effectKeys,
+      command: "advance_checkpoint",
+      reason: inspection.kind === "incremental" ? "remote_change" : inspection.kind,
+      expected: inspection.boundary.checkpoint,
+      next: {
+        generation: inspection.boundary.checkpoint.generation + 1,
+        cursor: inspection.boundary.authority_cursor
+      }
+    } satisfies ActionDraft);
+  }
 
   const ids = new Map<string, string>();
   for (const draft of drafts) {


### PR DESCRIPTION
## Summary
- omit checkpoints from exact incremental plans when neither effects nor cursor advancement exist
- apply empty reviewed plans without preparing a journal, pruning caches, or writing durable state
- preserve checkpoint-only plans for initialization, rebuilds, and filtered cursor advances
- enforce identical behavior in the TypeScript and Rust engines

## Verification
- `pnpm test:fast`
- `cargo clippy -p mdbase-connect-mirror --all-targets -- -D warnings`
- `pnpm check:architecture`
- `pnpm profile:mirror:check`
- `pnpm check:mirror:mobile`
- focused durable byte/mtime/generation and 2,000-record zero-write regressions

The 10,000-record performance profiles now report `state_writes: 0` for every no-op case.