### PR TITLE
Prepare beta.40 release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,6 +1,7 @@
 name: Desktop Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,6 +1,7 @@
 name: Publish npm packages
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.0-beta.40
+
+Beta.40 completes the operational hardening found while upgrading and live
+testing beta.39's exact-document sync engine.
+
+- Incompatible prerelease mirror state is identified from its minimal version
+  envelope before current-schema decoding, so upgrades fail at the deliberate
+  rebuild boundary rather than at an incidental nested field.
+- A blocked legacy mirror no longer hides healthy replicas or retries forever;
+  list results isolate its structured error and background scheduling waits for
+  operator rebuild.
+- An exact idle incremental inspection is now a stable empty plan. Applying it
+  performs no journal, checkpoint, cache, generation, timestamp, or durable
+  state write, while real cursor advances and effectful plans still checkpoint.
+- Tag-triggered npm and desktop publishers may be manually rerun against the
+  exact existing tag after an Actions outage.
+
 ## 0.1.0-beta.39
 
 Beta.39 deliberately rewrites the unreleased sync-v1 contract around exact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "async-trait",
  "axum",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "async-trait",
  "axum",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.39"
+version = "0.1.0-beta.40"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,10 +144,15 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.39
-git tag -a v0.1.0-beta.39 -m "mdbase connect 0.1.0-beta.39"
-git push origin v0.1.0-beta.39
+pnpm version:check v0.1.0-beta.40
+git tag -a v0.1.0-beta.40 -m "mdbase connect 0.1.0-beta.40"
+git push origin v0.1.0-beta.40
 ```
+
+If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,
+dispatch the same workflow manually and select that exact existing tag as the
+workflow ref. The workflow's existing tag/version checks remain authoritative;
+do not dispatch it from a branch or substitute a different commit.
 
 The tag starts the only full desktop build. The four platform builders do not
 open deployment records; the single publish job enters the `desktop-release`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.39" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.40" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.39",
+  "version": "0.1.0-beta.40",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- coordinate current main as `0.1.0-beta.40`, including the live-found upgrade isolation and durable no-op fixes
- add changelog/release metadata across Rust, npm, desktop, portal, server, and MCP surfaces
- allow exact-tag manual dispatch of npm and desktop release workflows after stale Actions queue records

## Verification
- `pnpm version:check v0.1.0-beta.40`
- `pnpm check:release-readiness`
- `pnpm check:npm-bootstrap`
- `pnpm check:architecture`
- locked Cargo metadata and exact hosted-provider lockfile parity
- sync/protocol/MCP build and test suites

The preceding source commits also passed the complete `pnpm test:fast`, strict mirror Clippy, mobile, architecture, and 10,000-record performance gates.