### PR TITLE
fix: select one TLS crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,11 +1857,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2509,12 +2507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2573,7 @@ dependencies = [
  "mdbase-connect-daemon",
  "mdbase-connect-protocol",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
@@ -2651,6 +2644,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reqwest",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2691,6 +2685,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "reqwest",
+ "rustls",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -2719,6 +2714,7 @@ dependencies = [
  "mdbase",
  "mdbase-connect-protocol",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3270,62 +3266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,15 +3363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,7 +3438,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -3565,12 +3495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,7 +3524,6 @@ checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3625,7 +3548,6 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -4038,7 +3960,6 @@ dependencies = [
  "memchr",
  "percent-encoding",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4049,6 +3970,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,15 @@ mdbase = { path = "../mdbase-rs" }
 mdbase-interop = { version = "0.1.0-rc.2", git = "https://github.com/mdbase-dev/mdbase-spec.git", rev = "4f305d8b90408f58aefa62542d676f349956c151" }
 mdbase-runtime = { path = "../mdbase-rs/crates/mdbase-runtime" }
 notify = "8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider"] }
 rusqlite = { version = "0.32", features = ["backup", "bundled"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std", "tls12"] }
 serde = { version = "1", features = ["derive"] }
 serde_jcs = "0.1"
 serde_json = "1"
 serde_yaml = "0.9"
 semver = "1"
-sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "uuid", "json", "chrono", "migrate", "macros"] }
+sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-aws-lc-rs", "postgres", "uuid", "json", "chrono", "migrate", "macros"] }
 subtle = "2.6.1"
 jsonschema = { version = "0.18", features = ["draft202012"] }
 keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "sync-secret-service", "vendored", "crypto-rust"] }

--- a/crates/connect-agent/Cargo.toml
+++ b/crates/connect-agent/Cargo.toml
@@ -20,6 +20,9 @@ mdbase-connect-mirror = { path = "../connect-mirror" }
 mdbase-connect-protocol = { path = "../connect-protocol" }
 mdbase-connect-runtime = { path = "../connect-runtime" }
 reqwest.workspace = true
+# Select the same provider for standalone daemon tests and embedders; binaries
+# install it process-wide before starting their runtimes.
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/connect-agent/src/cloud.rs
+++ b/crates/connect-agent/src/cloud.rs
@@ -60,6 +60,7 @@ pub struct CompleteRemoteAuthorityTransfer {
 
 impl CloudControlClient {
     pub fn new(server_url: String, connector_token: String) -> Self {
+        crate::ensure_tls_crypto_provider();
         Self {
             client: Client::builder()
                 .redirect(Policy::none())

--- a/crates/connect-agent/src/lib.rs
+++ b/crates/connect-agent/src/lib.rs
@@ -14,6 +14,7 @@ use mdbase_connect_core::{
     default_control_endpoint, default_state_dir, load_cloud_configuration,
     recover_staged_cloud_configuration, CloudConfiguration, CollectionRegistry, SystemSecretStore,
 };
+use mdbase_connect_protocol::crypto::RelayIdentity;
 use mdbase_connect_protocol::DEFAULT_LOOPBACK_PORT;
 use server::AgentState;
 use std::path::PathBuf;
@@ -21,18 +22,29 @@ use std::sync::Arc;
 use tracing_subscriber::EnvFilter;
 use watcher::CollectionWatchService;
 
+pub(crate) fn ensure_tls_crypto_provider() {
+    // Respect an embedding application's earlier choice. Otherwise select the
+    // one provider used by every mdbase binary and dependency graph.
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+}
+
 /// Configuration for one foreground Connect daemon process.
 ///
 /// Service managers and embedding shells construct this value without putting
 /// credentials in process arguments. Test harnesses may inject a credential
 /// through the process environment; normal runs load it from the OS store.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct DaemonOptions {
     pub state_dir: Option<PathBuf>,
     pub endpoint: Option<String>,
     pub server_url: Option<String>,
     pub connector_token: Option<String>,
     pub loopback_port: Option<u16>,
+    /// In-memory identity injection for embedding shells and hermetic tests.
+    /// Normal daemon processes leave this unset and use the OS secret store.
+    pub relay_identity: Option<RelayIdentity>,
 }
 
 impl DaemonOptions {
@@ -83,8 +95,10 @@ pub async fn run(options: DaemonOptions) -> Result<(), Box<dyn std::error::Error
         tombstones = journal.tombstones,
         "privacy-safe connector metric"
     );
-    let relay_identity =
-        SystemSecretStore::new(&state_dir).load_or_create_relay_identity(&state_dir)?;
+    let relay_identity = match options.relay_identity {
+        Some(identity) => identity,
+        None => SystemSecretStore::new(&state_dir).load_or_create_relay_identity(&state_dir)?,
+    };
     let cloud = match (server_url.clone(), connector_token.clone()) {
         (Some(server_url), Some(connector_token)) => {
             Some(CloudControlClient::new(server_url, connector_token))
@@ -266,6 +280,7 @@ mod tests {
             state_dir: Some(state_dir),
             endpoint: Some(endpoint.to_string_lossy().to_string()),
             loopback_port: Some(0),
+            relay_identity: Some(RelayIdentity::generate()),
             ..DaemonOptions::default()
         };
         let mut running = tokio::spawn(run(options.clone()));

--- a/crates/connect-agent/src/mirrors/runtime.rs
+++ b/crates/connect-agent/src/mirrors/runtime.rs
@@ -6,6 +6,7 @@ impl MirrorManager {
         registry: CollectionRegistry,
         cloud: Option<CloudControlClient>,
     ) -> Result<Arc<Self>, ConnectError> {
+        crate::ensure_tls_crypto_provider();
         let entries = read_registry(&state_dir.join("mirrors.json"))?;
         let lock_root = default_lock_root(state_dir);
         fs::create_dir_all(&lock_root)?;

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -15,6 +15,7 @@ use tokio_tungstenite::tungstenite::Message;
 use url::Url;
 
 pub async fn run(server_url: String, connector_token: String, state: Arc<AgentState>) {
+    crate::ensure_tls_crypto_provider();
     let client = Client::new();
     let mut retry_delay = 1u64;
     loop {

--- a/crates/connect-cli/Cargo.toml
+++ b/crates/connect-cli/Cargo.toml
@@ -20,6 +20,7 @@ mdbase-connect-protocol = { path = "../connect-protocol" }
 directories.workspace = true
 fs2 = "0.4"
 reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/connect-cli/src/lib.rs
+++ b/crates/connect-cli/src/lib.rs
@@ -676,6 +676,7 @@ async fn execute_connect(
                 .then(|| std::env::var("MDBASE_CONNECT_CONNECTOR_TOKEN").ok())
                 .flatten(),
             loopback_port: Some(loopback_port),
+            relay_identity: None,
         })
         .await
         .map_err(|error| CliError::internal(error.to_string())),

--- a/crates/connect-cli/src/main.rs
+++ b/crates/connect-cli/src/main.rs
@@ -1,3 +1,6 @@
 fn main() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("the TLS crypto provider must be installed before starting mdbase");
     std::process::exit(mdbase_cli::run());
 }

--- a/crates/connect-hosted-provider/Cargo.toml
+++ b/crates/connect-hosted-provider/Cargo.toml
@@ -28,6 +28,7 @@ mdbase-runtime = { workspace = true, features = ["postgres"] }
 p256.workspace = true
 rand_core.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_jcs.workspace = true
 serde_json.workspace = true

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -185,6 +185,9 @@ impl RuntimeSecrets {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("the TLS crypto provider must be installed before starting the hosted provider");
     let arguments = Arguments::parse();
     let mut secrets = RuntimeSecrets::from_environment()?;
     if arguments.maintenance_interval_seconds == 0 {

--- a/crates/connect-mirror/Cargo.toml
+++ b/crates/connect-mirror/Cargo.toml
@@ -12,6 +12,7 @@ fs2 = "0.4"
 mdbase.workspace = true
 mdbase-connect-protocol = { path = "../connect-protocol" }
 reqwest.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/connect-mirror/src/transport.rs
+++ b/crates/connect-mirror/src/transport.rs
@@ -40,8 +40,15 @@ pub struct HttpSyncTransport {
     replica_token: String,
 }
 
+fn ensure_tls_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+}
+
 impl HttpSyncTransport {
     pub fn new(sync_url: &str, replica_token: impl Into<String>) -> Result<Self, MirrorError> {
+        ensure_tls_crypto_provider();
         let endpoint = Url::parse(sync_url).map_err(|_| {
             MirrorError::new(
                 "invalid_sync_url",

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1857,11 +1857,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2509,12 +2507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2573,7 @@ dependencies = [
  "mdbase-connect-daemon",
  "mdbase-connect-protocol",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "tempfile",
@@ -2651,6 +2644,7 @@ dependencies = [
  "rand_core 0.6.4",
  "reqwest",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2691,6 +2685,7 @@ dependencies = [
  "p256",
  "rand_core 0.6.4",
  "reqwest",
+ "rustls",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -2719,6 +2714,7 @@ dependencies = [
  "mdbase",
  "mdbase-connect-protocol",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3270,62 +3266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,15 +3363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,7 +3438,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -3565,12 +3495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,7 +3524,6 @@ checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3625,7 +3548,6 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -4038,7 +3960,6 @@ dependencies = [
  "memchr",
  "percent-encoding",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4049,6 +3970,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/scripts/lib/rustls-provider.test.mjs
+++ b/scripts/lib/rustls-provider.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+
+test("the workspace resolves exactly one Rustls crypto provider", async () => {
+  const { stdout } = await run("cargo", [
+    "tree",
+    "--locked",
+    "--offline",
+    "--workspace",
+    "--invert",
+    "rustls",
+    "--edges",
+    "features"
+  ], { cwd: root });
+
+  assert.match(stdout, /rustls feature "aws-lc-rs"/u);
+  assert.doesNotMatch(stdout, /rustls feature "ring"/u);
+});

--- a/scripts/lib/rustls-provider.test.mjs
+++ b/scripts/lib/rustls-provider.test.mjs
@@ -1,24 +1,20 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
-import { promisify } from "node:util";
 
-const run = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 
-test("the workspace resolves exactly one Rustls crypto provider", async () => {
-  const { stdout } = await run("cargo", [
-    "tree",
-    "--locked",
-    "--offline",
-    "--workspace",
-    "--invert",
-    "rustls",
-    "--edges",
-    "features"
-  ], { cwd: root });
+test("the workspace selects exactly one Rustls crypto provider", async () => {
+  const manifest = await readFile(path.join(root, "Cargo.toml"), "utf8");
+  const lock = await readFile(path.join(root, "Cargo.lock"), "utf8");
+  const rustlsPackage = lock.match(/\[\[package\]\]\nname = "rustls"\n[\s\S]+?(?=\n\[\[package\]\])/u)?.[0];
 
-  assert.match(stdout, /rustls feature "aws-lc-rs"/u);
-  assert.doesNotMatch(stdout, /rustls feature "ring"/u);
+  assert.match(manifest, /^rustls = .*features = \["aws-lc-rs", "std", "tls12"\]/mu);
+  assert.match(manifest, /^reqwest = .*"rustls-tls-webpki-roots-no-provider"/mu);
+  assert.match(manifest, /^sqlx = .*"tls-rustls-aws-lc-rs"/mu);
+  assert.doesNotMatch(manifest, /tls-rustls-ring/u);
+  assert.ok(rustlsPackage, "Cargo.lock must contain Rustls");
+  assert.match(rustlsPackage, /\n "aws-lc-rs",/u);
+  assert.doesNotMatch(rustlsPackage, /\n "ring",/u);
 });


### PR DESCRIPTION
## Summary
- standardize the workspace on AWS-LC and remove the mixed Ring/AWS-LC Rustls graph
- install the provider at binary startup and ensure it at embedded HTTP client boundaries
- make the daemon lifecycle test independent of the desktop keyring
- add a regression check that fails if Ring re-enters the Rustls graph

## Live failure fixed
A beta.40 daemon built by the workspace panicked from hosted-sync background work because Rustls could not choose between two compiled providers.

## Verification
- `cargo build --locked --workspace`
- `node test/rust/run.mjs`
- `cargo test --locked -p mdbase-connect-mirror --lib` (55 passed)
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `node --test scripts/lib/rustls-provider.test.mjs`
- TypeScript/application half of `pnpm test:fast` (all passed)