### PR TITLE
ci: harden prerelease verification and desktop contracts

### DIFF
--- a/.github/workflows/editor-pages.yml
+++ b/.github/workflows/editor-pages.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Verify production assets
         run: node apps/editor/scripts/verify-deployment-assets.mjs apps/editor/dist/assets https://editor.mdbase.dev/
         env:
-          MDBASE_ASSET_VERIFY_ATTEMPTS: 12
+          MDBASE_ASSET_VERIFY_ATTEMPTS: 61
           MDBASE_ASSET_VERIFY_DELAY_MS: 5000
 
   deploy-cloudflare-staging:
@@ -133,5 +133,5 @@ jobs:
       - name: Verify staging assets
         run: node apps/editor/scripts/verify-deployment-assets.mjs apps/editor/dist/assets https://editor-staging.mdbase.dev/
         env:
-          MDBASE_ASSET_VERIFY_ATTEMPTS: 12
+          MDBASE_ASSET_VERIFY_ATTEMPTS: 61
           MDBASE_ASSET_VERIFY_DELAY_MS: 5000

--- a/apps/desktop/scripts/docker-server-e2e.mjs
+++ b/apps/desktop/scripts/docker-server-e2e.mjs
@@ -61,9 +61,7 @@ try {
   });
   const pairingWindow = await pairingApp.firstWindow({ timeout: 30_000 });
   pairingWindow.setDefaultTimeout(30_000);
-  await pairingWindow
-    .getByRole("heading", { name: "Connect this computer." })
-    .waitFor();
+  await waitForDesktopHeading(pairingWindow, "Connect this computer.");
   await pairingWindow
     .getByText("Use another Connect server", { exact: true })
     .click();
@@ -397,6 +395,33 @@ function launchDesktop(userData, connectorToken) {
         : {})
     }
   });
+}
+
+async function waitForDesktopHeading(window, name) {
+  try {
+    await window.getByRole("heading", { name }).waitFor();
+  } catch (error) {
+    const diagnostics = await Promise.race([
+      window.evaluate(() => ({
+        url: location.href,
+        title: document.title,
+        readyState: document.readyState,
+        body: document.body?.innerText.slice(0, 4_000) ?? ""
+      })),
+      new Promise((_, reject) => setTimeout(
+        () => reject(new Error("renderer diagnostics timed out")),
+        2_000
+      ))
+    ]).catch((diagnosticError) => ({
+      diagnosticError: diagnosticError instanceof Error
+        ? diagnosticError.message
+        : String(diagnosticError)
+    }));
+    throw new Error(
+      `Desktop did not render the expected heading: ${JSON.stringify(diagnostics)}`,
+      { cause: error }
+    );
+  }
 }
 
 async function closeDesktop(application) {

--- a/apps/desktop/src/main/control-client.ts
+++ b/apps/desktop/src/main/control-client.ts
@@ -1,7 +1,7 @@
 import { createConnection } from "node:net";
 import { randomUUID } from "node:crypto";
 
-const LOCAL_CONTROL_PROTOCOL_VERSION = 2;
+const LOCAL_CONTROL_PROTOCOL_VERSION = 3;
 const MAX_LOCAL_CONTROL_RESPONSE_BYTES = 32 * 1024 * 1024;
 
 export interface ControlResponse<T = unknown> {

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -135,16 +135,21 @@ describe("mdbase editor", () => {
     const title = row.querySelector(".note-title")?.textContent;
     expect(title).toBeTruthy();
 
-    fireEvent.mouseEnter(row);
-    await waitFor(() => expect(document.querySelector(".note-preview")).not.toBeNull(), { timeout: 1_500 });
-    const preview = screen.getByRole("tooltip");
-    expect(preview).toHaveAccessibleName(/Preview of/);
-    expect(preview.querySelector("header strong")?.textContent).toBeTruthy();
-    expect(preview.querySelector("header span")?.textContent).toMatch(/\.md$/);
-    expect(row).toHaveAttribute("aria-describedby", "note-preview-popover");
+    vi.useFakeTimers();
+    try {
+      fireEvent.mouseEnter(row);
+      await act(() => vi.advanceTimersByTimeAsync(400));
+      const preview = screen.getByRole("tooltip");
+      expect(preview).toHaveAccessibleName(/Preview of/);
+      expect(preview.querySelector("header strong")?.textContent).toBeTruthy();
+      expect(preview.querySelector("header span")?.textContent).toMatch(/\.md$/);
+      expect(row).toHaveAttribute("aria-describedby", "note-preview-popover");
 
-    fireEvent.mouseLeave(row);
-    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+      fireEvent.mouseLeave(row);
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not reload the collection index after saving one note", async () => {

--- a/scripts/lib/local-control-protocol.test.mjs
+++ b/scripts/lib/local-control-protocol.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const rustSource = await readFile(
+  new URL("../../crates/connect-protocol/src/lib.rs", import.meta.url),
+  "utf8"
+);
+const desktopSource = await readFile(
+  new URL("../../apps/desktop/src/main/control-client.ts", import.meta.url),
+  "utf8"
+);
+
+function protocolVersion(source, pattern, owner) {
+  const match = source.match(pattern);
+  assert.ok(match, `${owner} must declare the local control protocol version`);
+  return Number(match[1]);
+}
+
+test("the desktop and Rust daemon use one local control protocol", () => {
+  const rustVersion = protocolVersion(
+    rustSource,
+    /pub const LOCAL_CONTROL_PROTOCOL_VERSION: u32 = (\d+);/u,
+    "Rust protocol"
+  );
+  const desktopVersion = protocolVersion(
+    desktopSource,
+    /const LOCAL_CONTROL_PROTOCOL_VERSION = (\d+);/u,
+    "desktop client"
+  );
+  assert.equal(desktopVersion, rustVersion);
+});


### PR DESCRIPTION
Stabilizes prerelease verification at the actual asynchronous boundaries:

- allow the Cloudflare editor deployment enough time to expose every source-map asset while still verifying the complete asset set
- use deterministic fake timers for the hover-preview delay instead of a loaded-runner wall-clock race
- align the desktop local-control client with daemon protocol 3
- enforce the cross-language local-control version contract in normal CI
- emit bounded renderer diagnostics when Electron never reaches its expected readiness heading

The protocol mismatch was reproduced locally against the packaged Docker boundary; it raised a native startup modal and made the renderer appear to time out. After alignment, the full Docker-backed Electron pairing, authorization, operation routing, revocation, pause, and server-restart path passes.

Verification:
- editor: 39 files / 266 tests
- hover preview: 10 consecutive focused passes
- desktop: 53 tests
- local-control contract regression
- full packaged Docker-backed Electron E2E