### PR TITLE
fix(sync): make initial writable conflicts actionable

### DIFF
--- a/crates/connect-mirror/src/sync_inspector.rs
+++ b/crates/connect-mirror/src/sync_inspector.rs
@@ -352,7 +352,8 @@ impl DirectoryMirror {
                         object.remote.exact().unwrap().path
                     ),
                     path: Some(object.remote.exact().unwrap().path.clone()),
-                    blocking: true,
+                    blocking: self.mode != SyncReplicaMode::ReadWrite
+                        || object.entity == SyncObjectKind::Resource,
                 });
             }
             if self.mode == SyncReplicaMode::ReadOnly

--- a/crates/connect-mirror/src/tests.rs
+++ b/crates/connect-mirror/src/tests.rs
@@ -1425,6 +1425,53 @@ async fn initialization_collision_changes_nothing() {
 }
 
 #[tokio::test]
+async fn writable_initialization_collision_becomes_a_resolvable_conflict() {
+    let conflicted = record("one.md", "Remote one");
+    let independent = record("two.md", "Remote two");
+    let (_temporary, mirror, _authority) = harness(
+        SyncReplicaMode::ReadWrite,
+        vec![conflicted.clone(), independent.clone()],
+    );
+    fs::create_dir_all(mirror.root()).unwrap();
+    fs::write(mirror.root().join("one.md"), "important local content").unwrap();
+
+    let plan = mirror.inspect().await.unwrap();
+    assert_eq!(plan.summary.downloads, 2);
+    assert_eq!(plan.summary.conflicts, 1);
+    assert_eq!(plan.summary.blocking_issues, 0);
+    assert!(plan.issues.iter().any(|issue| {
+        issue.code == "local_collision"
+            && issue.path.as_deref() == Some("one.md")
+            && !issue.blocking
+    }));
+
+    let result = mirror.apply(&plan).await.unwrap();
+    assert_eq!(result.status, "attention");
+    assert_eq!(result.conflicts, 1);
+    let status = mirror.status().unwrap();
+    assert_eq!(status.conflicts.len(), 1);
+    assert_eq!(status.conflicts[0].record_id, conflicted.record_id);
+    assert_eq!(
+        fs::read_to_string(mirror.root().join("one.md")).unwrap(),
+        "important local content"
+    );
+    assert_eq!(
+        fs::read_to_string(mirror.root().join("two.md")).unwrap(),
+        independent.document
+    );
+
+    mirror
+        .resolve_conflict(conflicted.record_id, MirrorResolution::Remote)
+        .await
+        .unwrap();
+    assert_eq!(
+        fs::read_to_string(mirror.root().join("one.md")).unwrap(),
+        conflicted.document
+    );
+    assert!(mirror.status().unwrap().conflicts.is_empty());
+}
+
+#[tokio::test]
 async fn inspection_is_deterministic_read_only_and_apply_rejects_a_stale_plan() {
     let (_temporary, mirror, authority) = harness(SyncReplicaMode::ReadWrite, Vec::new());
 

--- a/packages/sync/src/mirror-files.test.ts
+++ b/packages/sync/src/mirror-files.test.ts
@@ -488,6 +488,42 @@ describe("portable collection file mirror", () => {
     expect(fileSystem.files.get("Archive 2/photo.png")).toEqual(neighborBytes);
   });
 
+  it("persists writable initialization file conflicts for explicit resolution", async () => {
+    const transport = new FileTransport();
+    const remoteBytes = utf8.encode("remote image bytes");
+    const localBytes = utf8.encode("important local image bytes");
+    const fileId = "00000000-0000-4000-8000-000000000012";
+    const descriptor = file(fileId, "images/collision.png", remoteBytes);
+    transport.files = [descriptor];
+    transport.bytes.set(fileId, remoteBytes);
+    const fileSystem = new BinaryFileSystem();
+    fileSystem.files.set(descriptor.path, localBytes);
+    const { mirror: target, stateStore } = writableMirror(transport, fileSystem);
+
+    const plan = await target.inspect();
+    expect(plan).toMatchObject({
+      kind: "initial",
+      summary: { conflicts: 1, blocking_issues: 0 },
+      issues: [{ code: "local_collision", path: descriptor.path, blocking: false }]
+    });
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "record_conflict", identity: fileId, entity: "file" })
+      ])
+    );
+
+    await expect(target.apply(plan)).resolves.toMatchObject({ status: "attention", conflicts: 1 });
+    expect(fileSystem.files.get(descriptor.path)).toEqual(localBytes);
+    expect((await stateStore.read())?.planned_conflicts).toHaveProperty(fileId);
+    expect(await target.status()).toMatchObject({
+      file_conflicts: [{ file_id: fileId, path: descriptor.path }]
+    });
+
+    await target.resolveFileConflict(fileId, "remote");
+    expect(fileSystem.files.get(descriptor.path)).toEqual(remoteBytes);
+    expect((await target.status()).file_conflicts).toEqual([]);
+  });
+
   it("matches excluded folders by portable Unicode identity", () => {
     const policy = {
       file_classes: ["image" as const],

--- a/packages/sync/src/mirror.test.ts
+++ b/packages/sync/src/mirror.test.ts
@@ -281,6 +281,48 @@ describe("platform-neutral directory mirror", () => {
     expect(await stateStore.read()).toBeNull();
   });
 
+  it("persists writable initialization conflicts while applying independent downloads", async () => {
+    const hosted = new MemoryAuthority();
+    hosted.seed(records(2));
+    const replicaId = hosted.registerReplica({ name: "Conflicted writer", mode: "read_write" });
+    const fileSystem = new TestFileSystem();
+    fileSystem.files.set("notes/00000.md", "important local bytes\n");
+    const stateStore = new MemoryMirrorStateStore();
+    const mirror = new WritableDirectoryMirror(replicaId, hosted.transport(replicaId), {
+      fileSystem,
+      stateStore,
+      runtime: deterministicRuntime()
+    });
+
+    const plan = await mirror.inspect();
+    expect(plan).toMatchObject({
+      kind: "initial",
+      summary: { downloads: 1, conflicts: 1, blocking_issues: 0 },
+      issues: [{ code: "local_collision", path: "notes/00000.md", blocking: false }]
+    });
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "record_conflict", identity: "portable-0" }),
+        expect.objectContaining({
+          command: "write_local",
+          target: expect.objectContaining({ path: "notes/00001.md" })
+        })
+      ])
+    );
+
+    await expect(mirror.apply(plan)).resolves.toMatchObject({
+      status: "attention",
+      conflicts: 1
+    });
+    expect(fileSystem.files.get("notes/00000.md")).toBe("important local bytes\n");
+    expect(fileSystem.files.get("notes/00001.md")).toBe(records(2)[1]!.document);
+    expect((await stateStore.read())?.planned_conflicts).toHaveProperty("portable-0");
+
+    await mirror.resolveConflict("portable-0", "remote");
+    expect(fileSystem.files.get("notes/00000.md")).toBe(records(2)[0]!.document);
+    expect((await stateStore.read())?.planned_conflicts).toEqual({});
+  });
+
   it("does not advance durable state when a mobile adapter fails mid-apply", async () => {
     const hosted = new MemoryAuthority({ snapshotPageSize: 1 });
     hosted.seed(records(3));

--- a/packages/sync/src/node.test.ts
+++ b/packages/sync/src/node.test.ts
@@ -444,7 +444,7 @@ describe("writable Markdown mirror", () => {
     }
   });
 
-  it("previews initial folder collisions before writing any hosted files", async () => {
+  it("persists initial folder conflicts while downloading independent hosted files", async () => {
     const hosted = new MemoryAuthority();
     const writer = hosted.registerReplica({ name: "Writer", mode: "read_write", allowedTypes: ["task"] });
     const replicaId = hosted.registerReplica({ name: "Writable laptop", mode: "read_write", allowedTypes: ["task"] });
@@ -466,9 +466,10 @@ describe("writable Markdown mirror", () => {
     });
     await expect(mirror.sync()).resolves.toMatchObject({
       status: "attention",
-      issues: [{ code: "local_collision", path: "b.md", blocking: true }]
+      conflicts: 1,
+      issues: [{ code: "local_collision", path: "b.md", blocking: false }]
     });
-    expect(fileSystem.files.has("a.md")).toBe(false);
+    expect(fileSystem.files.has("a.md")).toBe(true);
     expect(fileSystem.files.get("b.md")).toContain("title: Different");
   });
 

--- a/packages/sync/src/sync-inspector.ts
+++ b/packages/sync/src/sync-inspector.ts
@@ -411,7 +411,7 @@ export class PlanOnlyMirrorInspector<Frontmatter extends JsonObject = JsonObject
           code: "local_collision",
           message: `${object.remote.object.path} differs locally from the exact authority object.`,
           path: object.remote.object.path,
-          blocking: true
+          blocking: this.mode !== "read_write" || object.entity === "resource"
         });
       }
       if (


### PR DESCRIPTION
Writable initialization/rebuild divergence already has an exact `record_conflict` action, so classifying the same record or file as globally blocking deadlocks conflict persistence and resolution.

This keeps receive-only mirrors, authority resources, and cross-identity path ownership collisions blocking while allowing writable record/file conflicts to persist alongside independent safe actions.

Verification:
- 164 TypeScript sync tests
- 56 Rust mirror tests
- TypeScript sync typecheck
- Rust mirror Clippy with warnings denied
- Rust formatting and diff checks