### PR TITLE
Bound credential-store startup and preserve local control

### DIFF
--- a/crates/connect-agent/src/bootstrap.rs
+++ b/crates/connect-agent/src/bootstrap.rs
@@ -1,0 +1,155 @@
+use mdbase_connect_core::{
+    load_cloud_configuration, recover_staged_cloud_configuration, CloudConfiguration, ConnectError,
+    SystemSecretStore,
+};
+use mdbase_connect_protocol::crypto::RelayIdentity;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const SECRET_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(crate) enum SecretBootstrap {
+    Available {
+        server_url: Option<String>,
+        connector_token: Option<String>,
+        relay_identity: RelayIdentity,
+    },
+    Unavailable(String),
+}
+
+pub(crate) fn bounded_secret_bootstrap(
+    state_dir: PathBuf,
+    server_url: Option<String>,
+    connector_token: Option<String>,
+    relay_identity: Option<RelayIdentity>,
+) -> Result<SecretBootstrap, ConnectError> {
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("mdbase-secret-bootstrap".to_string())
+        .spawn(move || {
+            let result = (|| {
+                let (server_url, connector_token) =
+                    resolve_cloud_credentials(&state_dir, server_url, connector_token)?;
+                let relay_identity = match relay_identity {
+                    Some(identity) => identity,
+                    None => SystemSecretStore::new(&state_dir)
+                        .load_or_create_relay_identity(&state_dir)?,
+                };
+                Ok(SecretBootstrap::Available {
+                    server_url,
+                    connector_token,
+                    relay_identity,
+                })
+            })();
+            let _ = sender.send(result);
+        })
+        .map_err(ConnectError::Io)?;
+    receive_secret_bootstrap(receiver, SECRET_BOOTSTRAP_TIMEOUT)
+}
+
+fn resolve_cloud_credentials(
+    state_dir: &Path,
+    server_url: Option<String>,
+    connector_token: Option<String>,
+) -> Result<(Option<String>, Option<String>), ConnectError> {
+    recover_staged_cloud_configuration(state_dir)?;
+    match (server_url, connector_token) {
+        (Some(server_url), Some(connector_token)) => {
+            let server_url = CloudConfiguration::new(&server_url)?.server_url;
+            SystemSecretStore::validate_connector_token(&connector_token)?;
+            Ok((Some(server_url), Some(connector_token)))
+        }
+        (None, None) => {
+            let Some(configuration) = load_cloud_configuration(state_dir)? else {
+                return Ok((None, None));
+            };
+            let token = SystemSecretStore::new(state_dir)
+                .connector_token()?
+                .ok_or_else(|| {
+                    ConnectError::CredentialStore(
+                        "Connect is configured but its operating-system credential is missing."
+                            .into(),
+                    )
+                })?;
+            Ok((Some(configuration.server_url), Some(token)))
+        }
+        _ => Err(ConnectError::Settings(
+            "Both server URL and connector credential are required for cloud relay".into(),
+        )),
+    }
+}
+
+fn receive_secret_bootstrap(
+    receiver: std::sync::mpsc::Receiver<Result<SecretBootstrap, ConnectError>>,
+    timeout: Duration,
+) -> Result<SecretBootstrap, ConnectError> {
+    match receiver.recv_timeout(timeout) {
+        Ok(Ok(bootstrap)) => Ok(bootstrap),
+        Ok(Err(error)) if error.code() == "credential_store_unavailable" => {
+            Ok(SecretBootstrap::Unavailable(error.to_string()))
+        }
+        Ok(Err(error)) => Err(error),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Ok(SecretBootstrap::Unavailable(
+            "The operating-system credential store did not respond before the two-second startup deadline."
+                .into(),
+        )),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(
+            ConnectError::CredentialStore(
+                "The credential bootstrap worker stopped without a result.".into(),
+            ),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_cloud_credentials_are_validated_before_use() {
+        let temporary = tempfile::tempdir().unwrap();
+        assert!(resolve_cloud_credentials(
+            temporary.path(),
+            Some("http://connect.example".to_string()),
+            Some("con_123456789012345678901234".to_string()),
+        )
+        .is_err());
+        assert!(resolve_cloud_credentials(
+            temporary.path(),
+            Some("https://connect.example".to_string()),
+            Some("not-a-credential".to_string()),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn a_stalled_credential_store_becomes_a_bounded_degraded_bootstrap() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let started = std::time::Instant::now();
+        let result = receive_secret_bootstrap(receiver, Duration::from_millis(20)).unwrap();
+        assert!(matches!(result, SecretBootstrap::Unavailable(_)));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(sender);
+    }
+
+    #[test]
+    fn credential_store_errors_degrade_but_configuration_errors_remain_fatal() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        sender
+            .send(Err(ConnectError::CredentialStore("locked".into())))
+            .unwrap();
+        assert!(matches!(
+            receive_secret_bootstrap(receiver, Duration::from_secs(1)).unwrap(),
+            SecretBootstrap::Unavailable(message) if message == "Credential store error: locked"
+        ));
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        sender
+            .send(Err(ConnectError::Settings("invalid".into())))
+            .unwrap();
+        match receive_secret_bootstrap(receiver, Duration::from_secs(1)) {
+            Err(error) => assert_eq!(error.code(), "invalid_config"),
+            Ok(_) => panic!("configuration errors must not degrade credential bootstrap"),
+        }
+    }
+}

--- a/crates/connect-agent/src/lib.rs
+++ b/crates/connect-agent/src/lib.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod cloud;
 mod loopback;
 mod mirrors;
@@ -8,12 +9,10 @@ mod server;
 mod test_support;
 mod watcher;
 
+use bootstrap::{bounded_secret_bootstrap, SecretBootstrap};
 use cloud::CloudControlClient;
 use fs2::FileExt;
-use mdbase_connect_core::{
-    default_control_endpoint, default_state_dir, load_cloud_configuration,
-    recover_staged_cloud_configuration, CloudConfiguration, CollectionRegistry, SystemSecretStore,
-};
+use mdbase_connect_core::{default_control_endpoint, default_state_dir, CollectionRegistry};
 use mdbase_connect_protocol::crypto::RelayIdentity;
 use mdbase_connect_protocol::DEFAULT_LOOPBACK_PORT;
 use server::AgentState;
@@ -65,11 +64,32 @@ pub async fn run(options: DaemonOptions) -> Result<(), Box<dyn std::error::Error
 
     let state_dir = options.state_dir()?;
     let _daemon_lease = DaemonLease::acquire(&state_dir)?;
-    let (server_url, connector_token) =
-        resolve_cloud_credentials(&state_dir, options.server_url, options.connector_token)?;
     let endpoint = options
         .endpoint
+        .clone()
         .unwrap_or_else(|| default_control_endpoint(&state_dir));
+    let secret_bootstrap = bounded_secret_bootstrap(
+        state_dir.clone(),
+        options.server_url,
+        options.connector_token,
+        options.relay_identity,
+    )?;
+    let (server_url, connector_token, relay_identity, credential_store_error) =
+        match secret_bootstrap {
+            SecretBootstrap::Available {
+                server_url,
+                connector_token,
+                relay_identity,
+            } => (server_url, connector_token, relay_identity, None),
+            SecretBootstrap::Unavailable(message) => {
+                tracing::warn!(
+                    error_code = "credential_store_unavailable",
+                    %message,
+                    "starting local control without cloud or direct access; restart after unlocking the credential store"
+                );
+                (None, None, RelayIdentity::generate(), Some(message))
+            }
+        };
     let registry = match CollectionRegistry::open(&state_dir) {
         Ok(registry) => registry,
         Err(error) => {
@@ -95,10 +115,6 @@ pub async fn run(options: DaemonOptions) -> Result<(), Box<dyn std::error::Error
         tombstones = journal.tombstones,
         "privacy-safe connector metric"
     );
-    let relay_identity = match options.relay_identity {
-        Some(identity) => identity,
-        None => SystemSecretStore::new(&state_dir).load_or_create_relay_identity(&state_dir)?,
-    };
     let cloud = match (server_url.clone(), connector_token.clone()) {
         (Some(server_url), Some(connector_token)) => {
             Some(CloudControlClient::new(server_url, connector_token))
@@ -125,9 +141,15 @@ pub async fn run(options: DaemonOptions) -> Result<(), Box<dyn std::error::Error
         cloud.clone(),
         relay_identity,
         runtime_timers,
+        credential_store_error.clone(),
     ));
     state.set_state_dir(state_dir.clone());
-    let mirror_manager = mirrors::MirrorManager::open(&state_dir, registry.clone(), cloud.clone())?;
+    let mirror_manager = mirrors::MirrorManager::open(
+        &state_dir,
+        registry.clone(),
+        cloud.clone(),
+        credential_store_error.clone(),
+    )?;
     state.set_mirror_manager(mirror_manager.clone());
     let mirror_worker = mirror_manager.start();
     let relay = match (server_url, connector_token) {
@@ -137,73 +159,56 @@ pub async fn run(options: DaemonOptions) -> Result<(), Box<dyn std::error::Error
     };
     let initialization_state = state.clone();
     let relay_state = state.clone();
-    let relay_worker = Arc::new(std::sync::Mutex::new(None));
-    let relay_worker_on_listening = relay_worker.clone();
+    let initialization_worker = Arc::new(std::sync::Mutex::new(None));
+    let initialization_worker_on_listening = initialization_worker.clone();
     tracing::info!(%endpoint, state_dir = %state_dir.display(), "starting local connector daemon");
-    let loopback = loopback::start(
-        options.loopback_port.unwrap_or(DEFAULT_LOOPBACK_PORT),
-        state.clone(),
-    )
-    .await?;
-    state.set_loopback_port(loopback.port());
+    let loopback = if credential_store_error.is_none() {
+        let loopback = loopback::start(
+            options.loopback_port.unwrap_or(DEFAULT_LOOPBACK_PORT),
+            state.clone(),
+        )
+        .await?;
+        state.set_loopback_port(loopback.port());
+        Some(loopback)
+    } else {
+        state.set_connection_state(mdbase_connect_protocol::AgentConnectionState::Offline);
+        None
+    };
     let result = server::serve(&endpoint, state, move || {
-        match registry.list() {
-            Ok(collections) => watcher.refresh(&collections),
-            Err(error) => tracing::error!(%error, "failed to initialize collection watchers"),
-        }
-        initialization_state.mark_initialized();
-        if let Some((server_url, connector_token)) = relay {
-            let worker = tokio::spawn(async move {
+        let worker = tokio::spawn(async move {
+            match registry.list() {
+                Ok(collections) => watcher.refresh(&collections),
+                Err(error) => tracing::error!(%error, "failed to initialize collection watchers"),
+            }
+            initialization_state.mark_initialized();
+            if let Some((server_url, connector_token)) = relay {
                 relay::run(server_url, connector_token, relay_state).await;
-            });
-            *relay_worker_on_listening
-                .lock()
-                .expect("relay worker lock poisoned") = Some(worker);
-        }
+            }
+        });
+        *initialization_worker_on_listening
+            .lock()
+            .expect("initialization worker lock poisoned") = Some(worker);
     })
     .await;
     mirror_worker.abort();
     let _ = mirror_worker.await;
     runtime_worker.abort();
     let _ = runtime_worker.await;
-    let relay_worker = {
-        relay_worker
+    let initialization_worker = {
+        initialization_worker
             .lock()
-            .expect("relay worker lock poisoned")
+            .expect("initialization worker lock poisoned")
             .take()
     };
-    if let Some(worker) = relay_worker {
+    if let Some(worker) = initialization_worker {
         worker.abort();
         let _ = worker.await;
     }
-    loopback.stop().await;
+    if let Some(loopback) = loopback {
+        loopback.stop().await;
+    }
     result?;
     Ok(())
-}
-
-fn resolve_cloud_credentials(
-    state_dir: &std::path::Path,
-    server_url: Option<String>,
-    connector_token: Option<String>,
-) -> Result<(Option<String>, Option<String>), Box<dyn std::error::Error + Send + Sync>> {
-    recover_staged_cloud_configuration(state_dir)?;
-    match (server_url, connector_token) {
-        (Some(server_url), Some(connector_token)) => {
-            let server_url = CloudConfiguration::new(&server_url)?.server_url;
-            SystemSecretStore::validate_connector_token(&connector_token)?;
-            Ok((Some(server_url), Some(connector_token)))
-        }
-        (None, None) => {
-            let Some(configuration) = load_cloud_configuration(state_dir)? else {
-                return Ok((None, None));
-            };
-            let token = SystemSecretStore::new(state_dir)
-                .connector_token()?
-                .ok_or("Connect is configured but its operating-system credential is missing.")?;
-            Ok((Some(configuration.server_url), Some(token)))
-        }
-        _ => Err("Both server URL and connector credential are required for cloud relay".into()),
-    }
 }
 
 fn initialize_tracing() {
@@ -253,23 +258,6 @@ mod tests {
     use super::*;
     use mdbase_connect_protocol::{ControlCommand, ControlRequest, ControlResponse};
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-
-    #[test]
-    fn explicit_cloud_credentials_are_validated_before_use() {
-        let temporary = tempfile::tempdir().unwrap();
-        assert!(resolve_cloud_credentials(
-            temporary.path(),
-            Some("http://connect.example".to_string()),
-            Some("con_123456789012345678901234".to_string()),
-        )
-        .is_err());
-        assert!(resolve_cloud_credentials(
-            temporary.path(),
-            Some("https://connect.example".to_string()),
-            Some("not-a-credential".to_string()),
-        )
-        .is_err());
-    }
 
     #[tokio::test]
     async fn one_daemon_owns_the_state_and_shutdown_is_graceful() {

--- a/crates/connect-agent/src/mirrors.rs
+++ b/crates/connect-agent/src/mirrors.rs
@@ -151,6 +151,7 @@ pub struct MirrorManager {
     cloud: Option<CloudControlClient>,
     client: Client,
     secrets: SystemSecretStore,
+    credential_store_error: Option<String>,
     entries: RwLock<Vec<MirrorRegistryEntry>>,
     syncing: StdMutex<HashSet<Uuid>>,
     operation_finished: Notify,

--- a/crates/connect-agent/src/mirrors/runtime.rs
+++ b/crates/connect-agent/src/mirrors/runtime.rs
@@ -5,6 +5,7 @@ impl MirrorManager {
         state_dir: &Path,
         registry: CollectionRegistry,
         cloud: Option<CloudControlClient>,
+        credential_store_error: Option<String>,
     ) -> Result<Arc<Self>, ConnectError> {
         crate::ensure_tls_crypto_provider();
         let entries = read_registry(&state_dir.join("mirrors.json"))?;
@@ -25,6 +26,7 @@ impl MirrorManager {
                 .build()
                 .map_err(|error| ConnectError::Cloud(error.to_string()))?,
             secrets: SystemSecretStore::new(state_dir),
+            credential_store_error,
             entries: RwLock::new(entries),
             syncing: StdMutex::new(HashSet::new()),
             operation_finished: Notify::new(),

--- a/crates/connect-agent/src/mirrors/state.rs
+++ b/crates/connect-agent/src/mirrors/state.rs
@@ -39,8 +39,23 @@ impl MirrorManager {
 
     pub(super) fn cloud(&self) -> Result<&CloudControlClient, ConnectError> {
         self.cloud.as_ref().ok_or_else(|| {
-            ConnectError::Cloud("Connect this computer to an account first.".to_string())
+            self.credential_store_unavailable().unwrap_or_else(|| {
+                ConnectError::Cloud("Connect this computer to an account first.".to_string())
+            })
         })
+    }
+
+    pub(super) fn credential_store_unavailable(&self) -> Option<ConnectError> {
+        self.credential_store_error
+            .as_ref()
+            .map(|message| ConnectError::CredentialStore(message.clone()))
+    }
+
+    pub(super) fn require_credential_store(&self) -> Result<(), ConnectError> {
+        match self.credential_store_unavailable() {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 
     pub(super) fn require_active(&self, entry: &MirrorRegistryEntry) -> Result<(), ConnectError> {

--- a/crates/connect-agent/src/mirrors/support.rs
+++ b/crates/connect-agent/src/mirrors/support.rs
@@ -140,7 +140,10 @@ pub(super) fn background_retry_delay(replica_id: Uuid, failures: u32) -> Duratio
 }
 
 pub(super) fn terminal_background_error(error: &ConnectError) -> bool {
-    error.code() == "mirror_state_upgrade_required"
+    matches!(
+        error.code(),
+        "mirror_state_upgrade_required" | "credential_store_unavailable"
+    )
 }
 
 pub(super) fn computer_name() -> String {

--- a/crates/connect-agent/src/mirrors/synchronization.rs
+++ b/crates/connect-agent/src/mirrors/synchronization.rs
@@ -218,6 +218,7 @@ impl MirrorManager {
     }
 
     pub(super) fn credentials(&self, replica_id: Uuid) -> Result<MirrorCredentials, ConnectError> {
+        self.require_credential_store()?;
         let value = self
             .secrets
             .mirror_credentials(replica_id)?
@@ -240,6 +241,7 @@ impl MirrorManager {
         entry: &mut MirrorRegistryEntry,
         credentials: &MirrorCredentials,
     ) -> Result<(), ConnectError> {
+        self.require_credential_store()?;
         self.validate_mirror_root(entry)?;
         mark_mirror(&entry.path, entry.collection_id).map_err(from_mirror)?;
         self.secrets
@@ -326,6 +328,7 @@ impl MirrorManager {
     }
 
     pub(super) fn finish_removal(&self, entry: &MirrorRegistryEntry) -> Result<(), ConnectError> {
+        self.require_credential_store()?;
         self.validate_mirror_root_if_present(entry)?;
         clear_mirror_marker(&entry.path, entry.collection_id).map_err(from_mirror)?;
         match fs::remove_dir_all(self.replica_state_dir(entry.replica_id)) {

--- a/crates/connect-agent/src/mirrors/tests.rs
+++ b/crates/connect-agent/src/mirrors/tests.rs
@@ -73,9 +73,35 @@ fn prerelease_state_upgrade_blocks_background_retry() {
         "Rebuild this prerelease mirror.",
     );
     let transient = mirror_error("mirror_transport_failed", "Try again.");
+    let credentials = ConnectError::CredentialStore("The login keyring is locked.".into());
 
     assert!(terminal_background_error(&upgrade));
+    assert!(terminal_background_error(&credentials));
     assert!(!terminal_background_error(&transient));
+}
+
+#[test]
+fn degraded_manager_rejects_secret_operations_without_touching_the_keyring() {
+    let temporary = tempfile::tempdir().unwrap();
+    let registry = CollectionRegistry::open(temporary.path()).unwrap();
+    let manager = MirrorManager::open(
+        temporary.path(),
+        registry,
+        None,
+        Some("The login keyring is locked.".into()),
+    )
+    .unwrap();
+
+    let credential_error = manager.credentials(Uuid::new_v4()).unwrap_err();
+    assert_eq!(credential_error.code(), "credential_store_unavailable");
+    assert!(credential_error
+        .to_string()
+        .contains("login keyring is locked"));
+
+    match manager.cloud() {
+        Err(error) => assert_eq!(error.code(), "credential_store_unavailable"),
+        Ok(_) => panic!("degraded mirror manager must not expose a cloud client"),
+    }
 }
 
 #[test]

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -33,6 +33,7 @@ pub struct AgentState {
     initialized: std::sync::atomic::AtomicBool,
     loopback_port: std::sync::atomic::AtomicU16,
     cloud: Option<CloudControlClient>,
+    credential_store_error: Option<String>,
     relay_identity: RelayIdentity,
     runtime_timers: Option<RuntimeTimerHandle>,
     mirrors: std::sync::RwLock<Option<Arc<MirrorManager>>>,
@@ -74,6 +75,7 @@ impl AgentState {
             initialized: std::sync::atomic::AtomicBool::new(false),
             loopback_port: std::sync::atomic::AtomicU16::new(0),
             cloud,
+            credential_store_error: None,
             relay_identity,
             runtime_timers: None,
             mirrors: std::sync::RwLock::new(None),
@@ -89,9 +91,11 @@ impl AgentState {
         cloud: Option<CloudControlClient>,
         relay_identity: RelayIdentity,
         runtime_timers: RuntimeTimerHandle,
+        credential_store_error: Option<String>,
     ) -> Self {
         let mut state = Self::with_identity(registry, watcher, cloud, relay_identity);
         state.runtime_timers = Some(runtime_timers);
+        state.credential_store_error = credential_store_error;
         state
     }
 
@@ -118,6 +122,12 @@ impl AgentState {
             .state_dir
             .write()
             .expect("state directory lock poisoned") = Some(state_dir);
+    }
+
+    pub(super) fn credential_store_unavailable(&self) -> Option<ConnectError> {
+        self.credential_store_error
+            .as_ref()
+            .map(|message| ConnectError::CredentialStore(message.clone()))
     }
 
     fn request_shutdown(&self) {

--- a/crates/connect-agent/src/server/account.rs
+++ b/crates/connect-agent/src/server/account.rs
@@ -3,7 +3,9 @@ use super::*;
 impl AgentState {
     pub(super) fn cloud(&self) -> Result<&CloudControlClient, ConnectError> {
         self.cloud.as_ref().ok_or_else(|| {
-            ConnectError::Cloud("Connect this computer to a portal first.".to_string())
+            self.credential_store_unavailable().unwrap_or_else(|| {
+                ConnectError::Cloud("Connect this computer to a portal first.".to_string())
+            })
         })
     }
 
@@ -22,6 +24,9 @@ impl AgentState {
         &self,
         params: mdbase_connect_protocol::AccountConfigureParams,
     ) -> Result<serde_json::Value, ConnectError> {
+        if let Some(error) = self.credential_store_unavailable() {
+            return Err(error);
+        }
         let _guard = self
             .account_configuration_lock
             .lock()
@@ -57,6 +62,9 @@ impl AgentState {
     }
 
     pub(super) fn clear_account(&self) -> Result<serde_json::Value, ConnectError> {
+        if let Some(error) = self.credential_store_unavailable() {
+            return Err(error);
+        }
         let _guard = self
             .account_configuration_lock
             .lock()


### PR DESCRIPTION
## Summary\n\n- bound OS credential bootstrap to a strict two-second startup deadline\n- make credential-store timeout/unavailability an explicit degraded daemon mode while keeping the local control socket available\n- start watcher and relay initialization in an owned background task so control requests remain responsive during startup\n- prevent mirror, account, cloud, and lifecycle operations from blocking on an unavailable credential store\n- classify credential unavailability as terminal operator state instead of repeatedly hammering the backend\n\nInvalid credential configuration remains fatal. Degraded startup does not expose an ephemeral application identity: direct loopback access is disabled until durable credentials are available.\n\n## Verification\n\n- pnpm test:fast\n- cargo clippy -p mdbase-connect-daemon --all-targets -- -D warnings\n- cargo fmt --all -- --check\n- architecture boundary checks\n- targeted daemon suite: 41 passing tests\n\n## Live locked-keyring acceptance\n\nTested over SSH with the desktop secret service actually locked:\n\n- immediate local ping returned pong: true, ready: false\n- immediate status returned beta.41, state: offline, direct_access_available: false\n- the control socket stayed responsive while watcher initialization completed; ready became true after about 17 seconds\n- mirror listing remained available\n- planning a disposable mirror failed in 9 ms with typed credential_store_unavailable\n- no credential-store hang and no access to the protected notes vault