### PR TITLE
Prepare beta.42 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.1.0-beta.42
+
+Beta.42 makes native startup deterministic when the operating-system
+credential service is locked or slow and completes cross-platform release
+verification for the beta.41 sync architecture.
+
+- Credential bootstrap has a strict two-second deadline. An unavailable store
+  enters an explicit offline mode that keeps local control responsive, disables
+  direct application access, and returns typed errors for secret-dependent
+  operations instead of hanging or repeatedly retrying.
+- Watcher and relay initialization run as an owned background startup task.
+  Local status is immediately available with `ready: false` until initialization
+  finishes, and shutdown still cancels the worker cleanly.
+- Desktop release portability tests accept native Windows CRLF checkouts while
+  preserving the same Rustls provider-ordering assertion on every platform.
+
 ## 0.1.0-beta.41
 
 Beta.41 completes the prerelease conflict workflow and the native runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.41"
+version = "0.1.0-beta.42"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.41
-git tag -a v0.1.0-beta.41 -m "mdbase connect 0.1.0-beta.41"
-git push origin v0.1.0-beta.41
+pnpm version:check v0.1.0-beta.42
+git tag -a v0.1.0-beta.42 -m "mdbase connect 0.1.0-beta.42"
+git push origin v0.1.0-beta.42
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.41" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.42" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.41",
+  "version": "0.1.0-beta.42",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary\n\n- publish the bounded credential-store bootstrap and responsive local-control startup as beta.42\n- include the cross-platform CRLF fix for desktop Rustls release verification\n- keep the desktop, native CLI/daemon, npm packages, server, provider, and MCP release identity aligned\n\n## Local release verification\n\n- pnpm version:check v0.1.0-beta.42\n- pnpm check:release-readiness\n- pnpm check:npm-bootstrap\n- pnpm audit:dependencies\n- pnpm check:architecture\n- pnpm package:audit\n- pnpm test:fast\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo fmt --all -- --check\n- pnpm typecheck\n- pnpm test:integration\n- pnpm e2e\n- pnpm e2e:sync\n- pnpm e2e:relay\n- pnpm e2e:provider\n- pnpm --filter @mdbase/connect-desktop package\n\nThe packaged Linux desktop bundle verified with its matching release-mode beta.42 native binary.