### PR TITLE
Make large sync fixture timeouts platform-neutral

### DIFF
--- a/packages/sync/src/mirror-files.test.ts
+++ b/packages/sync/src/mirror-files.test.ts
@@ -31,6 +31,9 @@ import type { SyncTransport } from "./sync-types.js";
 
 const utf8 = new TextEncoder();
 const text = new TextDecoder();
+// Completion guard only; chunk, download, and cache assertions below are the
+// performance invariants and remain deterministic across runner speeds.
+const STREAMING_FIXTURE_TIMEOUT_MS = 60_000;
 
 class BinaryFileSystem implements MirrorFileSystem {
   readonly files = new Map<string, Uint8Array>();
@@ -456,7 +459,7 @@ describe("portable collection file mirror", () => {
 
     await target.sync();
     expect(transport.downloads).toBe(1);
-  }, 15_000);
+  }, STREAMING_FIXTURE_TIMEOUT_MS);
 
   it("applies folder exclusions to Markdown and files without prefix-neighbor mistakes", async () => {
     const transport = new FileTransport();

--- a/packages/sync/src/mirror.test.ts
+++ b/packages/sync/src/mirror.test.ts
@@ -13,6 +13,10 @@ import {
   type MirrorState
 } from "./mirror.js";
 
+// Completion guard only; exact read/write counts and stable state below are
+// the performance invariants and remain deterministic across runner speeds.
+const LARGE_VAULT_FIXTURE_TIMEOUT_MS = 30_000;
+
 class TestFileSystem implements MirrorFileSystem {
   readonly files = new Map<string, string>();
   reads = 0;
@@ -1315,5 +1319,5 @@ describe("platform-neutral directory mirror", () => {
     expect(stateAfter).toEqual(stateBefore);
     expect(planBefore.actions).toEqual([]);
     expect(planAfter.fingerprint).toBe(planBefore.fingerprint);
-  });
+  }, LARGE_VAULT_FIXTURE_TIMEOUT_MS);
 });

--- a/packages/sync/src/node-files.test.ts
+++ b/packages/sync/src/node-files.test.ts
@@ -9,6 +9,9 @@ import {
 } from "./node.js";
 
 const utf8 = new TextEncoder();
+// Completion guard only; exact bytes, cache placement, and pruning assertions
+// below remain the platform-neutral behavioral contract.
+const FILESYSTEM_FIXTURE_TIMEOUT_MS = 30_000;
 
 function digest(value: Uint8Array): `sha256:${string}` {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
@@ -95,7 +98,7 @@ describe("Node collection file adapters", () => {
       await rm(root, { recursive: true, force: true });
       await rm(stateRoot, { recursive: true, force: true });
     }
-  });
+  }, FILESYSTEM_FIXTURE_TIMEOUT_MS);
 
   it("excludes hidden and reserved trees from discovery", async () => {
     const root = await mkdtemp(join(tmpdir(), "mdbase-node-files-"));


### PR DESCRIPTION
## Summary
- treat large sync fixture timeouts as deadlock guards rather than performance assertions
- retain exact chunk, download, cache, read, write, and stable-state assertions as the deterministic performance contract
- use bounded 30–60 second completion budgets that tolerate slower macOS Intel release runners

## Evidence
The immutable beta.42 desktop workflow passed Linux, Windows, and macOS ARM, but its macOS Intel job timed out twice under runner contention: the 2,000-record no-op fixture exceeded 5s, the R2 streaming fixture exceeded 15s, and on the retry the filesystem cache fixture exceeded 5s. No behavioral assertion failed (162/165 sync tests passed before the timeout guard aborted the rest).

Local validation:
- targeted sync suite: 165/165 tests passed
- `pnpm test:fast`
- `pnpm typecheck`
- `git diff --check`