### PR TITLE
Document native mdbase CLI ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ suspected vulnerabilities.
 
 ## Command line
 
+This repository is the home of the supported native `mdbase` CLI. It replaces
+the retired TypeScript CLI; TypeScript SDK packages remain supported libraries,
+not command-line implementations. CLI binaries follow mdbase connect's own beta
+release cadence and are not version-locked to the core and adapter RC train.
+
 The desktop app includes the unified `mdbase` CLI and background daemon. The
 same native executable is also published as a standalone headless archive for
 Linux, macOS, and Windows. Direct collection commands are top-level; identity,

--- a/docs/unified-cli.md
+++ b/docs/unified-cli.md
@@ -4,6 +4,10 @@
 
 The ecosystem ships one native command named `mdbase`.
 
+mdbase connect is the source and distribution home of this supported CLI. Its
+native binaries follow Connect's independent beta cadence; a core, runtime, or
+adapter release candidate does not imply a new Connect beta.
+
 ```text
 mdbase <data-command>
 mdbase connect <control-command>


### PR DESCRIPTION
## Summary

- identify mdbase connect as the source and distribution home of the supported native `mdbase` CLI
- state that the retired TypeScript CLI is not the supported command-line implementation
- document that native CLI binaries retain Connect’s independent beta cadence

## Verification

- documentation-only change
- `git diff --check`

This deliberately does not cut a new Connect beta.