### PR TITLE
Fix setup approval and hosted MCP access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.0-beta.44
+
+Beta.44 is a managed-service hotfix for application setup and hosted MCP
+authority access.
+
+- Application approval now applies the complete setup the user reviewed,
+  including managed updates and auxiliary type packs when a collection already
+  provides the required contract. The portal names every declared definition
+  pack, and the application SDK performs only one initial setup assessment.
+- The MCP gateway retains each hosted grant's signing key and signs both
+  provider operations and refresh-token exchanges. Hosted collection calls no
+  longer fail immediately with a provider 401 or misleading `invalid_grant`.
+- Closed-registration login pages link people without an invitation to the
+  beta access request page.
+
 ## 0.1.0-beta.43
 
 Beta.43 completes the coordinated beta.42 desktop release without changing the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/portal/src/auth-view.tsx
+++ b/apps/portal/src/auth-view.tsx
@@ -95,9 +95,12 @@ export function Login() {
                 </a>}
           </React.Fragment>)}
         </div>}
-        {config.password_registration && (
+        {config.registration !== "open" && (
           <p className="auth-footnote">
-            New here? Your invitation email contains the one-time account setup link.
+            Don’t have an invite? <a href="https://mdbase.dev/beta/">Request beta access</a>.
+            {config.password_registration && (
+              <> Already invited? Your invitation email contains the one-time account setup link.</>
+            )}
           </p>
         )}
       </section>

--- a/apps/portal/src/authorization-view.tsx
+++ b/apps/portal/src/authorization-view.tsx
@@ -642,7 +642,7 @@ export function ApprovalForm({
 
   async function decide(decision: "approved" | "denied") {
     const preparingSetup = decision === "approved"
-      && (contractSetups.length > 0 || configurationSetup.length > 0);
+      && (setup.length > 0 || configurationSetup.length > 0);
     if (preparingSetup) onSetupActivityChange?.(true);
     setSubmitting(decision);
     setError("");
@@ -872,6 +872,18 @@ export function ApprovalForm({
           <small>These happen only after you allow access and the collection validates them.</small>
         </div>
         <div className="approval-section-content contract-setup-list">
+          {setup.length > 0 && <div className="configuration-setup-list">
+            {setup.map((provision) => (
+              <div className="configuration-setup-item" key={provision.manifest.id}>
+                <span aria-hidden="true">+</span>
+                <div>
+                  <strong>{provision.manifest.name ?? provision.manifest.id}</strong>
+                  <code>{provision.manifest.version}</code>
+                  <small>{provision.manifest.description ?? "Install or update the application definitions declared by this version."}</small>
+                </div>
+              </div>
+            ))}
+          </div>}
           {setupContracts.map((contract) => {
             const key = `${contract.id}@${contract.version}`;
             const choice = setupChoices[key];
@@ -925,6 +937,7 @@ function authorizationNeedsSetup(
   const collection = collections.find((candidate) => candidate.id === request.collection_id);
   if (!collection) return false;
   return (request.provisions.configuration?.length ?? 0) > 0
+    || request.provisions.type_packs.length > 0
     || request.requirements.contracts.some((required) =>
       !collection.contracts.some((contract) =>
         contract.id === required.id

--- a/apps/portal/src/portal-model.ts
+++ b/apps/portal/src/portal-model.ts
@@ -36,12 +36,9 @@ export function formatDeviceCode(value: string) {
 }
 export function neededProvisions(
   request: Pick<PendingAuthorization, "requirements" | "provisions">,
-  collection: Pick<AvailableCollection, "contracts">
+  _collection: Pick<AvailableCollection, "contracts">
 ): TypePackProvision[] {
-  const missing = request.requirements.contracts.filter((requirement) => !hasContract(collection.contracts, requirement));
-  return request.provisions.type_packs.filter((provision) =>
-    provision.provides.some((provided) => missing.some((requirement) => sameContract(provided, requirement)))
-  );
+  return request.provisions.type_packs;
 }
 
 export function hasContract(contracts: ContractRequirement[], required: ContractRequirement) { return contracts.some((contract) => sameContract(contract, required)); }

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -2178,6 +2178,11 @@ select {
   font-size: 0.72rem;
 }
 
+.auth-panel > .auth-footnote a {
+  color: var(--accent-dark);
+  text-underline-offset: 0.16em;
+}
+
 .quiet-auth-link {
   display: inline-block;
   margin-top: 1.4rem;

--- a/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
@@ -638,19 +638,12 @@ impl HostedProvider {
         } else {
             contract_setups
         };
-        let selected_type_packs = provisions
-            .type_packs
-            .into_iter()
-            .filter(|provision| {
-                provision.provides.iter().any(|provided| {
-                    missing_contracts.contains(&(
-                        provided.id.clone(),
-                        provided.version.clone(),
-                        provided.digest.clone(),
-                    ))
-                })
-            })
-            .collect();
+        // Approval is the user's review of the application's complete declared
+        // setup, not only the subset that happens to supply a missing contract.
+        // Applying every declared pack also keeps managed resources and packs
+        // without a contract (for example an application's auxiliary types)
+        // consistent with the post-authorization setup assessment.
+        let selected_type_packs = provisions.type_packs;
         let setup = AssessCollectionSetupInput {
             application_id: application_id.to_string(),
             declaration_digest: declaration_digest.to_string(),

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.43"
+version = "0.1.0-beta.44"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.43
-git tag -a v0.1.0-beta.43 -m "mdbase connect 0.1.0-beta.43"
-git push origin v0.1.0-beta.43
+pnpm version:check v0.1.0-beta.44
+git tag -a v0.1.0-beta.44 -m "mdbase connect 0.1.0-beta.44"
+git push origin v0.1.0-beta.44
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/application-session.test.ts
+++ b/packages/client/src/application-session.test.ts
@@ -307,6 +307,7 @@ describe("MdbaseApplicationSession", () => {
     });
 
     await session.start();
+    expect(fixture.value.assessCollectionSetup).toHaveBeenCalledOnce();
     expect(session.getSnapshot()).toMatchObject({
       status: "setup_review_required",
       update: {

--- a/packages/client/src/application-session.ts
+++ b/packages/client/src/application-session.ts
@@ -235,9 +235,6 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
       operations: operationsForSession(capabilities)
     });
     this.base = base;
-    this.stopBase = base.subscribe(() => {
-      if (this.base === base) void this.refresh();
-    });
     try {
       const started = await base.start(options);
       if (!started.ok) {
@@ -247,6 +244,9 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
       if (generation !== this.lifecycleGeneration || options.signal?.aborted) {
         throw requestAbortReason(options.signal ?? new AbortController().signal);
       }
+      this.stopBase = base.subscribe(() => {
+        if (this.base === base) void this.refresh();
+      });
       await this.refresh(true, options);
       if (generation !== this.lifecycleGeneration || options.signal?.aborted) {
         throw requestAbortReason(options.signal ?? new AbortController().signal);

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/app.test.ts
+++ b/services/mcp/src/app.test.ts
@@ -219,6 +219,10 @@ describe("mdbase MCP gateway", () => {
     );
     expect(stored.rows).toHaveLength(2);
     expect(stored.rows.every((row) => !row.credentials_ciphertext.includes("upstream-access"))).toBe(true);
+    await db.query(
+      "UPDATE mcp_connections SET access_expires_at = now() - interval '1 second' WHERE collection_id = $1",
+      [secondCollectionId]
+    );
 
     const address = await app.listen({ host: "127.0.0.1", port: 0 });
     const client = new Client({ name: "gateway-test", version: "1.0.0" });
@@ -242,7 +246,15 @@ describe("mdbase MCP gateway", () => {
       valid: true,
       result: { results: [{ path: "notes/second.md" }] }
     });
-    expect(upstream.operationAuthorizations).toContain("Bearer hosted-access-two");
+    expect(upstream.operationAuthorizations).toContain("Bearer hosted-access-two-refreshed");
+    expect(upstream.refreshProofs).toHaveLength(1);
+    expect(upstream.operationProofs).toHaveLength(1);
+    for (const proof of [...upstream.refreshProofs, ...upstream.operationProofs]) {
+      expect(proof.version).toBe("1");
+      expect(proof.timestamp).toMatch(/^\d+$/);
+      expect(proof.nonce).toMatch(/^[0-9a-f-]{36}$/);
+      expect(proof.signature).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
     const localQuery = await client.callTool({
       name: "query_records",
       arguments: { connection_id: connections[0].id, types: ["note"], limit: 5 }
@@ -291,6 +303,8 @@ async function fakeUpstream(realFetch: typeof fetch) {
   }> = [];
   const operationAuthorizations: string[] = [];
   const operationOrigins: string[] = [];
+  const refreshProofs: AuthorityProofHeaders[] = [];
+  const operationProofs: AuthorityProofHeaders[] = [];
   const localInputs: unknown[] = [];
   const connectorKeys = await crypto.subtle.generateKey(
     { name: "ECDH", namedCurve: "P-256" },
@@ -327,10 +341,17 @@ async function fakeUpstream(realFetch: typeof fetch) {
     }
     if (url.href === "https://connect.example/oauth/token") {
       const body = new URLSearchParams(String(init?.body));
-      const second = body.get("code") === "second-upstream-code";
+      const refreshing = body.get("grant_type") === "refresh_token";
+      const second = body.get("code") === "second-upstream-code"
+        || body.get("refresh_token")?.startsWith("upstream-refresh-two") === true;
+      if (refreshing) refreshProofs.push(proofHeaders(init));
       return Response.json({
-        access_token: second ? "upstream-access-two" : "upstream-access-one",
-        refresh_token: second ? "upstream-refresh-two" : "upstream-refresh-one",
+        access_token: second
+          ? (refreshing ? "upstream-access-two-refreshed" : "upstream-access-two")
+          : (refreshing ? "upstream-access-one-refreshed" : "upstream-access-one"),
+        refresh_token: second
+          ? (refreshing ? "upstream-refresh-two-refreshed" : "upstream-refresh-two")
+          : (refreshing ? "upstream-refresh-one-refreshed" : "upstream-refresh-one"),
         token_type: "Bearer",
         expires_in: 3_600,
         refresh_expires_in: 2_592_000,
@@ -353,7 +374,7 @@ async function fakeUpstream(realFetch: typeof fetch) {
           operations_url: `https://sync.example/v1/authorities/${secondCollectionId}/operations`,
           sync_url: `https://sync.example/v1/authorities/${secondCollectionId}/sync`,
           replica_id: "40000000-0000-4000-8000-000000000002",
-          access_token: "hosted-access-two",
+          access_token: refreshing ? "hosted-access-two-refreshed" : "hosted-access-two",
           proof_public_key: applicationSigningPublicKeys[1]
         } } : {})
       });
@@ -380,6 +401,7 @@ async function fakeUpstream(realFetch: typeof fetch) {
       const headers = new Headers(init?.headers);
       operationAuthorizations.push(headers.get("authorization")!);
       operationOrigins.push(headers.get("origin")!);
+      operationProofs.push(proofHeaders(init));
       return Response.json({
         result: {
           valid: true,
@@ -398,7 +420,26 @@ async function fakeUpstream(realFetch: typeof fetch) {
     authorizationProofs,
     operationAuthorizations,
     operationOrigins,
+    refreshProofs,
+    operationProofs,
     localInputs
+  };
+}
+
+interface AuthorityProofHeaders {
+  version: string | null;
+  timestamp: string | null;
+  nonce: string | null;
+  signature: string | null;
+}
+
+function proofHeaders(init?: RequestInit): AuthorityProofHeaders {
+  const headers = new Headers(init?.headers);
+  return {
+    version: headers.get("x-mdbase-proof-version"),
+    timestamp: headers.get("x-mdbase-proof-timestamp"),
+    nonce: headers.get("x-mdbase-proof-nonce"),
+    signature: headers.get("x-mdbase-proof-signature")
   };
 }
 

--- a/services/mcp/src/connect.ts
+++ b/services/mcp/src/connect.ts
@@ -3,6 +3,7 @@ import {
   applicationInstallationId,
   decryptRelayResponse,
   encryptRelayRequest,
+  signAuthorityRequest,
   signApplicationAuthorization,
   type GrantKeyRecord,
   type GrantKeyStore
@@ -63,6 +64,7 @@ interface StoredCredentials {
     operationsUrl: string;
     replicaId: string;
     accessToken: string;
+    proofPublicKey: string;
   };
 }
 
@@ -319,14 +321,26 @@ export class ConnectGateway {
       url = `${connection.upstream_url}/v1/authorities/${encodeURIComponent(connection.collection_id)}/operations/${operation}`;
       bearer = credentials.accessToken;
     }
+    const serializedBody = JSON.stringify(body);
+    const proof = credentials.authority
+      ? await this.authorityProof(
+          connection,
+          credentials.authority.proofPublicKey,
+          "POST",
+          url,
+          serializedBody,
+          bearer
+        )
+      : {};
     const response = await fetch(url, {
       method: "POST",
       headers: {
         authorization: `Bearer ${bearer}`,
         "content-type": "application/json",
-        origin: this.applicationOrigin
+        origin: this.applicationOrigin,
+        ...proof
       },
-      body: JSON.stringify(body)
+      body: serializedBody
     });
     return {
       ok: response.ok,
@@ -357,14 +371,29 @@ export class ConnectGateway {
         throw new GatewayOperationError("connection_expired", `Reconnect ${connection.display_name} to continue.`);
       }
       const credentials = this.credentials(connection);
-      const response = await fetch(`${connection.upstream_url}/oauth/token`, {
+      const refreshUrl = `${connection.upstream_url}/oauth/token`;
+      const refreshBody = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: credentials.refreshToken,
+        client_id: connection.upstream_client_id
+      }).toString();
+      const proof = credentials.authority
+        ? await this.authorityProof(
+            connection,
+            credentials.authority.proofPublicKey,
+            "POST",
+            refreshUrl,
+            refreshBody,
+            credentials.refreshToken
+          )
+        : {};
+      const response = await fetch(refreshUrl, {
         method: "POST",
-        headers: { "content-type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({
-          grant_type: "refresh_token",
-          refresh_token: credentials.refreshToken,
-          client_id: connection.upstream_client_id
-        })
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          ...proof
+        },
+        body: refreshBody
       });
       const raw = await response.json().catch(() => null);
       if (!response.ok) throw upstreamError(raw, `Reconnect ${connection.display_name} to continue.`);
@@ -402,6 +431,34 @@ export class ConnectGateway {
     } finally {
       client.release();
     }
+  }
+
+  private async authorityProof(
+    connection: ConnectionRow,
+    publicKey: string,
+    method: string,
+    url: string,
+    body: string,
+    credential: string
+  ): Promise<Record<string, string>> {
+    if (!connection.key_handle) {
+      throw new GatewayOperationError(
+        "missing_grant_key",
+        `Reconnect ${connection.display_name} to restore signed authority access.`
+      );
+    }
+    const target = new URL(url);
+    return signAuthorityRequest(
+      this.keyStore,
+      connection.key_handle,
+      publicKey,
+      {
+        method,
+        target: `${target.pathname}${target.search}`,
+        body,
+        credential
+      }
+    );
   }
 
   private async assertTokenBinding(
@@ -450,8 +507,10 @@ export class ConnectGateway {
       [setId, this.connectUrl, token.collection_id]
     );
     const previousKey = previous.rows[0]?.key_handle ?? null;
-    const storedKey = token.authority ? null : keyHandle;
-    if (token.authority) await this.keyStore.delete(keyHandle);
+    // Hosted authority access is bearer-and-proof bound. Keep the same grant
+    // signing key used during authorization so operations and refreshes can be
+    // signed for the lifetime of this connection.
+    const storedKey = keyHandle;
     const result = await this.db.query<ConnectionRow>(
       `INSERT INTO mcp_connections
          (id, connection_set_id, upstream_url, upstream_client_id, collection_id,
@@ -513,7 +572,8 @@ function credentialsFromToken(token: ConnectTokenResponse): StoredCredentials {
       authority: {
         operationsUrl: token.authority.operations_url,
         replicaId: token.authority.replica_id,
-        accessToken: token.authority.access_token
+        accessToken: token.authority.access_token,
+        proofPublicKey: token.authority.proof_public_key
       }
     } : {})
   };

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.43" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.44" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.43",
+  "version": "0.1.0-beta.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -2172,6 +2172,7 @@ describe("mdbase connect server", () => {
           configuration: [expect.objectContaining({ id: "workout-base-sources" })]
         }),
         provisions: expect.objectContaining({
+          type_packs: [pack],
           configuration: [expect.objectContaining({
             operation: "set_add",
             value: "views/workouts/**/*.base"

--- a/services/server/src/features/authorizations/approval-service.ts
+++ b/services/server/src/features/authorizations/approval-service.ts
@@ -600,16 +600,17 @@ export async function approveHostedAuthorization(
       availableDescriptors
     );
     let availableContracts = contractRequirements(availableDescriptors);
-    const provisions = requiredTypePackProvisions(
+    const contractProvisions = requiredTypePackProvisions(
       pending.requirements,
       pending.provisions,
       availableContracts
     );
-    if (!provisions) {
+    if (!contractProvisions) {
       throw new RequestValidationError(
         "This hosted collection does not provide the contracts required by the application."
       );
     }
+    const provisions = pending.provisions.type_packs ?? [];
     const hasApplicationSetup = provisions.length > 0
       || (pending.provisions.configuration?.length ?? 0) > 0;
     if (hasApplicationSetup) {


### PR DESCRIPTION
## What changed

- apply the complete application setup reviewed during authorization, including managed updates and auxiliary type packs
- avoid duplicate application setup assessments during session startup
- retain hosted MCP grant keys and sign both provider operations and refresh-token exchanges
- include the recent closed-beta access link change
- prepare the coordinated beta.44 release

## Root cause

Initial approval filtered setup to type packs that supplied a currently missing contract. Collections that already implemented the contract therefore skipped managed and auxiliary resources, but the application immediately assessed the complete declaration and requested setup again. Separately, the MCP gateway discarded the signing key for hosted grants and sent unsigned authority requests, so hosted operations and refreshes failed after a successful reconnect.

## Impact

Existing conformant collections complete authorization without a setup loop, and newly reconnected hosted MCP collections can execute and refresh normally.

## Validation

- `pnpm build && pnpm typecheck && pnpm test`
- `cargo fmt --all --check && cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm e2e`
- `pnpm e2e:provider`
- architecture, release-readiness, and version checks
