### PR TITLE
Fix beta.44 dependency audit gate

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   fast-uri@>=3.0.0 <3.1.5: 3.1.5
   fast-uri@>=4.0.0 <4.1.2: 4.1.2
   ip-address@<10.3.1: 10.3.1
+  nanoid@<3.3.17: 3.3.17
   postcss@<=8.5.22: 8.5.23
   undici@>=6.0.0 <6.28.0: 6.28.0
   undici@>=7.0.0 <7.29.0: 7.29.0
@@ -3312,8 +3313,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7671,7 +7672,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nearley@2.20.1:
     dependencies:
@@ -7939,7 +7940,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,11 +31,20 @@ overrides:
   "fast-uri@>=3.0.0 <3.1.5": "3.1.5"
   "fast-uri@>=4.0.0 <4.1.2": "4.1.2"
   "ip-address@<10.3.1": "10.3.1"
+  "nanoid@<3.3.17": "3.3.17"
   "postcss@<=8.5.22": "8.5.23"
   "undici@>=6.0.0 <6.28.0": "6.28.0"
   "undici@>=7.0.0 <7.29.0": "7.29.0"
   "tar@<7.5.21": "7.5.21"
   "tmp@<0.2.6": "0.2.7"
+
+# appdmg only uses image-size for PNG DMG backgrounds. The affected ICNS,
+# JXL, and HEIF parsers are not reachable there, and the advisory's patched
+# image-size 2.0.3 release has not yet been published to npm.
+auditConfig:
+  ignoreGhsas:
+    - GHSA-w3rx-r6r6-pgpr
+    - GHSA-5p2g-fcmc-qvqq
 
 minimumReleaseAgeExclude:
   - hono@4.12.34


### PR DESCRIPTION
## Summary
- pin nanoid to the patched 3.3.17 release
- narrowly ignore the two image-size parser advisories until the referenced patched release is published
- document why appdmg cannot reach the affected parsers

## Verification
- pnpm audit:dependencies
- pnpm version:check
- git diff --check