### PR TITLE
Make definition adoption reviewable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.1.0-beta.45
+
+Beta.45 makes pre-existing application definitions reviewable and completes
+the beta.44 application-setup hotfix.
+
+- Collection setup can carry exact, digest-pinned consent to adopt a managed
+  definition that already exists without a type-pack receipt. The SDK prepares
+  that review automatically, so application update buttons are enabled without
+  silently changing the collection.
+- Hosted and local approval retry the reviewed setup with those exact digests.
+  Files owned by another pack, seed definitions, and definitions changed after
+  installation remain conflicts; a change between review and apply is rejected.
+
 ## 0.1.0-beta.44
 
 Beta.44 is a managed-service hotfix for application setup and hosted MCP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-core/src/registry/operation_execution.rs
+++ b/crates/connect-core/src/registry/operation_execution.rs
@@ -236,6 +236,11 @@ fn engine_collection_setup(
             Ok(mdbase::v03::CollectionSetupTypePack {
                 provision: CollectionRegistry::engine_type_pack_provision(provision)?,
                 options: mdbase::v03::CollectionSetupTypePackOptions {
+                    adopt_resources: input
+                        .type_pack_adoptions
+                        .get(&provision.manifest.id)
+                        .cloned()
+                        .unwrap_or_default(),
                     preserve_seed_targets,
                     contract_setups: provision_setups
                         .into_iter()

--- a/crates/connect-core/src/registry/operations.rs
+++ b/crates/connect-core/src/registry/operations.rs
@@ -200,7 +200,7 @@ impl CollectionRegistry {
                 })
             })
             .collect::<Result<Vec<_>, ConnectError>>()?;
-        let setup = mdbase::v03::CollectionSetup {
+        let mut setup = mdbase::v03::CollectionSetup {
             application_id: application_id.to_string(),
             declaration_digest: declaration_digest.to_string(),
             requirements: mdbase::v03::CollectionSetupRequirements {
@@ -232,7 +232,12 @@ impl CollectionRegistry {
         let registered = self.get(id)?;
         let provider = self.provider_for(&registered)?;
         let applied = provider.with_collection(|collection| {
-            let assessment = collection.assess_collection_setup(&setup);
+            let mut assessment = collection.assess_collection_setup(&setup);
+            if assessment.result["applicable"].as_bool() != Some(true)
+                && add_reviewable_setup_adoptions(&mut setup, &assessment)
+            {
+                assessment = collection.assess_collection_setup(&setup);
+            }
             if !assessment.valid || assessment.result["applicable"].as_bool() != Some(true) {
                 return Err(type_pack_setup_error(&assessment));
             }
@@ -819,6 +824,33 @@ impl CollectionRegistry {
         debug_assert_eq!(resolved.allowed_types, allowed_types);
         Ok(Some(resolved))
     }
+}
+
+fn add_reviewable_setup_adoptions(
+    setup: &mut mdbase::v03::CollectionSetup,
+    result: &mdbase::v03::OperationResult,
+) -> bool {
+    let adoptions = mdbase_connect_protocol::reviewable_type_pack_adoptions(&result.result);
+    let mut changed = false;
+    for (pack_id, resources) in adoptions {
+        let Some(pack) = setup
+            .provisions
+            .type_packs
+            .iter_mut()
+            .find(|pack| pack.provision.manifest["id"].as_str() == Some(pack_id.as_str()))
+        else {
+            continue;
+        };
+        for (target, current_digest) in resources {
+            changed |= pack
+                .options
+                .adopt_resources
+                .insert(target, current_digest.clone())
+                .as_deref()
+                != Some(current_digest.as_str());
+        }
+    }
+    changed
 }
 
 fn type_pack_setup_error(result: &mdbase::v03::OperationResult) -> ConnectError {

--- a/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
@@ -644,7 +644,7 @@ impl HostedProvider {
         // without a contract (for example an application's auxiliary types)
         // consistent with the post-authorization setup assessment.
         let selected_type_packs = provisions.type_packs;
-        let setup = AssessCollectionSetupInput {
+        let mut setup = AssessCollectionSetupInput {
             application_id: application_id.to_string(),
             declaration_digest: declaration_digest.to_string(),
             requirements: ApplicationCollectionSetupRequirements {
@@ -655,8 +655,9 @@ impl HostedProvider {
                 type_packs: selected_type_packs,
             },
             contract_setups: effective_setups.clone(),
+            type_pack_adoptions: BTreeMap::new(),
         };
-        let assessment = self
+        let mut assessment = self
             .execute_read_operation(
                 collection_id,
                 "assess_collection_setup",
@@ -667,6 +668,24 @@ impl HostedProvider {
                 })?,
             )
             .await?;
+        if assessment.result["applicable"].as_bool() != Some(true) {
+            let adoptions =
+                mdbase_connect_protocol::reviewable_type_pack_adoptions(&assessment.result);
+            if !adoptions.is_empty() {
+                setup.type_pack_adoptions = adoptions;
+                assessment = self
+                    .execute_read_operation(
+                        collection_id,
+                        "assess_collection_setup",
+                        &serde_json::to_value(&setup).map_err(|error| {
+                            ApiError::internal(format!(
+                                "Collection setup review input could not serialize: {error}"
+                            ))
+                        })?,
+                    )
+                    .await?;
+            }
+        }
         if !assessment.valid || assessment.result["applicable"].as_bool() != Some(true) {
             return Err(type_pack_provision_error(&assessment));
         }

--- a/crates/connect-hosted-provider/src/provider/tests.rs
+++ b/crates/connect-hosted-provider/src/provider/tests.rs
@@ -32,6 +32,49 @@ fn contract_setup_targets_missing_contracts_only() {
 }
 
 #[test]
+fn collection_setup_review_only_adopts_unmanaged_digest_pinned_resources() {
+    let current = format!("sha256:{}", "1".repeat(64));
+    let result = OperationResult {
+        valid: true,
+        diagnostics: Vec::new(),
+        result: json!({
+            "type_packs": [{
+                "desired": { "id": "dev.mdbase.requests" },
+                "resources": [
+                    {
+                        "target": "_types/request.md",
+                        "mode": "managed",
+                        "action": "conflict",
+                        "current_digest": current
+                    },
+                    {
+                        "target": "_schemas/changed.json",
+                        "mode": "managed",
+                        "action": "conflict",
+                        "current_digest": format!("sha256:{}", "2".repeat(64)),
+                        "installed_digest": format!("sha256:{}", "3".repeat(64))
+                    },
+                    {
+                        "target": "_types/seed.md",
+                        "mode": "seed",
+                        "action": "conflict",
+                        "current_digest": format!("sha256:{}", "4".repeat(64))
+                    }
+                ]
+            }]
+        }),
+    };
+
+    assert_eq!(
+        mdbase_connect_protocol::reviewable_type_pack_adoptions(&result.result),
+        BTreeMap::from([(
+            "dev.mdbase.requests".to_string(),
+            BTreeMap::from([("_types/request.md".to_string(), current)])
+        )])
+    );
+}
+
+#[test]
 fn authority_manifest_matches_the_node_promotion_fixture() {
     let entries = BTreeMap::from([
         (

--- a/crates/connect-hosted-provider/src/workspace/contract_setup_tests.rs
+++ b/crates/connect-hosted-provider/src/workspace/contract_setup_tests.rs
@@ -112,6 +112,7 @@ fn applies_hosted_configuration_and_receipt_as_one_setup() {
             type_packs: Vec::new(),
         },
         contract_setups: Vec::new(),
+        type_pack_adoptions: Default::default(),
     };
     let assessment = workspace.assess_collection_setup(&setup).unwrap();
     assert!(assessment.valid, "{:?}", assessment.diagnostics);
@@ -143,6 +144,60 @@ fn applies_hosted_configuration_and_receipt_as_one_setup() {
     assert!(receipt.contains("dev.mdbase.tasknotes"));
     let retried = workspace.assess_collection_setup(&setup).unwrap();
     assert_eq!(retried.result["status"], "current");
+}
+
+#[test]
+fn makes_preexisting_managed_resources_applicable_with_digest_pinned_adoption() {
+    let provision = work_item_provision();
+    let contract_resource = provision
+        .resources
+        .iter()
+        .find(|resource| resource.source == "contract.md")
+        .unwrap();
+    let mut resources = super::tests::resources();
+    resources.push((
+        "_contracts/example.work-item.md".to_string(),
+        format!("{}\n<!-- pre-existing -->\n", contract_resource.document),
+    ));
+    let workspace = WorkingSet::materialize(resources, []).unwrap();
+    let mut setup = AssessCollectionSetupInput {
+        application_id: "dev.mdbase.tests".to_string(),
+        declaration_digest: format!("sha256:{}", "a".repeat(64)),
+        requirements: ApplicationCollectionSetupRequirements::default(),
+        provisions: ApplicationCollectionSetupProvisions {
+            configuration: Vec::new(),
+            type_packs: vec![provision],
+        },
+        contract_setups: Vec::new(),
+        type_pack_adoptions: BTreeMap::new(),
+    };
+
+    let conflict = workspace.assess_collection_setup(&setup).unwrap();
+    assert_eq!(conflict.result["applicable"], false);
+    let resource = conflict.result["type_packs"][0]["resources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|resource| resource["action"] == "conflict")
+        .unwrap();
+    setup.type_pack_adoptions.insert(
+        "example.work-items".to_string(),
+        [(
+            resource["target"].as_str().unwrap().to_string(),
+            resource["current_digest"].as_str().unwrap().to_string(),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    let reviewed = workspace.assess_collection_setup(&setup).unwrap();
+
+    assert!(reviewed.valid, "{:?}", reviewed.diagnostics);
+    assert_eq!(reviewed.result["applicable"], true);
+    assert_eq!(
+        reviewed.result["type_packs"][0]["resources"][0]["action"],
+        "update"
+    );
 }
 
 #[test]

--- a/crates/connect-hosted-provider/src/workspace/type_packs.rs
+++ b/crates/connect-hosted-provider/src/workspace/type_packs.rs
@@ -97,6 +97,11 @@ pub(super) fn engine_collection_setup(
             Ok(mdbase::v03::CollectionSetupTypePack {
                 provision: engine_type_pack_provision(provision)?,
                 options: mdbase::v03::CollectionSetupTypePackOptions {
+                    adopt_resources: input
+                        .type_pack_adoptions
+                        .get(&provision.manifest.id)
+                        .cloned()
+                        .unwrap_or_default(),
                     preserve_seed_targets,
                     contract_setups: provision_setups
                         .into_iter()

--- a/crates/connect-protocol/src/applications.rs
+++ b/crates/connect-protocol/src/applications.rs
@@ -148,6 +148,49 @@ pub struct AssessCollectionSetupInput {
     pub provisions: ApplicationCollectionSetupProvisions,
     #[serde(default)]
     pub contract_setups: Vec<ContractSetupChoice>,
+    /// Digest-pinned consent to adopt pre-existing, unmanaged resources, keyed
+    /// first by type-pack id and then by collection target.
+    #[serde(default)]
+    pub type_pack_adoptions:
+        std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
+}
+
+/// Returns the exact current digests that can be offered for explicit adoption.
+/// Resources with an installed digest were previously managed and are excluded;
+/// the engine remains authoritative when a target is owned by another pack.
+pub fn reviewable_type_pack_adoptions(
+    assessment: &Value,
+) -> BTreeMap<String, BTreeMap<String, String>> {
+    let mut adoptions = BTreeMap::new();
+    let Some(type_packs) = assessment["type_packs"].as_array() else {
+        return adoptions;
+    };
+    for pack in type_packs {
+        let Some(pack_id) = pack.pointer("/desired/id").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(resources) = pack["resources"].as_array() else {
+            continue;
+        };
+        let resources = resources
+            .iter()
+            .filter(|resource| {
+                resource["action"] == "conflict"
+                    && resource["mode"] == "managed"
+                    && resource.get("installed_digest").is_none()
+            })
+            .filter_map(|resource| {
+                Some((
+                    resource["target"].as_str()?.to_string(),
+                    resource["current_digest"].as_str()?.to_string(),
+                ))
+            })
+            .collect::<BTreeMap<_, _>>();
+        if !resources.is_empty() {
+            adoptions.insert(pack_id.to_string(), resources);
+        }
+    }
+    adoptions
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.44"
+version = "0.1.0-beta.45"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.44
-git tag -a v0.1.0-beta.44 -m "mdbase connect 0.1.0-beta.44"
-git push origin v0.1.0-beta.44
+pnpm version:check v0.1.0-beta.45
+git tag -a v0.1.0-beta.45 -m "mdbase connect 0.1.0-beta.45"
+git push origin v0.1.0-beta.45
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/application-session.test.ts
+++ b/packages/client/src/application-session.test.ts
@@ -324,4 +324,114 @@ describe("MdbaseApplicationSession", () => {
       expectedAssessmentDigest: assessment.assessmentDigest
     }), expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: null }));
   });
+
+  it("makes unmanaged managed definitions reviewable with digest-pinned adoption", async () => {
+    const desired = {
+      id: "dev.mdbase.requests",
+      version: "1.0.0",
+      digest: `sha256:${"a".repeat(64)}`,
+      installedBy: "dev.mdbase.session-test",
+      resources: []
+    };
+    const conflictResource = {
+      source: "types/request.md",
+      target: "_types/request.md",
+      kind: "type" as const,
+      mode: "managed" as const,
+      action: "conflict" as const,
+      digest: `sha256:${"b".repeat(64)}`,
+      currentDigest: `sha256:${"c".repeat(64)}`,
+      reason: "_types/request.md exists but is not managed by dev.mdbase.requests."
+    };
+    const baseAssessment: CollectionSetupAssessment = {
+      status: "conflict",
+      applicable: false,
+      applicationId: "dev.mdbase.session-test",
+      declarationDigest: `sha256:${"d".repeat(64)}`,
+      provisionDigest: `sha256:${"e".repeat(64)}`,
+      collectionRevision: `sha256:${"f".repeat(64)}`,
+      finalCollectionRevision: `sha256:${"0".repeat(64)}`,
+      configuration: [],
+      typePacks: [{
+        status: "conflict",
+        applicable: false,
+        assessmentDigest: `sha256:${"1".repeat(64)}`,
+        desired,
+        resources: [conflictResource],
+        lock: { target: "mdbase.lock.yaml", action: "create", digest: `sha256:${"2".repeat(64)}` },
+        contractSetups: { choices: [], resources: [] }
+      }],
+      finalResourceRevisions: {},
+      assessmentDigest: `sha256:${"3".repeat(64)}`
+    };
+    const reviewedAssessment: CollectionSetupAssessment = {
+      ...baseAssessment,
+      status: "provision",
+      applicable: true,
+      assessmentDigest: `sha256:${"4".repeat(64)}`,
+      typePacks: [{
+        ...baseAssessment.typePacks[0]!,
+        status: "install",
+        applicable: true,
+        resources: [{ ...conflictResource, action: "update" }]
+      }]
+    };
+    const declaration = manifest({
+      requirements: {
+        contracts: [],
+        capabilities: {
+          contract_version: 1,
+          required: ["collection.inspect", "records.read", "collection.setup.apply"]
+        }
+      },
+      provisions: {
+        type_packs: [{
+          manifest: {
+            kind: "mdbase.type-pack",
+            id: desired.id,
+            version: desired.version,
+            resources: []
+          },
+          resources: [],
+          provides: []
+        }]
+      }
+    });
+    const fixture = connectFixture(
+      declaration,
+      ["describe", "read", "assess_collection_setup", "apply_collection_setup"],
+      reviewedAssessment
+    );
+    fixture.value.assessCollectionSetup
+      .mockResolvedValueOnce(connectSuccess(baseAssessment))
+      .mockResolvedValueOnce(connectSuccess(reviewedAssessment));
+    const session = new MdbaseApplicationSession(fixture.facade as never, {
+      selection: new MdbaseMemorySelection(),
+      verificationStore: new MdbaseMemoryVerificationStore()
+    });
+
+    await session.start();
+
+    expect(fixture.value.assessCollectionSetup).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        typePackAdoptions: {
+          [desired.id]: { [conflictResource.target]: conflictResource.currentDigest }
+        }
+      }),
+      expect.anything()
+    );
+    expect(session.getSnapshot()).toMatchObject({
+      status: "setup_review_required",
+      update: { canApply: true, typePacks: [{ canApply: true }] }
+    });
+
+    await session.applyCollectionSetup();
+
+    expect(fixture.applyCollectionSetup).toHaveBeenCalledWith(expect.objectContaining({
+      typePackAdoptions: {
+        [desired.id]: { [conflictResource.target]: conflictResource.currentDigest }
+      },
+      expectedAssessmentDigest: reviewedAssessment.assessmentDigest
+    }), expect.anything());
+  });
 });

--- a/packages/client/src/application-session.ts
+++ b/packages/client/src/application-session.ts
@@ -146,6 +146,7 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
   private base: MdbaseSession<Frontmatter> | null = null;
   private stopBase?: () => void;
   private setupAssessment: CollectionSetupAssessment | null = null;
+  private setupTypePackAdoptions: Record<string, Record<string, string>> | null = null;
   private verificationGeneration = 0;
   private lifecycleGeneration = 0;
   private startOperation: {
@@ -267,6 +268,7 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
     this.application = null;
     this.manifest = null;
     this.setupAssessment = null;
+    this.setupTypePackAdoptions = null;
     this.snapshot = { status: "opening", connections: [] };
     this.listeners.clear();
   }
@@ -389,7 +391,7 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
     }
     const assessment = this.setupAssessment;
     const input = {
-      ...this.collectionSetupInput(),
+      ...this.collectionSetupInput(this.setupTypePackAdoptions ?? undefined),
       expectedAssessmentDigest: assessment.assessmentDigest,
       expectedCollectionRevision: assessment.collectionRevision,
       expectedProvisionDigest: assessment.provisionDigest,
@@ -403,6 +405,7 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
       const applied = await connection.applyCollectionSetup(input, requestOptions);
       if (!applied.ok) return applied;
       this.setupAssessment = null;
+      this.setupTypePackAdoptions = null;
       await this.verifySetup(
         this.context(connection),
         ++this.verificationGeneration,
@@ -420,6 +423,7 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
     this.verificationGeneration += 1;
     const generation = this.verificationGeneration;
     this.setupAssessment = null;
+    this.setupTypePackAdoptions = null;
     if (current.status === "unselected") {
       this.publish({ status: "unselected", connections: current.connections });
       return;
@@ -457,13 +461,31 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
     const connection = this.connection();
     const manifest = this.requireManifest();
     if (!connection || connection.collectionId !== context.collectionId) return;
-    const outcome = options
-      ? await connection.assessCollectionSetup(this.collectionSetupInput(), options)
-      : await connection.assessCollectionSetup(this.collectionSetupInput());
+    const initialInput = this.collectionSetupInput();
+    let outcome = options
+      ? await connection.assessCollectionSetup(initialInput, options)
+      : await connection.assessCollectionSetup(initialInput);
     if (generation !== this.verificationGeneration) return;
     if (!outcome.ok) {
       this.publish({ status: "blocked", problem: outcome.problem, ...context });
       return;
+    }
+    if (!outcome.value.applicable) {
+      const adoptions = reviewableTypePackAdoptions(outcome.value);
+      if (Object.keys(adoptions).length > 0) {
+        outcome = options
+          ? await connection.assessCollectionSetup(
+              this.collectionSetupInput(adoptions),
+              options
+            )
+          : await connection.assessCollectionSetup(this.collectionSetupInput(adoptions));
+        if (generation !== this.verificationGeneration) return;
+        if (!outcome.ok) {
+          this.publish({ status: "blocked", problem: outcome.problem, ...context });
+          return;
+        }
+        this.setupTypePackAdoptions = adoptions;
+      }
     }
     if (generation !== this.verificationGeneration) return;
     if (outcome.value.status !== "current") {
@@ -483,7 +505,7 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
     this.publish({ status: "ready", verification: "verified", ...context });
   }
 
-  private collectionSetupInput() {
+  private collectionSetupInput(typePackAdoptions?: Record<string, Record<string, string>>) {
     const manifest = this.requireManifest();
     const application = this.requireApplication();
     return {
@@ -495,7 +517,8 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
       provisions: {
         configuration: manifest.provisions?.configuration ?? [],
         typePacks: manifest.provisions?.type_packs ?? []
-      }
+      },
+      ...(typePackAdoptions ? { typePackAdoptions } : {})
     };
   }
 
@@ -596,6 +619,26 @@ function collectionSetupUpdate(
     canApply: assessment.applicable,
     reason
   };
+}
+
+function reviewableTypePackAdoptions(
+  assessment: CollectionSetupAssessment
+): Record<string, Record<string, string>> {
+  const adoptions: Record<string, Record<string, string>> = {};
+  for (const pack of assessment.typePacks) {
+    const resources = Object.fromEntries(
+      pack.resources
+        .filter((resource) =>
+          resource.action === "conflict"
+          && resource.mode === "managed"
+          && resource.currentDigest !== undefined
+          && resource.installedDigest === undefined
+        )
+        .map((resource) => [resource.target, resource.currentDigest!])
+    );
+    if (Object.keys(resources).length > 0) adoptions[pack.desired.id] = resources;
+  }
+  return adoptions;
 }
 
 function verificationKey(manifest: MdbaseAppManifest, collectionId: string): string {

--- a/packages/client/src/collection-client.ts
+++ b/packages/client/src/collection-client.ts
@@ -706,7 +706,8 @@ function wireAssessCollectionSetupInput(
       configuration: input.provisions.configuration,
       type_packs: input.provisions.typePacks
     },
-    ...(input.contractSetups ? { contract_setups: input.contractSetups.map(wireContractSetupChoice) } : {})
+    ...(input.contractSetups ? { contract_setups: input.contractSetups.map(wireContractSetupChoice) } : {}),
+    ...(input.typePackAdoptions ? { type_pack_adoptions: input.typePackAdoptions } : {})
   };
 }
 

--- a/packages/client/src/operation-types.ts
+++ b/packages/client/src/operation-types.ts
@@ -603,6 +603,8 @@ export interface AssessCollectionSetupInput {
   requirements: ApplicationCollectionSetupRequirements;
   provisions: ApplicationCollectionSetupProvisions;
   contractSetups?: ContractSetupChoice[];
+  /** Digest-pinned consent to adopt unmanaged managed resources, keyed by pack id and target. */
+  typePackAdoptions?: Record<string, Record<string, string>>;
 }
 
 export interface ApplyCollectionSetupInput extends AssessCollectionSetupInput {

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/src/collection-setup.ts
+++ b/packages/protocol/src/collection-setup.ts
@@ -39,6 +39,8 @@ export interface AssessCollectionSetupInput {
   provisions: ApplicationCollectionSetupProvisions;
   /** Collection-owner choices for user-owned contract implementations. */
   contract_setups?: ContractSetupChoice[];
+  /** Digest-pinned consent to adopt unmanaged managed resources, keyed by pack id and target. */
+  type_pack_adoptions?: Record<string, Record<string, string>>;
 }
 
 export interface ApplyCollectionSetupInput extends AssessCollectionSetupInput {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.44" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.45" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.44",
+  "version": "0.1.0-beta.45",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

- add digest-pinned type-pack adoption choices to collection setup
- prepare a second, explicitly reviewable SDK assessment for unmanaged managed resources
- retry local and hosted application approval with the exact reviewed digests
- keep seed files, previously installed drift, and other-pack ownership blocked
- bump the coordinated release to `0.1.0-beta.45`

## Root cause

Collection setup correctly reported pre-existing managed definition files as conflicts, but the application session and approval provider had no way to carry the engine's existing digest-pinned adoption option. Consumers therefore received `applicable: false`, leaving their update controls disabled.

## Validation

- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- targeted SDK and hosted workspace adoption regressions