### PR TITLE
Repair beta invitation signup and email webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.0-beta.47
+
+Beta.47 repairs invitation account creation and email delivery tracking for the
+invite-only beta.
+
+- Invitation acceptance now locks only the invitation row before creating the
+  account, avoiding PostgreSQL's prohibition on locking the nullable side of an
+  outer join while retaining single-use invitation semantics.
+- Resend delivery webhooks use contiguous PostgreSQL parameters, allowing
+  delivery, bounce, suppression, and complaint events to update email state.
+- The account creation form no longer suggests connecting Google later.
+
 ## 0.1.0-beta.46
 
 Beta.46 separates hosted replica storage allowances and repairs Google account

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/portal/src/auth-view.tsx
+++ b/apps/portal/src/auth-view.tsx
@@ -441,7 +441,7 @@ export function Signup() {
         <p className="eyebrow">Private preview / invitation</p>
         <h1>{ready ? "Create your account" : "This invitation can’t be opened"}</h1>
         <p>{ready
-          ? "Your email is already verified by this one-time invitation. Create a password to finish setting up your account. After signing in, you can connect Google for future sign-ins."
+          ? "Your email is already verified by this one-time invitation. Create a password to finish setting up your account."
           : invitationToken
             ? "The link is invalid, expired, already used, or account setup is temporarily unavailable."
             : "Open the complete account setup link from your invitation email."}</p>

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.46"
+version = "0.1.0-beta.47"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.46
-git tag -a v0.1.0-beta.46 -m "mdbase connect 0.1.0-beta.46"
-git push origin v0.1.0-beta.46
+pnpm version:check v0.1.0-beta.47
+git tag -a v0.1.0-beta.47 -m "mdbase connect 0.1.0-beta.47"
+git push origin v0.1.0-beta.47
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.46" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.47" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/email-provider-webhooks.ts
+++ b/services/server/src/email-provider-webhooks.ts
@@ -115,19 +115,19 @@ async function applyEvent(
   if (state) {
     await db.query(
       `UPDATE email_jobs SET
-         state = $3,
-         delivered_at = CASE WHEN $3 = 'delivered' THEN $4 ELSE delivered_at END,
+         state = $2,
+         delivered_at = CASE WHEN $2 = 'delivered' THEN $3 ELSE delivered_at END,
          last_error_code = CASE
-           WHEN $3 = 'failed' THEN replace($5, 'email.', '')
+           WHEN $2 = 'failed' THEN replace($4, 'email.', '')
            ELSE last_error_code
          END,
-         last_provider_event_at = $4,
+         last_provider_event_at = $3,
          updated_at = now()
        WHERE provider = 'resend'
          AND provider_message_id = $1
-         AND (last_provider_event_at IS NULL OR last_provider_event_at <= $4)
+         AND (last_provider_event_at IS NULL OR last_provider_event_at <= $3)
          AND state NOT IN ('cancelled', 'uncertain')`,
-      [event.data.email_id, eventId, state, event.created_at, event.type]
+      [event.data.email_id, state, event.created_at, event.type]
     );
   }
 

--- a/services/server/src/password-auth.ts
+++ b/services/server/src/password-auth.ts
@@ -275,13 +275,12 @@ export class PasswordAccountService {
       await connection.query("BEGIN");
       const settings = await this.policy.currentForAccountChange(connection);
       requireSignupEnabled(settings);
-      const invitation = await connection.query<InvitationRow>(
-        `SELECT invitation.id, invitation.email, invitation.normalized_email,
-                invitation.terms_version, invitation.privacy_version,
-                entitlement.profile_code AS entitlement_profile
-         FROM invitations invitation
-         LEFT JOIN invitation_entitlements entitlement
-           ON entitlement.invitation_id = invitation.id
+      const invitation = await connection.query<
+        Omit<InvitationRow, "entitlement_profile">
+      >(
+        `SELECT id, email, normalized_email, terms_version, privacy_version,
+                expires_at
+         FROM invitations
          WHERE token_hash = $1
            AND accepted_at IS NULL
            AND revoked_at IS NULL
@@ -289,8 +288,18 @@ export class PasswordAccountService {
          FOR UPDATE`,
         [invitationHash]
       );
-      const row = invitation.rows[0];
-      if (!row) throw new InvalidInvitationError();
+      const lockedInvitation = invitation.rows[0];
+      if (!lockedInvitation) throw new InvalidInvitationError();
+      const entitlement = await connection.query<{ profile_code: string }>(
+        `SELECT profile_code
+         FROM invitation_entitlements
+         WHERE invitation_id = $1`,
+        [lockedInvitation.id]
+      );
+      const row: InvitationRow = {
+        ...lockedInvitation,
+        entitlement_profile: entitlement.rows[0]?.profile_code ?? null
+      };
       agreementsMatch(row, input);
       const currentAgreements = requiredAgreements(settings);
       if (


### PR DESCRIPTION
## Summary
- lock the invitation row without locking the nullable side of an outer join
- fix PostgreSQL parameter numbering in Resend delivery webhook updates
- remove the Google-later sentence from invitation account creation
- prepare `v0.1.0-beta.47`

## Focused validation
- `pnpm --filter @mdbase/connect-server exec vitest run src/password-auth.test.ts src/email-provider-webhooks.test.ts`
- `pnpm --filter @mdbase/connect-server build`
- `pnpm --filter @mdbase/connect-portal build`
- `pnpm version:check`
- `pnpm check:release-readiness`
- PostgreSQL 16 smoke: invitation acceptance plus Resend delivered-event ingestion

This is a production beta signup hotfix. Please run only the repository-required protected-branch and deployment checks.
