### PR TITLE
Add signup recovery invitation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.0-beta.48
+
+Beta.48 adds a safe recovery path for invitations affected by the beta.47
+signup incident.
+
+- Managed invitation resends can use a recovery-only transactional template
+  that apologizes for the failed signup and delivers the fresh one-time link in
+  the same email.
+- Recovery resends retain the invitation entitlement, invalidate the previous
+  link, omit credentials from operator output, and identify the email template
+  in the operator result and audited reason.
+
 ## 0.1.0-beta.47
 
 Beta.47 repairs invitation account creation and email delivery tracking for the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.47"
+version = "0.1.0-beta.48"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/instance-administration.md
+++ b/docs/instance-administration.md
@@ -129,6 +129,10 @@ force `--send-email enabled --token-output omitted`.
 Invitation delivery uses `invitation/<invitation-id>` as the provider
 idempotency key. `invite resend --id ...` intentionally creates a replacement
 invitation and emails it; the previous active invitation becomes invalid.
+Use `--email-template signup-recovery` only when replacing an invitation whose
+signup failed because of a confirmed service incident. It sends the apology
+and fresh one-time link together without exposing that credential to an
+operator or marketing system. Standard resends omit the option.
 Invitation revocation is an exact-replay mutation and therefore also requires
 `--operation-id`.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.47
-git tag -a v0.1.0-beta.47 -m "mdbase connect 0.1.0-beta.47"
-git push origin v0.1.0-beta.47
+pnpm version:check v0.1.0-beta.48
+git tag -a v0.1.0-beta.48 -m "mdbase connect 0.1.0-beta.48"
+git push origin v0.1.0-beta.48
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.47" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.48" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -287,10 +287,12 @@ describe("authentication operator command", () => {
   it("omits invitation credentials from managed delivery and replacement output", async () => {
     const base = await fixture();
     await configurePolicy(base);
+    const deliveredSubjects: string[] = [];
     const context = {
       ...base,
       emailTransport: {
-        async send() {
+        async send(message: Parameters<EmailTransport["send"]>[0]) {
+          deliveredSubjects.push(message.subject);
           return { provider: "test", messageId: randomMessageId() };
         }
       }
@@ -324,11 +326,14 @@ describe("authentication operator command", () => {
       "--actor",
       "operator:test",
       "--reason",
-      "Replace the previous delivery"
+      "Replace the previous delivery",
+      "--email-template",
+      "signup-recovery"
     ], context) as {
       invitation: {
         id: string;
         replaces_invitation_id: string;
+        email_template: string;
       };
       sensitive: boolean;
     };
@@ -337,6 +342,11 @@ describe("authentication operator command", () => {
     expect(resent.invitation.replaces_invitation_id).toBe(
       created.invitation.id
     );
+    expect(resent.invitation.email_template).toBe("signup_recovery");
+    expect(deliveredSubjects).toEqual([
+      "Your mdbase connect invitation",
+      "A fresh mdbase connect invitation"
+    ]);
     expect(JSON.stringify(resent)).not.toContain("inv_");
   });
 

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -17,7 +17,10 @@ import {
   EmailDeliveryError,
   type EmailTransport
 } from "./email.js";
-import { sendInvitationEmail } from "./invitation-email.js";
+import {
+  sendInvitationEmail,
+  type InvitationEmailTemplate
+} from "./invitation-email.js";
 import {
   InstanceAdminService,
   type HostedReplicaRevoker,
@@ -384,7 +387,8 @@ async function createInvitation(
 
 async function createAndDeliverInvitation(
   flags: Map<string, string>,
-  context: AuthAdminContext
+  context: AuthAdminContext,
+  emailTemplate: InvitationEmailTemplate = "standard"
 ): Promise<unknown> {
   const policy = new AuthenticationPolicyStore(
     context.db,
@@ -463,7 +467,8 @@ async function createAndDeliverInvitation(
   };
   const output = {
     invitation: {
-      ...invitationOutput
+      ...invitationOutput,
+      email_template: emailTemplate
     },
     delivery: { status: "not_requested" as const },
     sensitive: showToken,
@@ -479,7 +484,8 @@ async function createAndDeliverInvitation(
       invitationId: invitation.id,
       to: invitation.email,
       invitationUrl,
-      expiresAt: invitation.expiresAt
+      expiresAt: invitation.expiresAt,
+      template: emailTemplate
     });
   } catch (error) {
     const failure = {
@@ -587,7 +593,7 @@ async function resendInvitation(
 ): Promise<unknown> {
   const flags = parseFlags(
     argv,
-    new Set(["id", "actor", "reason", "expires-in"])
+    new Set(["id", "actor", "reason", "expires-in", "email-template"])
   );
   const invitationId = requiredFlag(flags, "id");
   const existing = await instanceAdmin(context).showInvitation(invitationId) as {
@@ -618,7 +624,14 @@ async function resendInvitation(
       existing.invitation.entitlement_profile
     );
   }
-  const result = await createAndDeliverInvitation(createFlags, context) as {
+  const emailTemplate = flags.has("email-template")
+    ? invitationEmailTemplate(requiredFlag(flags, "email-template"))
+    : "standard";
+  const result = await createAndDeliverInvitation(
+    createFlags,
+    context,
+    emailTemplate
+  ) as {
     invitation: Record<string, unknown>;
   };
   return {
@@ -813,6 +826,14 @@ function tokenOutput(value: string): "shown" | "omitted" {
   );
 }
 
+function invitationEmailTemplate(value: string): InvitationEmailTemplate {
+  if (value === "standard") return "standard";
+  if (value === "signup-recovery") return "signup_recovery";
+  throw new AuthAdminUsageError(
+    "--email-template must be standard or signup-recovery."
+  );
+}
+
 function entitlementProfile(value: string): string {
   if (/^[a-z][a-z0-9_]{0,99}$/u.test(value)) return value;
   throw new AuthAdminUsageError("Entitlement profile is invalid.");
@@ -922,7 +943,7 @@ export function usage(): string {
     "  auth-admin invite list [--status <status>] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin invite show --id <uuid>",
     "  auth-admin invite revoke --id <uuid> --operation-id <uuid> --actor <id> --reason <text>",
-    "  auth-admin invite resend --id <uuid> --actor <id> --reason <text> [--expires-in <seconds>]",
+    "  auth-admin invite resend --id <uuid> --actor <id> --reason <text> [--expires-in <seconds>] [--email-template standard|signup-recovery]",
     "  auth-admin beta list [--status pending|invited] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin entitlements show --user <uuid|email>",
     "  auth-admin entitlements grant --user <uuid|email> --profile <code> --operation-id <uuid> --actor <id> --reason <text>",

--- a/services/server/src/invitation-email.test.ts
+++ b/services/server/src/invitation-email.test.ts
@@ -39,6 +39,22 @@ describe("invitation email", () => {
     })).toThrow(/URL is invalid/);
   });
 
+  it("renders a signup-recovery apology with only the fresh invitation link", () => {
+    const rendered = renderInvitationEmail({
+      ...invitation,
+      template: "signup_recovery"
+    });
+    expect(rendered.subject).toBe("A fresh mdbase connect invitation");
+    expect(rendered.text).toContain(
+      "your previous invitation link didn’t work because of a signup problem on our side"
+    );
+    expect(rendered.text).toContain("That problem is now fixed.");
+    expect(rendered.text).toContain("previous invitation link no longer works");
+    expect(rendered.text).toContain(invitation.invitationUrl);
+    expect(rendered.html).toContain("A fresh invitation.");
+    expect(rendered.html).toContain(invitation.invitationUrl);
+  });
+
   it("uses the invitation identity as the provider idempotency key", async () => {
     const send = vi.fn(async () => ({
       provider: "test",

--- a/services/server/src/invitation-email.ts
+++ b/services/server/src/invitation-email.ts
@@ -9,7 +9,10 @@ export interface InvitationEmailInput {
   to: string;
   invitationUrl: string;
   expiresAt: Date;
+  template?: InvitationEmailTemplate;
 }
+
+export type InvitationEmailTemplate = "standard" | "signup_recovery";
 
 export function renderInvitationEmail(
   input: Omit<InvitationEmailInput, "invitationId">
@@ -27,32 +30,69 @@ export function renderInvitationEmail(
   const escapedUrl = escapeHtml(invitationUrl);
   const escapedEmail = escapeHtml(input.to);
   const escapedExpiry = escapeHtml(expiry);
+  const signupRecovery = input.template === "signup_recovery";
+  const subject = signupRecovery
+    ? "A fresh mdbase connect invitation"
+    : "Your mdbase connect invitation";
+  const text = signupRecovery
+    ? [
+        "mdbase connect",
+        "",
+        "Your invitation is ready.",
+        "",
+        "I’m sorry — your previous invitation link didn’t work because of a signup problem on our side. That problem is now fixed.",
+        "",
+        `Use this new one-time link to create the account for ${input.to}:`,
+        invitationUrl,
+        "",
+        "Your previous invitation link no longer works.",
+        `This new invitation expires ${expiry}.`,
+        "",
+        "Thanks for trying mdbase connect while it’s in private preview."
+      ].join("\n")
+    : [
+        "mdbase connect",
+        "",
+        "You’re invited to the private preview.",
+        "",
+        `Create the account for ${input.to}:`,
+        invitationUrl,
+        "",
+        `This one-time invitation expires ${expiry}.`,
+        "",
+        "If you weren’t expecting this invitation, you can ignore this email.",
+        "",
+        "mdbase connect gives applications access to the Markdown collections you choose."
+      ].join("\n");
+  const preheader = signupRecovery
+    ? "Your fresh mdbase connect invitation is ready."
+    : "Create your invited mdbase connect account.";
+  const heading = signupRecovery ? "A fresh invitation." : "You’re invited.";
+  const introduction = signupRecovery
+    ? `<p style="margin:0 0 16px;font-size:16px;line-height:1.55;color:#46515d">I’m sorry — your previous invitation link didn’t work because of a signup problem on our side. That problem is now fixed.</p>
+              <p style="margin:0 0 20px;font-size:16px;line-height:1.55;color:#46515d">Use this new one-time link to create the account for <strong>${escapedEmail}</strong>.</p>`
+    : `<p style="margin:0 0 20px;font-size:16px;line-height:1.55;color:#46515d">Create the private-preview account for <strong>${escapedEmail}</strong>. Your email is verified by this one-time link.</p>`;
+  const invitationNote = signupRecovery
+    ? `<p style="margin:0 0 9px;font-size:13px;line-height:1.5;color:#66717c">Your previous invitation link no longer works.</p>
+              <p style="margin:0;font-size:13px;line-height:1.5;color:#66717c">This new invitation expires ${escapedExpiry}.</p>`
+    : `<p style="margin:0 0 9px;font-size:13px;line-height:1.5;color:#66717c">This invitation expires ${escapedExpiry}.</p>
+              <p style="margin:0;font-size:13px;line-height:1.5;color:#66717c">If you weren’t expecting it, you can ignore this email.</p>`;
+  const footer = signupRecovery
+    ? "Thanks for trying mdbase connect while it’s in private preview."
+    : "mdbase connect gives applications access to the Markdown collections you choose.";
   return {
     to: input.to,
-    subject: "Your mdbase connect invitation",
-    text: [
-      "mdbase connect",
-      "",
-      "You’re invited to the private preview.",
-      "",
-      `Create the account for ${input.to}:`,
-      invitationUrl,
-      "",
-      `This one-time invitation expires ${expiry}.`,
-      "",
-      "If you weren’t expecting this invitation, you can ignore this email.",
-      "",
-      "mdbase connect gives applications access to the Markdown collections you choose."
-    ].join("\n"),
+    subject,
+    text,
     html: `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Your mdbase connect invitation</title>
+  <title>${subject}</title>
 </head>
 <body style="margin:0;background:#f8f9fa;color:#222831;font-family:Arial,sans-serif">
-  <div style="display:none;max-height:0;overflow:hidden">Create your invited mdbase connect account.</div>
+  <div style="display:none;max-height:0;overflow:hidden">${preheader}</div>
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f8f9fa">
     <tr>
       <td align="center" style="padding:40px 20px">
@@ -62,17 +102,16 @@ export function renderInvitationEmail(
           </tr>
           <tr>
             <td style="padding:12px 34px 34px">
-              <h1 style="margin:0 0 16px;font-size:27px;line-height:1.2;color:#222831">You’re invited.</h1>
-              <p style="margin:0 0 20px;font-size:16px;line-height:1.55;color:#46515d">Create the private-preview account for <strong>${escapedEmail}</strong>. Your email is verified by this one-time link.</p>
+              <h1 style="margin:0 0 16px;font-size:27px;line-height:1.2;color:#222831">${heading}</h1>
+              ${introduction}
               <p style="margin:0 0 24px">
                 <a href="${escapedUrl}" style="display:inline-block;padding:11px 16px;border:1px solid #8f99a5;border-radius:4px;color:#1d5f87;font-family:monospace;font-size:13px;font-weight:bold;text-decoration:none">Create your account</a>
               </p>
-              <p style="margin:0 0 9px;font-size:13px;line-height:1.5;color:#66717c">This invitation expires ${escapedExpiry}.</p>
-              <p style="margin:0;font-size:13px;line-height:1.5;color:#66717c">If you weren’t expecting it, you can ignore this email.</p>
+              ${invitationNote}
             </td>
           </tr>
           <tr>
-            <td style="padding:22px 34px;border-top:1px solid #e5e8ec;font-size:12px;line-height:1.5;color:#7a838d">mdbase connect gives applications access to the Markdown collections you choose.</td>
+            <td style="padding:22px 34px;border-top:1px solid #e5e8ec;font-size:12px;line-height:1.5;color:#7a838d">${footer}</td>
           </tr>
         </table>
       </td>


### PR DESCRIPTION
## Summary
- add a recovery-only transactional invitation email with apology and fresh link
- allow audited managed resends to select `--email-template signup-recovery`
- preserve standard invitation behavior and omit invitation credentials from operator output
- prepare `v0.1.0-beta.48`

## Focused validation
- `pnpm --filter @mdbase/connect-server exec vitest run src/invitation-email.test.ts src/auth-admin.test.ts`
- `pnpm --filter @mdbase/connect-server build`
- `pnpm version:check`
- `pnpm check:release-readiness`

Production recovery cohort selection and delivery are tracked privately in cloud ops.
