### PR TITLE
Improve local contention and file downloads for beta.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.0-beta.51
+
+Beta.51 improves resilience under local registry contention and reduces file
+download latency.
+
+- Relay operations distinguish retryable SQLite contention from rejected
+  requests and report that the operation was not sent.
+- Connector watchers batch registry writes to shorten transactions and reduce
+  lock contention while preserving operation ordering.
+- Framed file downloads prefetch subsequent chunks without changing integrity
+  verification or retry behavior.
+
 ## 0.1.0-beta.50
 
 Beta.50 makes application authorization independent from collection repair and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-agent/src/server/operation_responses.rs
+++ b/crates/connect-agent/src/server/operation_responses.rs
@@ -224,4 +224,21 @@ mod tests {
             Some(ConnectOperationOutcome::Rejected)
         );
     }
+
+    #[test]
+    fn sqlite_contention_is_retryable_and_not_sent() {
+        let error = ConnectError::Registry(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            None,
+        ));
+
+        let problem =
+            operation_problem(&error).with_operation_outcome(ConnectOperationOutcome::NotSent);
+
+        assert_eq!(problem.code, "registry_busy");
+        assert_eq!(
+            problem.operation_outcome,
+            Some(ConnectOperationOutcome::NotSent)
+        );
+    }
 }

--- a/crates/connect-agent/src/server/operations.rs
+++ b/crates/connect-agent/src/server/operations.rs
@@ -570,7 +570,15 @@ impl AgentState {
                 )
             }
             Ok(EncryptedRequestClaim::Conflict) => return rejected(),
-            Err(_) => return rejected(),
+            Err(ConnectError::EncryptedRelayRejected) => return rejected(),
+            Err(error) => {
+                return encrypted_problem_response(
+                    &keys,
+                    metadata,
+                    operation_problem(&error)
+                        .with_operation_outcome(ConnectOperationOutcome::NotSent),
+                )
+            }
         }
 
         if let Some(mutation_identifier) = mutation {

--- a/crates/connect-agent/src/server/tests.rs
+++ b/crates/connect-agent/src/server/tests.rs
@@ -434,6 +434,45 @@ fn encrypted_operations_round_trip_and_replays_return_the_durable_receipt() {
         panic!("expected cached encrypted response")
     };
     assert_eq!(replay_envelope, envelope);
+
+    let database = rusqlite::Connection::open(state_dir.join("connector.sqlite")).unwrap();
+    database.execute_batch("BEGIN IMMEDIATE").unwrap();
+    let busy_metadata = RelayMetadata {
+        binding: &binding,
+        request_id: Uuid::new_v4(),
+        operation: "describe",
+        counter: "2",
+    };
+    let busy_ciphertext = keys
+        .encrypt_json(
+            RelayDirection::Request,
+            busy_metadata,
+            &serde_json::json!({}),
+        )
+        .unwrap();
+    let busy_response = state
+        .handle_relay_message(RelayMessage::EncryptedOperationRequest {
+            envelope: busy_metadata.envelope(busy_ciphertext),
+        })
+        .unwrap();
+    let RelayMessage::EncryptedOperationResponse {
+        envelope: busy_envelope,
+    } = busy_response
+    else {
+        panic!("expected encrypted registry contention response")
+    };
+    let busy_body: serde_json::Value = keys
+        .decrypt_json(
+            RelayDirection::Response,
+            busy_metadata,
+            &busy_envelope.ciphertext,
+        )
+        .unwrap();
+    assert_eq!(busy_body["ok"], false);
+    assert_eq!(busy_body["problem"]["code"], "registry_busy");
+    assert_eq!(busy_body["problem"]["operation_outcome"], "not_sent");
+    database.execute_batch("ROLLBACK").unwrap();
+
     fs::remove_dir_all(test_root).unwrap();
 }
 

--- a/crates/connect-agent/src/watcher.rs
+++ b/crates/connect-agent/src/watcher.rs
@@ -208,23 +208,31 @@ fn start_worker(
                     if let Err(error) = result {
                         tracing::warn!(collection_id = %collection_id, %error, "collection rescan failed");
                     }
+                    let mut events = Vec::new();
                     while let Ok(Some(event)) = watcher.recv_timeout(Duration::ZERO) {
-                        persist_event(&registry, collection_id, &event, runtime_events.as_ref());
+                        events.push(event);
                     }
+                    persist_events(&registry, collection_id, &events, runtime_events.as_ref());
                     let _ = ready.send(());
                 }
+                let mut events = Vec::new();
                 loop {
                     match watcher.recv_timeout(Duration::ZERO) {
-                        Ok(Some(event)) => {
-                            persist_event(&registry, collection_id, &event, runtime_events.as_ref())
-                        }
+                        Ok(Some(event)) => events.push(event),
                         Ok(None) => break,
                         Err(error) => {
+                            persist_events(
+                                &registry,
+                                collection_id,
+                                &events,
+                                runtime_events.as_ref(),
+                            );
                             tracing::warn!(collection_id = %collection_id, %error, "collection watcher stopped");
                             return;
                         }
                     }
                 }
+                persist_events(&registry, collection_id, &events, runtime_events.as_ref());
                 // External filesystem events may wait up to this interval;
                 // explicit mutation synchronization unparks the worker and is
                 // processed immediately without a polling tax.
@@ -239,12 +247,15 @@ fn start_worker(
     })
 }
 
-fn persist_event(
+fn persist_events(
     registry: &CollectionRegistry,
     collection_id: Uuid,
-    event: &mdbase::watch::WatchEvent,
+    events: &[mdbase::watch::WatchEvent],
     runtime_events: Option<&tokio::sync::mpsc::UnboundedSender<CollectionRuntimeEvent>>,
 ) {
+    if events.is_empty() {
+        return;
+    }
     match registry.get(collection_id) {
         Ok(collection) if collection.enabled => {}
         Ok(_) => {
@@ -263,22 +274,21 @@ fn persist_event(
             return;
         }
     }
-    if let Err(error) = registry.mark_file_inventory_dirty(collection_id) {
-        tracing::warn!(collection_id = %collection_id, %error, "failed to mark the file inventory dirty");
-    }
-    match registry.append_change(collection_id, event) {
+    match registry.append_changes(collection_id, events) {
         Err(error) => {
-            tracing::warn!(collection_id = %collection_id, %error, "failed to persist collection change");
+            tracing::warn!(collection_id = %collection_id, event_count = events.len(), %error, "failed to persist collection changes");
         }
-        Ok(cursor) => {
+        Ok(cursors) => {
             if let Some(runtime_events) = runtime_events {
-                let _ = runtime_events.send(CollectionRuntimeEvent {
-                    collection_id,
-                    cursor,
-                    event: event.clone(),
-                });
+                for (event, cursor) in events.iter().zip(cursors.iter().copied()) {
+                    let _ = runtime_events.send(CollectionRuntimeEvent {
+                        collection_id,
+                        cursor,
+                        event: event.clone(),
+                    });
+                }
             }
-            tracing::debug!(collection_id = %collection_id, event_type = %event.event_type, sequence = event.sequence, cursor, "collection change recorded");
+            tracing::debug!(collection_id = %collection_id, event_count = events.len(), first_cursor = cursors.first(), last_cursor = cursors.last(), "collection changes recorded");
         }
     }
 }

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -201,6 +201,14 @@ impl ConnectError {
             Self::AuthorityTransferInProgress { .. } => "authority_transfer_in_progress",
             Self::AuthorityRetired => "authority_retired",
             Self::AuthorityTransferMismatch => "authority_transfer_mismatch",
+            Self::Registry(error)
+                if matches!(
+                    error.sqlite_error_code(),
+                    Some(rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked)
+                ) =>
+            {
+                "registry_busy"
+            }
             Self::Registry(_) => "registry_failed",
             Self::RegistryCorrupt { .. } => "registry_corrupt",
             Self::RegistrySchemaIncompatible { .. } => "registry_schema_incompatible",

--- a/crates/connect-core/src/registry/descriptions.rs
+++ b/crates/connect-core/src/registry/descriptions.rs
@@ -114,37 +114,63 @@ impl CollectionRegistry {
         collection_id: Uuid,
         event: &mdbase::watch::WatchEvent,
     ) -> Result<u64, ConnectError> {
+        self.append_changes(collection_id, std::slice::from_ref(event))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ConnectError::InvalidInput("A collection change is required.".into()))
+    }
+
+    pub fn append_changes(
+        &self,
+        collection_id: Uuid,
+        events: &[mdbase::watch::WatchEvent],
+    ) -> Result<Vec<u64>, ConnectError> {
         self.get(collection_id)?;
-        let mut payload = event.payload.clone();
-        if let Some(object) = payload.as_object_mut() {
-            object.remove("before");
-            object.remove("after");
+        if events.is_empty() {
+            return Ok(Vec::new());
         }
         let mut connection = self.connection()?;
-        let transaction = connection.transaction()?;
-        let cursor: i64 = transaction.query_row(
-            "SELECT COALESCE(MAX(cursor), 0) + 1 FROM collection_changes WHERE collection_id = ?1",
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        Self::mark_file_inventory_dirty_in(
+            &transaction,
+            collection_id,
+            u64::try_from(events.len()).unwrap_or(u64::MAX),
+        )?;
+        let mut cursor: i64 = transaction.query_row(
+            "SELECT COALESCE(MAX(cursor), 0) FROM collection_changes WHERE collection_id = ?1",
             [collection_id.to_string()],
             |row| row.get(0),
         )?;
-        transaction.execute(
-            "INSERT INTO collection_changes
-               (collection_id, cursor, event_type, occurred_at, payload)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![
-                collection_id.to_string(),
-                cursor,
-                event.event_type,
-                event.occurred_at,
-                serde_json::to_string(&payload)?,
-            ],
-        )?;
+        let mut cursors = Vec::with_capacity(events.len());
+        for event in events {
+            cursor = cursor.checked_add(1).ok_or_else(|| {
+                ConnectError::CollectionOpen("collection change cursor exhausted".into())
+            })?;
+            let mut payload = event.payload.clone();
+            if let Some(object) = payload.as_object_mut() {
+                object.remove("before");
+                object.remove("after");
+            }
+            transaction.execute(
+                "INSERT INTO collection_changes
+                   (collection_id, cursor, event_type, occurred_at, payload)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    collection_id.to_string(),
+                    cursor,
+                    event.event_type,
+                    event.occurred_at,
+                    serde_json::to_string(&payload)?,
+                ],
+            )?;
+            cursors.push(cursor as u64);
+        }
         transaction.execute(
             "DELETE FROM collection_changes WHERE collection_id = ?1 AND cursor <= ?2",
             params![collection_id.to_string(), cursor.saturating_sub(2_000)],
         )?;
         transaction.commit()?;
-        Ok(cursor as u64)
+        Ok(cursors)
     }
 
     pub(super) fn refresh_summary_metadata(

--- a/crates/connect-core/src/registry/files.rs
+++ b/crates/connect-core/src/registry/files.rs
@@ -70,18 +70,27 @@ impl CollectionRegistry {
     /// for every collection watcher event, including record and configuration events.
     pub fn mark_file_inventory_dirty(&self, id: Uuid) -> Result<(), ConnectError> {
         self.get(id)?;
-        self.connection()?.execute(
+        Self::mark_file_inventory_dirty_in(&self.connection()?, id, 1)?;
+        Ok(())
+    }
+
+    pub(super) fn mark_file_inventory_dirty_in(
+        connection: &Connection,
+        id: Uuid,
+        generations: u64,
+    ) -> Result<(), ConnectError> {
+        let generations = i64::try_from(generations).unwrap_or(i64::MAX);
+        connection.execute(
             "INSERT INTO collection_file_inventory_state
                 (collection_id, observed_generation, reconciled_generation,
                  index_revision, reconciled_at_ms)
-             VALUES (?1, 1, 0, 0, 0)
+             VALUES (?1, ?2, 0, 0, 0)
              ON CONFLICT(collection_id) DO UPDATE SET
-                observed_generation = CASE
-                    WHEN observed_generation < 9223372036854775807
-                    THEN observed_generation + 1
-                    ELSE observed_generation
-                END",
-            [id.to_string()],
+                observed_generation = MIN(
+                    9223372036854775807,
+                    observed_generation + ?2
+                )",
+            params![id.to_string(), generations],
         )?;
         Ok(())
     }

--- a/crates/connect-core/src/registry/tests/operations.rs
+++ b/crates/connect-core/src/registry/tests/operations.rs
@@ -955,3 +955,36 @@ fn change_pages_resume_by_cursor_and_omit_record_snapshots() {
     assert!(page.events[0].payload.get("after").is_none());
     assert_eq!(page.cursor, 1);
 }
+
+#[test]
+fn watcher_change_bursts_share_one_ordered_inventory_write() {
+    let state = tempdir().unwrap();
+    let collection_parent = tempdir().unwrap();
+    let registry = CollectionRegistry::open(state.path()).unwrap();
+    let collection = registry
+        .create(collection_parent.path().join("notes"), Some("Notes"), "UTC")
+        .unwrap();
+    let events = ["one.md", "two.md"].map(|path| mdbase::watch::WatchEvent {
+        event_type: "mdbase.record.modified".to_string(),
+        sequence: 1,
+        occurred_at: "2026-08-09T12:00:00.000Z".to_string(),
+        payload: json!({ "path": path, "before": {}, "after": {} }),
+    });
+
+    assert_eq!(
+        registry.append_changes(collection.id, &events).unwrap(),
+        vec![1, 2]
+    );
+    let connection = registry.connection().unwrap();
+    let (observed_generation, changes): (u64, u64) = connection
+        .query_row(
+            "SELECT observed_generation,
+                    (SELECT COUNT(*) FROM collection_changes WHERE collection_id = ?1)
+             FROM collection_file_inventory_state WHERE collection_id = ?1",
+            [collection.id.to_string()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(observed_generation, 2);
+    assert_eq!(changes, 2);
+}

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.50"
+version = "0.1.0-beta.51"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.50
-git tag -a v0.1.0-beta.50 -m "mdbase connect 0.1.0-beta.50"
-git push origin v0.1.0-beta.50
+pnpm version:check v0.1.0-beta.51
+git tag -a v0.1.0-beta.51 -m "mdbase connect 0.1.0-beta.51"
+git push origin v0.1.0-beta.51
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/files.test.ts
+++ b/packages/client/src/files.test.ts
@@ -903,7 +903,7 @@ describe("MdbaseFileClient", () => {
     expect(objectFetch).not.toHaveBeenCalled();
   });
 
-  it("streams encrypted frames in order with one negotiated part in memory", async () => {
+  it("prefetches encrypted frames concurrently and emits them in order", async () => {
     const content = bytes("framed chunks stay ordered");
     const file = descriptor("framed.bin", content);
     let active = 0;
@@ -933,7 +933,7 @@ describe("MdbaseFileClient", () => {
     }, framed);
 
     await expect(client.downloadBytes(file, { concurrency: 4 })).resolves.toEqual(content);
-    expect(maximumActive).toBe(1);
+    expect(maximumActive).toBe(4);
   });
 
   it("requires the streaming API for downloads above the bounded convenience limit", async () => {

--- a/packages/client/src/files.ts
+++ b/packages/client/src/files.ts
@@ -480,7 +480,7 @@ export class MdbaseFileClient {
     startupSignal: AbortSignal
   ): Promise<ReadableStream<Uint8Array>> {
     this.requireAction("read");
-    validConcurrency(options.concurrency);
+    const concurrency = validConcurrency(options.concurrency);
     const transferId = crypto.randomUUID();
     let session: FileTransferSession;
     try {
@@ -518,11 +518,38 @@ export class MdbaseFileClient {
     let hostedReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
     let receivedBytes = 0;
     let closed = false;
+    const deliveryController = new AbortController();
+    const deliverySignal = options.signal
+      ? AbortSignal.any([options.signal, deliveryController.signal])
+      : deliveryController.signal;
+    type FramedChunkResult =
+      | { readonly ok: true; readonly chunk: Uint8Array }
+      | { readonly ok: false; readonly error: unknown };
+    const framedChunks = new Map<number, Promise<FramedChunkResult>>();
+    let nextFramedPart = 0;
+    const queueFramedChunks = () => {
+      if (session.strategy.kind !== "framed_chunks") return;
+      while (nextFramedPart < partCount && framedChunks.size < concurrency) {
+        const index = nextFramedPart;
+        nextFramedPart += 1;
+        const pending = retryChunk(
+          () => this.framed!.downloadChunk(session, index, deliverySignal),
+          deliverySignal
+        ).then<FramedChunkResult, FramedChunkResult>(
+          (chunk) => ({ ok: true, chunk }),
+          (error: unknown) => ({ ok: false, error })
+        );
+        framedChunks.set(index, pending);
+      }
+    };
     const finish = async () => {
       if (closed) return;
       closed = true;
+      deliveryController.abort();
       await hostedReader?.cancel().catch(() => undefined);
       hostedReader = null;
+      await Promise.all(framedChunks.values());
+      framedChunks.clear();
       await this.abort(transferId);
     };
     const verify = () => {
@@ -534,7 +561,7 @@ export class MdbaseFileClient {
     return new ReadableStream<Uint8Array>({
       pull: async (controller) => {
         try {
-          throwIfAborted(options.signal);
+          throwIfAborted(deliverySignal);
           if (session.strategy.kind === "object_ranges") {
             while (true) {
               if (!hostedReader) {
@@ -551,9 +578,9 @@ export class MdbaseFileClient {
                     session,
                     partIndex,
                     partRemaining,
-                    options.signal
+                    deliverySignal
                   ),
-                  options.signal
+                  deliverySignal
                 );
                 hostedReader = body.getReader();
               }
@@ -603,16 +630,22 @@ export class MdbaseFileClient {
           }
           const offset = partIndex * partSize;
           const length = Math.min(partSize, file.size - offset);
-          const chunk = await retryChunk(
-            () => this.framed!.downloadChunk(session, partIndex, options.signal),
-            options.signal
-          );
+          queueFramedChunks();
+          const pending = framedChunks.get(partIndex);
+          if (!pending) {
+            throw connectError("invalid_operation_response", "A file chunk was not scheduled.");
+          }
+          const result = await pending;
+          framedChunks.delete(partIndex);
+          if (!result.ok) throw result.error;
+          const chunk = result.chunk;
           if (chunk.byteLength !== length) {
             throw connectError("invalid_operation_response", "A file chunk had the wrong byte length.");
           }
           hash.update(chunk);
           receivedBytes += chunk.byteLength;
           partIndex += 1;
+          queueFramedChunks();
           options.onProgress?.({
             phase: "downloading",
             transferredBytes: receivedBytes,

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.50" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.51" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- report retryable local SQLite contention as a not-sent operation instead of a relay rejection
- batch watcher registry writes to shorten transactions and reduce lock contention
- prefetch framed download chunks while preserving integrity checks and retries
- prepare the consistent v0.1.0-beta.51 release metadata and changelog

## Validation
- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace`
- `pnpm check:architecture`
- `pnpm version:check v0.1.0-beta.51`
- `pnpm check:release-readiness`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`

## Release impact
This is the follow-up beta.51 release containing the three user-authored commits that landed locally after beta.50 was cut.