### PR TITLE
Use EmbedPDF for focused PDF viewing

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -29,6 +29,7 @@
     "@codemirror/search": "^6.7.1",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
+    "@embedpdf/react-pdf-viewer": "^2.15.0",
     "@fontsource/atkinson-hyperlegible": "^5.3.0",
     "@fontsource/azeret-mono": "^5.3.0",
     "@lezer/highlight": "^1.2.3",

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -1997,6 +1997,8 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
                 onDismissLinkPreview={notePreviewController.dismiss}
                 embeddedFiles={embeddedFiles}
                 onOpenFile={setOpenFileAsset}
+                files={fileInventory.files}
+                onOpenFileLink={navigateToFile}
                 insertion={attachments.insertion}
               />
             </Suspense>

--- a/apps/editor/src/CodeEditor.tsx
+++ b/apps/editor/src/CodeEditor.tsx
@@ -36,9 +36,9 @@ import { tags } from "@lezer/highlight";
 import { useEffect, useRef } from "react";
 import { parseDocument as parseYamlDocument } from "yaml";
 import type { FileAssetSnapshot } from "./file-asset-store";
-import { resolveFileReference } from "./file-references";
 import type { ResolvedFileReference } from "./use-file-assets";
 import { fileEmbedPresentation } from "./code-editor-file-embeds";
+import { writerInteractions } from "./code-editor-writer-interactions";
 import { linkMatches, wikilinkFor, type LinkSuggestion } from "./links";
 import type { NotePreviewAnchor, NotePreviewSource } from "./NotePreview";
 import type { CollectionFile } from "./model";
@@ -93,6 +93,8 @@ interface MarkdownEdit {
 
 const rememberedEditors = new Map<string, RememberedEditor>();
 const rememberedEditorLimit = 40;
+
+export { internalLinkPathAt } from "./code-editor-writer-interactions";
 
 export function CodeEditor({
   value,
@@ -763,184 +765,6 @@ const markdownMarkerNames = new Set([
   "ListMark",
   "LinkMark"
 ]);
-
-function writerInteractions(
-  suggestions: () => LinkSuggestion[],
-  files: () => CollectionFile[],
-  currentPath: () => string | undefined,
-  onOpenLink: () => ((path: string) => void) | undefined,
-  onOpenFileLink: () => ((file: CollectionFile) => void) | undefined,
-  onCreateLink: () => ((target: string, label: string | undefined, format: "wikilink" | "markdown") => void) | undefined,
-  onPreviewLink: () => ((path: string, anchor: NotePreviewAnchor, source: NotePreviewSource) => void) | undefined,
-  onDismissLinkPreview: () => (() => void) | undefined
-): Extension {
-  let hoveredPath: string | undefined;
-  const dismissPreview = (view: EditorView) => {
-    if (!hoveredPath) return;
-    hoveredPath = undefined;
-    view.dom.classList.remove("cm-hovering-link");
-    onDismissLinkPreview()?.();
-  };
-  return EditorView.domEventHandlers({
-    mousedown(event, view) {
-      const task = taskTarget(event);
-      if (task && event.button === 0) return toggleTask(view, task, event);
-      const renderedLink = event.target instanceof Element
-        ? event.target.closest(".cm-rendered-link")
-        : null;
-      if (!renderedLink || event.button !== 0) return false;
-      event.preventDefault();
-      return true;
-    },
-    keydown(event, view) {
-      const task = taskTarget(event);
-      if (!task || (event.key !== "Enter" && event.key !== " ")) return false;
-      return toggleTask(view, task, event);
-    },
-    click(event, view) {
-      const rendered = event.target instanceof Element
-        ? event.target.closest<HTMLElement>(".cm-rendered-link")
-        : null;
-      if (!rendered && !event.metaKey && !event.ctrlKey) return false;
-      const renderedFrom = rendered ? Number(rendered.dataset.linkFrom) : undefined;
-      const position = Number.isFinite(renderedFrom)
-        ? renderedFrom!
-        : view.posAtCoords({ x: event.clientX, y: event.clientY });
-      if (position === null) return false;
-      const link = markdownLinkAt(view.state.doc.toString(), position);
-      if (!link) return false;
-      if (/^https?:\/\//i.test(link.target)) {
-        event.preventDefault();
-        window.open(link.target, "_blank", "noopener,noreferrer");
-        return true;
-      }
-      if (!link.target || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(link.target)) return false;
-      const path = resolveSuggestionPath(link.target, suggestions(), currentPath());
-      const file = resolveFileReference(link.target, link.format, files(), currentPath());
-      const openLink = onOpenLink();
-      const openFileLink = onOpenFileLink();
-      const createLink = onCreateLink();
-      if (!path && !file && !createLink) return false;
-      if (path && !openLink) return false;
-      if (file && !openFileLink) return false;
-      event.preventDefault();
-      dismissPreview(view);
-      if (path) openLink?.(path);
-      else if (file) openFileLink?.(file);
-      else createLink?.(link.target, link.label, link.format);
-      return true;
-    },
-    mousemove(event, view) {
-      const position = view.posAtCoords({ x: event.clientX, y: event.clientY });
-      const path = position === null
-        ? undefined
-        : internalLinkPathAt(view.state.doc.toString(), position, suggestions(), currentPath());
-      if (!path) {
-        dismissPreview(view);
-        return false;
-      }
-      if (hoveredPath === path) return false;
-      if (hoveredPath) onDismissLinkPreview()?.();
-      hoveredPath = path;
-      view.dom.classList.add("cm-hovering-link");
-      const coordinates = view.coordsAtPos(position ?? 0);
-      const anchor: NotePreviewAnchor = {
-        left: event.clientX,
-        right: event.clientX,
-        top: coordinates?.top ?? event.clientY,
-        bottom: coordinates?.bottom ?? event.clientY
-      };
-      onPreviewLink()?.(path, anchor, "editor");
-      return false;
-    },
-    mouseleave(_event, view) {
-      dismissPreview(view);
-      return false;
-    }
-  });
-}
-
-function taskTarget(event: Event): HTMLElement | null {
-  return event.target instanceof Element ? event.target.closest<HTMLElement>(".cm-task-checkbox") : null;
-}
-
-function toggleTask(view: EditorView, target: HTMLElement, event: Event): boolean {
-  const from = Number(target.dataset.taskFrom);
-  if (!Number.isFinite(from)) return false;
-  const source = view.state.sliceDoc(from, from + 3);
-  if (!/^\[[ xX]\]$/.test(source)) return false;
-  event.preventDefault();
-  view.dispatch({
-    changes: { from: from + 1, to: from + 2, insert: source[1].toLocaleLowerCase() === "x" ? " " : "x" },
-    scrollIntoView: true,
-    userEvent: "input"
-  });
-  view.focus();
-  return true;
-}
-
-interface MarkdownLinkTarget {
-  target: string;
-  label?: string;
-  format: "wikilink" | "markdown";
-}
-
-function markdownLinkAt(doc: string, position: number): MarkdownLinkTarget | undefined {
-  const lineStart = doc.lastIndexOf("\n", position - 1) + 1;
-  const lineEnd = doc.indexOf("\n", position);
-  const end = lineEnd < 0 ? doc.length : lineEnd;
-  const line = doc.slice(lineStart, end);
-  for (const match of line.matchAll(/\[\[([^\]]+)\]\]|\[([^\]]*)\]\(([^)]+)\)/g)) {
-    const from = lineStart + match.index;
-    const to = from + match[0].length;
-    if (position < from || position > to || doc[from - 1] === "!") continue;
-    if (match[1] !== undefined) {
-      const [target, label] = match[1].split("|", 2);
-      return {
-        target: target.split("#", 1)[0].trim(),
-        label: label?.trim() || undefined,
-        format: "wikilink"
-      };
-    }
-    return {
-      target: (match[3] ?? "").replace(/^<|>$/g, "").split("#", 1)[0].trim(),
-      label: match[2]?.trim() || undefined,
-      format: "markdown"
-    };
-  }
-  return undefined;
-}
-
-export function internalLinkPathAt(
-  doc: string,
-  position: number,
-  suggestions: LinkSuggestion[],
-  sourcePath?: string
-): string | undefined {
-  const link = markdownLinkAt(doc, position);
-  if (!link || /^https?:\/\//i.test(link.target)) return undefined;
-  return resolveSuggestionPath(link.target, suggestions, sourcePath);
-}
-
-function resolveSuggestionPath(target: string, suggestions: LinkSuggestion[], sourcePath?: string): string | undefined {
-  const normalized = target.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\.md$/i, "").toLocaleLowerCase();
-  const exact = suggestions.find((suggestion) => suggestion.path.replace(/\.md$/i, "").toLocaleLowerCase() === normalized);
-  if (exact) return exact.path;
-  const sourceFolder = sourcePath?.includes("/") ? sourcePath.slice(0, sourcePath.lastIndexOf("/")) : "";
-  const candidates = suggestions.filter((suggestion) => {
-    const filename = suggestion.path.split("/").at(-1)?.replace(/\.md$/i, "").toLocaleLowerCase();
-    return filename === normalized
-      || suggestion.title.toLocaleLowerCase() === normalized
-      || suggestion.aliases?.some((alias) => alias.toLocaleLowerCase() === normalized);
-  });
-  return candidates.sort((left, right) => {
-    const leftFolder = left.path.slice(0, Math.max(0, left.path.lastIndexOf("/")));
-    const rightFolder = right.path.slice(0, Math.max(0, right.path.lastIndexOf("/")));
-    return Number(rightFolder === sourceFolder) - Number(leftFolder === sourceFolder)
-      || left.path.length - right.path.length
-      || left.path.localeCompare(right.path);
-  })[0]?.path;
-}
 
 function yamlLinter(view: EditorView): readonly Diagnostic[] {
   const source = view.state.doc.toString();

--- a/apps/editor/src/CodeEditor.tsx
+++ b/apps/editor/src/CodeEditor.tsx
@@ -36,10 +36,12 @@ import { tags } from "@lezer/highlight";
 import { useEffect, useRef } from "react";
 import { parseDocument as parseYamlDocument } from "yaml";
 import type { FileAssetSnapshot } from "./file-asset-store";
+import { resolveFileReference } from "./file-references";
 import type { ResolvedFileReference } from "./use-file-assets";
 import { fileEmbedPresentation } from "./code-editor-file-embeds";
 import { linkMatches, wikilinkFor, type LinkSuggestion } from "./links";
 import type { NotePreviewAnchor, NotePreviewSource } from "./NotePreview";
+import type { CollectionFile } from "./model";
 
 type EditorLanguage = "markdown" | "json" | "yaml" | "yaml-frontmatter" | "plain";
 type EditorVariant = "writer" | "source";
@@ -69,6 +71,8 @@ interface CodeEditorProps {
   onDismissLinkPreview?: () => void;
   embeddedFiles?: ResolvedFileReference[];
   onOpenFile?: (asset: Extract<FileAssetSnapshot, { status: "ready" }>) => void;
+  files?: CollectionFile[];
+  onOpenFileLink?: (file: CollectionFile) => void;
   insertion?: { id: number; text: string; block?: boolean };
   onBlur?: () => void;
 }
@@ -114,6 +118,8 @@ export function CodeEditor({
   onDismissLinkPreview,
   embeddedFiles = [],
   onOpenFile,
+  files = [],
+  onOpenFileLink,
   insertion,
   onBlur
 }: CodeEditorProps) {
@@ -137,6 +143,8 @@ export function CodeEditor({
   const onDismissLinkPreviewRef = useRef(onDismissLinkPreview);
   const embeddedFilesRef = useRef(embeddedFiles);
   const onOpenFileRef = useRef(onOpenFile);
+  const filesRef = useRef(files);
+  const onOpenFileLinkRef = useRef(onOpenFileLink);
   const appliedInsertion = useRef<number | undefined>(undefined);
   const lineSeparator = useRef(lineSeparatorFor(value));
 
@@ -150,6 +158,8 @@ export function CodeEditor({
   onDismissLinkPreviewRef.current = onDismissLinkPreview;
   embeddedFilesRef.current = embeddedFiles;
   onOpenFileRef.current = onOpenFile;
+  filesRef.current = files;
+  onOpenFileLinkRef.current = onOpenFileLink;
 
   useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
 
@@ -175,8 +185,10 @@ export function CodeEditor({
       ) : []),
       variant === "writer" ? writerInteractions(
         () => linkSuggestionsRef.current,
+        () => filesRef.current,
         () => currentPathRef.current,
         () => onOpenLinkRef.current,
+        () => onOpenFileLinkRef.current,
         () => onCreateLinkRef.current,
         () => onPreviewLinkRef.current,
         () => onDismissLinkPreviewRef.current
@@ -754,8 +766,10 @@ const markdownMarkerNames = new Set([
 
 function writerInteractions(
   suggestions: () => LinkSuggestion[],
+  files: () => CollectionFile[],
   currentPath: () => string | undefined,
   onOpenLink: () => ((path: string) => void) | undefined,
+  onOpenFileLink: () => ((file: CollectionFile) => void) | undefined,
   onCreateLink: () => ((target: string, label: string | undefined, format: "wikilink" | "markdown") => void) | undefined,
   onPreviewLink: () => ((path: string, anchor: NotePreviewAnchor, source: NotePreviewSource) => void) | undefined,
   onDismissLinkPreview: () => (() => void) | undefined
@@ -802,13 +816,17 @@ function writerInteractions(
       }
       if (!link.target || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(link.target)) return false;
       const path = resolveSuggestionPath(link.target, suggestions(), currentPath());
+      const file = resolveFileReference(link.target, link.format, files(), currentPath());
       const openLink = onOpenLink();
+      const openFileLink = onOpenFileLink();
       const createLink = onCreateLink();
-      if (!path && !createLink) return false;
+      if (!path && !file && !createLink) return false;
       if (path && !openLink) return false;
+      if (file && !openFileLink) return false;
       event.preventDefault();
       dismissPreview(view);
       if (path) openLink?.(path);
+      else if (file) openFileLink?.(file);
       else createLink?.(link.target, link.label, link.format);
       return true;
     },

--- a/apps/editor/src/CodeEditor.ui.test.tsx
+++ b/apps/editor/src/CodeEditor.ui.test.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { CodeEditor } from "./CodeEditor";
+import type { ResolvedFileReference } from "./use-file-assets";
+
+vi.mock("./inline-pdf-viewer", () => ({
+  mountInlinePdfViewer: vi.fn(() => ({ unmount: vi.fn() }))
+}));
 
 describe("rendered Markdown links", () => {
   it("opens a rendered link without moving the caret into its source", async () => {
@@ -20,3 +25,69 @@ describe("rendered Markdown links", () => {
     expect(screen.getByRole("link", { name: "the documentation" })).toBeInTheDocument();
   });
 });
+
+describe("PDF links and embeds", () => {
+  it("focuses an embedded PDF in place without opening a modal", async () => {
+    render(<CodeEditor
+      value={"Intro.\n\n![[Documents/paper.pdf]]"}
+      label="Note body"
+      language="markdown"
+      variant="writer"
+      embeddedFiles={[pdfReference]}
+    />);
+
+    const open = await screen.findByRole("button", { name: "Open paper.pdf" });
+    fireEvent.click(open);
+
+    const viewer = await screen.findByRole("region", { name: "Embedded PDF, paper.pdf" });
+    expect(viewer).toHaveFocus();
+    expect(screen.queryByRole("dialog", { name: "Preview paper.pdf" })).not.toBeInTheDocument();
+  });
+
+  it("opens a PDF wikilink in the file workspace", async () => {
+    const openFile = vi.fn();
+    render(<CodeEditor
+      value={"Intro.\nRead [[Documents/paper.pdf]]."}
+      label="Note body"
+      language="markdown"
+      variant="writer"
+      files={[pdfReference.asset.file]}
+      onOpenFileLink={openFile}
+    />);
+
+    fireEvent.click(await screen.findByRole("link", { name: "Documents/paper.pdf" }));
+    expect(openFile).toHaveBeenCalledWith(pdfReference.asset.file);
+  });
+});
+
+const pdfReference: ResolvedFileReference = {
+  from: 8,
+  to: 32,
+  target: "Documents/paper.pdf",
+  format: "wikilink",
+  block: true,
+  file: {
+    fileId: "00000000-0000-4000-8000-000000000003",
+    path: "Documents/paper.pdf",
+    revision: "pdf-1",
+    contentDigest: `sha256:${"3".repeat(64)}`,
+    size: 10,
+    mediaType: "application/pdf",
+    mediaClass: "pdf",
+    modifiedAt: "2026-08-09T00:00:00Z"
+  },
+  asset: {
+    status: "ready",
+    url: "blob:pdf",
+    file: {
+      fileId: "00000000-0000-4000-8000-000000000003",
+      path: "Documents/paper.pdf",
+      revision: "pdf-1",
+      contentDigest: `sha256:${"3".repeat(64)}`,
+      size: 10,
+      mediaType: "application/pdf",
+      mediaClass: "pdf",
+      modifiedAt: "2026-08-09T00:00:00Z"
+    }
+  }
+};

--- a/apps/editor/src/EmbedPdfViewer.tsx
+++ b/apps/editor/src/EmbedPdfViewer.tsx
@@ -1,0 +1,15 @@
+import { PDFViewer } from "@embedpdf/react-pdf-viewer";
+
+export function EmbedPdfViewer({ src, filename }: { src: string; filename: string }) {
+  return <div className="embedpdf-viewer" aria-label={`PDF viewer, ${filename}`}>
+    <PDFViewer
+      config={{
+        src,
+        tabBar: "never",
+        theme: { preference: "system" },
+        disabledCategories: ["annotation", "form", "redaction", "insert", "history", "document-open", "document-close"]
+      }}
+      style={{ width: "100%", height: "100%" }}
+    />
+  </div>;
+}

--- a/apps/editor/src/FileViewer.tsx
+++ b/apps/editor/src/FileViewer.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon as ArrowLeft, FileIcon as File, XIcon as X } from "./icon
 import type { FileAssetSnapshot } from "./file-asset-store";
 import type { CollectionFile } from "./model";
 import { collectionFileTitle, formatFileSize } from "./collection-browser";
+import { EmbedPdfViewer } from "./EmbedPdfViewer";
 
 export function FileWorkspace({ file, asset, leadingActions, onBack, onRetry }: {
   file: CollectionFile;
@@ -54,7 +55,7 @@ export function FileViewer({ asset, onClose }: {
 function FileContent({ asset }: { asset: Extract<FileAssetSnapshot, { status: "ready" }> }) {
   const filename = collectionFileTitle(asset.file);
   if (asset.file.mediaClass === "image") return <img src={asset.url} alt={filename} />;
-  if (asset.file.mediaClass === "pdf") return <iframe src={`${asset.url}#toolbar=1&navpanes=0&view=FitH`} title={filename} />;
+  if (asset.file.mediaClass === "pdf") return <EmbedPdfViewer src={asset.url} filename={filename} />;
   if (asset.file.mediaClass === "audio") return <audio src={asset.url} controls preload="metadata" aria-label={filename} />;
   if (asset.file.mediaClass === "video") return <video src={asset.url} controls preload="metadata" aria-label={filename} />;
   return <div className="file-workspace-message"><File aria-hidden="true" /><strong>{filename}</strong><span>{formatFileSize(asset.file.size)} · Preview unavailable. Use Open original to view this file.</span></div>;

--- a/apps/editor/src/code-editor-file-embeds.ts
+++ b/apps/editor/src/code-editor-file-embeds.ts
@@ -4,6 +4,8 @@ import type { FileAssetSnapshot } from "./file-asset-store";
 import type { ResolvedFileReference } from "./use-file-assets";
 
 class FileEmbedWidget extends WidgetType {
+  private unmountInlinePdf?: () => void;
+
   constructor(
     readonly reference: ResolvedFileReference,
     readonly open: ((asset: Extract<FileAssetSnapshot, { status: "ready" }>) => void) | undefined
@@ -34,11 +36,17 @@ class FileEmbedWidget extends WidgetType {
         image.loading = "lazy";
         preview.append(image);
       } else if (asset.file.mediaClass === "pdf") {
-        const frame = document.createElement("iframe");
-        frame.src = `${asset.url}#toolbar=0&navpanes=0&view=FitH`;
-        frame.title = filename;
-        frame.tabIndex = -1;
-        preview.append(frame);
+        const cover = document.createElement("button");
+        cover.type = "button";
+        cover.className = "cm-file-embed-pdf-cover";
+        cover.setAttribute("aria-label", `Open ${filename}`);
+        const mark = document.createElement("span");
+        mark.textContent = "PDF";
+        const prompt = document.createElement("span");
+        prompt.textContent = "Open document";
+        cover.append(mark, prompt);
+        cover.addEventListener("click", () => this.activatePdf(preview, cover, asset.url, filename));
+        preview.append(cover);
       } else {
         const media = document.createElement(asset.file.mediaClass === "audio" ? "audio" : "video");
         media.src = asset.url;
@@ -62,7 +70,7 @@ class FileEmbedWidget extends WidgetType {
     name.textContent = label ?? filename;
     detail.textContent = asset.file.path;
     caption.append(name, detail);
-    if (asset.status === "ready" && asset.file.mediaClass !== "audio" && asset.file.mediaClass !== "video" && this.open) {
+    if (asset.status === "ready" && asset.file.mediaClass !== "audio" && asset.file.mediaClass !== "video" && asset.file.mediaClass !== "pdf" && this.open) {
       const open = document.createElement("button");
       open.type = "button";
       open.className = "cm-file-embed-open";
@@ -79,7 +87,29 @@ class FileEmbedWidget extends WidgetType {
   }
 
   ignoreEvent(event: Event) {
-    return event.target instanceof Element && Boolean(event.target.closest("button, audio, video"));
+    return event.target instanceof Element && Boolean(event.target.closest("button, audio, video, .cm-file-embed-pdf-viewer"));
+  }
+
+  destroy() {
+    this.unmountInlinePdf?.();
+  }
+
+  private activatePdf(preview: HTMLElement, cover: HTMLElement, src: string, filename: string) {
+    if (preview.classList.contains("cm-file-embed-active")) return;
+    preview.classList.add("cm-file-embed-active");
+    preview.setAttribute("aria-label", `PDF embed, ${filename}`);
+    const viewer = document.createElement("div");
+    viewer.className = "cm-file-embed-pdf-viewer";
+    viewer.tabIndex = 0;
+    viewer.setAttribute("role", "region");
+    viewer.setAttribute("aria-label", `Embedded PDF, ${filename}`);
+    cover.replaceWith(viewer);
+    viewer.focus({ preventScroll: true });
+    void import("./inline-pdf-viewer").then(({ mountInlinePdfViewer }) => {
+      if (!viewer.isConnected) return;
+      const root = mountInlinePdfViewer(viewer, src, filename);
+      this.unmountInlinePdf = () => root.unmount();
+    });
   }
 }
 

--- a/apps/editor/src/code-editor-writer-interactions.ts
+++ b/apps/editor/src/code-editor-writer-interactions.ts
@@ -1,0 +1,184 @@
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { resolveFileReference } from "./file-references";
+import type { LinkSuggestion } from "./links";
+import type { CollectionFile } from "./model";
+import type { NotePreviewAnchor, NotePreviewSource } from "./NotePreview";
+
+interface MarkdownLinkTarget {
+  target: string;
+  label?: string;
+  format: "wikilink" | "markdown";
+}
+
+export function writerInteractions(
+  suggestions: () => LinkSuggestion[],
+  files: () => CollectionFile[],
+  currentPath: () => string | undefined,
+  onOpenLink: () => ((path: string) => void) | undefined,
+  onOpenFileLink: () => ((file: CollectionFile) => void) | undefined,
+  onCreateLink: () => ((target: string, label: string | undefined, format: "wikilink" | "markdown") => void) | undefined,
+  onPreviewLink: () => ((path: string, anchor: NotePreviewAnchor, source: NotePreviewSource) => void) | undefined,
+  onDismissLinkPreview: () => (() => void) | undefined
+): Extension {
+  let hoveredPath: string | undefined;
+  const dismissPreview = (view: EditorView) => {
+    if (!hoveredPath) return;
+    hoveredPath = undefined;
+    view.dom.classList.remove("cm-hovering-link");
+    onDismissLinkPreview()?.();
+  };
+  return EditorView.domEventHandlers({
+    mousedown(event, view) {
+      const task = taskTarget(event);
+      if (task && event.button === 0) return toggleTask(view, task, event);
+      const renderedLink = event.target instanceof Element
+        ? event.target.closest(".cm-rendered-link")
+        : null;
+      if (!renderedLink || event.button !== 0) return false;
+      event.preventDefault();
+      return true;
+    },
+    keydown(event, view) {
+      const task = taskTarget(event);
+      if (!task || (event.key !== "Enter" && event.key !== " ")) return false;
+      return toggleTask(view, task, event);
+    },
+    click(event, view) {
+      const rendered = event.target instanceof Element
+        ? event.target.closest<HTMLElement>(".cm-rendered-link")
+        : null;
+      if (!rendered && !event.metaKey && !event.ctrlKey) return false;
+      const renderedFrom = rendered ? Number(rendered.dataset.linkFrom) : undefined;
+      const position = Number.isFinite(renderedFrom)
+        ? renderedFrom!
+        : view.posAtCoords({ x: event.clientX, y: event.clientY });
+      if (position === null) return false;
+      const link = markdownLinkAt(view.state.doc.toString(), position);
+      if (!link) return false;
+      if (/^https?:\/\//i.test(link.target)) {
+        event.preventDefault();
+        window.open(link.target, "_blank", "noopener,noreferrer");
+        return true;
+      }
+      if (!link.target || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(link.target)) return false;
+      const path = resolveSuggestionPath(link.target, suggestions(), currentPath());
+      const file = resolveFileReference(link.target, link.format, files(), currentPath());
+      const openLink = onOpenLink();
+      const openFileLink = onOpenFileLink();
+      const createLink = onCreateLink();
+      if (!path && !file && !createLink) return false;
+      if (path && !openLink) return false;
+      if (file && !openFileLink) return false;
+      event.preventDefault();
+      dismissPreview(view);
+      if (path) openLink?.(path);
+      else if (file) openFileLink?.(file);
+      else createLink?.(link.target, link.label, link.format);
+      return true;
+    },
+    mousemove(event, view) {
+      const position = view.posAtCoords({ x: event.clientX, y: event.clientY });
+      const path = position === null
+        ? undefined
+        : internalLinkPathAt(view.state.doc.toString(), position, suggestions(), currentPath());
+      if (!path) {
+        dismissPreview(view);
+        return false;
+      }
+      if (hoveredPath === path) return false;
+      if (hoveredPath) onDismissLinkPreview()?.();
+      hoveredPath = path;
+      view.dom.classList.add("cm-hovering-link");
+      const coordinates = view.coordsAtPos(position ?? 0);
+      const anchor: NotePreviewAnchor = {
+        left: event.clientX,
+        right: event.clientX,
+        top: coordinates?.top ?? event.clientY,
+        bottom: coordinates?.bottom ?? event.clientY
+      };
+      onPreviewLink()?.(path, anchor, "editor");
+      return false;
+    },
+    mouseleave(_event, view) {
+      dismissPreview(view);
+      return false;
+    }
+  });
+}
+
+function taskTarget(event: Event): HTMLElement | null {
+  return event.target instanceof Element ? event.target.closest<HTMLElement>(".cm-task-checkbox") : null;
+}
+
+function toggleTask(view: EditorView, target: HTMLElement, event: Event): boolean {
+  const from = Number(target.dataset.taskFrom);
+  if (!Number.isFinite(from)) return false;
+  const source = view.state.sliceDoc(from, from + 3);
+  if (!/^\[[ xX]\]$/.test(source)) return false;
+  event.preventDefault();
+  view.dispatch({
+    changes: { from: from + 1, to: from + 2, insert: source[1].toLocaleLowerCase() === "x" ? " " : "x" },
+    scrollIntoView: true,
+    userEvent: "input"
+  });
+  view.focus();
+  return true;
+}
+
+function markdownLinkAt(doc: string, position: number): MarkdownLinkTarget | undefined {
+  const lineStart = doc.lastIndexOf("\n", position - 1) + 1;
+  const lineEnd = doc.indexOf("\n", position);
+  const end = lineEnd < 0 ? doc.length : lineEnd;
+  const line = doc.slice(lineStart, end);
+  for (const match of line.matchAll(/\[\[([^\]]+)\]\]|\[([^\]]*)\]\(([^)]+)\)/g)) {
+    const from = lineStart + match.index;
+    const to = from + match[0].length;
+    if (position < from || position > to || doc[from - 1] === "!") continue;
+    if (match[1] !== undefined) {
+      const [target, label] = match[1].split("|", 2);
+      return {
+        target: target.split("#", 1)[0].trim(),
+        label: label?.trim() || undefined,
+        format: "wikilink"
+      };
+    }
+    return {
+      target: (match[3] ?? "").replace(/^<|>$/g, "").split("#", 1)[0].trim(),
+      label: match[2]?.trim() || undefined,
+      format: "markdown"
+    };
+  }
+  return undefined;
+}
+
+export function internalLinkPathAt(
+  doc: string,
+  position: number,
+  suggestions: LinkSuggestion[],
+  sourcePath?: string
+): string | undefined {
+  const link = markdownLinkAt(doc, position);
+  if (!link || /^https?:\/\//i.test(link.target)) return undefined;
+  return resolveSuggestionPath(link.target, suggestions, sourcePath);
+}
+
+function resolveSuggestionPath(target: string, suggestions: LinkSuggestion[], sourcePath?: string): string | undefined {
+  const normalized = target.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\.md$/i, "").toLocaleLowerCase();
+  const exact = suggestions.find((suggestion) => suggestion.path.replace(/\.md$/i, "").toLocaleLowerCase() === normalized);
+  if (exact) return exact.path;
+  const sourceFolder = sourcePath?.includes("/") ? sourcePath.slice(0, sourcePath.lastIndexOf("/")) : "";
+  const candidates = suggestions.filter((suggestion) => {
+    const filename = suggestion.path.split("/").at(-1)?.replace(/\.md$/i, "").toLocaleLowerCase();
+    return filename === normalized
+      || suggestion.title.toLocaleLowerCase() === normalized
+      || suggestion.aliases?.some((alias) => alias.toLocaleLowerCase() === normalized);
+  });
+  return candidates.sort((left, right) => {
+    const leftFolder = left.path.slice(0, Math.max(0, left.path.lastIndexOf("/")));
+    const rightFolder = right.path.slice(0, Math.max(0, right.path.lastIndexOf("/")));
+    return Number(rightFolder === sourceFolder) - Number(leftFolder === sourceFolder)
+      || left.path.length - right.path.length
+      || left.path.localeCompare(right.path);
+  })[0]?.path;
+}

--- a/apps/editor/src/demo-gateway.ts
+++ b/apps/editor/src/demo-gateway.ts
@@ -913,4 +913,23 @@ function mediaClass(path: string, mediaType: string): CollectionFile["mediaClass
 }
 
 const FRONTMATTER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540"><rect width="960" height="540" fill="#f5f8fb"/><g fill="none" stroke="#243444" stroke-width="16" stroke-linecap="square"><path d="M230 122h500M230 418h500"/><path d="M230 220h135M230 320h135"/></g><g fill="none" stroke-width="16" stroke-linecap="square"><path d="M415 220h315" stroke="#2878a6"/><path d="M415 320h315" stroke="#243444"/></g></svg>`;
-const DEMO_PDF = "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 0/Kids[]>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF";
+const DEMO_PDF = `%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>endobj
+4 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+5 0 obj<</Length 111>>stream
+BT /F1 24 Tf 72 700 Td (Interface notes) Tj /F1 12 Tf 0 -34 Td (A calm place for durable Markdown and its files.) Tj ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f\x20
+0000000009 00000 n\x20
+0000000058 00000 n\x20
+0000000115 00000 n\x20
+0000000241 00000 n\x20
+0000000311 00000 n\x20
+trailer<</Size 6/Root 1 0 R>>
+startxref
+472
+%%EOF`;

--- a/apps/editor/src/inline-pdf-viewer.tsx
+++ b/apps/editor/src/inline-pdf-viewer.tsx
@@ -1,0 +1,8 @@
+import { createRoot, type Root } from "react-dom/client";
+import { EmbedPdfViewer } from "./EmbedPdfViewer";
+
+export function mountInlinePdfViewer(container: HTMLElement, src: string, filename: string): Root {
+  const root = createRoot(container);
+  root.render(<EmbedPdfViewer src={src} filename={filename} />);
+  return root;
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -79,6 +79,12 @@
 .code-editor-writer .cm-file-embed video { width: 100%; display: block; border: 0; background: var(--canvas); }
 .code-editor-writer .cm-file-embed img { max-height: min(56vh, 560px); object-fit: contain; }
 .code-editor-writer .cm-file-embed iframe { height: min(48vh, 460px); pointer-events: none; }
+.code-editor-writer .cm-file-embed-pdf-cover { min-height: clamp(180px, 32vh, 320px); display: grid; place-content: center; justify-items: center; gap: 12px; border: 0; border-radius: 0; background: radial-gradient(circle at 50% 30%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 42%), linear-gradient(145deg, var(--white), var(--canvas)); color: inherit; cursor: pointer; }
+.code-editor-writer .cm-file-embed-pdf-cover span:first-child { display: grid; place-items: center; width: 72px; height: 88px; border: 1px solid color-mix(in srgb, var(--accent) 58%, var(--line)); border-radius: 5px 15px 5px 5px; background: color-mix(in srgb, var(--accent-soft) 72%, var(--white)); color: var(--accent-strong); box-shadow: 0 14px 36px var(--color-shadow); font-family: var(--mono); font-size: 13px; font-weight: 700; letter-spacing: .09em; }
+.code-editor-writer .cm-file-embed-pdf-cover span:last-child { color: var(--muted); font-size: 11px; font-weight: 700; }
+.code-editor-writer .cm-file-embed-pdf-cover:focus-visible { outline: 2px solid var(--accent); outline-offset: -3px; }
+.code-editor-writer .cm-file-embed-pdf-viewer { width: 100%; height: clamp(460px, 68vh, 760px); min-height: 0; overflow: hidden; outline: 0; background: var(--canvas); cursor: default; }
+.code-editor-writer .cm-file-embed-active { border-color: var(--line-strong); box-shadow: 0 14px 42px var(--color-shadow); }
 .code-editor-writer .cm-file-embed audio { width: calc(100% - 24px); margin: 24px 12px; }
 .code-editor-writer .cm-file-embed-status { min-height: 120px; display: grid; place-items: center; padding: 24px; color: var(--faint); font-size: 11px; text-align: center; }
 .code-editor-writer .cm-file-embed figcaption { min-width: 0; display: flex; align-items: baseline; gap: 10px; padding: 9px 12px 10px; border-top: 1px solid var(--line); background: var(--white); line-height: 1.25; }
@@ -104,7 +110,7 @@
 .file-open-original:hover { background: var(--selected); }
 .file-viewer-content { min-width: 0; min-height: 0; display: grid; place-items: center; overflow: auto; background: color-mix(in srgb, var(--canvas) 88%, var(--ink)); }
 .file-viewer-image img { max-width: 100%; max-height: 100%; display: block; object-fit: contain; }
-.file-viewer-pdf iframe { width: 100%; height: 100%; border: 0; background: var(--canvas); }
+.embedpdf-viewer { width: 100%; height: 100%; min-width: 0; min-height: 0; overflow: hidden; background: var(--canvas); }
 .file-viewer-audio audio { width: min(560px, calc(100% - 48px)); }
 .file-viewer-video video { max-width: 100%; max-height: 100%; }
 .file-workspace { grid-template-rows: 52px minmax(0, 1fr); background: var(--canvas); }
@@ -113,7 +119,7 @@
 .file-workspace-content { min-width: 0; min-height: 0; display: grid; place-items: center; overflow: auto; background: color-mix(in srgb, var(--canvas) 94%, var(--ink)); }
 .file-workspace-content.file-viewer-image { padding: clamp(18px, 4vw, 56px); }
 .file-workspace-content.file-viewer-image img { max-width: 100%; max-height: 100%; display: block; border: 1px solid var(--line); border-radius: 5px; box-shadow: 0 18px 52px var(--color-shadow); object-fit: contain; }
-.file-workspace-content.file-viewer-pdf iframe { width: 100%; height: 100%; border: 0; background: var(--canvas); }
+.file-workspace-content.file-viewer-pdf .embedpdf-viewer { width: 100%; height: 100%; background: var(--canvas); }
 .file-workspace-message { width: min(420px, calc(100% - 40px)); display: grid; justify-items: center; gap: 8px; color: var(--faint); text-align: center; }
 .file-workspace-message > svg { width: 32px; height: 32px; margin-bottom: 4px; }
 .file-workspace-message strong { color: var(--ink); font-size: 14px; }

--- a/apps/editor/tests/editor.spec.ts
+++ b/apps/editor/tests/editor.spec.ts
@@ -277,6 +277,33 @@ test("renders linked collection images inline and in the file preview", async ({
   await expect(preview).not.toBeAttached();
 });
 
+test("focuses embedded PDFs in place and opens PDF wikilinks in the file workspace", async ({ page }) => {
+  await page.goto("?demo=12");
+  const body = page.getByRole("textbox", { name: "Note body" });
+  await body.locator(".cm-line").first().click();
+  await page.keyboard.press("Control+End");
+  await page.keyboard.insertText("\n\n![[Documents/interface-notes.pdf]]\n\n[[Documents/interface-notes.pdf]]");
+  await body.locator(".cm-line").first().click();
+
+  const open = page.getByRole("button", { name: "Open interface-notes.pdf" });
+  await expect(open).toBeVisible();
+  await open.click();
+
+  await expect(page.getByRole("dialog", { name: "Preview interface-notes.pdf" })).toHaveCount(0);
+  const inlineViewer = page.getByRole("region", { name: "Embedded PDF, interface-notes.pdf" });
+  await expect(inlineViewer).toBeFocused();
+  const embedPdf = inlineViewer.getByLabel("PDF viewer, interface-notes.pdf");
+  await expect(embedPdf).toBeVisible();
+  await expect.poll(() => embedPdf.evaluate((viewer) => {
+    const root = viewer.querySelector("embedpdf-container")?.shadowRoot;
+    return [...(root?.querySelectorAll("img") ?? [])].some((image) => image.naturalWidth > 0);
+  })).toBe(true);
+
+  await page.getByRole("link", { name: "Documents/interface-notes.pdf" }).click();
+  await expect(page.getByRole("main", { name: "File viewer, interface-notes.pdf" })).toBeVisible();
+  await expect(page.getByLabel("PDF viewer, interface-notes.pdf")).toBeVisible();
+});
+
 test("uses one fixed-choice control across settings, note creation, and type editing", async ({ page }) => {
   await page.goto("?demo=12");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.6
         version: 6.43.7
+      '@embedpdf/react-pdf-viewer':
+        specifier: ^2.15.0
+        version: 2.15.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@fontsource/atkinson-hyperlegible':
         specifier: ^5.3.0
         version: 5.3.0
@@ -579,12 +582,25 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
@@ -787,6 +803,377 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@embedpdf/core@2.15.0':
+    resolution: {integrity: sha512-0yaPCgvbE5/cBf+5rHBUsRUm8i6hSl894xjC19HTOmb8DqrhxOxbOQSyjiTbJTQK52zZrNL79SigsPgGHPrYWA==}
+    peerDependencies:
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/engines@2.15.0':
+    resolution: {integrity: sha512-fW5UoqpDRkAWDbGMl3y6ril3l2qXzoYz+klt4O2P8gWzYzhG3fmr0L2+qzjD+BPO+QfYMNNvmBI+teT/nYjm/g==}
+    peerDependencies:
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/fonts-arabic@1.0.0':
+    resolution: {integrity: sha512-SnGvQb+LwPZQO2WjjvlmXrJZolJUfLYbLZQSaYUw1vrQyMyJKT4LewvJGG+hZ+Yz2fz7OMIQ+4Gc98mGODZtOg==}
+
+  '@embedpdf/fonts-hebrew@1.0.0':
+    resolution: {integrity: sha512-5HVAKGL7VqPeTxxADDrSqAFBxfmAXdP8fIqrPwJIKkqdK2643bOer8CqnnpO3/nPoFhkzxhttWMB9BGiqSW62w==}
+
+  '@embedpdf/fonts-jp@1.0.0':
+    resolution: {integrity: sha512-BY2tv/mcICUUKf+M/bizf3RU65PMqKClJ/e5o9mgMibxyML0OQvEDwYMRPODQkKgJKXCO3ScHmVvcmXp6kt+fA==}
+
+  '@embedpdf/fonts-kr@1.0.0':
+    resolution: {integrity: sha512-bh88HXSvOBS581kgmihWY7Ijp9hBsvlmXogFG5LSNx9UBAobRcakZiFMGieRBc06hUSkpo7WhjaFM/z/SfQ8dQ==}
+
+  '@embedpdf/fonts-latin@1.0.0':
+    resolution: {integrity: sha512-LLYysdr8O6sRNzhmW3PbF3AeA8xnqvOi4XLFfIfNlW5uEZ+qsJdcfd78Q78sFJMhlaOAYFMziMMsnOzmx463rA==}
+
+  '@embedpdf/fonts-sc@1.0.0':
+    resolution: {integrity: sha512-ETXl7XCwaQLSSvMO3EUDwMNqtL64kX2LlFxarTRi/NsIGGOIxUurGfKtrkmtnKHrWy1jAJSt6oxK2uJhvdvQIw==}
+
+  '@embedpdf/fonts-tc@1.0.0':
+    resolution: {integrity: sha512-rGZJbVD6DYS5BbXdpEMnWkpVF0Knar+bsiyb2o3+YRx7O8eyFubEBQUSUInirQk69HA6fc3GhYCg7TyC/oD76Q==}
+
+  '@embedpdf/models@2.15.0':
+    resolution: {integrity: sha512-gHr+hAN094kmzCB+6J2zaiHS8o4tKeY0IfTOxVEGwqntgKk8LCWD3s+P7dlVY3V8XUVmdyFWhFt7zwm0uw+VMg==}
+
+  '@embedpdf/pdfium@2.15.0':
+    resolution: {integrity: sha512-KgpRND2MYcdbhzb2EMb4WzWcJYrR0A6JXvhMv4WthEHKt6qmNo2v/MC68bpYvpveYT9GNnUnY/+TG5MpXY3pRw==}
+
+  '@embedpdf/plugin-annotation@2.15.0':
+    resolution: {integrity: sha512-1g7Ls9ak/TLaRY42H1GxLriH91yBxaP3ezFDbyGSfW/nV1V5tLJ8d1OZG7Dm1HbhAcnzSt7nOXOZRqFnmhpjyQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-history': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0
+      '@embedpdf/plugin-scroll': 2.15.0
+      '@embedpdf/plugin-selection': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-attachment@2.15.0':
+    resolution: {integrity: sha512-vv8uzyqNSujrXKsmIKyV9D/8UnWfyo/MLY5lSQFoFy8Egecbqlbe8LTFcyHYA3fNhvKds+JFLV1khxnnp6tBoA==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-bookmark@2.15.0':
+    resolution: {integrity: sha512-pioAUfmKWiM0uc1PkGL3um7SPpcSrtcNhzdV6sgKDtLYxNBzObaCRbsQzGr0vFRayMNkDIlsRsx2yiLK6D+JcQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-capture@2.15.0':
+    resolution: {integrity: sha512-uPmO/U1WMitYQMbXnMj+H4lla4bTj+mtxLPbu4Ck2P/f5MK4Id1LT+AGo8zvVRELYLWyWrkS/R/5FIhB+xpAIA==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-commands@2.15.0':
+    resolution: {integrity: sha512-2XgtXSRlkZRtI108xaV3p3zxBJ4uMHpwqrMXvbTRcCFMU5lXH+ntjTYy7/j6mI5ghtp03/pLeZxD5rG/CwRixg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-document-manager@2.15.0':
+    resolution: {integrity: sha512-M8EwOuonICSHfOklTMwk0XfyPhG9v9EMDRU9Pvz0zAe1DJzUPtIxUh+CgxtFSSnUeKSfxE7JpTRryrbUW0XcGg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-export@2.15.0':
+    resolution: {integrity: sha512-GFmC4nkZZnH1swivfSwLako2YV6d60QPSPUqvozQaMWDuE8rNq/ElYISVihkEAxbhI4h3q5AkhDKyCVFeJJVbg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-form@2.15.0':
+    resolution: {integrity: sha512-0kUqf/BHsNeHhUAdcSz3Dsqy5qNvDgQP6IhhMq5KLH+mtMoUuYiEyOGwHSY97V4vxAG9MF/UexT+CP4LfL3Yvg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0
+      '@embedpdf/plugin-history': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-fullscreen@2.15.0':
+    resolution: {integrity: sha512-DYyoUrWD9E6NkPCaeGZQH/qpKUgJ20rXi9tOtZIc/cRAvynfcjWNCamwWXd7cDbLwrkbo+5rJIwTponKLXh5oQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-history@2.15.0':
+    resolution: {integrity: sha512-3Dk4Atc5vdHsTjC8tJ8MOGPcUJLkCWbMzt3sTllmyNc534qTZtUvFHDeaaB65u50EJGjFRpUJ6Xcnp9A81lMdg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-i18n@2.15.0':
+    resolution: {integrity: sha512-xSbkJcj1Fc7dKyV7lhBU9d0xuH4wGKcPwRmkMxOvi3KJ/XD3zgfqdFMazDICN+rzth40gHSeRNhyCKZpXeYkuQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-interaction-manager@2.15.0':
+    resolution: {integrity: sha512-YCMvTvu4Fm1KNuEhj+CftzG+T6F1+/QhI7eaYft9Lp5xm3CYSXdR3pNfGwNFy5XkDUDwB1IscLTiU0q75viMCw==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-pan@2.15.0':
+    resolution: {integrity: sha512-bgFM7xTJRNzkFs5CH9apv5USR7Db2fdbNVbHq/U1GanEyz/71gZGoDWUN9FF/FbNvBfSfvPYZDv9DLJYLbeoBQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0
+      '@embedpdf/plugin-viewport': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-print@2.15.0':
+    resolution: {integrity: sha512-IS6Wvi7zY0iozdYmVwfZXSjKURBe4AqhuyV1QtbcUS1hZxe0ASRETGiHe9ONpuokWemZmYDHNyTrdF7+5hdLEw==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-redaction@2.15.0':
+    resolution: {integrity: sha512-H4WgRSSqBlWtP7sgDbAqWW/w6HAyjA3RS6lMuEmCMF19trDyQMdeAC8ZyQkFCYudFk9L+ydradSbNBYK18PfDw==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0
+      '@embedpdf/plugin-history': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0
+      '@embedpdf/plugin-selection': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-render@2.15.0':
+    resolution: {integrity: sha512-EVfn8XsdU10VgrSs9qKo8nqjfUyt2/NWFJtlW3nX4sZ74Pi9xSvEa7/B99/LYZZMa0ENzi+4HKAXiQ6NUXisDg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-rotate@2.15.0':
+    resolution: {integrity: sha512-mhfDC8NCQ8H6ati3O6smA6ZxZoMgPGtloEeY6gs61+zoxPKyXiuCpxZKJctRfYdrTdoRgXpFa3fKflwStMcgFg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-scroll@2.15.0':
+    resolution: {integrity: sha512-UqjLH3lafrpqN1qcxIpfd1MfWW5Fdf6/4LjneUabHt+3gxy1qd2KU9oPR5wwinsh3vmjn90qURsnqIHL5jnaOg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-viewport': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-search@2.15.0':
+    resolution: {integrity: sha512-mMzy8uo3xvDMjSc+xuBMgdI/mmmpgbZ6xKTmNxpF0d8BcaWu6Zp9a4ewamfjBwg8WF/qUW49U6HYZsiRr3NUEQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-selection@2.15.0':
+    resolution: {integrity: sha512-iEnhx0jeQrbze7WHkHhZtF21yfGBuqF2B+V2efLHT2O0a2fnof+PEVaQQRgERSfrwRvLvyEJL9ud54E41ahsRQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-signature@2.15.0':
+    resolution: {integrity: sha512-aFD6sHExivqdCK3U2Xns/nsZxS9jhMAgdJTrumc3eenCzGbXAHhX7wkzgIDfZs3AyKRepbUnz9wmM6lNG+IKoQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-spread@2.15.0':
+    resolution: {integrity: sha512-Gj1Nl9E/T92MkaBxL+BCH8WHfzvfM+Vb9vgTPi0gnV7Jr1SaWrtIQpMlYom21f4p9pT/m7KuBVz3xA+NV8r39A==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-stamp@2.15.0':
+    resolution: {integrity: sha512-QjrzwCUVYoRX/zp8FpMByGgmUxvovARmd+xSaMtH70iHAPZxpvSLJ9DpoV2sbtEiwnQYrIZJry6TzCtB2bNvXQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0
+      '@embedpdf/plugin-i18n': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-thumbnail@2.15.0':
+    resolution: {integrity: sha512-39EojqobHmvSvk2ejKeh58m43ApGS3cie/sVZP+pkXr6MRogX6+ivMa5GfoqBzh9wdZAZ3l4XTd+RQ4kFZ4aqQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-tiling@2.15.0':
+    resolution: {integrity: sha512-zBjKCToAkL1tYvkIjFCjsbfUzZ0QBPczL3wRy/IdNZ9CQuZrqqqp3xEFrI4Nz2o9XQd9heBlMA9Zo/yieuazqA==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0
+      '@embedpdf/plugin-scroll': 2.15.0
+      '@embedpdf/plugin-viewport': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-ui@2.15.0':
+    resolution: {integrity: sha512-6aixrGLylfOk7S+TZojxBjXlR7ToZ4OD4td1b/wfuu8Nmtv7RmNnwu2F7h6aLp54VIhjdHCIrgzWUOjWLqSAJw==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0
+      '@embedpdf/plugin-scroll': 2.15.0
+      '@embedpdf/plugin-viewport': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-viewport@2.15.0':
+    resolution: {integrity: sha512-MXNBQOitr1cAoCoBKwAR3O78eLtHBbIngOkWqgm6EpWTdoYDBVhZlvVcmwmjheZKjMJFnU3sFr98w6Qwix3Cjg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/plugin-zoom@2.15.0':
+    resolution: {integrity: sha512-d+YhwqcQNZaaHczVGe4pbaAYQXWO4MEoivcW7jOpE31VnKqEAdjCMye8F0ctcF5OjgbXeb6AKCk4L4fDdLF4mg==}
+    peerDependencies:
+      '@embedpdf/core': 2.15.0
+      '@embedpdf/plugin-scroll': 2.15.0
+      '@embedpdf/plugin-viewport': 2.15.0
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+
+  '@embedpdf/react-pdf-viewer@2.15.0':
+    resolution: {integrity: sha512-Y8X/N9BZAnIChAUP9LkU19erRv0E56AkAmcWDC4vyjuhpLK2qIlMqqv7gApGffXxUEpQay5qMt3K6V2kjZS2/w==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@embedpdf/snippet@2.15.0':
+    resolution: {integrity: sha512-oTJBxqCIqCM1SIXSYt7AmzzUO0J9yi9vFFRVzWc4BRDmX/K6Jp98EIwa7WTVQSylbhvOIGEOnOnqm9ZDx+sg0g==}
+
+  '@embedpdf/utils@2.15.0':
+    resolution: {integrity: sha512-13UEMPpu5XrxmYI/MPiLtJC3R3b1g8ii3zfhQ3g1WpECybnwTuhBgwqaOvqw3rVCKCnXEgNMs4PBCzLyFpZZTw==}
+    peerDependencies:
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -1089,6 +1476,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1469,6 +1859,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.12':
+    resolution: {integrity: sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1576,6 +1971,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
@@ -1754,6 +2152,33 @@ packages:
   '@vscode/sudo-prompt@9.3.2':
     resolution: {integrity: sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==}
 
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
+
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
+
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
+
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
+
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
+
+  '@vue/server-renderer@3.5.41':
+    resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1912,6 +2337,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -1944,6 +2373,10 @@ packages:
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2083,6 +2516,10 @@ packages:
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@0.5.3:
     resolution: {integrity: sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==}
@@ -2248,6 +2685,9 @@ packages:
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
+  devalue@5.9.0:
+    resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
+
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
@@ -2337,6 +2777,10 @@ packages:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -2397,6 +2841,17 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.3.2:
+    resolution: {integrity: sha512-40GyiEJevYKXzYTHtZkFqAgTjLOuFcaXMao8TPyOlnWTlkHDlvZ6mPMJaJyOqVwrVCgomEG1WhJd81w0X+IcCw==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -2408,6 +2863,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2878,6 +3336,9 @@ packages:
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
@@ -3059,6 +3520,9 @@ packages:
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
@@ -3663,6 +4127,14 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prettier@3.9.5:
     resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
@@ -4121,11 +4593,18 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte@5.56.8:
+    resolution: {integrity: sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==}
+    engines: {node: '>=18'}
+
   svix@1.99.1:
     resolution: {integrity: sha512-JfpvbAg5iT5NagDAfOq3e6Ci6NbOMbMm6C3DnfDBB60m2JDK+Z2hXPE9XNAmutb53DCdPoih1V70IbklZnX09A==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -4395,6 +4874,14 @@ packages:
       jsdom:
         optional: true
 
+  vue@3.5.41:
+    resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -4551,6 +5038,9 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -4594,9 +5084,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -5093,6 +5594,424 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/engines': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/engines@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/fonts-arabic': 1.0.0
+      '@embedpdf/fonts-hebrew': 1.0.0
+      '@embedpdf/fonts-jp': 1.0.0
+      '@embedpdf/fonts-kr': 1.0.0
+      '@embedpdf/fonts-latin': 1.0.0
+      '@embedpdf/fonts-sc': 1.0.0
+      '@embedpdf/fonts-tc': 1.0.0
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/pdfium': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/fonts-arabic@1.0.0': {}
+
+  '@embedpdf/fonts-hebrew@1.0.0': {}
+
+  '@embedpdf/fonts-jp@1.0.0': {}
+
+  '@embedpdf/fonts-kr@1.0.0': {}
+
+  '@embedpdf/fonts-latin@1.0.0': {}
+
+  '@embedpdf/fonts-sc@1.0.0': {}
+
+  '@embedpdf/fonts-tc@1.0.0': {}
+
+  '@embedpdf/models@2.15.0': {}
+
+  '@embedpdf/pdfium@2.15.0': {}
+
+  '@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673)':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-history': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-interaction-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-scroll': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-selection': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/utils': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-attachment@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-bookmark@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-capture@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-render@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-render': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-commands@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-document-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-export@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-form@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673))(@embedpdf/plugin-history@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0(a6af0122725a50e23b60eed07e784673)
+      '@embedpdf/plugin-history': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/utils': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-fullscreen@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-history@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-i18n@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-pan@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-viewport': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-print@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-redaction@2.15.0(bdf11565ea62b71f1017cd22094dbf0a)':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0(a6af0122725a50e23b60eed07e784673)
+      '@embedpdf/plugin-history': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-interaction-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-selection': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/utils': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-render@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-rotate@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-scroll@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-viewport': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-search@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-selection@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-interaction-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/utils': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-signature@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0(a6af0122725a50e23b60eed07e784673)
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-spread@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-stamp@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673))(@embedpdf/plugin-i18n@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0(a6af0122725a50e23b60eed07e784673)
+      '@embedpdf/plugin-i18n': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-thumbnail@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-render@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-tiling@2.15.0(67c9fba1141826415e83ebf1139f6f30)':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-scroll': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-viewport': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-ui@2.15.0(67c9fba1141826415e83ebf1139f6f30)':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-render': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-scroll': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-viewport': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/plugin-zoom@2.15.0(06dcf9b757304a820b614c84eb886ac7)':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/plugin-scroll': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-viewport': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
+  '@embedpdf/react-pdf-viewer@2.15.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/snippet': 2.15.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - preact-render-to-string
+      - svelte
+      - vue
+
+  '@embedpdf/snippet@2.15.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@embedpdf/core': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/engines': 2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/models': 2.15.0
+      '@embedpdf/pdfium': 2.15.0
+      '@embedpdf/plugin-annotation': 2.15.0(a6af0122725a50e23b60eed07e784673)
+      '@embedpdf/plugin-attachment': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-bookmark': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-capture': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-render@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-commands': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-document-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-export': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-form': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673))(@embedpdf/plugin-history@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-fullscreen': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-history': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-i18n': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-interaction-manager': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-pan': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-print': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-redaction': 2.15.0(bdf11565ea62b71f1017cd22094dbf0a)
+      '@embedpdf/plugin-render': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-rotate': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-scroll': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-viewport@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-search': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-selection': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-interaction-manager@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-signature': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-spread': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-stamp': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-annotation@2.15.0(a6af0122725a50e23b60eed07e784673))(@embedpdf/plugin-i18n@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-thumbnail': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(@embedpdf/plugin-render@2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-tiling': 2.15.0(67c9fba1141826415e83ebf1139f6f30)
+      '@embedpdf/plugin-ui': 2.15.0(67c9fba1141826415e83ebf1139f6f30)
+      '@embedpdf/plugin-viewport': 2.15.0(@embedpdf/core@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2)))(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
+      '@embedpdf/plugin-zoom': 2.15.0(06dcf9b757304a820b614c84eb886ac7)
+      preact: 10.29.8
+      tailwind-merge: 3.6.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@embedpdf/utils@2.15.0(preact@10.29.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      preact: 10.29.8
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      svelte: 5.56.8
+      vue: 3.5.41(typescript@7.0.2)
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -5386,6 +6305,11 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -5724,6 +6648,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.12(acorn@8.17.0)':
+    dependencies:
+      acorn: 8.17.0
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -5849,6 +6777,8 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
+  '@types/trusted-types@2.0.7': {}
+
   '@types/web-push@3.6.4':
     dependencies:
       '@types/node': 24.13.3
@@ -5971,6 +6901,60 @@ snapshots:
       tinyrainbow: 3.1.0
 
   '@vscode/sudo-prompt@9.3.2': {}
+
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.41':
+    dependencies:
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.23
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.41':
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/reactivity@3.5.41':
+    dependencies:
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-core@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-dom@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.41':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/shared@3.5.41': {}
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -6144,6 +7128,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  aria-query@5.3.1: {}
+
   aria-query@5.3.2: {}
 
   asn1.js@5.4.1:
@@ -6170,6 +7156,8 @@ snapshots:
       fastq: 1.20.1
 
   axe-core@4.12.1: {}
+
+  axobject-query@4.1.0: {}
 
   balanced-match@4.0.4: {}
 
@@ -6332,6 +7320,8 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
+  clsx@2.1.1: {}
+
   color-convert@0.5.3:
     optional: true
 
@@ -6463,6 +7453,8 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
+
+  devalue@5.9.0: {}
 
   dir-compare@4.2.0:
     dependencies:
@@ -6615,6 +7607,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@7.0.1: {}
+
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
@@ -6683,6 +7677,12 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  esm-env@1.2.2: {}
+
+  esrap@2.3.2:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
@@ -6690,6 +7690,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -7278,6 +8280,10 @@ snapshots:
   is-property@1.0.2:
     optional: true
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   is-stream@1.1.0: {}
 
   is-unicode-supported@0.1.0: {}
@@ -7457,6 +8463,8 @@ snapshots:
       strip-bom: 3.0.0
 
   loader-runner@4.3.2: {}
+
+  locate-character@3.0.0: {}
 
   locate-path@2.0.0:
     dependencies:
@@ -7957,6 +8965,8 @@ snapshots:
   postject@1.0.0-alpha.6:
     dependencies:
       commander: 9.5.0
+
+  preact@10.29.8: {}
 
   prettier@3.9.5: {}
 
@@ -8459,11 +9469,34 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svelte@5.56.8:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.12(acorn@8.17.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.17.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      esrap: 2.3.2
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   svix@1.99.1:
     dependencies:
       standardwebhooks: 1.0.0
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.6.0: {}
 
   tapable@2.3.3: {}
 
@@ -8693,6 +9726,16 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vue@3.5.41(typescript@7.0.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-sfc': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/server-renderer': 3.5.41
+      '@vue/shared': 3.5.41
+    optionalDependencies:
+      typescript: 7.0.2
+
   w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
@@ -8858,6 +9901,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zimmerframe@1.1.4: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## What changed

- replace browser PDF iframes with the EmbedPDF PDFium viewer
- activate embedded PDFs in place and focus the viewer without moving the CodeMirror caret
- navigate PDF wiki links to the main file workspace
- keep the PDF implementation lazy-loaded and aligned with the editor theme

## Why

The browser-native iframe produced a poor, inconsistent preview. Clicking an embedded PDF also moved the caret onto its source line, which removed the rendered embed. PDF wiki links were resolved only against notes and could not open collection files.

## Validation

- 269 editor unit tests
- production editor build
- bundle-size and CSP checks
- browser coverage for inline PDF focus, PDFium rendering, and PDF wiki-link navigation
