### PR TITLE
Remove verified file cleanup from the download critical path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.0-beta.52
+
+Beta.52 removes avoidable latency after a file download has already completed
+and passed integrity verification.
+
+- Browser clients expose verified file bytes immediately while best-effort
+  transfer cleanup continues outside the document-loading critical path.
+- Cancellation and failed downloads still wait for cleanup, preserving the
+  existing recovery and integrity guarantees.
+
 ## 0.1.0-beta.51
 
 Beta.51 improves resilience under local registry contention and reduces file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.51"
+version = "0.1.0-beta.52"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.51
-git tag -a v0.1.0-beta.51 -m "mdbase connect 0.1.0-beta.51"
-git push origin v0.1.0-beta.51
+pnpm version:check v0.1.0-beta.52
+git tag -a v0.1.0-beta.52 -m "mdbase connect 0.1.0-beta.52"
+git push origin v0.1.0-beta.52
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/files.test.ts
+++ b/packages/client/src/files.test.ts
@@ -538,6 +538,44 @@ describe("MdbaseFileClient", () => {
     expect(aborted).toBe(true);
   });
 
+  it("does not keep verified download bytes behind best-effort session cleanup", async () => {
+    const content = bytes("verified before cleanup");
+    const file = descriptor("Assets/verified.bin", content);
+    let releaseCleanup!: () => void;
+    let cleanupStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      cleanupStarted = resolve;
+    });
+    const cleanup = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const client = fileClient(async (method, path, input) => {
+      if (path === "downloads") {
+        return uploadSession(
+          input.transfer_id,
+          { kind: "object_ranges", part_size: content.length },
+          content.length,
+          "download"
+        );
+      }
+      if (method === "DELETE") {
+        cleanupStarted();
+        await cleanup;
+        return { protocol_version: 1, type: "file_transfer_status", state: "aborted" };
+      }
+      throw new Error(`Unexpected control path ${path}`);
+    }, undefined, {
+      async downloadPart() {
+        return byteStream(content);
+      }
+    });
+
+    const result = client.downloadBytes(file);
+    await started;
+    await expect(result).resolves.toEqual(content);
+    releaseCleanup();
+  });
+
   it("fails closed on corrupt object bytes and cleans up the transfer", async () => {
     const content = bytes("expected");
     const file = descriptor("expected.bin", content);

--- a/packages/client/src/files.ts
+++ b/packages/client/src/files.ts
@@ -567,8 +567,8 @@ export class MdbaseFileClient {
               if (!hostedReader) {
                 if (partIndex >= partCount) {
                   verify();
-                  await finish();
                   controller.close();
+                  void finish();
                   return;
                 }
                 const offset = partIndex * partSize;
@@ -624,8 +624,8 @@ export class MdbaseFileClient {
           }
           if (partIndex >= partCount) {
             verify();
-            await finish();
             controller.close();
+            void finish();
             return;
           }
           const offset = partIndex * partSize;
@@ -656,8 +656,8 @@ export class MdbaseFileClient {
           }
           controller.enqueue(chunk);
           if (partIndex === partCount) {
-            await finish();
             controller.close();
+            void finish();
           }
         } catch (error) {
           await finish();

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.51" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.52" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.51",
+  "version": "0.1.0-beta.52",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- expose integrity-verified browser file downloads before best-effort transfer cleanup completes
- retain awaited cleanup for cancellation and failures
- add a regression test for a deliberately stalled cleanup response
- prepare the coordinated beta.52 release

## Validation

- `pnpm version:check v0.1.0-beta.52`
- `pnpm check:npm-bootstrap`
- `pnpm check:release-readiness`
- `pnpm audit:dependencies`
- `pnpm check:architecture`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm package:audit`