### PR TITLE
Prepare beta.53 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.0-beta.53
+
+Beta.53 requires application sessions that request full-collection access to
+hold a matching full-collection grant.
+
+- Contract-scoped grants no longer satisfy full-collection application
+  requirements and trigger renewed authorization.
+- Contract-scoped application requirements continue to work with
+  contract-scoped grants.
+
 ## 0.1.0-beta.52
 
 Beta.52 removes avoidable latency after a file download has already completed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "axum",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.52"
+version = "0.1.0-beta.53"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,9 +144,9 @@ and production; tag creation never rebuilds them.
 The tag must exactly match every package and the Rust workspace version:
 
 ```bash
-pnpm version:check v0.1.0-beta.52
-git tag -a v0.1.0-beta.52 -m "mdbase connect 0.1.0-beta.52"
-git push origin v0.1.0-beta.52
+pnpm version:check v0.1.0-beta.53
+git tag -a v0.1.0-beta.53 -m "mdbase connect 0.1.0-beta.53"
+git push origin v0.1.0-beta.53
 ```
 
 If a tag-triggered npm or desktop run is lost during a GitHub Actions outage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/application-session.test.ts
+++ b/packages/client/src/application-session.test.ts
@@ -32,7 +32,8 @@ function manifest(overrides: Partial<MdbaseAppManifest> = {}): MdbaseAppManifest
 
 function connection(
   operations = ["describe", "read", "update"],
-  assessment?: CollectionSetupAssessment
+  assessment?: CollectionSetupAssessment,
+  access: "contract" | "full_collection" = "full_collection"
 ) {
   let currentAssessment = assessment;
   const applyCollectionSetup = vi.fn(async () => {
@@ -57,7 +58,7 @@ function connection(
       collectionId,
       displayName: "Test collection",
       operations,
-      scope: { contracts: [], access: "full_collection" },
+      scope: { contracts: [], access },
       authority: { kind: "hosted", durability: "provider" },
       route: "remote",
       directAccess: "disabled"
@@ -80,9 +81,10 @@ function connection(
 function connectFixture(
   declaration: MdbaseAppManifest,
   grantedOperations?: string[],
-  assessment?: CollectionSetupAssessment
+  assessment?: CollectionSetupAssessment,
+  access?: "contract" | "full_collection"
 ) {
-  const connected = connection(grantedOperations, assessment);
+  const connected = connection(grantedOperations, assessment, access);
   const authorize = vi.fn(async () => connectSuccess({ kind: "redirect", url: "https://connect.example" }));
   const register = vi.fn(async () => connectSuccess({
     id: "01922222-2222-7222-8222-222222222222",
@@ -230,6 +232,31 @@ describe("MdbaseApplicationSession", () => {
           "records.update": { state: "requires_authorization", requirement: "optional" }
         }
       }
+    });
+  });
+
+  it("requires renewed authorization when a full-collection application has a contract-scoped grant", async () => {
+    const declaration = manifest({
+      requirements: {
+        contracts: [],
+        access: "full_collection",
+        capabilities: {
+          contract_version: 1,
+          required: ["collection.inspect", "records.read"]
+        }
+      }
+    });
+    const fixture = connectFixture(declaration, undefined, undefined, "contract");
+    const session = new MdbaseApplicationSession(fixture.facade as never, {
+      selection: new MdbaseMemorySelection()
+    });
+
+    const started = await session.start();
+
+    expect(started.ok && started.value.status).toBe("authorization_required");
+    expect(session.getSnapshot()).toMatchObject({
+      status: "authorization_required",
+      info: { scope: { access: "contract" } }
     });
   });
 

--- a/packages/client/src/application-session.test.ts
+++ b/packages/client/src/application-session.test.ts
@@ -260,6 +260,27 @@ describe("MdbaseApplicationSession", () => {
     });
   });
 
+  it("accepts a contract-scoped grant for a contract-scoped application", async () => {
+    const declaration = manifest({
+      requirements: {
+        contracts: [],
+        access: "contract",
+        capabilities: {
+          contract_version: 1,
+          required: ["collection.inspect", "records.read"]
+        }
+      }
+    });
+    const fixture = connectFixture(declaration, undefined, undefined, "contract");
+    const session = new MdbaseApplicationSession(fixture.facade as never, {
+      selection: new MdbaseMemorySelection()
+    });
+
+    const started = await session.start();
+
+    expect(started.ok && started.value.status).toBe("ready");
+  });
+
   it("carries request options through ensureCapabilities authorization", async () => {
     const fixture = connectFixture(manifest(), ["describe", "read"]);
     const session = new MdbaseApplicationSession(fixture.facade as never, {

--- a/packages/client/src/application-session.ts
+++ b/packages/client/src/application-session.ts
@@ -433,7 +433,10 @@ export class MdbaseApplicationSession<Frontmatter extends JsonObject = JsonObjec
       return;
     }
     const context = this.context(current.connection);
-    if (!context.capabilities.requiredAvailable) {
+    if (
+      !context.capabilities.requiredAvailable
+      || !accessRequirementSatisfied(this.manifest, context.info)
+    ) {
       this.publish({ status: "authorization_required", ...context });
       return;
     }
@@ -651,6 +654,14 @@ function verificationValue(manifest: MdbaseAppManifest): string {
     requirements: manifest.requirements?.configuration ?? [],
     provisions: manifest.provisions ?? {}
   });
+}
+
+function accessRequirementSatisfied(
+  manifest: MdbaseAppManifest,
+  connection: MdbaseConnectionInfo
+): boolean {
+  return manifest.requirements?.access !== "full_collection"
+    || connection.scope.access === "full_collection";
 }
 
 function declarationIdFromFamilyIdentity(familyIdentity: string): string {

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.52" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.53" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What changed

Prepare the coordinated `0.1.0-beta.53` release from the tested client fix at `69d7c2a`.

- Bump all package manifests, Rust workspace and lockfiles, and the MCP advertised version.
- Update the release checklist commands for `v0.1.0-beta.53`.
- Document the full-collection grant requirement for application sessions in the changelog.

## Why

Application sessions that request `full_collection` access must not treat a contract-scoped grant as sufficient. The beta.53 client fix requires renewed authorization until the granted collection scope is full-collection.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm version:check v0.1.0-beta.53`
- `pnpm check:release-readiness`
- `pnpm check:npm-bootstrap`
- `pnpm check:architecture`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm --filter @mdbase-dev/connect test -- src/application-session.test.ts` (170 tests passed)
- `pnpm --filter @mdbase-dev/connect typecheck`
- `pnpm --filter @mdbase-dev/connect test:public-api`
