### PR TITLE
Ship portal, hosted mutation, and editor consistency fixes

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -1271,7 +1271,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     }
   }
 
-  async function saveRecordSource(path: string, source: string, previousSource: string): Promise<boolean> {
+  async function saveRecordSource(path: string, source: string, previousSource: string): Promise<NoteDocument | false> {
     const session = noteSessions.current.get(path);
     if (!session || session.deleted) return false;
     if (noteSessions.current.active === session) setPropertiesError(undefined);
@@ -1302,7 +1302,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
         setSaveState("saved");
       }
       touchSession(session);
-      return true;
+      return updated;
     } catch (error) {
       const message = gatewayError(error);
       session.error = message;

--- a/apps/editor/src/PropertiesPanel.test.tsx
+++ b/apps/editor/src/PropertiesPanel.test.tsx
@@ -89,7 +89,12 @@ describe("typed note properties", () => {
 
   it("shows and saves the complete exact record source", async () => {
     const user = userEvent.setup();
-    const onSaveDocument = vi.fn();
+    const onSaveDocument = vi.fn(async (document: string) => ({
+      ...sourceNote,
+      document,
+      body: document.slice(document.indexOf("---\n") + 4),
+      revision: "revision-6"
+    }));
     const onClose = vi.fn();
     render(<PropertiesPanel note={sourceNote} types={[]} onClose={onClose} onSave={async () => undefined} onSaveDocument={onSaveDocument} />);
 
@@ -106,8 +111,65 @@ describe("typed note properties", () => {
     onSaveDocument.mockClear();
     fireEvent.change(editor, { target: { value: `${normalized}More again.\n` } });
     await user.click(screen.getByRole("button", { name: "Save source" }));
-    await waitFor(() => expect(onSaveDocument).toHaveBeenCalledWith(`${normalized}More again.\n`, sourceNote.document));
+    await waitFor(() => expect(onSaveDocument).toHaveBeenCalledWith(`${normalized}More again.\n`, `${normalized}More.\n`));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("rebases field drafts when an exact source save changes frontmatter", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn(async () => undefined);
+    const oldDocument = "---\ntitle: Quoted\ncustom: old\n---\nBody\n";
+    const noteWithFieldEdit = {
+      ...sourceNote,
+      frontmatter: { title: "Quoted", custom: "old" },
+      effectiveFrontmatter: { title: "Quoted", custom: "old" },
+      document: oldDocument,
+      body: "Body\n",
+      revision: "revision-fields"
+    };
+    const onSaveDocument = vi.fn(async (document: string): Promise<NoteDocument> => ({
+      ...noteWithFieldEdit,
+      frontmatter: { title: "Quoted", custom: "from-source" },
+      effectiveFrontmatter: { title: "Quoted", custom: "from-source" },
+      document,
+      revision: "revision-source"
+    }));
+    const view = render(<PropertiesPanel
+      note={sourceNote}
+      types={[]}
+      onClose={vi.fn()}
+      onSave={onSave}
+      onSaveDocument={onSaveDocument}
+    />);
+
+    await user.click(screen.getByRole("tab", { name: "JSON" }));
+    fireEvent.change(screen.getByLabelText("Raw frontmatter JSON"), {
+      target: { value: JSON.stringify(noteWithFieldEdit.frontmatter, null, 2) }
+    });
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(sourceNote.path, noteWithFieldEdit.frontmatter), { timeout: 1_500 });
+    view.rerender(<PropertiesPanel
+      note={noteWithFieldEdit}
+      types={[]}
+      onClose={vi.fn()}
+      onSave={onSave}
+      onSaveDocument={onSaveDocument}
+    />);
+
+    await user.click(screen.getByRole("tab", { name: "Source" }));
+    const sourceEditor = screen.getByLabelText("Complete record source");
+    const nextDocument = oldDocument.replace("custom: old", "custom: from-source");
+    fireEvent.change(sourceEditor, { target: { value: nextDocument } });
+    fireEvent.blur(sourceEditor);
+    await waitFor(() => expect(onSaveDocument).toHaveBeenCalledWith(nextDocument, oldDocument));
+    const fieldSaveCount = onSave.mock.calls.length;
+    await new Promise((resolve) => window.setTimeout(resolve, 650));
+    expect(onSave).toHaveBeenCalledTimes(fieldSaveCount);
+
+    await user.click(screen.getByRole("tab", { name: "JSON" }));
+    expect(screen.getByLabelText("Raw frontmatter JSON")).toHaveValue(JSON.stringify({
+      title: "Quoted",
+      custom: "from-source"
+    }, null, 2));
   });
 });
 

--- a/apps/editor/src/PropertiesPanel.tsx
+++ b/apps/editor/src/PropertiesPanel.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { CollectionTypeDescriptor, JsonObject } from "@mdbase-dev/connect";
 import { CodeEditor } from "./CodeEditor";
 import type { NoteDocument } from "./model";
-import { composeRecordSource } from "./record-source";
+import { composeRecordSource, parseRecordSource } from "./record-source";
 import { propertyValidationErrors, StructuredPropertiesEditor } from "./StructuredPropertiesEditor";
 
 interface PropertiesPanelProps {
@@ -17,7 +17,7 @@ interface PropertiesPanelProps {
   error?: string;
   onClose: () => void;
   onSave: (path: string, value: JsonObject) => Promise<void>;
-  onSaveDocument?: (document: string, previousDocument: string) => Promise<boolean> | boolean | void;
+  onSaveDocument?: (document: string, previousDocument: string) => Promise<NoteDocument | false> | NoteDocument | false;
 }
 
 export function PropertiesPanel({
@@ -33,21 +33,23 @@ export function PropertiesPanel({
   const initialDocument = note.document ?? composeRecordSource(note.frontmatter, note.body ?? "");
   const contract = useMemo(() => mergedSchema(note.types, types), [note.types, types]);
   const [draft, setDraft] = useState<JsonObject>(initial);
+  const [persistedFrontmatter, setPersistedFrontmatter] = useState(initial);
   const [mode, setMode] = useState<"fields" | "json" | "source">("fields");
   const [raw, setRaw] = useState(() => JSON.stringify(initial, null, 2));
   const [source, setSource] = useState(initialDocument);
+  const [persistedDocument, setPersistedDocument] = useState(initialDocument);
   const sourceBaseline = useRef(initialDocument);
   const latestSource = useRef(source);
   const sourceSaveCallback = useRef(onSaveDocument);
-  const sourceSavePromise = useRef<Promise<boolean> | undefined>(undefined);
+  const sourceSavePromise = useRef<Promise<NoteDocument | false> | undefined>(undefined);
   const lastSourceSubmitted = useRef(initialDocument);
   const [rawError, setRawError] = useState<string>();
   const [structuredFieldsValid, setStructuredFieldsValid] = useState(true);
   const [autoSaveState, setAutoSaveState] = useState<"saved" | "waiting" | "saving">("saved");
   const [saving, setSaving] = useState(false);
-  const changed = JSON.stringify(draft) !== JSON.stringify(initial);
-  const sourceChanged = source !== initialDocument;
-  const initialFingerprint = JSON.stringify(initial);
+  const changed = JSON.stringify(draft) !== JSON.stringify(persistedFrontmatter);
+  const sourceChanged = source !== persistedDocument;
+  const initialFingerprint = JSON.stringify(persistedFrontmatter);
   const draftFingerprint = JSON.stringify(draft);
   const validationFingerprint = JSON.stringify(propertyValidationErrors(draft, contract));
   const fieldsInvalid = Boolean(rawError) || !structuredFieldsValid || validationFingerprint !== "{}";
@@ -56,6 +58,7 @@ export function PropertiesPanel({
   const saveCallback = useRef(onSave);
   const lastSubmitted = useRef(initialFingerprint);
   const saveGeneration = useRef(0);
+  const fieldsBaseline = useRef(initial);
 
   useEffect(() => { latestDraft.current = draft; }, [draft]);
   useEffect(() => { latestFieldsInvalid.current = fieldsInvalid; }, [fieldsInvalid]);
@@ -63,8 +66,21 @@ export function PropertiesPanel({
   latestSource.current = source;
   sourceSaveCallback.current = onSaveDocument;
   useEffect(() => {
+    const previous = fieldsBaseline.current;
+    fieldsBaseline.current = initial;
+    setPersistedFrontmatter(initial);
+    setDraft((current) => {
+      if (JSON.stringify(current) !== JSON.stringify(previous)) return current;
+      setRaw(JSON.stringify(initial, null, 2));
+      latestDraft.current = initial;
+      lastSubmitted.current = JSON.stringify(initial);
+      return initial;
+    });
+  }, [initial]);
+  useEffect(() => {
     const previous = sourceBaseline.current;
     sourceBaseline.current = initialDocument;
+    setPersistedDocument(initialDocument);
     setSource((current) => {
       if (current !== previous) return current;
       latestSource.current = initialDocument;
@@ -134,23 +150,47 @@ export function PropertiesPanel({
       return;
     }
     if (sourceSavePromise.current) {
-      const succeeded = await sourceSavePromise.current;
-      if (succeeded && closeAfterSave) onClose();
+      const saved = await sourceSavePromise.current;
+      if (saved && closeAfterSave) onClose();
       return;
     }
     const next = source;
     const baseline = sourceBaseline.current;
     lastSourceSubmitted.current = next;
     setSaving(true);
-    const pending = Promise.resolve(onSaveDocument?.(next, baseline))
-      .then((result) => result !== false)
-      .catch(() => false);
+    const pending: Promise<NoteDocument | false> = onSaveDocument
+      ? Promise.resolve(onSaveDocument(next, baseline))
+        .catch(() => false as const)
+      : Promise.resolve(false as const);
     sourceSavePromise.current = pending;
-    const succeeded = await pending;
+    const saved = await pending;
     sourceSavePromise.current = undefined;
     setSaving(false);
-    if (!succeeded) lastSourceSubmitted.current = baseline;
-    if (succeeded && closeAfterSave) onClose();
+    if (!saved) {
+      lastSourceSubmitted.current = baseline;
+      return;
+    }
+    acceptPersistedDocument(saved, next);
+    if (closeAfterSave) onClose();
+  }
+
+  function acceptPersistedDocument(saved: NoteDocument, submittedSource: string) {
+    const persistedSource = saved.document ?? submittedSource;
+    const persistedFrontmatter = saved.frontmatter ?? parseRecordSource(persistedSource).frontmatter;
+    saveGeneration.current += 1;
+    fieldsBaseline.current = persistedFrontmatter;
+    sourceBaseline.current = persistedSource;
+    latestDraft.current = persistedFrontmatter;
+    latestSource.current = persistedSource;
+    lastSubmitted.current = JSON.stringify(persistedFrontmatter);
+    lastSourceSubmitted.current = persistedSource;
+    setDraft(structuredClone(persistedFrontmatter));
+    setPersistedFrontmatter(structuredClone(persistedFrontmatter));
+    setRaw(JSON.stringify(persistedFrontmatter, null, 2));
+    setRawError(undefined);
+    setSource(persistedSource);
+    setPersistedDocument(persistedSource);
+    setAutoSaveState("saved");
   }
 
   function closePanel() {

--- a/apps/portal/portal-model.test.mjs
+++ b/apps/portal/portal-model.test.mjs
@@ -1,6 +1,45 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { message } from "./src/portal-model.ts";
+import { capturePortalBootstrapSecrets, message } from "./src/portal-model.ts";
+
+test("captures one-time auth fragments before rendering and removes them from history", () => {
+  const replacements = [];
+  const secrets = capturePortalBootstrapSecrets(
+    {
+      hash: "#invitation=%20invite-secret%20&reset=reset-secret",
+      pathname: "/signup",
+      search: "?return_to=%2Fauthorize%2Frequest"
+    },
+    {
+      state: { preserved: true },
+      replaceState(state, title, url) {
+        replacements.push({ state, title, url });
+      }
+    }
+  );
+
+  assert.deepEqual(secrets, {
+    invitationToken: "invite-secret",
+    resetToken: "reset-secret"
+  });
+  assert.deepEqual(replacements, [{
+    state: { preserved: true },
+    title: "",
+    url: "/signup?return_to=%2Fauthorize%2Frequest"
+  }]);
+  assert.equal(Object.isFrozen(secrets), true);
+});
+
+test("does not rewrite unrelated fragments", () => {
+  let replaced = false;
+  const secrets = capturePortalBootstrapSecrets(
+    { hash: "#section", pathname: "/login", search: "" },
+    { state: null, replaceState() { replaced = true; } }
+  );
+
+  assert.deepEqual(secrets, { invitationToken: "", resetToken: "" });
+  assert.equal(replaced, false);
+});
 
 test("renders the first collection setup diagnostic with its path", () => {
   const error = Object.assign(

--- a/apps/portal/src/auth-view.tsx
+++ b/apps/portal/src/auth-view.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import { api, ApiError } from "./api";
 import {
-  invitationTokenFromFragment,
   isAuthorizationReturnTarget,
   message,
-  returnTarget,
-  tokenFromFragment
+  returnTarget
 } from "./portal-model";
 import { Loading, PageBrand } from "./portal-ui";
 
@@ -257,8 +255,7 @@ export function ForgotPassword() {
   );
 }
 
-export function ResetPassword() {
-  const [resetToken] = useState(() => tokenFromFragment("reset"));
+export function ResetPassword({ resetToken }: { resetToken: string }) {
   const [config, setConfig] = useState<AuthConfig | null>(null);
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
@@ -359,8 +356,7 @@ export function ResetPassword() {
   );
 }
 
-export function Signup() {
-  const [invitationToken] = useState(invitationTokenFromFragment);
+export function Signup({ invitationToken }: { invitationToken: string }) {
   const [config, setConfig] = useState<AuthConfig | null>(null);
   const [invitation, setInvitation] = useState<InvitationPreview | null>(null);
   const [name, setName] = useState("");

--- a/apps/portal/src/main.tsx
+++ b/apps/portal/src/main.tsx
@@ -21,21 +21,25 @@ import {
 } from "./authority-workflows";
 import { Authorization, DeviceAuthorization } from "./authorization-view";
 import { editorRedirectTarget } from "./editor-redirect";
-import { editorConnectUrl } from "./portal-model";
+import {
+  capturePortalBootstrapSecrets,
+  editorConnectUrl,
+  type PortalBootstrapSecrets
+} from "./portal-model";
 import { GettingStarted } from "./onboarding-view";
 import "./styles.css";
 
-function Portal() {
+function Portal({ bootstrapSecrets }: { bootstrapSecrets: PortalBootstrapSecrets }) {
   const pairingId = location.pathname.match(/^\/pair\/([0-9a-f-]+)$/i)?.[1];
   const mirrorPairingId = location.pathname.match(/^\/mirror\/([0-9a-f-]+)$/i)?.[1];
   const authorityAdoptionId = location.pathname.match(/^\/adopt\/([0-9a-f-]+)$/i)?.[1];
   const authorityTransferId = location.pathname.match(/^\/transfer\/([0-9a-f-]+)$/i)?.[1];
   const authorizationId = location.pathname.match(/^\/authorize\/([0-9a-f-]+)$/i)?.[1];
   if (location.pathname === "/login") return <Login />;
-  if (location.pathname === "/signup") return <Signup />;
+  if (location.pathname === "/signup") return <Signup invitationToken={bootstrapSecrets.invitationToken} />;
   if (location.pathname === "/getting-started") return <GettingStarted />;
   if (location.pathname === "/forgot-password") return <ForgotPassword />;
-  if (location.pathname === "/reset-password") return <ResetPassword />;
+  if (location.pathname === "/reset-password") return <ResetPassword resetToken={bootstrapSecrets.resetToken} />;
   if (location.pathname === "/device") return <DeviceAuthorization />;
   if (pairingId) return <Pairing pairingId={pairingId} />;
   if (mirrorPairingId) return <MirrorPairing pairingId={mirrorPairingId} />;
@@ -55,4 +59,7 @@ function EditorRedirect() {
   return <main className="portal-redirect" aria-live="polite">Opening mdbase Connect in the editor…</main>;
 }
 
-createRoot(document.getElementById("root")!).render(<React.StrictMode><Portal /></React.StrictMode>);
+const bootstrapSecrets = capturePortalBootstrapSecrets();
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode><Portal bootstrapSecrets={bootstrapSecrets} /></React.StrictMode>
+);

--- a/apps/portal/src/portal-model.ts
+++ b/apps/portal/src/portal-model.ts
@@ -70,17 +70,28 @@ export function returnTarget() {
   const target = new URL(requested, location.origin);
   return target.origin === location.origin ? target.href : "/";
 }
-export function invitationTokenFromFragment() {
-  return tokenFromFragment("invitation");
-}
-export function tokenFromFragment(name: string) {
-  const token = new URLSearchParams(location.hash.slice(1))
-    .get(name)
-    ?.trim() ?? "";
-  if (location.hash) {
-    history.replaceState(history.state, "", `${location.pathname}${location.search}`);
+export type PortalBootstrapSecrets = Readonly<{
+  invitationToken: string;
+  resetToken: string;
+}>;
+
+export function capturePortalBootstrapSecrets(
+  currentLocation: Pick<Location, "hash" | "pathname" | "search"> = location,
+  currentHistory: Pick<History, "replaceState" | "state"> = history
+): PortalBootstrapSecrets {
+  const parameters = new URLSearchParams(currentLocation.hash.slice(1));
+  const secrets = Object.freeze({
+    invitationToken: parameters.get("invitation")?.trim() ?? "",
+    resetToken: parameters.get("reset")?.trim() ?? ""
+  });
+  if (secrets.invitationToken || secrets.resetToken) {
+    currentHistory.replaceState(
+      currentHistory.state,
+      "",
+      `${currentLocation.pathname}${currentLocation.search}`
+    );
   }
-  return token;
+  return secrets;
 }
 export function isAuthorizationReturnTarget() {
   try {

--- a/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_dispatch.rs
@@ -185,12 +185,14 @@ impl HostedProvider {
             }
             "create" | "update" | "delete" | "rename" => {
                 let request_input = input;
-                let mutation_lease = mutation_lease.ok_or_else(|| {
-                    ApiError::internal("Hosted record mutation has no journal lease.")
-                })?;
-                let prepared = self
-                    .load_operation_preparation(collection_id, mutation_lease)
-                    .await?;
+                let is_preflight =
+                    request_input.get("dry_run").and_then(Value::as_bool) == Some(true);
+                let prepared = if let Some(mutation_lease) = mutation_lease {
+                    self.load_operation_preparation(collection_id, mutation_lease)
+                        .await?
+                } else {
+                    None
+                };
                 let (input, selector) = if prepared.is_some() {
                     let selector = contract_scope
                         .as_ref()
@@ -239,8 +241,20 @@ impl HostedProvider {
                 } else {
                     (request_input.clone(), None)
                 };
-                let result = self
-                    .write_operation(
+                let result = if is_preflight {
+                    self.preflight_record_operation(
+                        collection_id,
+                        replica,
+                        operation,
+                        request_id,
+                        input,
+                    )
+                    .await?
+                } else {
+                    let mutation_lease = mutation_lease.ok_or_else(|| {
+                        ApiError::internal("Hosted record mutation has no journal lease.")
+                    })?;
+                    self.write_operation(
                         RecordOperationContext {
                             collection_id,
                             token,
@@ -252,7 +266,8 @@ impl HostedProvider {
                         input,
                         prepared,
                     )
-                    .await?;
+                    .await?
+                };
                 if operation == "delete" {
                     return Ok(result);
                 }

--- a/crates/connect-hosted-provider/src/provider/operation_records.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_records.rs
@@ -1,14 +1,19 @@
 use super::mutation_journal::HostedMutationLease;
 use super::*;
 
+enum RecordOperationPreparation<'a> {
+    Preflight,
+    Mutation(&'a HostedMutationLease),
+}
+
 impl HostedProvider {
-    pub(super) async fn prepare_record_operation(
+    async fn prepare_record_operation(
         &self,
         collection_id: Uuid,
         replica: &Replica,
         operation: &str,
         request_id: Uuid,
-        mutation_lease: &HostedMutationLease,
+        preparation: RecordOperationPreparation<'_>,
         input: Value,
     ) -> ApiResult<PreparedRecordOperation> {
         let mut operation_input = input.as_object().cloned().ok_or_else(|| {
@@ -165,22 +170,72 @@ impl HostedProvider {
             previous_path,
             include_document,
         };
-        if prepared
+        let dry_run = prepared
             .semantic_input
             .get("dry_run")
             .and_then(Value::as_bool)
-            != Some(true)
-        {
-            self.store_operation_preparation_in(
-                &mut transaction,
-                &data_key,
-                mutation_lease,
-                &prepared,
-            )
-            .await?;
+            == Some(true);
+        match (preparation, dry_run) {
+            (RecordOperationPreparation::Preflight, true) => {}
+            (RecordOperationPreparation::Mutation(mutation_lease), false) => {
+                self.store_operation_preparation_in(
+                    &mut transaction,
+                    &data_key,
+                    mutation_lease,
+                    &prepared,
+                )
+                .await?;
+            }
+            (RecordOperationPreparation::Preflight, false) => {
+                return Err(ApiError::internal(
+                    "Hosted record mutation entered read-only preparation.",
+                ));
+            }
+            (RecordOperationPreparation::Mutation(_), true) => {
+                return Err(ApiError::internal(
+                    "Hosted record preflight entered mutation preparation.",
+                ));
+            }
         }
         transaction.commit().await?;
         Ok(prepared)
+    }
+
+    pub(super) async fn preflight_record_operation(
+        &self,
+        collection_id: Uuid,
+        replica: &Replica,
+        operation: &str,
+        request_id: Uuid,
+        input: Value,
+    ) -> ApiResult<Value> {
+        if input.get("dry_run").and_then(Value::as_bool) != Some(true) {
+            return Err(ApiError::internal(
+                "Hosted record preflight requires a dry-run operation.",
+            ));
+        }
+        let prepared = self
+            .prepare_record_operation(
+                collection_id,
+                replica,
+                operation,
+                request_id,
+                RecordOperationPreparation::Preflight,
+                input,
+            )
+            .await?;
+        let result = self
+            .execute_read_operation(
+                collection_id,
+                &prepared.semantic_operation,
+                &Value::Object(prepared.semantic_input),
+            )
+            .await?;
+        serde_json::to_value(result).map_err(|error| {
+            ApiError::internal(format!(
+                "Hosted operation preflight could not serialize: {error}"
+            ))
+        })
     }
 
     pub(super) async fn write_operation(
@@ -198,29 +253,10 @@ impl HostedProvider {
                         context.replica,
                         context.operation,
                         context.request_id,
-                        context.mutation_lease,
+                        RecordOperationPreparation::Mutation(context.mutation_lease),
                         input,
                     )
                     .await?;
-                if prepared
-                    .semantic_input
-                    .get("dry_run")
-                    .and_then(Value::as_bool)
-                    == Some(true)
-                {
-                    let result = self
-                        .execute_read_operation(
-                            context.collection_id,
-                            &prepared.semantic_operation,
-                            &Value::Object(prepared.semantic_input),
-                        )
-                        .await?;
-                    return serde_json::to_value(result).map_err(|error| {
-                        ApiError::internal(format!(
-                            "Hosted operation preflight could not serialize: {error}"
-                        ))
-                    });
-                }
                 prepared
             }
         };


### PR DESCRIPTION
## What changed

- Capture one-time portal auth fragments before the first render.
- Separate hosted record preflights from mutation execution.
- Rebase editor projections after source saves.

These fixes close production request-path races and keep authorization, hosted writes, and editor state consistent with the authoritative source.

## Validation

- cargo fmt --all --check
- cargo test --workspace
- pnpm typecheck
- pnpm test
- pnpm e2e
