### PR TITLE
Bound large relay messages below NATS payload limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.1.0-beta.59
+
+Beta.59 makes legitimate large relay operations independent of the broker's
+per-message payload ceiling.
+
+- Relay requests and responses use bounded, versioned fragmentation below the
+  active NATS `max_payload`, with strict logical-message and aggregate-memory
+  limits, assembly deadlines, and malformed-frame rejection.
+- JSON operations and opaque binary file frames share the same transport, so
+  large collection listings and file traffic cannot terminate a Connect server.
+- Multi-instance relay coverage now exercises requests and responses above the
+  broker ceiling, concurrency, connector fencing, disconnects, and recovery.
+
 ## 0.1.0-beta.58
 
 Beta.58 closes two staging findings from the beta.57 compatibility rollout.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.58"
+version = "0.1.0-beta.59"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -140,6 +140,24 @@ try {
   assert(largeResult.status === 200 && largeResult.body.result?.input_bytes === large.length,
     `Large transient relay payload failed: ${JSON.stringify(largeResult.body)}`);
 
+  const oversizedBrokerResponseBytes = 6 * 1_024 * 1_024;
+  const oversizedBrokerResponse = await operation(urlB, fixture, "query", {
+    response_bytes: oversizedBrokerResponseBytes
+  });
+  assert(
+    oversizedBrokerResponse.status === 200
+      && oversizedBrokerResponse.body.result?.blob?.length === oversizedBrokerResponseBytes,
+    `A legitimate response above NATS max_payload did not use bounded framing: ${JSON.stringify({
+      status: oversizedBrokerResponse.status,
+      body: oversizedBrokerResponse.body.result && {
+        ...oversizedBrokerResponse.body.result,
+        blob: `[${oversizedBrokerResponse.body.result.blob?.length} bytes]`
+      }
+    })}`
+  );
+  assert((await fetch(`${urlA}/health`)).ok && (await fetch(`${urlB}/health`)).ok,
+    "A large framed response terminated a Connect instance");
+
   await database.query("UPDATE grants SET operations = $2::jsonb WHERE id = $1", [
     fixture.grantId,
     JSON.stringify(["read"])
@@ -610,7 +628,10 @@ async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner
       result: {
         owner,
         operation: message.operation,
-        input_bytes: typeof message.input?.blob === "string" ? message.input.blob.length : 0
+        input_bytes: typeof message.input?.blob === "string" ? message.input.blob.length : 0,
+        ...(Number.isSafeInteger(message.input?.response_bytes)
+          ? { blob: "x".repeat(message.input.response_bytes) }
+          : {})
       }
     }));
   });

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -13,6 +13,7 @@ import {
   encodeRelayFileFrame,
   FILE_TRANSFER_PROTOCOL_VERSION,
   GRANT_ENCRYPTION_PROTOCOL_VERSION,
+  MAX_FILE_CHUNK_BYTES,
   OPERATION_TRANSPORT_PROTOCOL_VERSION,
   RELAY_CAPABILITIES
 } from "../packages/protocol/dist/index.js";
@@ -240,7 +241,9 @@ try {
     encryption,
     transferId: uploadTransferId,
     direction: "upload",
-    plaintextLength: 128
+    // The encrypted frame is larger than NATS's 4 MiB max_payload once its
+    // protocol header and authentication tag are included.
+    plaintextLength: MAX_FILE_CHUNK_BYTES
   });
   const relayedUpload = await fetch(
     `${urlA}/v1/authorities/${fixture.localCollectionId}/files/upload`,
@@ -265,7 +268,7 @@ try {
     encryption,
     transferId: downloadTransferId,
     direction: "download",
-    plaintextLength: 96
+    plaintextLength: MAX_FILE_CHUNK_BYTES
   });
   connectorB.setDownloadFrame(downloadFrame);
   const relayedDownload = await fetch(
@@ -694,7 +697,7 @@ function opaqueFileFrame({ fixture, encryption, transferId, direction, plaintext
       collection_id: fixture.localCollectionId,
       transfer_id: transferId,
       direction,
-      chunk_size: 64 * 1024,
+      chunk_size: Math.max(64 * 1024, plaintextLength),
       chunk_index: 0,
       offset: 0,
       plaintext_length: plaintextLength,

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.58" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.59" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.58",
+  "version": "0.1.0-beta.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/relay-broker-framing.test.ts
+++ b/services/server/src/relay-broker-framing.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROKER_LOGICAL_MESSAGE_LIMIT_BYTES,
+  BrokerFrameAssembler,
+  BrokerFrameError,
+  encodeBrokerFrames,
+  inspectBrokerFrame
+} from "./relay-broker-framing.js";
+
+describe("relay broker framing", () => {
+  it("round-trips a multi-megabyte response below a small broker payload ceiling", () => {
+    const value = new Uint8Array(5 * 1_024 * 1_024 + 37);
+    for (let index = 0; index < value.length; index += 1) value[index] = index % 251;
+    const frames = encodeBrokerFrames(value, 2, 128 * 1_024);
+    expect(frames.length).toBeGreaterThan(40);
+    expect(frames.every((frame) => frame.byteLength < 128 * 1_024)).toBe(true);
+
+    const assembler = new BrokerFrameAssembler();
+    let result: Uint8Array | null = null;
+    for (const frame of [...frames].reverse()) {
+      result = assembler.accept(frame, 2) ?? result;
+    }
+    expect(result?.byteLength).toBe(value.byteLength);
+    expect(Buffer.compare(Buffer.from(result!), Buffer.from(value))).toBe(0);
+  });
+
+  it("represents an empty message with one valid frame", () => {
+    const frames = encodeBrokerFrames(new Uint8Array(), 1, 64 * 1_024);
+    expect(frames).toHaveLength(1);
+    expect(new BrokerFrameAssembler().accept(frames[0]!, 1)).toEqual(new Uint8Array());
+  });
+
+  it("rejects duplicate, mismatched, malformed, and oversized sequences", () => {
+    const frames = encodeBrokerFrames(new Uint8Array(200_000), 1, 64 * 1_024);
+    const assembler = new BrokerFrameAssembler();
+    expect(assembler.accept(frames[0]!, 1)).toBeNull();
+    expect(() => assembler.accept(frames[0]!, 1)).toThrowError(BrokerFrameError);
+    expect(() => new BrokerFrameAssembler().accept(frames[1]!, 2))
+      .toThrowError(BrokerFrameError);
+    expect(() => inspectBrokerFrame(Uint8Array.of(1, 2, 3)))
+      .toThrowError(BrokerFrameError);
+    expect(() => encodeBrokerFrames(
+      new Uint8Array(BROKER_LOGICAL_MESSAGE_LIMIT_BYTES + 1),
+      1,
+      64 * 1_024
+    )).toThrowError(BrokerFrameError);
+  });
+});

--- a/services/server/src/relay-broker-framing.ts
+++ b/services/server/src/relay-broker-framing.ts
@@ -1,0 +1,341 @@
+import {
+  createInbox,
+  type Msg,
+  type NatsConnection,
+  type Subscription
+} from "@nats-io/transport-node";
+
+const FRAME_MAGIC = 0x4d444252; // MDBR
+const FRAME_VERSION = 1;
+const FRAME_HEADER_BYTES = 20;
+const FRAME_SAFETY_BYTES = 1_024;
+const PREFERRED_FRAME_BYTES = 512 * 1_024;
+const MAX_FRAME_COUNT = 65_536;
+
+export const BROKER_LOGICAL_MESSAGE_LIMIT_BYTES = 64 * 1_024 * 1_024;
+const BROKER_ASSEMBLY_TIMEOUT_MS = 35_000;
+const BROKER_PENDING_MESSAGE_LIMIT = 512;
+const BROKER_BUFFER_LIMIT_BYTES = 256 * 1_024 * 1_024;
+
+export type BrokerFrameKind = 1 | 2;
+
+export interface BrokerFrameMetadata {
+  kind: BrokerFrameKind;
+  totalBytes: number;
+  chunkIndex: number;
+  chunkCount: number;
+  payload: Uint8Array;
+}
+
+/**
+ * Splits one logical broker message into frames that remain safely below the
+ * active NATS server's payload ceiling. The logical limit is deliberately
+ * independent of that deployment setting so changing brokers cannot change
+ * Connect's application contract.
+ */
+export function encodeBrokerFrames(
+  value: Uint8Array,
+  kind: BrokerFrameKind,
+  brokerMaxPayloadBytes: number
+): Uint8Array[] {
+  if (value.byteLength > BROKER_LOGICAL_MESSAGE_LIMIT_BYTES) {
+    throw new BrokerFrameError("broker_message_too_large");
+  }
+  if (!Number.isSafeInteger(brokerMaxPayloadBytes)
+      || brokerMaxPayloadBytes <= FRAME_HEADER_BYTES + FRAME_SAFETY_BYTES) {
+    throw new BrokerFrameError("broker_payload_limit_invalid");
+  }
+  const frameBytes = Math.min(
+    PREFERRED_FRAME_BYTES,
+    brokerMaxPayloadBytes - FRAME_SAFETY_BYTES
+  );
+  const chunkBytes = frameBytes - FRAME_HEADER_BYTES;
+  const chunkCount = Math.max(1, Math.ceil(value.byteLength / chunkBytes));
+  if (chunkCount > MAX_FRAME_COUNT) {
+    throw new BrokerFrameError("broker_message_too_fragmented");
+  }
+
+  const frames: Uint8Array[] = [];
+  for (let index = 0; index < chunkCount; index += 1) {
+    const start = index * chunkBytes;
+    const end = Math.min(value.byteLength, start + chunkBytes);
+    const payload = value.subarray(start, end);
+    const frame = new Uint8Array(FRAME_HEADER_BYTES + payload.byteLength);
+    const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+    view.setUint32(0, FRAME_MAGIC);
+    view.setUint8(4, FRAME_VERSION);
+    view.setUint8(5, kind);
+    view.setUint16(6, 0);
+    view.setUint32(8, value.byteLength);
+    view.setUint32(12, index);
+    view.setUint32(16, chunkCount);
+    frame.set(payload, FRAME_HEADER_BYTES);
+    frames.push(frame);
+  }
+  return frames;
+}
+
+export function inspectBrokerFrame(value: Uint8Array): BrokerFrameMetadata {
+  if (value.byteLength < FRAME_HEADER_BYTES) {
+    throw new BrokerFrameError("broker_frame_truncated");
+  }
+  const view = new DataView(value.buffer, value.byteOffset, value.byteLength);
+  const kind = view.getUint8(5);
+  const totalBytes = view.getUint32(8);
+  const chunkIndex = view.getUint32(12);
+  const chunkCount = view.getUint32(16);
+  if (view.getUint32(0) !== FRAME_MAGIC
+      || view.getUint8(4) !== FRAME_VERSION
+      || (kind !== 1 && kind !== 2)
+      || view.getUint16(6) !== 0
+      || totalBytes > BROKER_LOGICAL_MESSAGE_LIMIT_BYTES
+      || chunkCount < 1
+      || chunkCount > MAX_FRAME_COUNT
+      || chunkIndex >= chunkCount) {
+    throw new BrokerFrameError("broker_frame_invalid");
+  }
+  const payload = value.subarray(FRAME_HEADER_BYTES);
+  if ((totalBytes === 0 && (chunkCount !== 1 || payload.byteLength !== 0))
+      || (totalBytes > 0 && payload.byteLength === 0)
+      || payload.byteLength > totalBytes) {
+    throw new BrokerFrameError("broker_frame_invalid");
+  }
+  return {
+    kind,
+    totalBytes,
+    chunkIndex,
+    chunkCount,
+    payload
+  };
+}
+
+/** Reassembles one bounded logical request or response, including out-of-order frames. */
+export class BrokerFrameAssembler {
+  private chunks: Array<Uint8Array | undefined> | undefined;
+  private expectedKind: BrokerFrameKind | undefined;
+  private expectedBytes = 0;
+  private receivedChunks = 0;
+  private bufferedBytes = 0;
+
+  get receivedBytes(): number {
+    return this.bufferedBytes;
+  }
+
+  accept(value: Uint8Array, expectedKind: BrokerFrameKind): Uint8Array | null {
+    const frame = inspectBrokerFrame(value);
+    if (frame.kind !== expectedKind) {
+      throw new BrokerFrameError("broker_frame_kind_mismatch");
+    }
+    if (!this.chunks) {
+      this.expectedKind = frame.kind;
+      this.expectedBytes = frame.totalBytes;
+      this.chunks = new Array(frame.chunkCount);
+    } else if (this.expectedKind !== frame.kind
+        || this.expectedBytes !== frame.totalBytes
+        || this.chunks.length !== frame.chunkCount) {
+      throw new BrokerFrameError("broker_frame_sequence_mismatch");
+    }
+    if (this.chunks[frame.chunkIndex]) {
+      throw new BrokerFrameError("broker_frame_duplicate");
+    }
+    const payload = Uint8Array.from(frame.payload);
+    this.chunks[frame.chunkIndex] = payload;
+    this.receivedChunks += 1;
+    this.bufferedBytes += payload.byteLength;
+    if (this.bufferedBytes > this.expectedBytes) {
+      throw new BrokerFrameError("broker_frame_length_mismatch");
+    }
+    if (this.receivedChunks !== this.chunks.length) return null;
+    if (this.bufferedBytes !== this.expectedBytes) {
+      throw new BrokerFrameError("broker_frame_length_mismatch");
+    }
+    const output = new Uint8Array(this.expectedBytes);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      if (!chunk) throw new BrokerFrameError("broker_frame_missing");
+      output.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return output;
+  }
+}
+
+export class BrokerFrameError extends Error {
+  constructor(readonly code: string) {
+    super(code);
+  }
+}
+
+interface IncomingBrokerAssembly {
+  assembler: BrokerFrameAssembler;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Bounded request/reply transport over Core NATS. Each logical payload has one
+ * private inbox and is fragmented below max_payload in both directions.
+ */
+export class NatsFramedTransport {
+  private readonly incoming = new Map<string, IncomingBrokerAssembly>();
+  private incomingBufferedBytes = 0;
+  private responseBufferedBytes = 0;
+
+  constructor(private readonly connection: NatsConnection) {}
+
+  close(): void {
+    for (const incoming of this.incoming.values()) clearTimeout(incoming.timer);
+    this.incoming.clear();
+    this.incomingBufferedBytes = 0;
+  }
+
+  request(subject: string, value: Uint8Array, timeoutMs: number): Promise<Uint8Array> {
+    const frames = this.frames(value, 1);
+    const inbox = createInbox();
+    const assembler = new BrokerFrameAssembler();
+    let settled = false;
+    let subscription: Subscription | undefined;
+    let timer: NodeJS.Timeout | undefined;
+
+    return new Promise((resolve, reject) => {
+      const finish = (error: Error | null, result?: Uint8Array): void => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        subscription?.unsubscribe();
+        this.responseBufferedBytes = Math.max(
+          0,
+          this.responseBufferedBytes - assembler.receivedBytes
+        );
+        if (error) reject(error);
+        else resolve(result ?? new Uint8Array());
+      };
+      subscription = this.connection.subscribe(inbox, {
+        callback: (error, message) => {
+          if (error) {
+            finish(new NatsFramedTransportError("broker_response_failed", { cause: error }));
+            return;
+          }
+          if (message.headers?.code === 503) {
+            finish(new NatsFramedTransportError("broker_no_responders"));
+            return;
+          }
+          try {
+            const metadata = inspectBrokerFrame(message.data);
+            if (this.responseBufferedBytes + metadata.payload.byteLength
+                > BROKER_BUFFER_LIMIT_BYTES) {
+              throw new BrokerFrameError("broker_response_capacity_exceeded");
+            }
+            const before = assembler.receivedBytes;
+            let complete: Uint8Array | null;
+            try {
+              complete = assembler.accept(message.data, 2);
+            } finally {
+              // accept() can reject only after observing an invalid cumulative
+              // length. Account for any copied bytes before finish() releases
+              // the assembly so concurrent capacity cannot be undercounted.
+              this.responseBufferedBytes += assembler.receivedBytes - before;
+            }
+            if (complete) finish(null, complete);
+          } catch (cause) {
+            finish(new NatsFramedTransportError("broker_response_invalid", { cause }));
+          }
+        }
+      });
+      timer = setTimeout(() => {
+        finish(new NatsFramedTransportError("broker_response_timeout"));
+      }, timeoutMs);
+      try {
+        for (const frame of frames) {
+          this.connection.publish(subject, frame, { reply: inbox });
+        }
+      } catch (cause) {
+        finish(new NatsFramedTransportError("broker_request_failed", { cause }));
+      }
+    });
+  }
+
+  async handle(
+    error: Error | null,
+    message: Msg,
+    handler: (value: Uint8Array) => Promise<Uint8Array>,
+    failure: () => Uint8Array
+  ): Promise<void> {
+    if (error || !message.reply) return;
+    const key = `${message.subject}\u0000${message.reply}`;
+    let incoming = this.incoming.get(key);
+    try {
+      const metadata = inspectBrokerFrame(message.data);
+      if (metadata.kind !== 1) throw new BrokerFrameError("broker_request_kind_invalid");
+      if (!incoming) {
+        if (this.incoming.size >= BROKER_PENDING_MESSAGE_LIMIT) {
+          throw new BrokerFrameError("broker_request_capacity_exceeded");
+        }
+        incoming = {
+          assembler: new BrokerFrameAssembler(),
+          timer: setTimeout(() => this.discardIncoming(key), BROKER_ASSEMBLY_TIMEOUT_MS)
+        };
+        this.incoming.set(key, incoming);
+      }
+      if (this.incomingBufferedBytes + metadata.payload.byteLength
+          > BROKER_BUFFER_LIMIT_BYTES) {
+        throw new BrokerFrameError("broker_request_capacity_exceeded");
+      }
+      const before = incoming.assembler.receivedBytes;
+      let complete: Uint8Array | null;
+      try {
+        complete = incoming.assembler.accept(message.data, 1);
+      } finally {
+        this.incomingBufferedBytes += incoming.assembler.receivedBytes - before;
+      }
+      if (!complete) return;
+      this.discardIncoming(key);
+      const reply = await handler(complete);
+      this.publishResponse(message.reply, reply, failure());
+    } catch {
+      this.discardIncoming(key);
+      this.publishResponse(message.reply, failure(), failure());
+    }
+  }
+
+  private discardIncoming(key: string): void {
+    const incoming = this.incoming.get(key);
+    if (!incoming) return;
+    clearTimeout(incoming.timer);
+    this.incoming.delete(key);
+    this.incomingBufferedBytes = Math.max(
+      0,
+      this.incomingBufferedBytes - incoming.assembler.receivedBytes
+    );
+  }
+
+  private publishResponse(subject: string, value: Uint8Array, failure: Uint8Array): void {
+    let frames: Uint8Array[];
+    try {
+      frames = this.frames(value, 2);
+    } catch {
+      try {
+        frames = this.frames(failure, 2);
+      } catch {
+        return;
+      }
+    }
+    try {
+      for (const frame of frames) this.connection.publish(subject, frame);
+    } catch {
+      // A disconnected broker makes the requester time out; it must never crash
+      // the HTTP process that happens to own this connector session.
+    }
+  }
+
+  private frames(value: Uint8Array, kind: BrokerFrameKind): Uint8Array[] {
+    const maxPayload = this.connection.info?.max_payload;
+    if (!maxPayload) throw new BrokerFrameError("broker_payload_limit_unavailable");
+    return encodeBrokerFrames(value, kind, maxPayload);
+  }
+}
+
+export class NatsFramedTransportError extends Error {
+  constructor(readonly code: string, options?: ErrorOptions) {
+    super(code, options);
+  }
+}

--- a/services/server/src/relay-broker.ts
+++ b/services/server/src/relay-broker.ts
@@ -1,7 +1,5 @@
 import {
   connect,
-  RequestError,
-  TimeoutError,
   type Msg,
   type NatsConnection,
   type Subscription
@@ -10,6 +8,10 @@ import {
   isConnectProblem,
   type ConnectProblem
 } from "@mdbase-dev/connect-protocol";
+import {
+  NatsFramedTransport,
+  NatsFramedTransportError
+} from "./relay-broker-framing.js";
 
 const SUBJECT_PREFIX = "mdbase.connect.relay.v1";
 const encoder = new TextEncoder();
@@ -163,8 +165,10 @@ export class LocalRelayBroker implements RelayBroker {
 
 export class NatsRelayBroker implements RelayBroker {
   private available = true;
+  private readonly framed: NatsFramedTransport;
 
   private constructor(private readonly connection: NatsConnection) {
+    this.framed = new NatsFramedTransport(connection);
     void this.monitorConnection();
   }
 
@@ -192,14 +196,14 @@ export class NatsRelayBroker implements RelayBroker {
     assertSubjectParts(input.connectorId, input.generation);
     const delivery = this.connection.subscribe(deliverySubject(input.connectorId, input.generation), {
       callback: (error, message) => {
-        void this.handleRequest(error, message, input.handle);
+        void this.handleRequest(error, message, input.handle).catch(() => undefined);
       }
     });
     const binaryDelivery = this.connection.subscribe(
       binaryDeliverySubject(input.connectorId, input.generation),
       {
         callback: (error, message) => {
-          void this.handleBinaryRequest(error, message, input.handleBinary);
+          void this.handleBinaryRequest(error, message, input.handleBinary).catch(() => undefined);
         }
       }
     );
@@ -226,20 +230,19 @@ export class NatsRelayBroker implements RelayBroker {
     this.assertAvailable();
     assertSubjectParts(connectorId, generation);
     try {
-      const response = await this.connection.request(
+      const response = await this.framed.request(
         deliverySubject(connectorId, generation),
         encodeJson(command),
-        { timeout: timeoutMs }
+        timeoutMs
       );
-      const reply = decodeJson(response.data);
+      const reply = decodeJson(response);
       if (!isRelayBrokerReply(reply)) {
         throw new RelayBrokerUnavailableError("The relay broker returned an invalid response.");
       }
       return reply;
     } catch (error) {
       if (error instanceof RelayBrokerUnavailableError) throw error;
-      if (error instanceof TimeoutError
-          || (error instanceof RequestError && error.isNoResponders())) {
+      if (isMissingRelayError(error)) {
         throw new RelayBrokerUnavailableError("No relay owns the current connector session.", {
           cause: error
         });
@@ -257,16 +260,15 @@ export class NatsRelayBroker implements RelayBroker {
     this.assertAvailable();
     assertSubjectParts(connectorId, generation);
     try {
-      const response = await this.connection.request(
+      const response = await this.framed.request(
         binaryDeliverySubject(connectorId, generation),
         frame,
-        { timeout: timeoutMs }
+        timeoutMs
       );
-      return decodeBinaryReply(response.data);
+      return decodeBinaryReply(response);
     } catch (error) {
       if (error instanceof RelayBrokerUnavailableError) throw error;
-      if (error instanceof TimeoutError
-          || (error instanceof RequestError && error.isNoResponders())) {
+      if (isMissingRelayError(error)) {
         throw new RelayBrokerUnavailableError("No relay owns the current connector session.", {
           cause: error
         });
@@ -291,6 +293,7 @@ export class NatsRelayBroker implements RelayBroker {
 
   async close(): Promise<void> {
     this.available = false;
+    this.framed.close();
     if (!this.connection.isClosed()) await this.connection.drain();
   }
 
@@ -318,19 +321,28 @@ export class NatsRelayBroker implements RelayBroker {
     message: Msg,
     handle: (command: RelayBrokerCommand) => Promise<RelayBrokerReply>
   ): Promise<void> {
-    if (error || !message.reply) return;
-    const decoded = decodeJson(message.data);
-    let reply: RelayBrokerReply;
-    if (!isRelayBrokerCommand(decoded)) {
-      reply = internalError("invalid_broker_command", "The relay command was invalid.");
-    } else {
-      try {
-        reply = await handle(decoded);
-      } catch {
-        reply = internalError("relay_delivery_failed", "The relay could not deliver the request.");
-      }
-    }
-    this.connection.publish(message.reply, encodeJson(reply));
+    await this.framed.handle(
+      error,
+      message,
+      async (data) => {
+        const decoded = decodeJson(data);
+        let reply: RelayBrokerReply;
+        if (!isRelayBrokerCommand(decoded)) {
+          reply = internalError("invalid_broker_command", "The relay command was invalid.");
+        } else {
+          try {
+            reply = await handle(decoded);
+          } catch {
+            reply = internalError("relay_delivery_failed", "The relay could not deliver the request.");
+          }
+        }
+        return encodeJson(reply);
+      },
+      () => encodeJson(internalError(
+        "relay_broker_payload_invalid",
+        "The relay broker message was invalid or exceeded its bounded transport limit."
+      ))
+    );
   }
 
   private async handleBinaryRequest(
@@ -338,14 +350,26 @@ export class NatsRelayBroker implements RelayBroker {
     message: Msg,
     handle: (frame: Uint8Array) => Promise<RelayBrokerBinaryReply>
   ): Promise<void> {
-    if (error || !message.reply) return;
-    let reply: RelayBrokerBinaryReply;
-    try {
-      reply = await handle(message.data);
-    } catch {
-      reply = binaryInternalError("relay_file_delivery_failed", "The relay could not deliver the file frame.");
-    }
-    this.connection.publish(message.reply, encodeBinaryReply(reply));
+    await this.framed.handle(
+      error,
+      message,
+      async (data) => {
+        let reply: RelayBrokerBinaryReply;
+        try {
+          reply = await handle(data);
+        } catch {
+          reply = binaryInternalError(
+            "relay_file_delivery_failed",
+            "The relay could not deliver the file frame."
+          );
+        }
+        return encodeBinaryReply(reply);
+      },
+      () => encodeBinaryReply(binaryInternalError(
+        "relay_broker_payload_invalid",
+        "The relay broker file message was invalid or exceeded its bounded transport limit."
+      ))
+    );
   }
 }
 
@@ -388,6 +412,11 @@ function assertSubjectParts(connectorId: string, generation: string): void {
       || !/^[0-9]+$/.test(generation)) {
     throw new RelayBrokerUnavailableError("Invalid relay routing metadata.");
   }
+}
+
+function isMissingRelayError(error: unknown): boolean {
+  return error instanceof NatsFramedTransportError
+    && (error.code === "broker_no_responders" || error.code === "broker_response_timeout");
 }
 
 function compareGeneration(left: string, right: string): number {


### PR DESCRIPTION
## Summary
- fragment every Core NATS relay request and response below the active broker max_payload
- bound logical size, aggregate buffering, pending assemblies, and assembly lifetime
- share the framed transport across JSON operations and opaque binary file frames
- prevent broker publish failures from terminating the Connect HTTP process
- release the fix consistently as 0.1.0-beta.59

## Verification
- pnpm typecheck
- pnpm test (58 server files / 298 server tests; 40 editor files / 270 editor tests; all workspace packages green)
- node test/rust/run.mjs
- pnpm e2e:relay (1.5 MiB request, 6 MiB response, maximum 4 MiB encrypted file upload and download whose framed bytes exceed the 4 MiB NATS ceiling, 200 concurrent operations, fencing, outage/restart/reconnect)
- pnpm package:audit
- pnpm check:architecture
- pnpm check:release-readiness
- pnpm audit:dependencies
- pnpm version:check v0.1.0-beta.59

Production deployment remains disabled for this staging-only rollout.