### PR TITLE
Keep heavy file relays responsive in beta60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.0-beta.60
+
+Beta.60 keeps large local collections responsive while binary files are served
+and makes bounded connector backpressure recoverable by applications.
+
+- Opening one indexed download no longer reconciles or hashes the rest of the
+  vault; the selected snapshot is still copied and digest-verified before any
+  bytes are released.
+- Stale paths are resolved with a metadata-only identity scan so authorization
+  is rechecked against a file's current path without restoring whole-vault work
+  to the request path.
+- Connector overload is an explicit `503` with `Retry-After`; the SDK applies
+  deadline-bound jittered backoff, reuses exact mutation envelopes, refreshes
+  read envelopes, and never retries unknown mutation outcomes.
+- File chunks use bounded retry backoff long enough to bridge a desktop daemon
+  restart while preserving cancellation and integrity checks.
+
 ## 0.1.0-beta.59
 
 Beta.59 makes legitimate large relay operations independent of the broker's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-agent/src/loopback.rs
+++ b/crates/connect-agent/src/loopback.rs
@@ -187,6 +187,19 @@ fn cors_error(status: StatusCode, code: &str, message: &str, origin: &str) -> Re
     )
 }
 
+fn cors_busy(message: &str, origin: &str) -> Response<Body> {
+    let mut response = cors_error(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "connector_busy",
+        message,
+        origin,
+    );
+    response
+        .headers_mut()
+        .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+    response
+}
+
 fn cors_response(mut response: Response<Body>, origin: &str) -> Response<Body> {
     if let Ok(value) = HeaderValue::from_str(origin) {
         response

--- a/crates/connect-agent/src/loopback/control.rs
+++ b/crates/connect-agent/src/loopback/control.rs
@@ -152,12 +152,7 @@ async fn encrypted_control(
         );
     }
     let Some(permit) = operation_permit(&state).await else {
-        return cors_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "connector_busy",
-            "The local connector is busy.",
-            &origin,
-        );
+        return cors_busy("The local connector is busy.", &origin);
     };
     let agent = state.agent.clone();
     let operation_origin = origin.clone();

--- a/crates/connect-agent/src/loopback/files.rs
+++ b/crates/connect-agent/src/loopback/files.rs
@@ -52,12 +52,7 @@ async fn file_upload(
         );
     }
     let Some(permit) = operation_permit(&state).await else {
-        return cors_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "connector_busy",
-            "The local connector is busy.",
-            &origin,
-        );
+        return cors_busy("The local connector is busy.", &origin);
     };
     let agent = state.agent.clone();
     let upload_origin = origin.clone();
@@ -98,12 +93,7 @@ async fn file_download(
         return denied();
     };
     let Some(permit) = operation_permit(&state).await else {
-        return cors_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "connector_busy",
-            "The local connector is busy.",
-            &origin,
-        );
+        return cors_busy("The local connector is busy.", &origin);
     };
     let agent = state.agent.clone();
     let download_origin = origin.clone();

--- a/crates/connect-agent/src/loopback/tests.rs
+++ b/crates/connect-agent/src/loopback/tests.rs
@@ -12,6 +12,17 @@ use std::fs;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+#[test]
+fn busy_responses_are_explicitly_retryable() {
+    let response = cors_busy("Busy.", "https://app.example");
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(response.headers().get(header::RETRY_AFTER).unwrap(), "1");
+    assert_eq!(
+        response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+        "https://app.example"
+    );
+}
+
 #[tokio::test]
 async fn exact_origin_host_and_protocol_one_are_enforced() {
     let fixture = fixture();

--- a/crates/connect-core/src/registry/file_transfers/download.rs
+++ b/crates/connect-core/src/registry/file_transfers/download.rs
@@ -45,83 +45,101 @@ impl CollectionRegistry {
                 "This collection is disabled on its computer.".to_string(),
             ));
         }
-        let provider = self.provider_for(&registered)?;
-        provider.with_collection_read(|collection| {
-            crate::LocalSyncStore::for_registry(self).assert_authority_available(id)?;
-            let snapshot = collection.snapshot()?;
-            let files = self.reconcile_files_loaded_reusing_cached_digests(
-                &registered,
-                collection,
-                &snapshot,
-            )?;
-            let descriptor = files
-                .into_iter()
-                .find(|file| {
-                    file.file_id == request.file_id
-                        && request
-                            .revision
-                            .as_ref()
-                            .is_none_or(|revision| revision == &file.revision)
-                })
-                .ok_or_else(|| {
-                    file_error(
-                        "file_revision_not_found",
-                        "The requested file revision is no longer available locally.",
-                    )
-                })?;
-            authorize_path(&descriptor.path)?;
-            let staging_name = format!("{}.download", request.transfer_id);
-            let staging = ensure_staging_root(Path::new(&registered.path))?.join(&staging_name);
-            remove_file_if_present(&staging)?;
-            create_private_staging_file(&staging)?;
-            let source = Path::new(&registered.path).join(&descriptor.path);
-            if let Err(error) = copy_verified_download(
-                &source,
-                &staging,
+        crate::LocalSyncStore::for_registry(self).assert_authority_available(id)?;
+        // The descriptor came from the durable file inventory. Do not refresh the
+        // entire collection while opening one download: a watcher-driven warmup may
+        // be hashing unrelated multi-gigabyte files and holds the reconcile lock.
+        // The snapshot copy below re-verifies the selected file's exact size and
+        // digest before any bytes are released, so a stale inventory still fails
+        // closed with file_changed_during_read.
+        let descriptor = self
+            .indexed_files(id)?
+            .into_iter()
+            .find(|file| file.file_id == request.file_id)
+            .ok_or_else(|| {
+                file_error(
+                    "file_revision_not_found",
+                    "The requested file revision is no longer available locally.",
+                )
+            })?;
+        match self.indexed_file_location(&registered, descriptor.file_id)? {
+            super::super::files::IndexedFileLocation::Current => {}
+            super::super::files::IndexedFileLocation::Moved(path) => {
+                authorize_path(&path)?;
+                return Err(file_error(
+                    "file_revision_not_found",
+                    "The file moved after it was listed; list files again before downloading.",
+                ));
+            }
+            super::super::files::IndexedFileLocation::Missing => {
+                return Err(file_error(
+                    "file_revision_not_found",
+                    "The requested file revision is no longer available locally.",
+                ));
+            }
+        }
+        if request
+            .revision
+            .as_ref()
+            .is_some_and(|revision| revision != &descriptor.revision)
+        {
+            return Err(file_error(
+                "file_revision_not_found",
+                "The requested file revision is no longer available locally.",
+            ));
+        }
+        authorize_path(&descriptor.path)?;
+        let staging_name = format!("{}.download", request.transfer_id);
+        let staging = ensure_staging_root(Path::new(&registered.path))?.join(&staging_name);
+        remove_file_if_present(&staging)?;
+        create_private_staging_file(&staging)?;
+        let source = Path::new(&registered.path).join(&descriptor.path);
+        if let Err(error) = copy_verified_download(
+            &source,
+            &staging,
+            descriptor.size,
+            &descriptor.content_digest,
+        ) {
+            let _ = remove_file_if_present(&staging);
+            return Err(error);
+        }
+        let created_at = Utc::now();
+        let expires_at = created_at + Duration::hours(TRANSFER_LIFETIME_HOURS);
+        let path_key = portable_path_key(&descriptor.path);
+        let inserted = self.connection()?.execute(
+            "INSERT INTO collection_file_transfers
+               (transfer_id, collection_id, owner_id, direction, state, file_id, path,
+                path_key, expected_size, expected_digest, media_type, base_revision,
+                chunk_size, staging_path, created_at, expires_at)
+             VALUES (?1, ?2, ?3, 'download', 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                     ?11, ?12, ?13, ?14)",
+            params![
+                request.transfer_id.to_string(),
+                id.to_string(),
+                owner_id.to_string(),
+                descriptor.file_id.to_string(),
+                descriptor.path,
+                path_key,
                 descriptor.size,
-                &descriptor.content_digest,
-            ) {
-                let _ = remove_file_if_present(&staging);
-                return Err(error);
-            }
-            let created_at = Utc::now();
-            let expires_at = created_at + Duration::hours(TRANSFER_LIFETIME_HOURS);
-            let path_key = portable_path_key(&descriptor.path);
-            let inserted = self.connection()?.execute(
-                "INSERT INTO collection_file_transfers
-                   (transfer_id, collection_id, owner_id, direction, state, file_id, path,
-                    path_key, expected_size, expected_digest, media_type, base_revision,
-                    chunk_size, staging_path, created_at, expires_at)
-                 VALUES (?1, ?2, ?3, 'download', 'open', ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                         ?11, ?12, ?13, ?14)",
-                params![
-                    request.transfer_id.to_string(),
-                    id.to_string(),
-                    owner_id.to_string(),
-                    descriptor.file_id.to_string(),
-                    descriptor.path,
-                    path_key,
-                    descriptor.size,
-                    descriptor.content_digest,
-                    descriptor.media_type,
-                    descriptor.revision,
-                    DEFAULT_FILE_CHUNK_BYTES,
-                    staging_name,
-                    created_at.to_rfc3339_opts(SecondsFormat::Millis, true),
-                    expires_at.to_rfc3339_opts(SecondsFormat::Millis, true),
-                ],
-            );
-            if let Err(error) = inserted {
-                let _ = remove_file_if_present(&staging);
-                return Err(error.into());
-            }
-            Ok(download_session(&required_download(
-                &self.connection()?,
-                id,
-                Some(owner_id),
-                request.transfer_id,
-            )?))
-        })
+                descriptor.content_digest,
+                descriptor.media_type,
+                descriptor.revision,
+                DEFAULT_FILE_CHUNK_BYTES,
+                staging_name,
+                created_at.to_rfc3339_opts(SecondsFormat::Millis, true),
+                expires_at.to_rfc3339_opts(SecondsFormat::Millis, true),
+            ],
+        );
+        if let Err(error) = inserted {
+            let _ = remove_file_if_present(&staging);
+            return Err(error.into());
+        }
+        Ok(download_session(&required_download(
+            &self.connection()?,
+            id,
+            Some(owner_id),
+            request.transfer_id,
+        )?))
     }
 
     pub fn read_file_download_chunk(

--- a/crates/connect-core/src/registry/file_transfers/tests.rs
+++ b/crates/connect-core/src/registry/file_transfers/tests.rs
@@ -470,6 +470,38 @@ fn download_reuses_unchanged_inventory_digests_before_verifying_selected_bytes()
 }
 
 #[test]
+fn download_open_does_not_wait_for_an_unrelated_inventory_reconcile() {
+    let (_state, root, registry, id) = registered();
+    fs::write(root.path().join("selected.bin"), b"selected bytes").unwrap();
+    fs::write(root.path().join("unrelated.bin"), b"unrelated bytes").unwrap();
+    let selected = registry
+        .reconcile_files(id)
+        .unwrap()
+        .into_iter()
+        .find(|file| file.path == "selected.bin")
+        .unwrap();
+
+    let reconcile_lock = registry.file_reconcile_lock(id).unwrap();
+    let reconcile_guard = reconcile_lock.lock().unwrap();
+    let request = download_request(&selected);
+    let worker_registry = registry.clone();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        sender
+            .send(worker_registry.open_file_download(id, owner(), &request, |_| Ok(())))
+            .unwrap();
+    });
+
+    let session = receiver
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("one-file download preparation must not wait for inventory reconciliation")
+        .unwrap();
+    assert_eq!(session.total_size, b"selected bytes".len() as u64);
+    drop(reconcile_guard);
+    worker.join().unwrap();
+}
+
+#[test]
 fn download_rejects_stale_revisions_other_owners_and_expired_snapshots() {
     let (_state, root, registry, id) = registered();
     fs::write(root.path().join("asset.bin"), b"download").unwrap();

--- a/crates/connect-core/src/registry/files.rs
+++ b/crates/connect-core/src/registry/files.rs
@@ -27,6 +27,13 @@ struct IndexedFile {
     physical_identity: Option<PhysicalFileIdentity>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum IndexedFileLocation {
+    Current,
+    Moved(String),
+    Missing,
+}
+
 #[derive(Debug)]
 struct ObservedFile<'a> {
     candidate: &'a CollectionFileCandidate,
@@ -280,21 +287,6 @@ impl CollectionRegistry {
         self.reconcile_files_loaded_internal(registered, collection, snapshot, preferences, false)
     }
 
-    pub(super) fn reconcile_files_loaded_reusing_cached_digests(
-        &self,
-        registered: &CollectionSummary,
-        collection: &mdbase::Collection,
-        snapshot: &CollectionSnapshot,
-    ) -> Result<Vec<CollectionFileDescriptor>, ConnectError> {
-        self.reconcile_files_loaded_internal(
-            registered,
-            collection,
-            snapshot,
-            &FileReconcilePreferences::default(),
-            true,
-        )
-    }
-
     fn reconcile_files_loaded_internal(
         &self,
         registered: &CollectionSummary,
@@ -344,6 +336,57 @@ impl CollectionRegistry {
             .into_values()
             .map(|file| file.descriptor)
             .collect())
+    }
+
+    /// Confirm one indexed file's current path without hashing or reconciling
+    /// unrelated files. A physical move is reported so authorization can be
+    /// checked against the live path before the stale revision is rejected.
+    pub(super) fn indexed_file_location(
+        &self,
+        registered: &CollectionSummary,
+        file_id: Uuid,
+    ) -> Result<IndexedFileLocation, ConnectError> {
+        let indexed = read_indexed_files(&self.connection()?, registered.id)?
+            .remove(&file_id)
+            .ok_or_else(|| ConnectError::File {
+                code: "file_revision_not_found".to_string(),
+                message: "The requested file revision is no longer available locally.".to_string(),
+            })?;
+        let indexed_path = Path::new(&registered.path).join(&indexed.descriptor.path);
+        if fs::symlink_metadata(&indexed_path).is_ok_and(|metadata| {
+            metadata.is_file()
+                && !metadata.file_type().is_symlink()
+                && physical_identity_matches(&metadata, indexed.physical_identity.as_ref())
+        }) {
+            return Ok(IndexedFileLocation::Current);
+        }
+        let Some(identity) = indexed.physical_identity.as_ref() else {
+            return Ok(IndexedFileLocation::Missing);
+        };
+        let provider = self.provider_for(registered)?;
+        let moved = provider.with_collection_read(|collection| {
+            let snapshot = collection.snapshot()?;
+            let managed_paths = snapshot
+                .resources
+                .iter()
+                .map(|resource| resource.path.clone())
+                .chain(snapshot.records.iter().map(|record| record.path.clone()))
+                .collect::<BTreeSet<_>>();
+            let inventory = discover_collection_files(collection, &managed_paths)?;
+            Ok::<_, ConnectError>(
+                inventory
+                    .files
+                    .into_iter()
+                    .find(|candidate| candidate.physical_identity.as_ref() == Some(identity))
+                    .map(|candidate| candidate.path),
+            )
+        })?;
+        if let Some(path) = moved {
+            self.mark_file_inventory_dirty(registered.id)?;
+            let _ = self.start_file_index_warmup(registered.id);
+            return Ok(IndexedFileLocation::Moved(path));
+        }
+        Ok(IndexedFileLocation::Missing)
     }
 
     fn reconcile_observed_files(
@@ -528,7 +571,7 @@ impl CollectionRegistry {
             .map_err(ConnectError::from)
     }
 
-    fn file_reconcile_lock(&self, id: Uuid) -> Result<Arc<Mutex<()>>, ConnectError> {
+    pub(super) fn file_reconcile_lock(&self, id: Uuid) -> Result<Arc<Mutex<()>>, ConnectError> {
         let mut locks = self
             .file_reconciles
             .lock()

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.59"
+version = "0.1.0-beta.60"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/connection-transport.ts
+++ b/packages/client/src/connection-transport.ts
@@ -66,6 +66,11 @@ import type {
   ConnectionTransportInternals,
   ConnectionTransportOptions
 } from "./connection-transport-internals.js";
+import {
+  isExplicitConnectorBusyResponse,
+  retryExplicitConnectorBusy
+} from "./transient-retry.js";
+import { probeLoopbackAccess, tokenSupportsDirectAccess } from "./direct-access.js";
 
 export type {
   ConnectionTransportInternals,
@@ -133,9 +138,7 @@ export class ConnectionTransport {
     return this.currentToken()?.authority ? "remote" : this.currentRoute;
   }
 
-  notifyStorageChanged(): void {
-    this.emitConnection();
-  }
+  notifyStorageChanged(): void { this.emitConnection(); }
 
   async checkDirectAccess(options: ConnectRequestOptions = {}): Promise<DirectAccessStatus> {
     return withRequestBudget(options, this.timeouts.watchStartMs, (budget) =>
@@ -176,12 +179,7 @@ export class ConnectionTransport {
     this.setRoute("relay");
   }
 
-  /**
-   * Return one offline-replication transport regardless of whether the
-   * authority is remote, directly connected, or relay connected.
-   * Authority credentials and routing stay private inside the SDK.
-   */
-
+  /** Return pending writes without exposing authority transport credentials. */
   pendingMutations(): readonly PendingMutationSummary[] {
     return this.storedPendingMutations().map((pending) => ({
       requestId: pending.requestId,
@@ -242,7 +240,9 @@ export class ConnectionTransport {
     input: unknown,
     options: ConnectRequestOptions,
     storedPending?: PendingMutation,
-    freshReadRetried = false
+    freshReadRetried = false,
+    connectorBusyRetries = 0,
+    knownRejectedMutationRetry = false
   ): Promise<Result> {
     throwIfCancelled(options.signal);
     let token = this.currentToken();
@@ -265,7 +265,8 @@ export class ConnectionTransport {
       ?? (isMutation(operation, input) ? crypto.randomUUID() : undefined);
     let attempt: OperationAttempt;
     try {
-      attempt = await this.sendOperation(token, operation, input, tryDirect, options, pendingRequestId);
+      attempt = await this.sendOperation(token, operation, input, tryDirect, options,
+        pendingRequestId, knownRejectedMutationRetry);
     } catch (error) {
       throw operationTransportError(
         error,
@@ -297,7 +298,8 @@ export class ConnectionTransport {
       token = await this.refreshAuthorization(options.signal);
       tryDirect = await this.shouldAttemptDirect(token);
       try {
-        attempt = await this.sendOperation(token, operation, input, tryDirect, options, pendingRequestId);
+        attempt = await this.sendOperation(token, operation, input, tryDirect, options,
+          pendingRequestId, knownRejectedMutationRetry);
       } catch (error) {
         throw operationTransportError(
           error,
@@ -310,6 +312,18 @@ export class ConnectionTransport {
       }
       response = attempt.response;
     }
+    const retryBusy = (error: unknown) => retryExplicitConnectorBusy<Result>({
+      error,
+      attempt,
+      completedRetries: connectorBusyRetries,
+      signal: options.signal,
+      knownRejectedMutationRetry,
+      clearPending: (requestId) => this.clearPendingMutation(requestId),
+      retry: (pending, knownRejected) => this.performOperationWithinBudget<Result>(
+        operation, input, options, pending, freshReadRetried, connectorBusyRetries + 1,
+        knownRejected
+      )
+    });
     let body: any;
     try {
       body = await decodeJsonResponse(
@@ -327,6 +341,8 @@ export class ConnectionTransport {
     }
     if (!response.ok) {
       const error = apiError(body, "operation_failed", "Collection operation failed.", response.status);
+      const recovery = await retryBusy(error);
+      if (recovery.retried) return recovery.result;
       if (error.code === "fresh_request_required"
           && !attempt.pendingMutation
           && !freshReadRetried) {
@@ -435,8 +451,11 @@ export class ConnectionTransport {
           "The collection authority returned an invalid operation problem."
         );
       }
+      const error = new MdbaseConnectError(body.problem);
+      const recovery = await retryBusy(error);
+      if (recovery.retried) return recovery.result;
       if (attempt.pendingMutation) this.clearPendingMutation(attempt.requestId);
-      throw new MdbaseConnectError(body.problem);
+      throw error;
     }
     if (body.ok !== true || !("result" in body)) {
       if (attempt.pendingMutation) throw unknownMutationOutcome(attempt.requestId,
@@ -528,7 +547,8 @@ export class ConnectionTransport {
     input: unknown,
     tryDirect: boolean,
     options: ConnectRequestOptions = {},
-    pendingRequestId?: string
+    pendingRequestId?: string,
+    knownRejectedMutationRetry = false
   ): Promise<OperationAttempt> {
     let body: unknown = input ?? {};
     let encryptedRequest: Awaited<ReturnType<typeof encryptRelayRequest>> | undefined;
@@ -551,7 +571,7 @@ export class ConnectionTransport {
           );
         }
         requestId = pending.requestId;
-        resumingMutation = true;
+        resumingMutation = !knownRejectedMutationRetry;
       }
       pendingMutation = true;
     }
@@ -650,7 +670,10 @@ export class ConnectionTransport {
           body: JSON.stringify(encryptedRequest),
           signal: options.signal
         }));
-        if (!directFallbackStatus(response.status)) {
+        if (
+          !directFallbackStatus(response.status)
+          || await isExplicitConnectorBusyResponse(response)
+        ) {
           if (response.ok) {
             this.markDirectAvailable();
             this.setRoute("direct");
@@ -755,18 +778,10 @@ export class ConnectionTransport {
   }
 
   private directCapable(token: StoredToken | null): boolean {
-    if (!token || token.authority || !token.encryption || !token.grantId || !token.keyHandle) return false;
-    if (this.directAccessMode === "disabled") return false;
-    if (typeof location !== "undefined"
-        && token.applicationOrigin
-        && token.applicationOrigin !== location.origin) return false;
-    return true;
+    return tokenSupportsDirectAccess(token, this.directAccessMode);
   }
 
-  hasResumableMutationTransport(): boolean {
-    const token = this.currentToken();
-    return Boolean(token);
-  }
+  hasResumableMutationTransport(): boolean { return this.currentToken() !== null; }
 
   private directEligible(token: StoredToken | null): token is StoredToken {
     return token !== null
@@ -794,26 +809,13 @@ export class ConnectionTransport {
 
   private async probeDirectAccess(signal?: AbortSignal): Promise<DirectAccessStatus> {
     this.setDirectStatus("checking");
-    try {
-      const response = await fetch(`${this.loopbackUrl}/v1/ready`, loopbackRequest({
-        method: "GET",
-        cache: "no-store",
-        signal
-      }));
-      const body = await decodeJsonResponse(
-        response,
-        "invalid_operation_response",
-        "The connector returned an invalid readiness response."
-      ).catch(() => null);
-      if (response.ok
-          && body?.service === "mdbase-connect"
-          && body?.loopback_protocol_version === 1
-          && body?.operation_transport_protocol_version === OPERATION_TRANSPORT_PROTOCOL_VERSION) {
-        this.markDirectAvailable();
-        return "available";
-      }
-    } catch {
-      // Permission denial, unsupported mixed content, and an absent connector all reject fetch.
+    if (await probeLoopbackAccess(
+      this.loopbackUrl,
+      OPERATION_TRANSPORT_PROTOCOL_VERSION,
+      signal
+    )) {
+      this.markDirectAvailable();
+      return "available";
     }
     if ((await localNetworkPermission()) === "denied") return this.setDirectStatus("denied");
     this.markDirectUnavailable();
@@ -847,9 +849,7 @@ export class ConnectionTransport {
     }
   }
 
-  private emitConnection(): void {
-    this.onChange();
-  }
+  private emitConnection(): void { this.onChange(); }
 
   private invalidateRejectedAuthorization(rejected: StoredToken): void {
     const current = parseStored<StoredToken>(this.storage.getItem(

--- a/packages/client/src/direct-access.ts
+++ b/packages/client/src/direct-access.ts
@@ -1,0 +1,41 @@
+import type { StoredToken } from "./internal-types.js";
+import { loopbackRequest } from "./operation-helpers.js";
+import { decodeJsonResponse } from "./runtime-utils.js";
+
+export function tokenSupportsDirectAccess(
+  token: StoredToken | null,
+  mode: "auto" | "disabled"
+): boolean {
+  if (!token || token.authority || !token.encryption || !token.grantId || !token.keyHandle) {
+    return false;
+  }
+  if (mode === "disabled") return false;
+  return typeof location === "undefined"
+    || !token.applicationOrigin
+    || token.applicationOrigin === location.origin;
+}
+
+export async function probeLoopbackAccess(
+  loopbackUrl: string,
+  expectedOperationProtocol: number,
+  signal?: AbortSignal
+): Promise<boolean> {
+  try {
+    const response = await fetch(`${loopbackUrl}/v1/ready`, loopbackRequest({
+      method: "GET",
+      cache: "no-store",
+      signal
+    }));
+    const body = await decodeJsonResponse(
+      response,
+      "invalid_operation_response",
+      "The connector returned an invalid readiness response."
+    ).catch(() => null);
+    return response.ok
+      && body?.service === "mdbase-connect"
+      && body?.loopback_protocol_version === 1
+      && body?.operation_transport_protocol_version === expectedOperationProtocol;
+  } catch {
+    return false;
+  }
+}

--- a/packages/client/src/file-transfer-internals.test.ts
+++ b/packages/client/src/file-transfer-internals.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { connectError } from "./errors.js";
+import { retryChunk } from "./file-transfer-internals.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("file transfer transient retries", () => {
+  it("backs off retryable availability failures long enough to bridge a restart", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const work = vi.fn()
+      .mockRejectedValueOnce(connectError("connector_busy", "Busy."))
+      .mockRejectedValueOnce(connectError("connector_offline", "Offline."))
+      .mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+    const result = retryChunk(work);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toEqual(new Uint8Array([1, 2, 3]));
+    expect(work).toHaveBeenCalledTimes(3);
+  });
+
+  it("never retries a canonical non-retryable failure", async () => {
+    const work = vi.fn().mockRejectedValue(connectError(
+      "invalid_operation_response",
+      "Invalid response."
+    ));
+
+    await expect(retryChunk(work)).rejects.toMatchObject({
+      code: "invalid_operation_response"
+    });
+    expect(work).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/client/src/file-transfer-internals.ts
+++ b/packages/client/src/file-transfer-internals.ts
@@ -5,6 +5,10 @@ import type {
 } from "@mdbase-dev/connect-protocol";
 import { MdbaseConnectError, connectError } from "./errors.js";
 import { IncrementalSha256 } from "./file-sha256.js";
+import {
+  MAX_TRANSIENT_CHUNK_ATTEMPTS,
+  waitForTransientChunkRetry
+} from "./transient-retry.js";
 
 const HASH_CHUNK_BYTES = 1024 * 1024;
 const DEFAULT_CONCURRENCY = 4;
@@ -193,12 +197,17 @@ export async function retryChunk<Result>(
   work: () => Promise<Result>,
   signal?: AbortSignal
 ): Promise<Result> {
-  for (let attempt = 1; attempt <= MAX_OBJECT_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= MAX_TRANSIENT_CHUNK_ATTEMPTS; attempt += 1) {
     throwIfAborted(signal);
     try {
       return await work();
     } catch (error) {
-      if (signal?.aborted || attempt === MAX_OBJECT_ATTEMPTS) throw error;
+      if (
+        signal?.aborted
+        || attempt === MAX_TRANSIENT_CHUNK_ATTEMPTS
+        || (error instanceof MdbaseConnectError && !error.retryable)
+      ) throw error;
+      await waitForTransientChunkRetry(attempt, signal);
     }
   }
   throw new Error("Unreachable file chunk retry state.");

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -3311,6 +3311,117 @@ schema:
     expect(requests[1]?.counter).not.toBe(requests[0]?.counter);
   });
 
+  it("backs off explicit connector overload and retries reads with fresh envelopes", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    const requests: EncryptedRelayOperationRequest[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as EncryptedRelayOperationRequest;
+      requests.push(request);
+      if (requests.length < 3) {
+        return new Response(JSON.stringify({
+          error: normalizeConnectProblem("connector_busy", "Try again shortly.")
+        }), {
+          status: 503,
+          headers: { "content-type": "application/json", "retry-after": "1" }
+        });
+      }
+      const envelope = await encryptedFixtureResponse(
+        fixture,
+        request,
+        {
+          ok: true,
+          result: { valid: true, result: { results: [] }, diagnostics: [] }
+        }
+      );
+      return new Response(JSON.stringify({ envelope }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    });
+
+    const outcome = fixture.connect.query();
+
+    await expect(outcome).resolves.toMatchObject({ ok: true });
+    expect(requests).toHaveLength(3);
+    expect(new Set(requests.map(({ request_id }) => request_id)).size).toBe(3);
+    expect(new Set(requests.map(({ counter }) => counter)).size).toBe(3);
+  });
+
+  it("retries a definitively rejected write with its exact encrypted envelope", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    const bodies: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const body = String(init?.body);
+      const request = JSON.parse(body) as EncryptedRelayOperationRequest;
+      bodies.push(body);
+      if (bodies.length === 1) {
+        return new Response(JSON.stringify({
+          error: normalizeConnectProblem("connector_busy", "Try again shortly.")
+        }), {
+          status: 503,
+          headers: { "content-type": "application/json", "retry-after": "1" }
+        });
+      }
+      const record = {
+        path: "busy-once.md",
+        revision: "sha256:record",
+        types: [],
+        frontmatter: {},
+        effective_frontmatter: {},
+        body: "",
+        file: { path: "busy-once.md" }
+      };
+      const envelope = await encryptedFixtureResponse(
+        fixture,
+        request,
+        { ok: true, result: { valid: true, result: record, diagnostics: [] } }
+      );
+      return new Response(JSON.stringify({ envelope }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    });
+
+    const outcome = fixture.connect.create({ path: "busy-once.md", frontmatter: {} });
+
+    await expect(outcome).resolves.toMatchObject({
+      ok: true,
+      value: { path: "busy-once.md" }
+    });
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1]).toBe(bodies[0]);
+    expect(fixture.connect.pendingMutations()).toEqual([]);
+  });
+
+  it("clears a definitively busy write when its retry wait is cancelled", async () => {
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    const controller = new AbortController();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      controller.abort("stop waiting");
+      return new Response(JSON.stringify({
+        error: normalizeConnectProblem("connector_busy", "Try again shortly.")
+      }), {
+        status: 503,
+        headers: { "content-type": "application/json" }
+      });
+    });
+
+    await expect(fixture.connect.create(
+      { path: "cancelled-busy.md", frontmatter: {} },
+      { signal: controller.signal }
+    )).resolves.toMatchObject({
+      ok: false,
+      problem: { code: "operation_cancelled", operation_outcome: "not_sent" }
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fixture.connect.pendingMutations()).toEqual([]);
+  });
+
   it("never converts a mutation fresh-request response into a second execution", async () => {
     const fixture = await encryptedConnection();
     fixture.connect.disableDirectAccess();

--- a/packages/client/src/local-file-transport.test.ts
+++ b/packages/client/src/local-file-transport.test.ts
@@ -28,6 +28,32 @@ const ids = {
 afterEach(() => vi.restoreAllMocks());
 
 describe("LocalFileTransport", () => {
+  it("backs off an explicit busy control response before sending a fresh envelope", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const fixture = await transportFixture("download", false);
+    const requests: Array<{ request_id: string; counter: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      const code = requests.length === 1 ? "connector_busy" : "connector_offline";
+      return new Response(
+        JSON.stringify({ error: { code, message: code } }),
+        { status: 503, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const controlled = fixture.transport.control(
+      fixture.token,
+      "GET",
+      "?limit=10",
+      undefined
+    );
+
+    await expect(controlled).rejects.toMatchObject({ code: "connector_offline" });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.request_id).not.toBe(requests[0]?.request_id);
+    expect(requests[1]?.counter).not.toBe(requests[0]?.counter);
+  });
+
   it("encrypts upload frames with the exact negotiated transfer binding", async () => {
     const fixture = await transportFixture("upload");
     const plaintext = new TextEncoder().encode("local upload");

--- a/packages/client/src/local-file-transport.ts
+++ b/packages/client/src/local-file-transport.ts
@@ -27,6 +27,12 @@ import {
   loopbackRequest
 } from "./operation-helpers.js";
 import { apiError, decodeJsonResponse } from "./runtime-utils.js";
+import {
+  isConnectorBusy,
+  isExplicitConnectorBusyResponse,
+  MAX_CONNECTOR_BUSY_RETRIES,
+  waitForConnectorAvailability
+} from "./transient-retry.js";
 
 interface LocalFileTransportOptions {
   keyStore: GrantKeyStore;
@@ -51,7 +57,7 @@ export class LocalFileTransport {
     input: unknown,
     signal?: AbortSignal
   ): Promise<Result> {
-    return this.controlAttempt<Result>(token, method, path, input, signal, false);
+    return this.controlAttempt<Result>(token, method, path, input, signal, false, 0);
   }
 
   private async controlAttempt<Result>(
@@ -60,7 +66,8 @@ export class LocalFileTransport {
     path: string,
     input: unknown,
     signal: AbortSignal | undefined,
-    freshReadRetried: boolean
+    freshReadRetried: boolean,
+    connectorBusyRetries: number
   ): Promise<Result> {
     requireEncryption(token);
     const controlInput = localFileControlInput(method, path, input);
@@ -82,7 +89,10 @@ export class LocalFileTransport {
         if (signal?.aborted) throw error;
         this.options.onDirectUnavailable();
       }
-      if (response && !directFallbackStatus(response.status)) {
+      if (response && (
+        !directFallbackStatus(response.status)
+        || await isExplicitConnectorBusyResponse(response)
+      )) {
         if (response.ok) this.options.onDirectAvailable();
         return this.decryptControlResponse<Result>(
           token,
@@ -92,7 +102,8 @@ export class LocalFileTransport {
           signal,
           encryptedRequest,
           response,
-          freshReadRetried
+          freshReadRetried,
+          connectorBusyRetries
         );
       }
       if (response) this.options.onDirectUnavailable();
@@ -120,7 +131,8 @@ export class LocalFileTransport {
       signal,
       encryptedRequest,
       response,
-      freshReadRetried
+      freshReadRetried,
+      connectorBusyRetries
     );
   }
 
@@ -132,7 +144,8 @@ export class LocalFileTransport {
     signal: AbortSignal | undefined,
     encryptedRequest: EncryptedRelayOperationRequest,
     response: Response,
-    freshReadRetried: boolean
+    freshReadRetried: boolean,
+    connectorBusyRetries: number
   ): Promise<Result> {
     const body = await decodeJsonResponse(
       response,
@@ -146,10 +159,31 @@ export class LocalFileTransport {
         "Collection file request failed.",
         response.status
       );
+      if (isConnectorBusy(error)
+          && connectorBusyRetries < MAX_CONNECTOR_BUSY_RETRIES) {
+        await waitForConnectorAvailability(connectorBusyRetries, signal);
+        return this.controlAttempt<Result>(
+          token,
+          method,
+          path,
+          input,
+          signal,
+          freshReadRetried,
+          connectorBusyRetries + 1
+        );
+      }
       if (error.code === "fresh_request_required"
           && method === "GET"
           && !freshReadRetried) {
-        return this.controlAttempt<Result>(token, method, path, input, signal, true);
+        return this.controlAttempt<Result>(
+          token,
+          method,
+          path,
+          input,
+          signal,
+          true,
+          connectorBusyRetries
+        );
       }
       throw error;
     }
@@ -171,9 +205,33 @@ export class LocalFileTransport {
         && decrypted.problem.code === "fresh_request_required"
         && method === "GET"
         && !freshReadRetried) {
-      return this.controlAttempt<Result>(token, method, path, input, signal, true);
+      return this.controlAttempt<Result>(
+        token,
+        method,
+        path,
+        input,
+        signal,
+        true,
+        connectorBusyRetries
+      );
     }
-    if (!decrypted.ok) throwEncryptedProblem(decrypted.problem);
+    if (!decrypted.ok) {
+      const error = encryptedProblem(decrypted.problem);
+      if (isConnectorBusy(error)
+          && connectorBusyRetries < MAX_CONNECTOR_BUSY_RETRIES) {
+        await waitForConnectorAvailability(connectorBusyRetries, signal);
+        return this.controlAttempt<Result>(
+          token,
+          method,
+          path,
+          input,
+          signal,
+          freshReadRetried,
+          connectorBusyRetries + 1
+        );
+      }
+      throw error;
+    }
     return decrypted.result;
   }
 
@@ -203,7 +261,10 @@ export class LocalFileTransport {
         if (signal?.aborted) throw error;
         this.options.onDirectUnavailable();
       }
-      if (response && !directFallbackStatus(response.status)) {
+      if (response && (
+        !directFallbackStatus(response.status)
+        || await isExplicitConnectorBusyResponse(response)
+      )) {
         if (response.ok) this.options.onDirectAvailable();
         return requireSuccessfulChunkResponse(
           response,
@@ -258,7 +319,10 @@ export class LocalFileTransport {
         if (signal?.aborted) throw error;
         this.options.onDirectUnavailable();
       }
-      if (response && !directFallbackStatus(response.status)) {
+      if (response && (
+        !directFallbackStatus(response.status)
+        || await isExplicitConnectorBusyResponse(response)
+      )) {
         if (response.ok) this.options.onDirectAvailable();
         return this.decryptDownloadResponse(token, session, chunkIndex, response);
       }
@@ -552,8 +616,8 @@ function validateDownloadFrame(
   }
 }
 
-function throwEncryptedProblem(problem: ConnectProblem): never {
-  throw serverConnectError(
+function encryptedProblem(problem: ConnectProblem): MdbaseConnectError {
+  return serverConnectError(
     problem.code === "unknown" ? problem.server_code : problem.code,
     problem.message,
     {

--- a/packages/client/src/transient-retry.ts
+++ b/packages/client/src/transient-retry.ts
@@ -1,0 +1,89 @@
+import { abortableDelay } from "./async.js";
+import { MdbaseConnectError, connectError } from "./errors.js";
+import type { OperationAttempt, PendingMutation } from "./internal-types.js";
+
+export const MAX_CONNECTOR_BUSY_RETRIES = 8;
+export const MAX_TRANSIENT_CHUNK_ATTEMPTS = 10;
+
+export function isConnectorBusy(error: unknown): error is MdbaseConnectError {
+  return error instanceof MdbaseConnectError && error.code === "connector_busy";
+}
+
+export async function retryExplicitConnectorBusy<Result>(options: {
+  error: unknown;
+  attempt: OperationAttempt;
+  completedRetries: number;
+  signal?: AbortSignal;
+  knownRejectedMutationRetry: boolean;
+  clearPending(requestId: string): void;
+  retry(pending: PendingMutation | undefined, knownRejected: boolean): Promise<Result>;
+}): Promise<{ retried: false } | { retried: true; result: Result }> {
+  if (!isConnectorBusy(options.error)
+      || options.completedRetries >= MAX_CONNECTOR_BUSY_RETRIES) {
+    return { retried: false };
+  }
+  try {
+    await waitForConnectorAvailability(options.completedRetries, options.signal);
+  } catch (error) {
+    if (options.attempt.pendingMutation
+        && (options.knownRejectedMutationRetry || !options.attempt.resumingMutation)) {
+      options.clearPending(options.attempt.requestId);
+    }
+    throw error;
+  }
+  return {
+    retried: true,
+    result: await options.retry(
+      options.attempt.pendingMutationRecord,
+      options.knownRejectedMutationRetry
+        || (options.attempt.pendingMutation === true && !options.attempt.resumingMutation)
+    )
+  };
+}
+
+export async function isExplicitConnectorBusyResponse(
+  response: Response
+): Promise<boolean> {
+  if (response.status !== 502 && response.status !== 503) return false;
+  const body = await response.clone().json().catch(() => null) as {
+    error?: string | { code?: unknown };
+  } | null;
+  return body?.error === "connector_busy"
+    || (typeof body?.error === "object"
+      && body.error?.code === "connector_busy");
+}
+
+export function waitForConnectorAvailability(
+  retryIndex: number,
+  signal?: AbortSignal
+): Promise<void> {
+  return retryDelay(jitteredBackoff(50, 800, retryIndex), signal);
+}
+
+export function waitForTransientChunkRetry(
+  completedAttempt: number,
+  signal?: AbortSignal
+): Promise<void> {
+  return retryDelay(jitteredBackoff(100, 1_000, completedAttempt - 1), signal);
+}
+
+async function retryDelay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  try {
+    await abortableDelay(milliseconds, signal);
+  } catch (cause) {
+    if (signal?.aborted) {
+      if (signal.reason instanceof MdbaseConnectError) throw signal.reason;
+      throw connectError(
+        "operation_cancelled",
+        "The operation was cancelled while waiting for connector capacity.",
+        { operationOutcome: "not_sent", cause }
+      );
+    }
+    throw cause;
+  }
+}
+
+function jitteredBackoff(base: number, cap: number, exponent: number): number {
+  const bounded = Math.min(cap, base * (2 ** Math.max(0, exponent)));
+  return Math.max(1, Math.round(bounded * (0.75 + Math.random() * 0.5)));
+}

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.59" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.60" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.59",
+  "version": "0.1.0-beta.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/features/files/local-routes.test.ts
+++ b/services/server/src/features/files/local-routes.test.ts
@@ -13,7 +13,7 @@ import {
 import Fastify from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DatabasePool } from "../../database-types.js";
-import type { RelayHub } from "../../relay.js";
+import { ConnectorOperationError, type RelayHub } from "../../relay.js";
 import { registerErrorHandler } from "../../platform/error-handler.js";
 import { registerLocalFileRoutes } from "./local-routes.js";
 
@@ -59,6 +59,25 @@ afterEach(async () => {
 });
 
 describe("local collection file relay routes", () => {
+  it("returns explicit file overload as retryable HTTP availability", async () => {
+    const { app, relay } = await fixture();
+    vi.mocked(relay.routeEncrypted).mockRejectedValue(new ConnectorOperationError(
+      "connector_busy",
+      "The connector is processing its bounded operation queue."
+    ));
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/authorities/${collectionId}/files/control`,
+      headers: { authorization: "Bearer token" },
+      payload: encryptedEnvelope()
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.headers["retry-after"]).toBe("1");
+    expect(response.json().error.code).toBe("connector_busy");
+  });
+
   it("routes an exactly bound encrypted control envelope", async () => {
     const { app, relay } = await fixture();
     const envelope = encryptedEnvelope();

--- a/services/server/src/features/files/local-routes.ts
+++ b/services/server/src/features/files/local-routes.ts
@@ -313,6 +313,12 @@ function relayError(reply: FastifyReply, error: unknown): unknown {
     return reply.code(503).send(apiError("connector_offline", error.message));
   }
   if (error instanceof ConnectorOperationError) {
+    if (error.code === "connector_busy") {
+      return reply
+        .header("retry-after", "1")
+        .code(503)
+        .send(apiError(error.code, error.message));
+    }
     return reply.code(502).send(apiError(error.code, error.message));
   }
   throw error;

--- a/services/server/src/features/operations/local-routes.test.ts
+++ b/services/server/src/features/operations/local-routes.test.ts
@@ -2,7 +2,7 @@ import Fastify from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DatabasePool } from "../../database-types.js";
 import { registerErrorHandler } from "../../platform/error-handler.js";
-import type { RelayHub } from "../../relay.js";
+import { ConnectorOperationError, type RelayHub } from "../../relay.js";
 import { registerLocalOperationRoutes } from "./local-routes.js";
 
 const collectionId = "11111111-1111-4111-8111-111111111111";
@@ -19,6 +19,25 @@ afterEach(async () => {
 });
 
 describe("local operation access failures", () => {
+  it("returns explicit overload as retryable HTTP availability", async () => {
+    const { app, relay } = recoveryFixture();
+    vi.mocked(relay.routeEncrypted).mockRejectedValue(new ConnectorOperationError(
+      "connector_busy",
+      "The connector is processing its bounded operation queue."
+    ));
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/authorities/${collectionId}/operations/create`,
+      headers: { authorization: "Bearer current-v5-token" },
+      payload: encryptedEnvelope(oldGrantId, "old-key", "create")
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.headers["retry-after"]).toBe("1");
+    expect(response.json().error.code).toBe("connector_busy");
+  });
+
   it("returns the typed required, granted, and missing operation details", async () => {
     const app = Fastify();
     apps.push(app);

--- a/services/server/src/features/operations/local-routes.ts
+++ b/services/server/src/features/operations/local-routes.ts
@@ -213,6 +213,12 @@ export function registerLocalOperationRoutes(
         }
         if (error instanceof ConnectorOperationError) {
           if (!operationRequestId) {
+            if (error.code === "connector_busy") {
+              return reply
+                .header("retry-after", "1")
+                .code(503)
+                .send(apiError(error.code, error.message));
+            }
             return reply.code(502).send(apiError(error.code, error.message));
           }
           return {


### PR DESCRIPTION
## Summary

- remove whole-vault file reconciliation from one-file download preparation while preserving selected-byte digest verification and live-path authorization
- expose connector overload as retryable HTTP availability and add deadline-aware jittered SDK recovery with exact mutation-envelope reuse
- add bounded file-chunk retries that bridge desktop restarts without retrying canonical non-retryable failures
- prepare 0.1.0-beta.60

## Verification

- `cargo test --workspace`
- `pnpm test`
- `pnpm typecheck`
- `pnpm e2e`
- `pnpm check:architecture`
- `pnpm check:release-readiness`
- `pnpm package:audit`
- focused selected-file lock, stale-path authorization, connector-busy mutation/read/control, cancellation, and file-chunk retry regressions

The browser SDK remains below its 64 KiB hard gzip ceiling (51,855 bytes); its deliberate backpressure/restart support adds 2,423 bytes over the prior checked-in baseline and therefore emits the existing review warning.