### PR TITLE
Break hosted notification readiness cycle in beta61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.0-beta.61
+
+Beta.61 makes hosted-provider readiness acyclic while retaining an exact,
+operator-visible account of durable notification recovery.
+
+- Provider readiness now covers only the authoritative database, blob store,
+  and key hierarchy; retryable notification callbacks no longer keep Connect
+  and its provider waiting on each other or trigger a platform restart loop.
+- Startup attempts notification recovery without making callback availability
+  a process-start dependency, and the background worker safely replays the
+  same durable invocation after the control plane recovers.
+- Recovery is single-flight and reports `pending`, `degraded`, or `ok` from the
+  actual durable outbox and runtime state, with privacy-safe transition metrics
+  and no false healthy result from an overlapping or lease-blocked sweep.
+
 ## 0.1.0-beta.60
 
 Beta.60 keeps large local collections responsive while binary files are served

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-hosted-provider/src/lib.rs
+++ b/crates/connect-hosted-provider/src/lib.rs
@@ -26,8 +26,9 @@ pub use key_wrapping::{
 };
 pub use notifications::{HostedNotificationConfig, HostedNotificationRuntime};
 pub use provider::{
-    HostedMutationJournalDiagnostics, HostedProvider, NotificationRecoveryStatus,
-    PrepareAuthorityImport, PrepareAuthorityTransfer, ProviderAccountLimits, ProviderAccountUsage,
-    ProviderAuthorityImport, ProviderAuthorityImportState, ProviderAuthorityTransfer,
-    ProviderAuthorityTransferState, ProviderLimits, RegisterReplica, ReplicaPurpose,
+    HostedMutationJournalDiagnostics, HostedProvider, NotificationRecoveryState,
+    NotificationRecoveryStatus, PrepareAuthorityImport, PrepareAuthorityTransfer,
+    ProviderAccountLimits, ProviderAccountUsage, ProviderAuthorityImport,
+    ProviderAuthorityImportState, ProviderAuthorityTransfer, ProviderAuthorityTransferState,
+    ProviderLimits, RegisterReplica, ReplicaPurpose,
 };

--- a/crates/connect-hosted-provider/src/main.rs
+++ b/crates/connect-hosted-provider/src/main.rs
@@ -388,7 +388,10 @@ async fn maintain_notifications(provider: HostedProvider, period: Duration) {
     loop {
         interval.tick().await;
         if let Err(error) = provider.recover_notifications(1_000).await {
-            tracing::error!(%error, "hosted notification recovery failed");
+            tracing::warn!(
+                error_code = %error.code,
+                "hosted notification recovery deferred"
+            );
         }
     }
 }

--- a/crates/connect-hosted-provider/src/notifications.rs
+++ b/crates/connect-hosted-provider/src/notifications.rs
@@ -210,6 +210,26 @@ impl HostedNotificationRuntime {
         Ok(processed)
     }
 
+    pub async fn has_pending_delivery(&self) -> ApiResult<bool> {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT
+               EXISTS (
+                 SELECT 1
+                 FROM hosted_provider_runtime_outbox
+                 WHERE processed_at IS NULL
+               )
+               OR EXISTS (
+                 SELECT 1
+                 FROM mdbase_runtime_runs
+                 WHERE namespace LIKE 'connect-hosted:%:notifications'
+                   AND status IN ('queued', 'running', 'waiting')
+               )",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(ApiError::from)
+    }
+
     async fn process_outbox(&self, limit: usize) -> ApiResult<usize> {
         let rows = sqlx::query(
             "SELECT candidate.collection_id, candidate.sequence, candidate.event_type,

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -180,6 +180,7 @@ pub struct HostedProvider {
     limits: ProviderLimits,
     working_sets: WorkingSetRegistry,
     notifications: Option<HostedNotificationRuntime>,
+    notification_recovery_guard: Arc<Mutex<()>>,
     notification_recovery: Arc<RwLock<NotificationRecoveryStatus>>,
     blob_store: Arc<dyn BlobStore>,
 }
@@ -187,10 +188,19 @@ pub struct HostedProvider {
 #[derive(Debug, Clone, Serialize)]
 pub struct NotificationRecoveryStatus {
     pub configured: bool,
-    pub recovery: &'static str,
+    pub recovery: NotificationRecoveryState,
     pub consecutive_failures: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_success_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationRecoveryState {
+    Disabled,
+    Pending,
+    Ok,
+    Degraded,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/connect-hosted-provider/src/provider/lifecycle.rs
+++ b/crates/connect-hosted-provider/src/provider/lifecycle.rs
@@ -29,13 +29,14 @@ impl HostedProvider {
                                 limits,
                                 working_sets: Arc::new(Mutex::new(HashMap::new())),
                                 notifications,
+                                notification_recovery_guard: Arc::new(Mutex::new(())),
                                 notification_recovery: Arc::new(RwLock::new(
                                     NotificationRecoveryStatus {
                                         configured: notification_config.is_some(),
                                         recovery: if notification_config.is_some() {
-                                            "pending"
+                                            NotificationRecoveryState::Pending
                                         } else {
-                                            "disabled"
+                                            NotificationRecoveryState::Disabled
                                         },
                                         consecutive_failures: 0,
                                         last_success_at: None,
@@ -46,7 +47,17 @@ impl HostedProvider {
                             provider.migrate_legacy_sync_receipts().await?;
                             if let Some(notifications) = &provider.notifications {
                                 notifications.prepare().await?;
-                                provider.recover_notifications(1_000).await?;
+                                // Notification delivery calls back into the Connect control
+                                // plane. It is durable and retryable, but it is not a core
+                                // dependency of the provider's storage and sync surfaces.
+                                // Failing startup here creates a readiness cycle when Connect
+                                // also probes this provider before becoming ready.
+                                if let Err(error) = provider.recover_notifications(1_000).await {
+                                    tracing::warn!(
+                                        error_code = %error.code,
+                                        "initial hosted notification recovery deferred"
+                                    );
+                                }
                             }
                             return Ok(provider);
                         }
@@ -102,15 +113,12 @@ impl HostedProvider {
         sqlx::query("SELECT 1").execute(&self.pool).await?;
         self.blob_store.ready().await?;
         self.verify_key_readiness().await?;
-        let status = self.notification_recovery.read().await.clone();
-        if status.configured && status.recovery != "ok" {
-            return Err(ApiError::new(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "notification_recovery_unavailable",
-                "Hosted notification recovery has not completed successfully.",
-            ));
-        }
-        Ok(status)
+        // Keep readiness acyclic: notification delivery is an outbound,
+        // durably-retried dependency on the Connect control plane, while
+        // Connect itself checks this endpoint before advertising readiness.
+        // Report degradation for operators without inviting the platform to
+        // restart a provider that can still serve authoritative data.
+        Ok(self.notification_recovery.read().await.clone())
     }
 
     async fn verify_key_readiness(&self) -> ApiResult<()> {
@@ -166,23 +174,65 @@ impl HostedProvider {
         let Some(notifications) = &self.notifications else {
             return Ok(0);
         };
+        // Mutation-triggered recovery and the periodic recovery loop can fire
+        // together. Only one sweep may own runtime leases and update the
+        // operator-visible state; callers that lose the race can rely on the
+        // in-flight durable sweep.
+        let Ok(_guard) = self.notification_recovery_guard.try_lock() else {
+            return Ok(0);
+        };
         match notifications.recover(limit).await {
             Ok(processed) => {
-                *self.notification_recovery.write().await = NotificationRecoveryStatus {
+                let pending = match notifications.has_pending_delivery().await {
+                    Ok(pending) => pending,
+                    Err(error) => {
+                        self.mark_notification_recovery_degraded(&error).await;
+                        return Err(error);
+                    }
+                };
+                let mut status = self.notification_recovery.write().await;
+                if pending {
+                    if status.recovery != NotificationRecoveryState::Degraded {
+                        status.recovery = NotificationRecoveryState::Pending;
+                    }
+                    return Ok(processed);
+                }
+                let recovered_from_degraded =
+                    status.recovery == NotificationRecoveryState::Degraded;
+                *status = NotificationRecoveryStatus {
                     configured: true,
-                    recovery: "ok",
+                    recovery: NotificationRecoveryState::Ok,
                     consecutive_failures: 0,
                     last_success_at: Some(Utc::now()),
                 };
+                drop(status);
+                if recovered_from_degraded {
+                    tracing::info!(
+                        target: "mdbase_connect::metrics",
+                        metric = "notification_recovery_restored",
+                        "privacy-safe hosted provider metric"
+                    );
+                }
                 Ok(processed)
             }
             Err(error) => {
-                let mut status = self.notification_recovery.write().await;
-                status.recovery = "degraded";
-                status.consecutive_failures = status.consecutive_failures.saturating_add(1);
+                self.mark_notification_recovery_degraded(&error).await;
                 Err(error)
             }
         }
+    }
+
+    async fn mark_notification_recovery_degraded(&self, error: &ApiError) {
+        let mut status = self.notification_recovery.write().await;
+        status.recovery = NotificationRecoveryState::Degraded;
+        status.consecutive_failures = status.consecutive_failures.saturating_add(1);
+        tracing::warn!(
+            target: "mdbase_connect::metrics",
+            metric = "notification_recovery_degraded",
+            error_code = %error.code,
+            consecutive_failures = status.consecutive_failures,
+            "privacy-safe hosted provider metric"
+        );
     }
 }
 
@@ -234,6 +284,18 @@ mod key_readiness_tests {
         state.healthy = false;
         assert!(!state.should_probe(start + KEY_READINESS_FAILURE_TTL - Duration::from_millis(1)));
         assert!(state.should_probe(start + KEY_READINESS_FAILURE_TTL));
+    }
+
+    #[test]
+    fn notification_recovery_states_have_stable_operator_values() {
+        for (state, expected) in [
+            (NotificationRecoveryState::Disabled, "disabled"),
+            (NotificationRecoveryState::Pending, "pending"),
+            (NotificationRecoveryState::Ok, "ok"),
+            (NotificationRecoveryState::Degraded, "degraded"),
+        ] {
+            assert_eq!(serde_json::to_value(state).unwrap(), json!(expected));
+        }
     }
 }
 

--- a/crates/connect-hosted-provider/src/provider/mutations.rs
+++ b/crates/connect-hosted-provider/src/provider/mutations.rs
@@ -627,7 +627,10 @@ impl HostedProvider {
             let provider = self.clone();
             tokio::spawn(async move {
                 if let Err(error) = provider.recover_notifications(100).await {
-                    tracing::warn!(%error, "hosted notification recovery deferred");
+                    tracing::warn!(
+                        error_code = %error.code,
+                        "hosted notification recovery deferred"
+                    );
                 }
             });
         }

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.60"
+version = "0.1.0-beta.61"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/hosted-provider.md
+++ b/docs/hosted-provider.md
@@ -3,11 +3,22 @@
 Status: accepted implementation architecture for the production hosted path
 
 The provider does not report readiness until its SQL migrations, embedded
-runtime migration, persisted grant validation, and an initial notification
-recovery pass all succeed. `/ready` includes the current notification recovery
-state; deployment and external smoke checks treat anything other than `ok` as a
-failed candidate. Serialized grant and runtime JSON therefore follows the same
-version-and-migrate discipline as ordinary SQL columns.
+runtime migration, persisted grant validation, authoritative database, object
+store, and key hierarchy are ready. Startup also attempts one bounded
+notification recovery pass, but the reverse callback into the Connect control
+plane is durable background work rather than a startup or readiness dependency.
+This keeps readiness acyclic because Connect itself checks the provider before
+advertising its own readiness.
+
+`/ready` includes the current notification recovery state. `pending` and
+`degraded` remain HTTP 200 core-readiness responses: deployment health checks
+must not restart the provider for them. External smoke tests and alerts instead
+track whether recovery remains non-`ok` beyond a bounded rollout or incident
+window, and release soak requires it to return to `ok`. Recovery is
+single-flight, preserves the exact durable invocation, and cannot return to
+`ok` while its outbox or non-terminal runtime work remains. Serialized grant
+and runtime JSON therefore follows the same version-and-migrate discipline as
+ordinary SQL columns.
 
 ## Boundaries
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -222,8 +222,10 @@ environment and verify it first.
   legal-document URLs before it is enabled.
 - Every secret is unique, stable where required, and stored outside Git.
 - Databases have encrypted off-host backups and a tested restore procedure.
-- `/ready`, resource exhaustion, certificate expiry, and backup failures alert
-  an operator.
+- Core `/ready` failures, persistent hosted-notification `pending`/`degraded`
+  states, resource exhaustion, certificate expiry, and backup failures alert an
+  operator. Notification degradation must not be wired back into platform
+  readiness or automatic process restarts.
 - Logs exclude authorization headers, request bodies, decrypted Markdown,
   private keys, and database credentials.
 - Deployments use immutable release tags and record the exact Git commit.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -855,6 +855,7 @@ schema:
   phase("running a hosted mutation through the durable notification runtime");
   const notificationSignals = [];
   const notificationRequests = [];
+  let notificationControlPlaneAvailable = false;
   const callbackPort = await availableTcpPort();
   notificationCallbackServer = createServer(async (request, response) => {
     const chunks = [];
@@ -862,7 +863,7 @@ schema:
     assert.equal(request.headers.authorization, `Bearer ${internalToken}`);
     const signal = JSON.parse(Buffer.concat(chunks).toString("utf8"));
     notificationRequests.push(signal);
-    if (notificationRequests.length === 1) {
+    if (!notificationControlPlaneAvailable) {
       response.writeHead(503, { "content-type": "application/json" });
       response.end(JSON.stringify({ error: { code: "temporarily_unavailable" } }));
       return;
@@ -875,11 +876,17 @@ schema:
     notificationCallbackServer.once("error", reject);
     notificationCallbackServer.listen(callbackPort, "127.0.0.1", resolveListen);
   });
-  const notificationProvider = await startProvider(databaseUrl, 0, masterKey, {
+  const notificationEnvironment = {
     MDBASE_CONNECT_CONTROL_PLANE_URL: `http://127.0.0.1:${callbackPort}`,
     MDBASE_CONNECT_HOSTED_MAINTENANCE_INTERVAL_SECONDS: "1",
     MDBASE_CONNECT_HOSTED_NOTIFICATION_INTERVAL_SECONDS: "1"
-  });
+  };
+  let notificationProvider = await startProvider(
+    databaseUrl,
+    0,
+    masterKey,
+    notificationEnvironment
+  );
   const notificationReady = await rawRequest(notificationProvider.url, "/ready");
   assert.equal(notificationReady.status, 200);
   assert.equal(notificationReady.body.notifications.configured, true);
@@ -987,6 +994,62 @@ schema:
     "Private notification title"
   ));
   assert.equal(notificationReceipt.status, "applied");
+  await waitFor(
+    () => notificationRequests.length >= 1,
+    "Hosted runtime did not attempt the unavailable notification callback",
+    600
+  );
+  const degradedReady = await waitFor(async () => {
+    const readiness = await rawRequest(notificationProvider.url, "/ready");
+    return readiness.status === 200 && readiness.body.notifications.recovery === "degraded"
+      ? readiness
+      : undefined;
+  }, "Hosted readiness did not report notification degradation", 600);
+  assert.equal(degradedReady.status, 200, JSON.stringify(degradedReady.body));
+  assert.equal(degradedReady.body.status, "ready");
+  assert.equal(degradedReady.body.notifications.recovery, "degraded");
+  assert.ok(degradedReady.body.notifications.consecutive_failures >= 1);
+
+  // Reproduce the production topology: Connect waits for provider readiness,
+  // while the provider's durable notification callback waits for Connect. A
+  // queued callback must not prevent the provider from binding or advertising
+  // its independent core readiness after restart.
+  await stopProvider(notificationProvider);
+  notificationProvider = await startProvider(
+    databaseUrl,
+    0,
+    masterKey,
+    notificationEnvironment
+  );
+  const restartedPendingReady = await rawRequest(notificationProvider.url, "/ready");
+  assert.equal(restartedPendingReady.status, 200, JSON.stringify(restartedPendingReady.body));
+  assert.equal(restartedPendingReady.body.status, "ready");
+  assert.ok(
+    ["pending", "degraded"].includes(restartedPendingReady.body.notifications.recovery),
+    JSON.stringify(restartedPendingReady.body)
+  );
+  if (restartedPendingReady.body.notifications.recovery === "degraded") {
+    assert.ok(restartedPendingReady.body.notifications.consecutive_failures >= 1);
+  }
+
+  notificationControlPlaneAvailable = true;
+  await waitFor(
+    () => notificationSignals.length === 1,
+    "Hosted runtime did not safely replay the notification after control-plane recovery",
+    600
+  );
+  const replayAttempts = notificationRequests.filter(
+    (request) => request.signal_id === notificationSignals[0].signal_id
+  );
+  assert.ok(replayAttempts.length >= 2);
+  for (const replay of replayAttempts) assert.deepEqual(replay, notificationSignals[0]);
+  await waitFor(async () => {
+    const recovery = await rawRequest(notificationProvider.url, "/ready");
+    return recovery.status === 200
+      && recovery.body.notifications.recovery === "ok"
+      && recovery.body.notifications.consecutive_failures === 0;
+  }, "Hosted notification recovery did not return to healthy", 600);
+
   const secondNotificationReceipt = await new HttpSyncTransport(
     authoritySyncUrl(notificationProvider.url, notificationCollectionId),
     notificationToken
@@ -1007,8 +1070,6 @@ schema:
   assert.match(notificationSignals[0].signal_id, /^inv_/);
   assert.equal(JSON.stringify(notificationSignals[0]).includes("private-notification"), false);
   assert.equal(JSON.stringify(notificationSignals[0]).includes("Private notification title"), false);
-  assert.equal(notificationRequests.length, 3);
-  assert.deepEqual(notificationRequests[0], notificationRequests[1]);
   assert.equal(notificationSignals[1].criterion_id, "task.created");
   assert.equal(Number(notificationSignals[0].cursor) < Number(notificationSignals[1].cursor), true);
   assert.notEqual(notificationSignals[0].signal_id, notificationSignals[1].signal_id);

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.60" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.61" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.60",
+  "version": "0.1.0-beta.61",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -12,12 +12,14 @@ import type {
 } from "@mdbase-dev/connect-protocol";
 import {
   AUTHORITY_PROOF_HEADERS,
-  AUTHORITY_PROOF_VERSION
+  AUTHORITY_PROOF_VERSION,
+  CONNECT_CONTRACT_SUPPORT,
+  HOSTED_PROVIDER_REQUIRED_CAPABILITIES
 } from "@mdbase-dev/connect-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
-import type { HostedProviderClient } from "./hosted-provider.js";
+import { HostedProviderClient } from "./hosted-provider.js";
 import { authorityProofMessage } from "./authority-proof.js";
 import { pkceChallenge, tokenHash } from "./security.js";
 import {
@@ -40,6 +42,7 @@ function p256PublicKey(): string {
 
 afterEach(async () => {
   while (resources.length) await resources.pop()?.();
+  vi.restoreAllMocks();
 });
 
 describe("mdbase connect server", () => {
@@ -110,6 +113,41 @@ describe("mdbase connect server", () => {
       protocol_version: 1,
       revision: "ae3a8d9"
     });
+  });
+
+  it("stays ready when the hosted provider reports retryable notification degradation", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      status: "ready",
+      provider: {
+        version: "0.1.0-beta.61",
+        capabilities: [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES],
+        contract_support: CONNECT_CONTRACT_SUPPORT
+      },
+      notifications: {
+        configured: true,
+        recovery: "degraded",
+        consecutive_failures: 2
+      }
+    }), { status: 200 }));
+    const hostedProvider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "x".repeat(40)
+    });
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedProvider,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+
+    const ready = await app.inject({ method: "GET", url: "/ready" });
+
+    expect(ready.statusCode).toBe(200);
+    expect(ready.json()).toEqual({ ok: true, service: "mdbase-connect" });
   });
 
   it("keeps malformed and oversized request bodies out of the server-error path", async () => {

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -194,6 +194,23 @@ describe("hosted provider control client", () => {
     await expect(provider.ready()).resolves.toBeUndefined();
   });
 
+  it("accepts core readiness while durable notification delivery is degraded", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      ...readinessDocument(),
+      notifications: {
+        configured: true,
+        recovery: "degraded",
+        consecutive_failures: 3
+      }
+    }), { status: 200 }));
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret"
+    });
+
+    await expect(provider.ready()).resolves.toBeUndefined();
+  });
+
   it.each<keyof ConnectContractSupport>([
     "operation_transport",
     "authorization_binding",


### PR DESCRIPTION
## What changed

- makes hosted-provider readiness depend only on its authoritative database, blob store, and key hierarchy
- treats the reverse notification callback into Connect as durable background recovery, so callback unavailability cannot prevent provider startup
- serializes notification recovery sweeps and derives `pending` / `degraded` / `ok` from durable outbox and runtime state
- adds privacy-safe recovery transition metrics
- releases the coordinated workspace version as `0.1.0-beta.61`

## Root cause

Connect checked hosted-provider readiness before becoming ready, while the hosted provider required notification recovery through a callback into Connect before it became ready. One safely replayable queued notification could therefore create a cyclic readiness dependency and a platform restart loop. Overlapping or lease-blocked recovery sweeps could also briefly overwrite a degraded state with a false healthy state.

## Impact

The provider can keep serving authoritative hosted data while Connect is temporarily unavailable. Queued callbacks retain their exact durable invocation identity and recover after Connect returns. Operators still receive explicit pending/degraded status and aggregate, payload-free telemetry.

## Validation

- `cargo test --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `pnpm test`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:release-readiness`
- `pnpm package:audit`
- `pnpm e2e`
- `pnpm e2e:relay`
- `pnpm e2e:provider`

The hosted-provider E2E now holds the callback at 503, verifies HTTP 200 core readiness before and after a real provider restart, confirms the exact invocation is safely replayed after recovery, and verifies the status returns to healthy.
