### PR TITLE
Preserve durable mutation outcomes across deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ their exact recovery identity across every SDK transport outcome.
   cancellable `not_sent` semantics.
 - The SDK retains pending mutation state when either an HTTP authority response
   or an encrypted connector receipt reports an unknown outcome, then recovers
-  with the exact same request ID and encrypted envelope.
+  with the same request ID, counter, ciphertext, operation, and payload while
+  refreshing only the unauthenticated scheduling deadline.
 - SDK-side deadlines after mutation dispatch also become unknown outcomes,
   while pre-dispatch cancellation remains definitively `not_sent`.
 - Aborted framed file downloads preserve typed `operation_cancelled` results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.0-beta.63
+
+Beta.63 makes execution deadlines truthful for durable mutations and preserves
+their exact recovery identity across every SDK transport outcome.
+
+- A relayed or direct durable mutation that outlives its caller's execution
+  deadline now returns `operation_outcome_unknown` instead of the incorrect
+  `operation_cancelled` / `not_sent`; queued work and reads retain their
+  cancellable `not_sent` semantics.
+- The SDK retains pending mutation state when either an HTTP authority response
+  or an encrypted connector receipt reports an unknown outcome, then recovers
+  with the exact same request ID and encrypted envelope.
+- SDK-side deadlines after mutation dispatch also become unknown outcomes,
+  while pre-dispatch cancellation remains definitively `not_sent`.
+- Aborted framed file downloads preserve typed `operation_cancelled` results
+  even on runtimes that surface an aborted fetch as `TypeError`.
+
 ## 0.1.0-beta.62
 
 Beta.62 bounds collection-query memory and connector admission under load while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-agent/src/loopback.rs
+++ b/crates/connect-agent/src/loopback.rs
@@ -173,6 +173,17 @@ fn cors_error(status: StatusCode, code: &str, message: &str, origin: &str) -> Re
     )
 }
 
+fn cors_problem(
+    status: StatusCode,
+    problem: mdbase_connect_protocol::ConnectProblem,
+    origin: &str,
+) -> Response<Body> {
+    cors_response(
+        (status, Json(json!({ "error": problem }))).into_response(),
+        origin,
+    )
+}
+
 fn cors_busy(message: &str, origin: &str) -> Response<Body> {
     let mut response = cors_error(
         StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/connect-agent/src/loopback/control.rs
+++ b/crates/connect-agent/src/loopback/control.rs
@@ -1,8 +1,11 @@
 use super::*;
-use crate::admission::{classify_operation, execution_timeout, queue_deadline, AdmissionRequest};
+use crate::admission::{
+    classify_operation, execution_timeout, queue_deadline, AdmissionRequest, WorkClass,
+};
 use axum::routing::{get, post};
 use mdbase_connect_protocol::{
-    RelayMessage, LOOPBACK_PROTOCOL_VERSION, OPERATION_TRANSPORT_PROTOCOL_VERSION,
+    ConnectOperationOutcome, ConnectProblem, RelayMessage, LOOPBACK_PROTOCOL_VERSION,
+    OPERATION_TRANSPORT_PROTOCOL_VERSION,
 };
 
 pub(super) fn routes() -> Router<LoopbackState> {
@@ -159,6 +162,8 @@ async fn encrypted_control(
         class: classify_operation(&envelope.operation, None),
         weight_bytes: envelope.ciphertext.len(),
     };
+    let class = admission.class;
+    let request_id = envelope.request_id;
     let Ok(permit) = state
         .agent
         .admission()
@@ -207,6 +212,16 @@ async fn encrypted_control(
             StatusCode::INTERNAL_SERVER_ERROR,
             "connector_failed",
             "The local connector could not complete this operation.",
+            &origin,
+        ),
+        Err(_) if class == WorkClass::Mutation => cors_problem(
+            StatusCode::CONFLICT,
+            ConnectProblem::new(
+                "operation_outcome_unknown",
+                "The durable mutation may have completed after its caller's deadline expired. Retry the exact same request to recover its result.",
+            )
+            .with_details(serde_json::json!({ "request_id": request_id }))
+            .with_operation_outcome(ConnectOperationOutcome::Unknown),
             &origin,
         ),
         Err(_) => cors_error(

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -175,10 +175,9 @@ async fn connect_once(
                                 );
                                 let cancellation = mdbase::OperationCancellation::new();
                                 let worker_cancellation = cancellation.clone();
-                                let timeout_response = relay_operation_rejection(
+                                let timeout_response = relay_operation_timeout(
                                     &relay_message,
-                                    "operation_cancelled",
-                                    "The connector operation exceeded its execution deadline.",
+                                    admission.class,
                                 );
                                 let execution = tokio::task::spawn_blocking(move || {
                                     let _permit = permit;
@@ -323,15 +322,50 @@ fn relay_operation_rejection(
     code: &str,
     message: &str,
 ) -> Option<RelayMessage> {
-    let problem = || {
+    relay_operation_problem(
+        request,
         ConnectProblem::new(code, message).with_operation_outcome(
             if code == "operation_cancelled" {
                 ConnectOperationOutcome::NotSent
             } else {
                 ConnectOperationOutcome::Rejected
             },
+        ),
+    )
+}
+
+fn relay_operation_timeout(request: &RelayMessage, class: WorkClass) -> Option<RelayMessage> {
+    let durable_mutation = class == WorkClass::Mutation
+        && matches!(request, RelayMessage::EncryptedOperationRequest { .. });
+    let problem = if durable_mutation {
+        ConnectProblem::new(
+            "operation_outcome_unknown",
+            "The durable mutation may have completed after its caller's deadline expired. Retry the exact same request to recover its result.",
         )
+        .with_details(serde_json::json!({ "request_id": relay_request_id(request)? }))
+        .with_operation_outcome(ConnectOperationOutcome::Unknown)
+    } else {
+        ConnectProblem::new(
+            "operation_cancelled",
+            "The connector operation exceeded its execution deadline.",
+        )
+        .with_operation_outcome(ConnectOperationOutcome::NotSent)
     };
+    relay_operation_problem(request, problem)
+}
+
+fn relay_request_id(request: &RelayMessage) -> Option<uuid::Uuid> {
+    match request {
+        RelayMessage::OperationRequest { request_id, .. } => Some(*request_id),
+        RelayMessage::EncryptedOperationRequest { envelope } => Some(envelope.request_id),
+        _ => None,
+    }
+}
+
+fn relay_operation_problem(
+    request: &RelayMessage,
+    problem: ConnectProblem,
+) -> Option<RelayMessage> {
     match request {
         RelayMessage::OperationRequest { request_id, .. } => {
             let protocol_version = match request {
@@ -345,14 +379,14 @@ fn relay_operation_rejection(
                 request_id: *request_id,
                 ok: false,
                 result: None,
-                problem: Some(problem()),
+                problem: Some(problem),
             })
         }
         RelayMessage::EncryptedOperationRequest { envelope } => {
             Some(RelayMessage::EncryptedOperationRejected {
                 protocol_version: envelope.protocol_version,
                 request_id: envelope.request_id,
-                problem: problem(),
+                problem,
             })
         }
         _ => None,
@@ -511,6 +545,63 @@ mod tests {
                 problem: Some(problem),
                 ..
             }) if returned == request_id && problem.code == "connector_busy"
+        ));
+    }
+
+    #[test]
+    fn execution_deadlines_never_report_admitted_mutations_as_not_sent() {
+        let request_id = uuid::Uuid::new_v4();
+        let encrypted = RelayMessage::EncryptedOperationRequest {
+            envelope: mdbase_connect_protocol::EncryptedRelayEnvelope {
+                protocol_version: mdbase_connect_protocol::OPERATION_TRANSPORT_PROTOCOL_VERSION,
+                suite: "P256-HKDF-SHA256-AES256GCM".to_string(),
+                request_id,
+                grant_id: uuid::Uuid::new_v4(),
+                application_id: uuid::Uuid::new_v4(),
+                connector_id: uuid::Uuid::new_v4(),
+                collection_id: uuid::Uuid::new_v4(),
+                operation: "create".to_string(),
+                scope_epoch: 1,
+                key_id: "deadline-test".to_string(),
+                counter: "1".to_string(),
+                deadline_unix_ms: Some(1),
+                ciphertext: "ciphertext".to_string(),
+            },
+        };
+        assert!(matches!(
+            relay_operation_timeout(&encrypted, WorkClass::Mutation),
+            Some(RelayMessage::EncryptedOperationRejected {
+                request_id: returned,
+                problem,
+                ..
+            }) if returned == request_id
+                && problem.code == "operation_outcome_unknown"
+                && problem.operation_outcome == Some(ConnectOperationOutcome::Unknown)
+                && problem.details == Some(serde_json::json!({ "request_id": request_id }))
+        ));
+    }
+
+    #[test]
+    fn execution_deadlines_cancel_reads_as_not_sent() {
+        let request_id = uuid::Uuid::new_v4();
+        let request = RelayMessage::OperationRequest {
+            protocol_version: mdbase_connect_protocol::OPERATION_TRANSPORT_PROTOCOL_VERSION,
+            request_id,
+            grant_id: uuid::Uuid::new_v4(),
+            collection_id: uuid::Uuid::new_v4(),
+            application_id: uuid::Uuid::new_v4(),
+            operation: "query".to_string(),
+            input: serde_json::json!({}),
+        };
+        assert!(matches!(
+            relay_operation_timeout(&request, WorkClass::Foreground),
+            Some(RelayMessage::OperationResponse {
+                request_id: returned,
+                problem: Some(problem),
+                ..
+            }) if returned == request_id
+                && problem.code == "operation_cancelled"
+                && problem.operation_outcome == Some(ConnectOperationOutcome::NotSent)
         ));
     }
 }

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.62"
+version = "0.1.0-beta.63"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/connection-transport.ts
+++ b/packages/client/src/connection-transport.ts
@@ -39,6 +39,8 @@ import { authorityProofHeaders } from "./authority-proof.js";
 import { PendingMutationStore } from "./pending-mutation-store.js";
 import {
   directFallbackStatus,
+  encryptedOperationError,
+  fetchOperationRequest,
   isMutation,
   localNetworkPermission,
   loopbackRequest,
@@ -351,6 +353,7 @@ export class ConnectionTransport {
           true
         );
       }
+      if (attempt.pendingMutation && error.outcomeUnknown) throw error;
       if (attempt.pendingMutation
           && (attempt.directDeliveryUncertain
             || (attempt.encryptedRequest && attempt.resumingMutation))) {
@@ -404,18 +407,12 @@ export class ConnectionTransport {
             true
           );
         }
+        if (!decrypted.ok) {
+          const error = encryptedOperationError(decrypted.problem);
+          if (attempt.pendingMutation && !error.outcomeUnknown) this.clearPendingMutation(attempt.requestId);
+          throw error;
+        }
         if (attempt.pendingMutation) this.clearPendingMutation(attempt.requestId);
-        if (!decrypted.ok) throw serverConnectError(
-          decrypted.problem.code === "unknown"
-            ? decrypted.problem.server_code
-            : decrypted.problem.code,
-          decrypted.problem.message,
-          {
-            details: decrypted.problem.details,
-            operationOutcome: decrypted.problem.operation_outcome ?? "rejected",
-            traceId: decrypted.problem.trace_id
-          }
-        );
         return decrypted.result;
       } catch (error) {
         if (error instanceof MdbaseConnectError) throw error;
@@ -451,7 +448,7 @@ export class ConnectionTransport {
       const error = new MdbaseConnectError(body.problem);
       const recovery = await retryBusy(error);
       if (recovery.retried) return recovery.result;
-      if (attempt.pendingMutation) this.clearPendingMutation(attempt.requestId);
+      if (attempt.pendingMutation && !error.outcomeUnknown) this.clearPendingMutation(attempt.requestId);
       throw error;
     }
     if (body.ok !== true || !("result" in body)) {
@@ -688,7 +685,10 @@ export class ConnectionTransport {
         directDeliveryUncertain = response.status >= 500;
         this.markDirectUnavailable();
       } catch (error) {
-        if (options.signal?.aborted) throw error;
+        if (options.signal?.aborted) {
+          if (pendingMutation) throw unknownMutationOutcome(requestId, error);
+          throw error;
+        }
         directDeliveryUncertain = true;
         if ((await localNetworkPermission()) === "denied") this.setDirectStatus("denied");
         else this.markDirectUnavailable();
@@ -726,7 +726,7 @@ export class ConnectionTransport {
           }
         );
       } catch (error) {
-        if (pendingMutation && (directDeliveryUncertain || resumingMutation)) throw unknownMutationOutcome(requestId, error);
+        if (pendingMutation) throw unknownMutationOutcome(requestId, error);
         throw error;
       }
       if (response.ok) this.setRoute("relay");
@@ -754,16 +754,14 @@ export class ConnectionTransport {
           token.authority.accessToken
         )
       : {};
-    const response = await fetch(operationUrl, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${token.authority?.accessToken ?? token.accessToken}`,
-          "content-type": "application/json",
-          ...proof
-        },
-        body: operationBody,
-        signal: options.signal
-      });
+    let response: Response;
+    try {
+      response = await fetchOperationRequest(operationUrl,
+        token.authority?.accessToken ?? token.accessToken, proof, operationBody, options.signal);
+    } catch (error) {
+      if (pendingMutation) throw unknownMutationOutcome(requestId, error);
+      throw error;
+    }
     if (response.ok) this.setRoute(token.authority ? "remote" : "relay");
     return {
       response,

--- a/packages/client/src/connection-transport.ts
+++ b/packages/client/src/connection-transport.ts
@@ -48,7 +48,8 @@ import {
   operationTransportError,
   sameAuthorization,
   throwIfCancelled,
-  unknownMutationOutcome
+  unknownMutationOutcome,
+  withOperationDeadline
 } from "./operation-helpers.js";
 import {
   apiError,
@@ -218,7 +219,7 @@ export class ConnectionTransport {
       this.performOperationWithinBudget<Result>(
         pending.operation,
         pending.request?.input ?? {},
-        { ...options, signal: budget.signal },
+        requestOptionsWithinBudget(options ?? {}, budget),
         pending
       )
     );
@@ -595,7 +596,9 @@ export class ConnectionTransport {
                 "The pending write belongs to a different transport. Reconnect before retrying it."
               );
             }
-            encryptedRequest = pending.envelope;
+            // Preserve the durable identity and ciphertext, but refresh the
+            // unauthenticated scheduling deadline for this recovery attempt.
+            encryptedRequest = withOperationDeadline(pending.envelope, options.deadlineUnixMs);
           } else {
             encryptedRequest = await encryptRelayRequest(
               this.keyStore,

--- a/packages/client/src/files.test.ts
+++ b/packages/client/src/files.test.ts
@@ -574,6 +574,33 @@ describe("MdbaseFileClient", () => {
     expect(aborted).toBe(true);
   });
 
+  it("preserves typed cancellation when an aborted framed fetch throws TypeError", async () => {
+    const content = bytes("cancel framed download");
+    const file = descriptor("cancel-framed.bin", content);
+    const controller = new AbortController();
+    const client = fileClient(async (method, path, input) => {
+      if (path === "downloads") {
+        return framedSession(input.transfer_id, content.length, "download", [], content.length);
+      }
+      if (method === "DELETE") return {};
+      throw new Error(`Unexpected control path ${path}`);
+    }, {
+      async uploadChunk() {
+        throw new Error("unexpected upload");
+      },
+      async downloadChunk() {
+        controller.abort("stop framed download");
+        throw new TypeError("fetch failed after abort");
+      }
+    });
+
+    const stream = await client.downloadStream(file, { signal: controller.signal });
+    await expect(stream.getReader().read()).rejects.toMatchObject({
+      code: "operation_cancelled",
+      problem: { operation_outcome: "not_sent" }
+    });
+  });
+
   it("does not keep verified download bytes behind best-effort session cleanup", async () => {
     const content = bytes("verified before cleanup");
     const file = descriptor("Assets/verified.bin", content);

--- a/packages/client/src/files.ts
+++ b/packages/client/src/files.ts
@@ -674,8 +674,14 @@ export class MdbaseFileClient {
             void finish();
           }
         } catch (error) {
+          const failure = options.signal?.aborted
+            ? connectError("operation_cancelled", "The file transfer was cancelled.", {
+                operationOutcome: "not_sent",
+                cause: options.signal.reason
+              })
+            : error;
           await finish();
-          controller.error(normalizeFileError(error));
+          controller.error(normalizeFileError(failure));
         }
       },
       cancel: finish

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -3018,6 +3018,107 @@ describe("direct loopback routing", () => {
     expect(outcome.ok ? undefined : outcome.problem.details?.request_id).toBe(pending?.requestId);
   });
 
+  it("retains a mutation when the authority reports an unknown deadline outcome", async () => {
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as EncryptedRelayOperationRequest;
+      return new Response(JSON.stringify({
+        error: normalizeConnectProblem(
+          "operation_outcome_unknown",
+          "The durable mutation continued after the deadline.",
+          {
+            operation_outcome: "unknown",
+            details: { request_id: request.request_id }
+          }
+        )
+      }), {
+        status: 409,
+        headers: { "content-type": "application/json" }
+      });
+    });
+
+    const outcome = await fixture.connect.create({
+      path: "deadline-unknown.md",
+      frontmatter: {}
+    });
+    expect(outcome).toMatchObject({
+      ok: false,
+      problem: {
+        code: "operation_outcome_unknown",
+        operation_outcome: "unknown",
+        details: { request_id: expect.any(String) }
+      }
+    });
+    expect(fixture.connect.pendingMutations()).toMatchObject([{
+      requestId: outcome.ok ? undefined : outcome.problem.details?.request_id,
+      operation: "create",
+      status: "outcome_unknown"
+    }]);
+  });
+
+  it("retains and recovers an encrypted unknown mutation receipt", async () => {
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    const bodies: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      const body = String(init?.body);
+      const request = JSON.parse(body) as EncryptedRelayOperationRequest;
+      bodies.push(body);
+      const plaintext = bodies.length === 1
+        ? {
+            ok: false,
+            problem: normalizeConnectProblem(
+              "operation_outcome_unknown",
+              "The durable mutation receipt is still being recovered.",
+              {
+                operation_outcome: "unknown",
+                details: { request_id: request.request_id }
+              }
+            )
+          }
+        : {
+            ok: true,
+            result: {
+              valid: true,
+              result: {
+                path: "encrypted-deadline.md",
+                revision: "sha256:record",
+                types: [],
+                frontmatter: {},
+                effective_frontmatter: {},
+                body: "",
+                file: { path: "encrypted-deadline.md" }
+              },
+              diagnostics: []
+            }
+          };
+      const envelope = await encryptedFixtureResponse(fixture, request, plaintext);
+      return new Response(JSON.stringify({ envelope }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    });
+
+    await expect(fixture.connect.create({
+      path: "encrypted-deadline.md",
+      frontmatter: {}
+    })).resolves.toMatchObject({
+      ok: false,
+      problem: { code: "operation_outcome_unknown", operation_outcome: "unknown" }
+    });
+    const pending = fixture.connect.pendingMutations<{ path: string }>();
+    expect(pending).toHaveLength(1);
+
+    await expect(pending[0]!.recover()).resolves.toMatchObject({
+      ok: true,
+      value: { path: "encrypted-deadline.md" }
+    });
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1]).toBe(bodies[0]);
+    expect(fixture.connect.pendingMutations()).toEqual([]);
+  });
+
   it("tracks multiple unknown writes and recovers an exact encrypted envelope", async () => {
     const fixture = await encryptedConnection();
     const requests: Array<{ url: string; body: string }> = [];
@@ -3148,6 +3249,36 @@ schema:
     ]);
     expect(new Set(requests.map(({ body }) => body))).toHaveLength(1);
     expect(fixture.connect.pendingMutation(pending!.requestId)).toMatchObject({ operation: "create" });
+  });
+
+  it("reports the SDK deadline as unknown after mutation dispatch", async () => {
+    const fixture = await encryptedConnection();
+    fixture.connect.disableDirectAccess();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) =>
+      await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) return reject(new Error("missing request signal"));
+        const abort = () => reject(signal.reason);
+        if (signal.aborted) abort();
+        else signal.addEventListener("abort", abort, { once: true });
+      })
+    );
+
+    await expect(fixture.connect.create(
+      { path: "sdk-deadline.md", frontmatter: {} },
+      { timeoutMs: 5 }
+    )).resolves.toMatchObject({
+      ok: false,
+      problem: {
+        code: "operation_outcome_unknown",
+        operation_outcome: "unknown",
+        details: { request_id: expect.any(String) }
+      }
+    });
+    expect(fixture.connect.pendingMutations()).toMatchObject([{
+      operation: "create",
+      status: "outcome_unknown"
+    }]);
   });
 
   it("retains unknown recovery state and its grant key across authorization loss", async () => {

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -3057,7 +3057,9 @@ describe("direct loopback routing", () => {
     }]);
   });
 
-  it("retains and recovers an encrypted unknown mutation receipt", async () => {
+  it("retains and recovers an encrypted unknown mutation receipt with a fresh deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-11T00:00:00Z"));
     const fixture = await encryptedConnection();
     fixture.connect.disableDirectAccess();
     const bodies: string[] = [];
@@ -3103,19 +3105,25 @@ describe("direct loopback routing", () => {
     await expect(fixture.connect.create({
       path: "encrypted-deadline.md",
       frontmatter: {}
-    })).resolves.toMatchObject({
+    }, { timeoutMs: 1_000 })).resolves.toMatchObject({
       ok: false,
       problem: { code: "operation_outcome_unknown", operation_outcome: "unknown" }
     });
     const pending = fixture.connect.pendingMutations<{ path: string }>();
     expect(pending).toHaveLength(1);
 
-    await expect(pending[0]!.recover()).resolves.toMatchObject({
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(pending[0]!.recover({ timeoutMs: 10_000 })).resolves.toMatchObject({
       ok: true,
       value: { path: "encrypted-deadline.md" }
     });
     expect(bodies).toHaveLength(2);
-    expect(bodies[1]).toBe(bodies[0]);
+    const [initial, recovered] = bodies.map((body) =>
+      JSON.parse(body) as EncryptedRelayOperationRequest
+    );
+    expect(recovered!.deadline_unix_ms).toBeGreaterThan(initial!.deadline_unix_ms!);
+    expect({ ...recovered, deadline_unix_ms: undefined })
+      .toEqual({ ...initial, deadline_unix_ms: undefined });
     expect(fixture.connect.pendingMutations()).toEqual([]);
   });
 
@@ -3189,11 +3197,16 @@ schema:
       ok: false,
       problem: { code: "operation_outcome_unknown", operation_outcome: "unknown" }
     });
-    expect(requests.at(-1)!.body).toBe(requests[0].body);
+    const originalEnvelope = JSON.parse(requests[0].body) as EncryptedRelayOperationRequest;
+    const recoveredEnvelope = JSON.parse(requests.at(-1)!.body) as EncryptedRelayOperationRequest;
+    expect(recoveredEnvelope.deadline_unix_ms)
+      .toBeGreaterThanOrEqual(originalEnvelope.deadline_unix_ms!);
+    expect({ ...recoveredEnvelope, deadline_unix_ms: undefined })
+      .toEqual({ ...originalEnvelope, deadline_unix_ms: undefined });
     expect(fixture.connect.pendingMutations()).toHaveLength(2);
   });
 
-  it("keeps an exact encrypted mutation resumable when waiting is cancelled after dispatch", async () => {
+  it("keeps an encrypted mutation identity resumable with a fresh recovery deadline", async () => {
     const fixture = await encryptedConnection();
     const controller = new AbortController();
     const input = { path: "cancelled.md", frontmatter: { title: "Cancelled wait" } };
@@ -3247,7 +3260,14 @@ schema:
       "http://127.0.0.1:28485/v1/operations",
       `${fixture.serverUrl}/v1/authorities/${fixture.collectionId}/operations/create`
     ]);
-    expect(new Set(requests.map(({ body }) => body))).toHaveLength(1);
+    const envelopes = requests.map(({ body }) =>
+      JSON.parse(body) as EncryptedRelayOperationRequest
+    );
+    expect(envelopes[1]!.deadline_unix_ms).toBeGreaterThanOrEqual(envelopes[0]!.deadline_unix_ms!);
+    expect(envelopes[2]!.deadline_unix_ms).toBe(envelopes[1]!.deadline_unix_ms);
+    expect(new Set(envelopes.map(({ deadline_unix_ms: _deadline, ...identity }) =>
+      JSON.stringify(identity)
+    ))).toHaveLength(1);
     expect(fixture.connect.pendingMutation(pending!.requestId)).toMatchObject({ operation: "create" });
   });
 

--- a/packages/client/src/operation-helpers.ts
+++ b/packages/client/src/operation-helpers.ts
@@ -2,7 +2,8 @@ import {
   isMutatingOperation,
   mutationFingerprint,
   type CollectionOperation,
-  type ConnectProblem
+  type ConnectProblem,
+  type EncryptedRelayOperationRequest
 } from "@mdbase-dev/connect-protocol";
 import { MdbaseConnectError, connectError, serverConnectError } from "./errors.js";
 import type { StoredToken } from "./internal-types.js";
@@ -40,6 +41,18 @@ export function directFallbackStatus(status: number): boolean {
 
 export function isMutation(operation: CollectionOperation, input?: unknown): boolean {
   return isMutatingOperation(operation, input);
+}
+
+export function withOperationDeadline(
+  request: EncryptedRelayOperationRequest,
+  deadlineUnixMs?: number
+): EncryptedRelayOperationRequest {
+  if (request.deadline_unix_ms === deadlineUnixMs) return request;
+  const { deadline_unix_ms: _previousDeadline, ...identity } = request;
+  return {
+    ...identity,
+    ...(deadlineUnixMs === undefined ? {} : { deadline_unix_ms: deadlineUnixMs })
+  };
 }
 
 export function uniqueOperations(operations: CollectionOperation[]): CollectionOperation[] {

--- a/packages/client/src/operation-helpers.ts
+++ b/packages/client/src/operation-helpers.ts
@@ -1,9 +1,10 @@
 import {
   isMutatingOperation,
   mutationFingerprint,
-  type CollectionOperation
+  type CollectionOperation,
+  type ConnectProblem
 } from "@mdbase-dev/connect-protocol";
-import { MdbaseConnectError, connectError } from "./errors.js";
+import { MdbaseConnectError, connectError, serverConnectError } from "./errors.js";
 import type { StoredToken } from "./internal-types.js";
 import type {
   DeleteInput,
@@ -95,6 +96,37 @@ export function operationTransportError(
     );
   }
   return error instanceof Error ? error : new Error(String(error));
+}
+
+export function encryptedOperationError(problem: ConnectProblem): MdbaseConnectError {
+  return serverConnectError(
+    problem.code === "unknown" ? problem.server_code : problem.code,
+    problem.message,
+    {
+      details: problem.details,
+      operationOutcome: problem.operation_outcome ?? "rejected",
+      traceId: problem.trace_id
+    }
+  );
+}
+
+export function fetchOperationRequest(
+  url: string,
+  accessToken: string,
+  proof: Record<string, string>,
+  body: string,
+  signal?: AbortSignal
+): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+      ...proof
+    },
+    body,
+    signal
+  });
 }
 
 export function isCancellation(error: unknown, signal?: AbortSignal): boolean {

--- a/packages/client/src/runtime-utils.ts
+++ b/packages/client/src/runtime-utils.ts
@@ -87,7 +87,12 @@ export function apiError(body: any, fallbackCode: string, fallbackMessage: strin
   return serverConnectError(
     oauthErrorCode(body) ?? body?.error?.code ?? fallbackCode,
     body?.error_description ?? body?.error?.message ?? fallbackMessage,
-    { status, details: body?.error?.details }
+    {
+      status,
+      details: body?.error?.details,
+      operationOutcome: body?.error?.operation_outcome,
+      traceId: body?.error?.trace_id
+    }
   );
 }
 

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/relay-e2e.mjs
+++ b/scripts/relay-e2e.mjs
@@ -253,7 +253,8 @@ try {
   await database.query(
     `UPDATE grants
      SET encryption = $2::jsonb,
-         file_capability = $3::jsonb
+         file_capability = $3::jsonb,
+         operations = $4::jsonb
      WHERE id = $1`, [
     fixture.grantId,
     JSON.stringify(encryption),
@@ -262,7 +263,8 @@ try {
       protocol_version: 1,
       actions: ["list", "read", "add", "replace"],
       scope: { kind: "collection" }
-    })
+    }),
+    JSON.stringify(["read", "query", "create"])
   ]);
   await builtB.relay.pushPolicy(fixture.connectorId);
   const uploadTransferId = randomUUID();
@@ -361,6 +363,31 @@ try {
       ciphertext: `[${encryptedResult.body.envelope.ciphertext?.length} bytes]`
     }
   })}`);
+
+  const timedMutation = {
+    ...encryptedEnvelope,
+    request_id: randomUUID(),
+    operation: "create",
+    counter: "2",
+    deadline_unix_ms: Date.now() + 250,
+    ciphertext: "bXV0YXRpb24"
+  };
+  const unknownMutation = await operation(urlA, fixture, "create", timedMutation);
+  assert(unknownMutation.status === 409
+      && unknownMutation.body.error?.code === "operation_outcome_unknown"
+      && unknownMutation.body.error?.operation_outcome === "unknown"
+      && unknownMutation.body.error?.details?.request_id === timedMutation.request_id,
+  `A post-dispatch mutation deadline lost its unknown outcome across NATS: ${JSON.stringify(unknownMutation)}`);
+
+  const recoveredMutation = await operation(urlA, fixture, "create", {
+    ...timedMutation,
+    deadline_unix_ms: Date.now() + 5_000
+  });
+  assert(recoveredMutation.status === 200
+      && recoveredMutation.body.envelope?.request_id === timedMutation.request_id
+      && recoveredMutation.body.envelope?.counter === timedMutation.counter
+      && recoveredMutation.body.envelope?.ciphertext === timedMutation.ciphertext,
+  `The same durable mutation identity did not recover with a fresh deadline: ${JSON.stringify(recoveredMutation)}`);
   await database.query("UPDATE grants SET encryption = NULL WHERE id = $1", [fixture.grantId]);
   await builtB.relay.pushPolicy(fixture.connectorId);
 
@@ -586,6 +613,7 @@ async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner
   });
   const policies = [];
   const messageTypes = [];
+  const encryptedRequestCounts = new Map();
   let closeDetails;
   let policyWaiter;
   let welcomeWaiter;
@@ -629,10 +657,16 @@ async function connectFakeConnector({ WebSocket: Socket, serverUrl, token, owner
       return;
     }
     if (message.type === "encrypted_operation_request") {
-      socket.send(JSON.stringify({
+      const respond = () => socket.send(JSON.stringify({
         ...message,
         type: "encrypted_operation_response"
       }));
+      const count = (encryptedRequestCounts.get(message.request_id) ?? 0) + 1;
+      encryptedRequestCounts.set(message.request_id, count);
+      if (message.operation === "create" && count === 1) {
+        return;
+      }
+      respond();
       return;
     }
     if (message.type !== "operation_request") return;

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.62" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.63" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.62",
+  "version": "0.1.0-beta.63",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -121,7 +121,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.62",
+        version: "0.1.0-beta.63",
         capabilities: [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES],
         contract_support: CONNECT_CONTRACT_SUPPORT
       },

--- a/services/server/src/features/operations/local-routes.test.ts
+++ b/services/server/src/features/operations/local-routes.test.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeConnectProblem } from "@mdbase-dev/connect-protocol";
 import type { DatabasePool } from "../../database-types.js";
 import { registerErrorHandler } from "../../platform/error-handler.js";
 import { ConnectorOperationError, type RelayHub } from "../../relay.js";
@@ -36,6 +37,37 @@ describe("local operation access failures", () => {
     expect(response.statusCode).toBe(503);
     expect(response.headers["retry-after"]).toBe("1");
     expect(response.json().error.code).toBe("connector_busy");
+  });
+
+  it("preserves an encrypted durable mutation's unknown outcome at the HTTP boundary", async () => {
+    const { app, relay } = recoveryFixture();
+    vi.mocked(relay.routeEncrypted).mockRejectedValue(ConnectorOperationError.fromProblem(
+      normalizeConnectProblem(
+        "operation_outcome_unknown",
+        "The durable mutation continued after the deadline.",
+        {
+          operation_outcome: "unknown",
+          details: { request_id: requestId }
+        }
+      )
+    ));
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/authorities/${collectionId}/operations/create`,
+      headers: { authorization: "Bearer current-v5-token" },
+      payload: {
+        ...encryptedEnvelope(activeGrantId, "current-key", "create"),
+        protocol_version: 3
+      }
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().error).toMatchObject({
+      code: "operation_outcome_unknown",
+      operation_outcome: "unknown",
+      details: { request_id: requestId }
+    });
   });
 
   it("returns the typed required, granted, and missing operation details", async () => {

--- a/services/server/src/features/operations/local-routes.ts
+++ b/services/server/src/features/operations/local-routes.ts
@@ -217,9 +217,11 @@ export function registerLocalOperationRoutes(
               return reply
                 .header("retry-after", "1")
                 .code(503)
-                .send(apiError(error.code, error.message));
+                .send({ error: error.problem });
             }
-            return reply.code(502).send(apiError(error.code, error.message));
+            return reply
+              .code(error.code === "operation_outcome_unknown" ? 409 : 502)
+              .send({ error: error.problem });
           }
           return {
             protocol_version: operationRequestProtocol,

--- a/services/server/src/relay-timeout.test.ts
+++ b/services/server/src/relay-timeout.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { EncryptedRelayEnvelope } from "@mdbase-dev/connect-protocol";
+import { relayExecutionTimeoutProblem } from "./relay.js";
+
+const requestId = "66666666-6666-4666-8666-666666666666";
+
+describe("relay execution timeout semantics", () => {
+  it.each(["create", "sync", "file_control"] as const)(
+    "reports an admitted encrypted %s as outcome unknown",
+    (operation) => {
+      expect(relayExecutionTimeoutProblem(envelope(operation), requestId)).toMatchObject({
+        code: "operation_outcome_unknown",
+        operation_outcome: "unknown",
+        details: { request_id: requestId }
+      });
+    }
+  );
+
+  it("keeps reads retryable with a not-sent outcome", () => {
+    expect(relayExecutionTimeoutProblem(envelope("query"), requestId)).toMatchObject({
+      code: "operation_cancelled",
+      operation_outcome: "not_sent"
+    });
+  });
+});
+
+function envelope(operation: EncryptedRelayEnvelope["operation"]): EncryptedRelayEnvelope {
+  return {
+    type: "encrypted_operation_request",
+    protocol_version: 3,
+    suite: "P256-HKDF-SHA256-AES256GCM",
+    request_id: requestId,
+    grant_id: "11111111-1111-4111-8111-111111111111",
+    application_id: "22222222-2222-4222-8222-222222222222",
+    connector_id: "33333333-3333-4333-8333-333333333333",
+    collection_id: "44444444-4444-4444-8444-444444444444",
+    operation,
+    scope_epoch: 1,
+    key_id: "test-key",
+    counter: "1",
+    ciphertext: "b3BhcXVl"
+  };
+}

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -22,6 +22,7 @@ import {
   OPERATION_TRANSPORT_PROTOCOL_VERSION,
   CONTRACT_SETUP_CAPABILITY,
   isConnectProblem,
+  isMutatingOperation,
   MINIMUM_CONNECTOR_VERSION,
   normalizeConnectProblem,
   RELAY_CAPABILITIES,
@@ -793,17 +794,17 @@ export class RelayHub {
       ? OPERATION_TIMEOUT_MS
       : expectedEncrypted.deadline_unix_ms - Date.now();
     if (deadlineTimeout <= 0) {
-      return Promise.reject(new ConnectorOperationError(
+      return Promise.reject(ConnectorOperationError.fromProblem(normalizeConnectProblem(
         "operation_cancelled",
-        "The operation deadline expired before connector execution."
-      ));
+        "The operation deadline expired before connector execution.",
+        { operation_outcome: "not_sent" }
+      )));
     }
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
-        reject(new ConnectorOperationError(
-          "connector_timeout",
-          "The connector operation timed out."
+        reject(ConnectorOperationError.fromProblem(
+          relayExecutionTimeoutProblem(expectedEncrypted, requestId)
         ));
       }, expectedType === "authorization_offer_response"
         ? OFFER_TIMEOUT_MS
@@ -864,6 +865,33 @@ export class RelayHub {
     }
     this.files.rejectForSocket(socket, error);
   }
+}
+
+export function relayExecutionTimeoutProblem(
+  request: EncryptedRelayEnvelope | undefined,
+  requestId: string
+): ConnectProblem {
+  if (request && encryptedOperationMayMutate(request.operation)) {
+    return normalizeConnectProblem(
+      "operation_outcome_unknown",
+      "The durable mutation may have completed after its caller's deadline expired. Retry the same mutation identity to recover its result.",
+      {
+        operation_outcome: "unknown",
+        details: { request_id: requestId }
+      }
+    );
+  }
+  return normalizeConnectProblem(
+    "operation_cancelled",
+    "The connector operation exceeded its execution deadline.",
+    { operation_outcome: "not_sent" }
+  );
+}
+
+function encryptedOperationMayMutate(operation: EncryptedRelayEnvelope["operation"]): boolean {
+  return operation === "file_control"
+    || operation === "sync"
+    || isMutatingOperation(operation, {});
 }
 
 function validProtocolUsageEntries(


### PR DESCRIPTION
## Summary
- report unknown instead of not-sent when an admitted encrypted durable mutation outlives its relay or direct execution deadline
- preserve the canonical unknown outcome through the Connect HTTP boundary and the multi-instance NATS relay timer
- retain pending mutation request IDs, counters, ciphertext, operations, and payloads across HTTP and encrypted unknown-outcome responses
- refresh only the unauthenticated scheduling deadline on receipt recovery so an expired deadline cannot prevent replay resolution
- classify SDK-side post-dispatch deadlines as unknown while preserving pre-dispatch cancellation semantics
- preserve typed cancellation for framed downloads when aborted fetch surfaces as TypeError
- bump the immutable candidate to 0.1.0-beta.63

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pnpm check:architecture, check:problems, check:operations, check:release-readiness
- pnpm build, typecheck, test, package:audit
- pnpm test:browser-storage, test:accessibility
- pnpm e2e
- pnpm e2e:relay, including post-dispatch mutation timeout and same-identity/fresh-deadline recovery across NATS
- focused expired-deadline recovery regression plus full client suite (190/190)
- full server suite (311/311)

Staging candidate only. No production deployment.
