### PR TITLE
Bound local connector execution and close timeout races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.1.0-beta.64
+
+Beta.64 keeps large local and relayed collections inside one explicit resource
+boundary while preserving foreground and durable-mutation capacity under load.
+
+- Local control, encrypted loopback, and relay operations share bounded
+  admission and stable collection-read workers; foreground, background, file,
+  and mutation work retain independent global and per-grant limits.
+- Read capacity remains held through serialized response delivery, preventing
+  slow WebSocket, loopback, or local-socket consumers from multiplying large
+  retained bodies after execution has nominally completed.
+- Cooperative read cancellation observes deadlines between bounded engine,
+  sync, inventory, and file phases. Timeout and durable mutation entry meet at
+  one atomic boundary so `not_sent` remains provable and post-boundary work is
+  recovered by exact request replay.
+- Idempotent upload-open and transfer-abort housekeeping no longer scans the
+  complete collection for mutation evidence; collection-changing file
+  operations retain manifest evidence.
+- Upload-open replay safely recovers an empty regular staging file left by a
+  crash before transfer-row insertion and rejects unsafe or non-empty orphans.
+
 ## 0.1.0-beta.63
 
 Beta.63 makes execution deadlines truthful for durable mutations and preserves

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-agent/src/admission.rs
+++ b/crates/connect-agent/src/admission.rs
@@ -11,6 +11,7 @@ const DEFAULT_QUEUE_WAIT: std::time::Duration = std::time::Duration::from_secs(5
 const MAX_OPERATION_EXECUTION: Duration = Duration::from_secs(30);
 const MAX_RETAINED_KEYED_SEMAPHORES: usize = 128;
 pub(crate) const MAX_CONCURRENT_READS: usize = 2;
+const MAX_CONCURRENT_BACKGROUND_READS: usize = 1;
 
 /// Convert the client's optional absolute deadline into a local, monotonic
 /// window. The hint can only shorten the connector's own maximum.
@@ -75,7 +76,6 @@ impl Default for AdmissionLimits {
         // Collection reads can hold an operation-scoped body snapshot. Keep
         // the desktop memory bound independent of a high core count.
         let operations = 4;
-        let reserved_mutations = (operations / 4).max(1);
         Self {
             operations,
             // Match the fixed read executor exactly. An extra admitted read
@@ -83,7 +83,7 @@ impl Default for AdmissionLimits {
             // the executor, turning ordinary contention into a late timeout.
             reads: MAX_CONCURRENT_READS,
             // Retain one foreground lane when background polling is active.
-            background: MAX_CONCURRENT_READS - reserved_mutations,
+            background: MAX_CONCURRENT_BACKGROUND_READS,
             files: 4,
             // A grant can run two reads while retaining one independent
             // mutation lane. Background work gets only one of the read lanes

--- a/crates/connect-agent/src/admission.rs
+++ b/crates/connect-agent/src/admission.rs
@@ -59,6 +59,9 @@ struct AdmissionLimits {
     background: usize,
     files: usize,
     operations_per_grant: usize,
+    mutations_per_grant: usize,
+    reads_per_grant: usize,
+    background_per_grant: usize,
     files_per_grant: usize,
     queued: usize,
     queued_per_grant: usize,
@@ -77,7 +80,13 @@ impl Default for AdmissionLimits {
             reads: operations - reserved_mutations,
             background: 2.min(operations - reserved_mutations),
             files: 4,
-            operations_per_grant: 2,
+            // A grant can run two reads while retaining one independent
+            // mutation lane. Background work gets only one of the read lanes
+            // so it cannot occupy all foreground capacity for that grant.
+            operations_per_grant: 3,
+            mutations_per_grant: 1,
+            reads_per_grant: 2,
+            background_per_grant: 1,
             files_per_grant: 2,
             queued: 64,
             queued_per_grant: 8,
@@ -166,6 +175,9 @@ pub(crate) struct AdmissionScheduler {
     background: Arc<Semaphore>,
     files: Arc<Semaphore>,
     operation_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
+    mutation_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
+    read_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
+    background_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
     file_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
     mutation_collections: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
     queue_counts: Arc<Mutex<QueueCounts>>,
@@ -180,6 +192,9 @@ impl Default for AdmissionScheduler {
 impl AdmissionScheduler {
     fn with_limits(limits: AdmissionLimits) -> Self {
         debug_assert!(limits.reads < limits.operations);
+        debug_assert!(limits.mutations_per_grant < limits.operations_per_grant);
+        debug_assert!(limits.reads_per_grant < limits.operations_per_grant);
+        debug_assert!(limits.background_per_grant < limits.reads_per_grant);
         Self {
             limits,
             operations: Arc::new(Semaphore::new(limits.operations)),
@@ -187,6 +202,9 @@ impl AdmissionScheduler {
             background: Arc::new(Semaphore::new(limits.background)),
             files: Arc::new(Semaphore::new(limits.files)),
             operation_grants: Mutex::new(HashMap::new()),
+            mutation_grants: Mutex::new(HashMap::new()),
+            read_grants: Mutex::new(HashMap::new()),
+            background_grants: Mutex::new(HashMap::new()),
             file_grants: Mutex::new(HashMap::new()),
             mutation_collections: Mutex::new(HashMap::new()),
             queue_counts: Arc::new(Mutex::new(QueueCounts::default())),
@@ -213,18 +231,23 @@ impl AdmissionScheduler {
             request.grant_id,
             request.weight_bytes,
         )?;
-        let mut permits = Vec::with_capacity(4);
+        let mut permits = Vec::with_capacity(6);
 
         match request.class {
             WorkClass::File => {
                 permits.push(
-                    acquire_before(self.grant_semaphore(request.grant_id, true), deadline).await?,
+                    acquire_before(self.file_grant_semaphore(request.grant_id), deadline).await?,
                 );
                 permits.push(acquire_before(self.files.clone(), deadline).await?);
             }
             WorkClass::Mutation => {
                 permits.push(
-                    acquire_before(self.grant_semaphore(request.grant_id, false), deadline).await?,
+                    acquire_before(self.mutation_grant_semaphore(request.grant_id), deadline)
+                        .await?,
+                );
+                permits.push(
+                    acquire_before(self.operation_grant_semaphore(request.grant_id), deadline)
+                        .await?,
                 );
                 permits.push(
                     acquire_before(
@@ -237,16 +260,28 @@ impl AdmissionScheduler {
             }
             WorkClass::Foreground => {
                 permits.push(
-                    acquire_before(self.grant_semaphore(request.grant_id, false), deadline).await?,
+                    acquire_before(self.read_grant_semaphore(request.grant_id), deadline).await?,
+                );
+                permits.push(
+                    acquire_before(self.operation_grant_semaphore(request.grant_id), deadline)
+                        .await?,
                 );
                 permits.push(acquire_before(self.reads.clone(), deadline).await?);
                 permits.push(acquire_before(self.operations.clone(), deadline).await?);
             }
             WorkClass::Background => {
                 permits.push(
-                    acquire_before(self.grant_semaphore(request.grant_id, false), deadline).await?,
+                    acquire_before(self.background_grant_semaphore(request.grant_id), deadline)
+                        .await?,
                 );
                 permits.push(acquire_before(self.background.clone(), deadline).await?);
+                permits.push(
+                    acquire_before(self.read_grant_semaphore(request.grant_id), deadline).await?,
+                );
+                permits.push(
+                    acquire_before(self.operation_grant_semaphore(request.grant_id), deadline)
+                        .await?,
+                );
                 permits.push(acquire_before(self.reads.clone(), deadline).await?);
                 permits.push(acquire_before(self.operations.clone(), deadline).await?);
             }
@@ -258,13 +293,49 @@ impl AdmissionScheduler {
         })
     }
 
-    fn grant_semaphore(&self, grant_id: Uuid, file: bool) -> Arc<Semaphore> {
-        let (map, permits) = if file {
-            (&self.file_grants, self.limits.files_per_grant)
-        } else {
-            (&self.operation_grants, self.limits.operations_per_grant)
-        };
-        keyed_semaphore(map, grant_id, permits, "admission grant lock poisoned")
+    fn operation_grant_semaphore(&self, grant_id: Uuid) -> Arc<Semaphore> {
+        keyed_semaphore(
+            &self.operation_grants,
+            grant_id,
+            self.limits.operations_per_grant,
+            "admission operation grant lock poisoned",
+        )
+    }
+
+    fn read_grant_semaphore(&self, grant_id: Uuid) -> Arc<Semaphore> {
+        keyed_semaphore(
+            &self.read_grants,
+            grant_id,
+            self.limits.reads_per_grant,
+            "admission read grant lock poisoned",
+        )
+    }
+
+    fn mutation_grant_semaphore(&self, grant_id: Uuid) -> Arc<Semaphore> {
+        keyed_semaphore(
+            &self.mutation_grants,
+            grant_id,
+            self.limits.mutations_per_grant,
+            "admission mutation grant lock poisoned",
+        )
+    }
+
+    fn background_grant_semaphore(&self, grant_id: Uuid) -> Arc<Semaphore> {
+        keyed_semaphore(
+            &self.background_grants,
+            grant_id,
+            self.limits.background_per_grant,
+            "admission background grant lock poisoned",
+        )
+    }
+
+    fn file_grant_semaphore(&self, grant_id: Uuid) -> Arc<Semaphore> {
+        keyed_semaphore(
+            &self.file_grants,
+            grant_id,
+            self.limits.files_per_grant,
+            "admission file grant lock poisoned",
+        )
     }
 
     fn collection_mutation_semaphore(&self, collection_id: Uuid) -> Arc<Semaphore> {
@@ -362,7 +433,10 @@ mod tests {
             reads: 3,
             background: 1,
             files: 2,
-            operations_per_grant: 2,
+            operations_per_grant: 3,
+            mutations_per_grant: 1,
+            reads_per_grant: 2,
+            background_per_grant: 1,
             files_per_grant: 1,
             queued: 8,
             queued_per_grant: 4,
@@ -408,7 +482,6 @@ mod tests {
         let mut limits = limits();
         limits.operations = 2;
         limits.reads = 1;
-        limits.operations_per_grant = 1;
         limits.queued_bytes = 16;
         limits.queued_bytes_per_grant = 8;
         let scheduler = Arc::new(AdmissionScheduler::with_limits(limits));
@@ -445,6 +518,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queued_reads_cannot_head_of_line_block_the_same_grants_mutation() {
+        let scheduler = Arc::new(AdmissionScheduler::with_limits(limits()));
+        let first = scheduler
+            .admit(request(1, 1, WorkClass::Foreground))
+            .await
+            .unwrap();
+        let second = scheduler
+            .admit(request(1, 1, WorkClass::Foreground))
+            .await
+            .unwrap();
+        let queued_scheduler = scheduler.clone();
+        let queued_read = tokio::spawn(async move {
+            queued_scheduler
+                .admit_before(
+                    request(1, 1, WorkClass::Foreground),
+                    TokioInstant::now() + Duration::from_secs(1),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        let mutation = scheduler
+            .admit_before(
+                request(1, 2, WorkClass::Mutation),
+                TokioInstant::now() + Duration::from_millis(20),
+            )
+            .await
+            .unwrap();
+        drop(mutation);
+        assert!(!queued_read.is_finished());
+
+        drop(first);
+        drop(second);
+        assert!(queued_read.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn background_work_leaves_same_grant_capacity_for_foreground_reads() {
+        let scheduler = Arc::new(AdmissionScheduler::with_limits(limits()));
+        let _background = scheduler
+            .admit(request(1, 1, WorkClass::Background))
+            .await
+            .unwrap();
+        let queued_scheduler = scheduler.clone();
+        let second_background = tokio::spawn(async move {
+            queued_scheduler
+                .admit_before(
+                    request(1, 1, WorkClass::Background),
+                    TokioInstant::now() + Duration::from_secs(1),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        let foreground = scheduler
+            .admit_before(
+                request(1, 1, WorkClass::Foreground),
+                TokioInstant::now() + Duration::from_millis(20),
+            )
+            .await
+            .unwrap();
+        assert!(!second_background.is_finished());
+
+        drop(foreground);
+        drop(_background);
+        assert!(second_background.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
     async fn mutations_are_serialized_per_collection() {
         let scheduler = AdmissionScheduler::with_limits(limits());
         let _first = scheduler
@@ -466,20 +608,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn one_grant_has_one_mutation_lane_across_collections() {
+        let scheduler = AdmissionScheduler::with_limits(limits());
+        let _first = scheduler
+            .admit(request(1, 9, WorkClass::Mutation))
+            .await
+            .unwrap();
+        let second = scheduler.admit_before(
+            request(1, 10, WorkClass::Mutation),
+            TokioInstant::now() + Duration::from_millis(10),
+        );
+        let other_grant = scheduler.admit_before(
+            request(2, 10, WorkClass::Mutation),
+            TokioInstant::now() + Duration::from_millis(10),
+        );
+
+        assert_eq!(second.await.unwrap_err(), AdmissionError::DeadlineExceeded);
+        assert!(other_grant.await.is_ok());
+    }
+
+    #[tokio::test]
     async fn keyed_admission_state_is_bounded_across_identity_churn() {
         let scheduler = AdmissionScheduler::with_limits(limits());
         for identity in 1..=(MAX_RETAINED_KEYED_SEMAPHORES as u128 * 4) {
-            drop(
-                scheduler
-                    .admit(request(identity, identity, WorkClass::Mutation))
-                    .await
-                    .unwrap(),
-            );
+            for class in [
+                WorkClass::Mutation,
+                WorkClass::Foreground,
+                WorkClass::Background,
+                WorkClass::File,
+            ] {
+                drop(
+                    scheduler
+                        .admit(request(identity, identity, class))
+                        .await
+                        .unwrap(),
+                );
+            }
         }
 
         let operation_grants = scheduler.operation_grants.lock().unwrap();
+        let mutation_grants = scheduler.mutation_grants.lock().unwrap();
+        let read_grants = scheduler.read_grants.lock().unwrap();
+        let background_grants = scheduler.background_grants.lock().unwrap();
+        let file_grants = scheduler.file_grants.lock().unwrap();
         let mutation_collections = scheduler.mutation_collections.lock().unwrap();
         assert!(operation_grants.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
+        assert!(mutation_grants.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
+        assert!(read_grants.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
+        assert!(background_grants.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
+        assert!(file_grants.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
         assert!(mutation_collections.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
         assert!(operation_grants
             .values()
@@ -487,6 +664,14 @@ mod tests {
         assert!(mutation_collections
             .values()
             .all(|entry| entry.strong_count() == 0));
+        assert!(mutation_grants
+            .values()
+            .all(|entry| entry.strong_count() == 0));
+        assert!(read_grants.values().all(|entry| entry.strong_count() == 0));
+        assert!(background_grants
+            .values()
+            .all(|entry| entry.strong_count() == 0));
+        assert!(file_grants.values().all(|entry| entry.strong_count() == 0));
     }
 
     #[test]

--- a/crates/connect-agent/src/admission.rs
+++ b/crates/connect-agent/src/admission.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 const DEFAULT_QUEUE_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
 const MAX_OPERATION_EXECUTION: Duration = Duration::from_secs(30);
 const MAX_RETAINED_KEYED_SEMAPHORES: usize = 128;
+pub(crate) const MAX_CONCURRENT_READS: usize = 2;
 
 /// Convert the client's optional absolute deadline into a local, monotonic
 /// window. The hint can only shorten the connector's own maximum.
@@ -77,8 +78,12 @@ impl Default for AdmissionLimits {
         let reserved_mutations = (operations / 4).max(1);
         Self {
             operations,
-            reads: operations - reserved_mutations,
-            background: 2.min(operations - reserved_mutations),
+            // Match the fixed read executor exactly. An extra admitted read
+            // would hold a deadline and capacity while queued invisibly on
+            // the executor, turning ordinary contention into a late timeout.
+            reads: MAX_CONCURRENT_READS,
+            // Retain one foreground lane when background polling is active.
+            background: MAX_CONCURRENT_READS - reserved_mutations,
             files: 4,
             // A grant can run two reads while retaining one independent
             // mutation lane. Background work gets only one of the read lanes
@@ -417,6 +422,13 @@ fn conservative_mutation_operation(operation: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_read_limits_match_executor_and_preserve_foreground_capacity() {
+        let limits = AdmissionLimits::default();
+        assert_eq!(limits.reads, MAX_CONCURRENT_READS);
+        assert!(limits.background < limits.reads);
+    }
 
     #[test]
     fn client_deadlines_only_shorten_the_connector_window() {

--- a/crates/connect-agent/src/admission.rs
+++ b/crates/connect-agent/src/admission.rs
@@ -1,7 +1,7 @@
 use mdbase_connect_protocol::mutation_operation_identifier;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::{timeout_at, Instant as TokioInstant};
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 const DEFAULT_QUEUE_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
 const MAX_OPERATION_EXECUTION: Duration = Duration::from_secs(30);
+const MAX_RETAINED_KEYED_SEMAPHORES: usize = 128;
 
 /// Convert the client's optional absolute deadline into a local, monotonic
 /// window. The hint can only shorten the connector's own maximum.
@@ -164,9 +165,9 @@ pub(crate) struct AdmissionScheduler {
     reads: Arc<Semaphore>,
     background: Arc<Semaphore>,
     files: Arc<Semaphore>,
-    operation_grants: Mutex<HashMap<Uuid, Arc<Semaphore>>>,
-    file_grants: Mutex<HashMap<Uuid, Arc<Semaphore>>>,
-    mutation_collections: Mutex<HashMap<Uuid, Arc<Semaphore>>>,
+    operation_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
+    file_grants: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
+    mutation_collections: Mutex<HashMap<Uuid, Weak<Semaphore>>>,
     queue_counts: Arc<Mutex<QueueCounts>>,
 }
 
@@ -263,21 +264,35 @@ impl AdmissionScheduler {
         } else {
             (&self.operation_grants, self.limits.operations_per_grant)
         };
-        let mut map = map.lock().expect("admission grant lock poisoned");
-        map.entry(grant_id)
-            .or_insert_with(|| Arc::new(Semaphore::new(permits)))
-            .clone()
+        keyed_semaphore(map, grant_id, permits, "admission grant lock poisoned")
     }
 
     fn collection_mutation_semaphore(&self, collection_id: Uuid) -> Arc<Semaphore> {
-        let mut map = self
-            .mutation_collections
-            .lock()
-            .expect("admission collection lock poisoned");
-        map.entry(collection_id)
-            .or_insert_with(|| Arc::new(Semaphore::new(1)))
-            .clone()
+        keyed_semaphore(
+            &self.mutation_collections,
+            collection_id,
+            1,
+            "admission collection lock poisoned",
+        )
     }
+}
+
+fn keyed_semaphore(
+    map: &Mutex<HashMap<Uuid, Weak<Semaphore>>>,
+    id: Uuid,
+    permits: usize,
+    poisoned: &str,
+) -> Arc<Semaphore> {
+    let mut map = map.lock().expect(poisoned);
+    if let Some(semaphore) = map.get(&id).and_then(Weak::upgrade) {
+        return semaphore;
+    }
+    if map.len() >= MAX_RETAINED_KEYED_SEMAPHORES {
+        map.retain(|_, semaphore| semaphore.strong_count() > 0);
+    }
+    let semaphore = Arc::new(Semaphore::new(permits));
+    map.insert(id, Arc::downgrade(&semaphore));
+    semaphore
 }
 
 async fn acquire_before(
@@ -291,10 +306,11 @@ async fn acquire_before(
 }
 
 pub(crate) fn classify_operation(operation: &str, input: Option<&Value>) -> WorkClass {
-    let mutation = input.map_or_else(
-        || conservative_mutation_operation(operation),
-        |input| mutation_operation_identifier(operation, input).is_some(),
-    );
+    let mutation = operation == "batch"
+        || input.map_or_else(
+            || conservative_mutation_operation(operation),
+            |input| mutation_operation_identifier(operation, input).is_some(),
+        );
     if mutation {
         WorkClass::Mutation
     } else if matches!(operation, "changes" | "list_timers") {
@@ -449,11 +465,39 @@ mod tests {
             .is_ok());
     }
 
+    #[tokio::test]
+    async fn keyed_admission_state_is_bounded_across_identity_churn() {
+        let scheduler = AdmissionScheduler::with_limits(limits());
+        for identity in 1..=(MAX_RETAINED_KEYED_SEMAPHORES as u128 * 4) {
+            drop(
+                scheduler
+                    .admit(request(identity, identity, WorkClass::Mutation))
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let operation_grants = scheduler.operation_grants.lock().unwrap();
+        let mutation_collections = scheduler.mutation_collections.lock().unwrap();
+        assert!(operation_grants.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
+        assert!(mutation_collections.len() <= MAX_RETAINED_KEYED_SEMAPHORES);
+        assert!(operation_grants
+            .values()
+            .all(|entry| entry.strong_count() == 0));
+        assert!(mutation_collections
+            .values()
+            .all(|entry| entry.strong_count() == 0));
+    }
+
     #[test]
     fn operation_classification_is_conservative_before_decryption() {
         assert_eq!(classify_operation("query", None), WorkClass::Foreground);
         assert_eq!(classify_operation("changes", None), WorkClass::Background);
         assert_eq!(classify_operation("sync", None), WorkClass::Mutation);
+        assert_eq!(
+            classify_operation("batch", Some(&serde_json::json!({"operations": []}))),
+            WorkClass::Mutation
+        );
         assert_eq!(
             classify_operation("create", Some(&serde_json::json!({"dry_run": true}))),
             WorkClass::Foreground

--- a/crates/connect-agent/src/lib.rs
+++ b/crates/connect-agent/src/lib.rs
@@ -3,6 +3,7 @@ mod bootstrap;
 mod cloud;
 mod loopback;
 mod mirrors;
+mod operation_executor;
 mod relay;
 mod runtime_notifications;
 mod server;

--- a/crates/connect-agent/src/loopback/control.rs
+++ b/crates/connect-agent/src/loopback/control.rs
@@ -1,7 +1,6 @@
 use super::*;
-use crate::admission::{
-    classify_operation, execution_timeout, queue_deadline, AdmissionRequest, WorkClass,
-};
+use crate::admission::{classify_operation, execution_timeout, queue_deadline, AdmissionRequest};
+use crate::server::OperationExecutionState;
 use axum::routing::{get, post};
 use mdbase_connect_protocol::{
     ConnectOperationOutcome, ConnectProblem, RelayMessage, LOOPBACK_PROTOCOL_VERSION,
@@ -162,7 +161,6 @@ async fn encrypted_control(
         class: classify_operation(&envelope.operation, None),
         weight_bytes: envelope.ciphertext.len(),
     };
-    let class = admission.class;
     let request_id = envelope.request_id;
     let Ok(permit) = state
         .agent
@@ -179,6 +177,8 @@ async fn encrypted_control(
     let cancellation = mdbase::OperationCancellation::new();
     let worker_cancellation = cancellation.clone();
     let mut cancel_on_drop = CancelOnDrop(Some(cancellation));
+    let execution_state = Arc::new(OperationExecutionState::default());
+    let worker_execution_state = execution_state.clone();
     let agent = state.agent.clone();
     let operation_origin = origin.clone();
     let execution = tokio::task::spawn_blocking(move || {
@@ -187,12 +187,20 @@ async fn encrypted_control(
             &operation_origin,
             envelope,
             &worker_cancellation,
+            &worker_execution_state,
         )
     });
     let outcome = tokio::time::timeout(execution_timeout(deadline_unix_ms), execution).await;
-    if outcome.is_ok() {
+    let timed_out_durable_mutation = if outcome.is_err() {
+        let durable_mutation = execution_state.begin_timeout();
+        if let Some(cancellation) = cancel_on_drop.0.take() {
+            cancellation.cancel();
+        }
+        durable_mutation
+    } else {
         cancel_on_drop.0 = None;
-    }
+        false
+    };
     match outcome {
         Ok(Ok(RelayMessage::EncryptedOperationResponse { envelope })) => cors_response(
             Json(json!({
@@ -214,7 +222,7 @@ async fn encrypted_control(
             "The local connector could not complete this operation.",
             &origin,
         ),
-        Err(_) if class == WorkClass::Mutation => cors_problem(
+        Err(_) if timed_out_durable_mutation => cors_problem(
             StatusCode::CONFLICT,
             ConnectProblem::new(
                 "operation_outcome_unknown",

--- a/crates/connect-agent/src/loopback/control.rs
+++ b/crates/connect-agent/src/loopback/control.rs
@@ -1,11 +1,25 @@
 use super::*;
-use crate::admission::{classify_operation, execution_timeout, queue_deadline, AdmissionRequest};
+use crate::admission::{
+    classify_operation, execution_timeout, queue_deadline, AdmissionPermit, AdmissionRequest,
+};
+use crate::operation_executor;
 use crate::server::OperationExecutionState;
 use axum::routing::{get, post};
 use mdbase_connect_protocol::{
     ConnectOperationOutcome, ConnectProblem, RelayMessage, LOOPBACK_PROTOCOL_VERSION,
     OPERATION_TRANSPORT_PROTOCOL_VERSION,
 };
+
+#[derive(serde::Serialize)]
+struct DirectOperationSuccess {
+    ok: bool,
+    envelope: RelayMessage,
+}
+
+struct EncodedDirectOperationSuccess {
+    body: Vec<u8>,
+    permit: AdmissionPermit,
+}
 
 pub(super) fn routes() -> Router<LoopbackState> {
     Router::new()
@@ -162,6 +176,7 @@ async fn encrypted_control(
         weight_bytes: envelope.ciphertext.len(),
     };
     let request_id = envelope.request_id;
+    let class = admission.class;
     let Ok(permit) = state
         .agent
         .admission()
@@ -181,14 +196,23 @@ async fn encrypted_control(
     let worker_execution_state = execution_state.clone();
     let agent = state.agent.clone();
     let operation_origin = origin.clone();
-    let execution = tokio::task::spawn_blocking(move || {
-        let _permit = permit;
-        agent.handle_direct_encrypted_operation_cancellable(
+    let execution = operation_executor::spawn_blocking(class, move || {
+        let response = agent.handle_direct_encrypted_operation_cancellable(
             &operation_origin,
             envelope,
             &worker_cancellation,
             &worker_execution_state,
-        )
+        );
+        match response {
+            response @ RelayMessage::EncryptedOperationResponse { .. } => {
+                serde_json::to_vec(&DirectOperationSuccess {
+                    ok: true,
+                    envelope: response,
+                })
+                .map(|body| Some(EncodedDirectOperationSuccess { body, permit }))
+            }
+            _ => Ok(None),
+        }
     });
     let outcome = tokio::time::timeout(execution_timeout(deadline_unix_ms), execution).await;
     let timed_out_durable_mutation = if outcome.is_err() {
@@ -202,21 +226,41 @@ async fn encrypted_control(
         false
     };
     match outcome {
-        Ok(Ok(RelayMessage::EncryptedOperationResponse { envelope })) => cors_response(
-            Json(json!({
-                "ok": true,
-                "envelope": RelayMessage::EncryptedOperationResponse { envelope }
-            }))
-            .into_response(),
-            &origin,
-        ),
-        Ok(Ok(_)) => cors_error(
+        Ok(Ok(Ok(Some(encoded)))) => {
+            let content_length = encoded.body.len();
+            let stream = futures_util::stream::unfold(
+                (
+                    axum::body::Bytes::from(encoded.body),
+                    encoded.permit,
+                ),
+                |(mut body, permit)| async move {
+                    if body.is_empty() {
+                        return None;
+                    }
+                    let chunk = body.split_to(body.len().min(64 * 1024));
+                    Some((
+                        Ok::<_, std::convert::Infallible>(chunk),
+                        (body, permit),
+                    ))
+                },
+            );
+            let mut response = Response::new(Body::from_stream(stream));
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            if let Ok(length) = HeaderValue::from_str(&content_length.to_string()) {
+                response.headers_mut().insert(header::CONTENT_LENGTH, length);
+            }
+            cors_response(response, &origin)
+        }
+        Ok(Ok(Ok(None))) => cors_error(
             StatusCode::FORBIDDEN,
             "direct_operation_rejected",
             "The local connector rejected this operation.",
             &origin,
         ),
-        Ok(Err(_)) => cors_error(
+        Ok(Ok(Err(_))) | Ok(Err(_)) => cors_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "connector_failed",
             "The local connector could not complete this operation.",

--- a/crates/connect-agent/src/operation_executor.rs
+++ b/crates/connect-agent/src/operation_executor.rs
@@ -1,0 +1,105 @@
+use crate::admission::WorkClass;
+use std::sync::OnceLock;
+use tokio::runtime::Runtime;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinHandle;
+
+const READ_WORKERS: usize = 2;
+
+/// Keep collection snapshots on a small, stable set of workers. Query bodies
+/// can establish a large allocator high-water mark, so allowing them onto the
+/// generic blocking pool makes retained memory grow with unrelated work.
+fn read_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(READ_WORKERS)
+            .thread_name("mdbase-read-worker")
+            .build()
+            .expect("collection read runtime must start")
+    })
+}
+
+/// Local control builds its protocol envelope after operation execution. Keep
+/// at most one response per read worker alive across that handoff and socket
+/// delivery, even when many local clients arrive concurrently.
+pub(crate) async fn reserve_local_response() -> OwnedSemaphorePermit {
+    static SLOTS: OnceLock<std::sync::Arc<Semaphore>> = OnceLock::new();
+    SLOTS
+        .get_or_init(|| std::sync::Arc::new(Semaphore::new(READ_WORKERS)))
+        .clone()
+        .acquire_owned()
+        .await
+        .expect("local response capacity must remain open")
+}
+
+pub(crate) fn spawn_blocking<T, F>(class: WorkClass, operation: F) -> JoinHandle<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    match class {
+        WorkClass::Foreground | WorkClass::Background => read_runtime().spawn_blocking(operation),
+        WorkClass::Mutation | WorkClass::File => tokio::task::spawn_blocking(operation),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn collection_reads_use_at_most_two_stable_workers() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut jobs = Vec::new();
+
+        for _ in 0..12 {
+            let active = active.clone();
+            let peak = peak.clone();
+            let class = if jobs.len() % 2 == 0 {
+                WorkClass::Foreground
+            } else {
+                WorkClass::Background
+            };
+            jobs.push(spawn_blocking(class, move || {
+                let current = active.fetch_add(1, Ordering::AcqRel) + 1;
+                peak.fetch_max(current, Ordering::AcqRel);
+                std::thread::sleep(Duration::from_millis(20));
+                active.fetch_sub(1, Ordering::AcqRel);
+                std::thread::current().id()
+            }));
+        }
+
+        let mut workers = HashSet::new();
+        for job in jobs {
+            workers.insert(job.await.expect("read worker must finish"));
+        }
+
+        assert!(peak.load(Ordering::Acquire) <= READ_WORKERS);
+        assert!(workers.len() <= READ_WORKERS);
+        assert!(!workers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn local_response_reservations_bound_completed_work() {
+        let first = reserve_local_response().await;
+        let second = reserve_local_response().await;
+        let waiting = tokio::spawn(reserve_local_response());
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiting.is_finished());
+
+        drop(first);
+        let third = tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .expect("released response capacity must admit the waiter")
+            .expect("response waiter must not fail");
+        drop((second, third));
+    }
+}

--- a/crates/connect-agent/src/operation_executor.rs
+++ b/crates/connect-agent/src/operation_executor.rs
@@ -1,10 +1,8 @@
-use crate::admission::WorkClass;
+use crate::admission::{WorkClass, MAX_CONCURRENT_READS};
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
-
-const READ_WORKERS: usize = 2;
 
 /// Keep collection snapshots on a small, stable set of workers. Query bodies
 /// can establish a large allocator high-water mark, so allowing them onto the
@@ -14,7 +12,7 @@ fn read_runtime() -> &'static Runtime {
     RUNTIME.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
-            .max_blocking_threads(READ_WORKERS)
+            .max_blocking_threads(MAX_CONCURRENT_READS)
             .thread_name("mdbase-read-worker")
             .build()
             .expect("collection read runtime must start")
@@ -27,11 +25,15 @@ fn read_runtime() -> &'static Runtime {
 pub(crate) async fn reserve_local_response() -> OwnedSemaphorePermit {
     static SLOTS: OnceLock<std::sync::Arc<Semaphore>> = OnceLock::new();
     SLOTS
-        .get_or_init(|| std::sync::Arc::new(Semaphore::new(READ_WORKERS)))
+        .get_or_init(|| std::sync::Arc::new(Semaphore::new(MAX_CONCURRENT_READS)))
         .clone()
         .acquire_owned()
         .await
         .expect("local response capacity must remain open")
+}
+
+pub(crate) fn reserves_local_response(class: WorkClass) -> bool {
+    matches!(class, WorkClass::Foreground | WorkClass::Background)
 }
 
 pub(crate) fn spawn_blocking<T, F>(class: WorkClass, operation: F) -> JoinHandle<T>
@@ -81,8 +83,8 @@ mod tests {
             workers.insert(job.await.expect("read worker must finish"));
         }
 
-        assert!(peak.load(Ordering::Acquire) <= READ_WORKERS);
-        assert!(workers.len() <= READ_WORKERS);
+        assert!(peak.load(Ordering::Acquire) <= MAX_CONCURRENT_READS);
+        assert!(workers.len() <= MAX_CONCURRENT_READS);
         assert!(!workers.is_empty());
     }
 
@@ -101,5 +103,13 @@ mod tests {
             .expect("released response capacity must admit the waiter")
             .expect("response waiter must not fail");
         drop((second, third));
+    }
+
+    #[test]
+    fn local_response_reservations_never_block_mutation_capacity() {
+        assert!(reserves_local_response(WorkClass::Foreground));
+        assert!(reserves_local_response(WorkClass::Background));
+        assert!(!reserves_local_response(WorkClass::Mutation));
+        assert!(!reserves_local_response(WorkClass::File));
     }
 }

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -1,7 +1,7 @@
 use crate::admission::{
     classify_operation, execution_timeout, queue_deadline, AdmissionRequest, WorkClass,
 };
-use crate::server::AgentState;
+use crate::server::{AgentState, OperationExecutionState};
 use futures_util::{SinkExt, StreamExt};
 use mdbase_connect_protocol::{
     AgentConnectionState, ConnectContractSupport, ConnectOperationOutcome, ConnectProblem,
@@ -175,15 +175,16 @@ async fn connect_once(
                                 );
                                 let cancellation = mdbase::OperationCancellation::new();
                                 let worker_cancellation = cancellation.clone();
-                                let timeout_response = relay_operation_timeout(
-                                    &relay_message,
-                                    admission.class,
-                                );
+                                let execution_state = Arc::new(OperationExecutionState::default());
+                                let worker_execution_state = execution_state.clone();
+                                let timeout_request = RelayTimeoutRequest::from_message(&relay_message)
+                                    .expect("admitted operation has timeout response metadata");
                                 let execution = tokio::task::spawn_blocking(move || {
                                     let _permit = permit;
                                     state_for_operation.handle_relay_message_cancellable(
                                         relay_message,
                                         &worker_cancellation,
+                                        &worker_execution_state,
                                     )
                                 });
                                 match tokio::time::timeout(execution_timeout(deadline_unix_ms), execution).await {
@@ -193,9 +194,13 @@ async fn connect_once(
                                     Ok(Ok(None)) => {}
                                     Ok(Err(error)) => tracing::warn!(%error, "relay operation task failed"),
                                     Err(_) => {
+                                        let durable_mutation = execution_state.begin_timeout();
                                         cancellation.cancel();
                                         tracing::warn!("relayed connector operation exceeded its execution deadline");
-                                        if let Some(response) = timeout_response {
+                                        if let Some(response) = relay_operation_timeout(
+                                            &timeout_request,
+                                            durable_mutation,
+                                        ) {
                                             let _ = responses.send(response).await;
                                         }
                                     }
@@ -334,15 +339,45 @@ fn relay_operation_rejection(
     )
 }
 
-fn relay_operation_timeout(request: &RelayMessage, class: WorkClass) -> Option<RelayMessage> {
-    let durable_mutation = class == WorkClass::Mutation
-        && matches!(request, RelayMessage::EncryptedOperationRequest { .. });
+#[derive(Clone, Copy)]
+struct RelayTimeoutRequest {
+    protocol_version: u32,
+    request_id: uuid::Uuid,
+    encrypted: bool,
+}
+
+impl RelayTimeoutRequest {
+    fn from_message(request: &RelayMessage) -> Option<Self> {
+        match request {
+            RelayMessage::OperationRequest {
+                protocol_version,
+                request_id,
+                ..
+            } => Some(Self {
+                protocol_version: *protocol_version,
+                request_id: *request_id,
+                encrypted: false,
+            }),
+            RelayMessage::EncryptedOperationRequest { envelope } => Some(Self {
+                protocol_version: envelope.protocol_version,
+                request_id: envelope.request_id,
+                encrypted: true,
+            }),
+            _ => None,
+        }
+    }
+}
+
+fn relay_operation_timeout(
+    request: &RelayTimeoutRequest,
+    durable_mutation: bool,
+) -> Option<RelayMessage> {
     let problem = if durable_mutation {
         ConnectProblem::new(
             "operation_outcome_unknown",
             "The durable mutation may have completed after its caller's deadline expired. Retry the exact same request to recover its result.",
         )
-        .with_details(serde_json::json!({ "request_id": relay_request_id(request)? }))
+        .with_details(serde_json::json!({ "request_id": request.request_id }))
         .with_operation_outcome(ConnectOperationOutcome::Unknown)
     } else {
         ConnectProblem::new(
@@ -351,15 +386,21 @@ fn relay_operation_timeout(request: &RelayMessage, class: WorkClass) -> Option<R
         )
         .with_operation_outcome(ConnectOperationOutcome::NotSent)
     };
-    relay_operation_problem(request, problem)
-}
-
-fn relay_request_id(request: &RelayMessage) -> Option<uuid::Uuid> {
-    match request {
-        RelayMessage::OperationRequest { request_id, .. } => Some(*request_id),
-        RelayMessage::EncryptedOperationRequest { envelope } => Some(envelope.request_id),
-        _ => None,
-    }
+    Some(if request.encrypted {
+        RelayMessage::EncryptedOperationRejected {
+            protocol_version: request.protocol_version,
+            request_id: request.request_id,
+            problem,
+        }
+    } else {
+        RelayMessage::OperationResponse {
+            protocol_version: request.protocol_version,
+            request_id: request.request_id,
+            ok: false,
+            result: None,
+            problem: Some(problem),
+        }
+    })
 }
 
 fn relay_operation_problem(
@@ -549,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_deadlines_never_report_admitted_mutations_as_not_sent() {
+    fn execution_deadlines_report_durable_mutations_as_unknown() {
         let request_id = uuid::Uuid::new_v4();
         let encrypted = RelayMessage::EncryptedOperationRequest {
             envelope: mdbase_connect_protocol::EncryptedRelayEnvelope {
@@ -568,8 +609,9 @@ mod tests {
                 ciphertext: "ciphertext".to_string(),
             },
         };
+        let timeout = RelayTimeoutRequest::from_message(&encrypted).unwrap();
         assert!(matches!(
-            relay_operation_timeout(&encrypted, WorkClass::Mutation),
+            relay_operation_timeout(&timeout, true),
             Some(RelayMessage::EncryptedOperationRejected {
                 request_id: returned,
                 problem,
@@ -579,6 +621,41 @@ mod tests {
                 && problem.operation_outcome == Some(ConnectOperationOutcome::Unknown)
                 && problem.details == Some(serde_json::json!({ "request_id": request_id }))
         ));
+    }
+
+    #[test]
+    fn conservative_admission_does_not_make_encrypted_reads_outcome_unknown() {
+        for operation in ["sync", "file_control"] {
+            let request_id = uuid::Uuid::new_v4();
+            let encrypted = RelayMessage::EncryptedOperationRequest {
+                envelope: mdbase_connect_protocol::EncryptedRelayEnvelope {
+                    protocol_version: mdbase_connect_protocol::OPERATION_TRANSPORT_PROTOCOL_VERSION,
+                    suite: "P256-HKDF-SHA256-AES256GCM".to_string(),
+                    request_id,
+                    grant_id: uuid::Uuid::new_v4(),
+                    application_id: uuid::Uuid::new_v4(),
+                    connector_id: uuid::Uuid::new_v4(),
+                    collection_id: uuid::Uuid::new_v4(),
+                    operation: operation.to_string(),
+                    scope_epoch: 1,
+                    key_id: "deadline-test".to_string(),
+                    counter: "1".to_string(),
+                    deadline_unix_ms: Some(1),
+                    ciphertext: "ciphertext".to_string(),
+                },
+            };
+            let timeout = RelayTimeoutRequest::from_message(&encrypted).unwrap();
+            assert!(matches!(
+                relay_operation_timeout(&timeout, false),
+                Some(RelayMessage::EncryptedOperationRejected {
+                    request_id: returned,
+                    problem,
+                    ..
+                }) if returned == request_id
+                    && problem.code == "operation_cancelled"
+                    && problem.operation_outcome == Some(ConnectOperationOutcome::NotSent)
+            ));
+        }
     }
 
     #[test]
@@ -593,8 +670,9 @@ mod tests {
             operation: "query".to_string(),
             input: serde_json::json!({}),
         };
+        let timeout = RelayTimeoutRequest::from_message(&request).unwrap();
         assert!(matches!(
-            relay_operation_timeout(&request, WorkClass::Foreground),
+            relay_operation_timeout(&timeout, false),
             Some(RelayMessage::OperationResponse {
                 request_id: returned,
                 problem: Some(problem),

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -1,6 +1,8 @@
 use crate::admission::{
-    classify_operation, execution_timeout, queue_deadline, AdmissionRequest, WorkClass,
+    classify_operation, execution_timeout, queue_deadline, AdmissionPermit, AdmissionRequest,
+    WorkClass,
 };
+use crate::operation_executor;
 use crate::server::{AgentState, OperationExecutionState};
 use futures_util::{SinkExt, StreamExt};
 use mdbase_connect_protocol::{
@@ -17,6 +19,11 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 use url::Url;
+
+struct EncodedOperationResponse {
+    body: String,
+    _permit: AdmissionPermit,
+}
 
 pub async fn run(server_url: String, connector_token: String, state: Arc<AgentState>) {
     crate::ensure_tls_crypto_provider();
@@ -93,6 +100,8 @@ async fn connect_once(
     };
     let (mut writer, mut reader) = socket.split();
     let (responses, mut response_rx) = tokio::sync::mpsc::channel::<RelayMessage>(64);
+    let (operation_responses, mut operation_response_rx) =
+        tokio::sync::mpsc::channel::<EncodedOperationResponse>(8);
     let (file_responses, mut file_response_rx) = tokio::sync::mpsc::channel::<RelayFileFrame>(8);
     let (policy_jobs, mut policy_job_rx) = tokio::sync::mpsc::channel::<(u64, RelayMessage)>(8);
     let (policy_applied, policy_applied_rx) = tokio::sync::watch::channel((0_u64, true));
@@ -139,6 +148,7 @@ async fn connect_once(
                         } else if let Some(admission) = relay_admission_request(&relay_message) {
                             let state_for_operation = state.clone();
                             let responses = responses.clone();
+                            let operation_responses = operation_responses.clone();
                             let policy_applied = policy_applied_rx.clone();
                             let required_policy_generation = received_policy_generation;
                             tokio::spawn(async move {
@@ -179,19 +189,30 @@ async fn connect_once(
                                 let worker_execution_state = execution_state.clone();
                                 let timeout_request = RelayTimeoutRequest::from_message(&relay_message)
                                     .expect("admitted operation has timeout response metadata");
-                                let execution = tokio::task::spawn_blocking(move || {
-                                    let _permit = permit;
-                                    state_for_operation.handle_relay_message_cancellable(
+                                let execution = operation_executor::spawn_blocking(admission.class, move || {
+                                    let response = state_for_operation.handle_relay_message_cancellable(
                                         relay_message,
                                         &worker_cancellation,
                                         &worker_execution_state,
-                                    )
+                                    );
+                                    match response {
+                                        Some(response) => serde_json::to_string(&response).map(|body| {
+                                            Some(EncodedOperationResponse {
+                                                body,
+                                                _permit: permit,
+                                            })
+                                        }),
+                                        None => Ok(None),
+                                    }
                                 });
                                 match tokio::time::timeout(execution_timeout(deadline_unix_ms), execution).await {
-                                    Ok(Ok(Some(response))) => {
-                                        let _ = responses.send(response).await;
+                                    Ok(Ok(Ok(Some(response)))) => {
+                                        let _ = operation_responses.send(response).await;
                                     }
-                                    Ok(Ok(None)) => {}
+                                    Ok(Ok(Ok(None))) => {}
+                                    Ok(Ok(Err(error))) => {
+                                        tracing::warn!(%error, "relay operation response serialization failed");
+                                    }
                                     Ok(Err(error)) => tracing::warn!(%error, "relay operation task failed"),
                                     Err(_) => {
                                         let durable_mutation = execution_state.begin_timeout();
@@ -284,6 +305,17 @@ async fn connect_once(
                     return Err("relay response channel closed".into());
                 };
                 writer.send(Message::Text(serde_json::to_string(&response)?.into())).await?;
+            }
+            response = operation_response_rx.recv() => {
+                let Some(response) = response else {
+                    return Err("relay operation response channel closed".into());
+                };
+                tokio::time::timeout(
+                    execution_timeout(None),
+                    writer.send(Message::Text(response.body.into())),
+                )
+                .await
+                .map_err(|_| "relay operation response delivery timed out")??;
             }
             response = file_response_rx.recv() => {
                 let Some(response) = response else {

--- a/crates/connect-agent/src/relay.rs
+++ b/crates/connect-agent/src/relay.rs
@@ -217,7 +217,12 @@ async fn connect_once(
                                     Err(_) => {
                                         let durable_mutation = execution_state.begin_timeout();
                                         cancellation.cancel();
-                                        tracing::warn!("relayed connector operation exceeded its execution deadline");
+                                        tracing::warn!(
+                                            request_id = %timeout_request.request_id,
+                                            class = ?admission.class,
+                                            durable_mutation,
+                                            "relayed connector operation exceeded its execution deadline"
+                                        );
                                         if let Some(response) = relay_operation_timeout(
                                             &timeout_request,
                                             durable_mutation,

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -357,7 +357,7 @@ where
                     }
                     _ => None,
                 };
-                if response_class.is_some() {
+                if response_class.is_some_and(crate::operation_executor::reserves_local_response) {
                     response_permit =
                         Some(crate::operation_executor::reserve_local_response().await);
                 }

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -390,7 +390,7 @@ where
         writer.write_all(&encoded).await?;
         writer.shutdown().await
     };
-    let delivery = if response_permit.is_some() {
+    let delivery = if response_class.is_some() {
         tokio::time::timeout(crate::admission::execution_timeout(None), delivery)
             .await
             .unwrap_or_else(|_| {

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -21,11 +21,54 @@ use mdbase_connect_protocol::{
     LOCAL_CONTROL_PROTOCOL_VERSION,
 };
 use std::io;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 const MAX_LOCAL_CONTROL_REQUEST_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Tracks whether an encrypted request has crossed from cancellable work into
+/// the durable mutation path. Admission is deliberately conservative before
+/// decryption, so its work class cannot safely answer this question.
+#[derive(Default)]
+pub(crate) struct OperationExecutionState {
+    state: AtomicU8,
+}
+
+impl OperationExecutionState {
+    const OPEN: u8 = 0;
+    const TIMED_OUT: u8 = 1;
+    const DURABLE_MUTATION: u8 = 2;
+
+    /// Atomically crosses the durable boundary. If timeout won the race, the
+    /// worker must not claim or execute the mutation.
+    pub(crate) fn begin_durable_mutation(&self) -> bool {
+        self.state
+            .compare_exchange(
+                Self::OPEN,
+                Self::DURABLE_MUTATION,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Atomically closes the cancellable boundary. Returns true only when the
+    /// worker had already won the durable transition.
+    pub(crate) fn begin_timeout(&self) -> bool {
+        match self.state.compare_exchange(
+            Self::OPEN,
+            Self::TIMED_OUT,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) | Err(Self::TIMED_OUT) => false,
+            Err(Self::DURABLE_MUTATION) => true,
+            Err(_) => unreachable!("operation execution state is closed"),
+        }
+    }
+}
 
 pub struct AgentState {
     registry: CollectionRegistry,
@@ -47,6 +90,7 @@ pub struct AgentState {
 mod account;
 mod authorization;
 mod control;
+mod durable_mutations;
 mod files;
 mod metrics;
 mod operation_responses;

--- a/crates/connect-agent/src/server.rs
+++ b/crates/connect-agent/src/server.rs
@@ -331,6 +331,8 @@ where
         return Ok(());
     }
     let mut shutdown_after_response = false;
+    let mut response_class = None;
+    let mut response_permit = None;
     let response = if encoded_request.len() as u64 > MAX_LOCAL_CONTROL_REQUEST_BYTES
         || encoded_request.last() != Some(&b'\n')
     {
@@ -343,6 +345,22 @@ where
         encoded_request.pop();
         match serde_json::from_slice::<ControlRequest>(&encoded_request) {
             Ok(request) => {
+                response_class = match &request.command {
+                    ControlCommand::CollectionOperation(params) => {
+                        Some(crate::admission::classify_operation(
+                            &params.operation,
+                            Some(&params.input),
+                        ))
+                    }
+                    ControlCommand::CollectionValidate(_) => {
+                        Some(crate::admission::WorkClass::Foreground)
+                    }
+                    _ => None,
+                };
+                if response_class.is_some() {
+                    response_permit =
+                        Some(crate::operation_executor::reserve_local_response().await);
+                }
                 shutdown_after_response = matches!(
                     &request.command,
                     ControlCommand::DaemonShutdown
@@ -358,14 +376,34 @@ where
             ),
         }
     };
-    let mut encoded = serde_json::to_vec(&response).map_err(io::Error::other)?;
+    let response_ok = response.ok;
+    let mut encoded = if let Some(class) = response_class {
+        crate::operation_executor::spawn_blocking(class, move || serde_json::to_vec(&response))
+            .await
+            .map_err(io::Error::other)?
+            .map_err(io::Error::other)?
+    } else {
+        serde_json::to_vec(&response).map_err(io::Error::other)?
+    };
     encoded.push(b'\n');
     let delivery = async {
         writer.write_all(&encoded).await?;
         writer.shutdown().await
-    }
-    .await;
-    if shutdown_after_response && response.ok {
+    };
+    let delivery = if response_permit.is_some() {
+        tokio::time::timeout(crate::admission::execution_timeout(None), delivery)
+            .await
+            .unwrap_or_else(|_| {
+                Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "local collection response delivery timed out",
+                ))
+            })
+    } else {
+        delivery.await
+    };
+    drop(response_permit);
+    if shutdown_after_response && response_ok {
         state.request_shutdown();
     }
     delivery

--- a/crates/connect-agent/src/server/control.rs
+++ b/crates/connect-agent/src/server/control.rs
@@ -1,7 +1,8 @@
 use super::*;
+use crate::admission::{classify_operation, execution_timeout, AdmissionRequest, WorkClass};
 
 impl AgentState {
-    pub(super) async fn execute(&self, request: ControlRequest) -> ControlResponse {
+    pub(super) async fn execute(self: &Arc<Self>, request: ControlRequest) -> ControlResponse {
         let id = request.id;
         if request.protocol_version != LOCAL_CONTROL_PROTOCOL_VERSION {
             return ControlResponse::failure(
@@ -116,10 +117,16 @@ impl AgentState {
                 result.and_then(|value| serde_json::to_value(value).map_err(ConnectError::from))
             }
             ControlCommand::CollectionValidate(params) => {
-                self.registry.validate(params.collection_id)
+                self.local_operation(
+                    params.collection_id,
+                    "validate".to_string(),
+                    serde_json::json!({}),
+                )
+                .await
             }
             ControlCommand::CollectionOperation(params) => {
-                self.local_operation(params.collection_id, &params.operation, &params.input)
+                self.local_operation(params.collection_id, params.operation, params.input)
+                    .await
             }
             ControlCommand::AccessSnapshot => self.access_snapshot().await,
             ControlCommand::AccessPause(params) => self
@@ -301,6 +308,73 @@ impl AgentState {
         match result {
             Ok(result) => ControlResponse::success(id, result),
             Err(error) => ControlResponse::failure(id, error.code(), error.to_string()),
+        }
+    }
+
+    async fn local_operation(
+        self: &Arc<Self>,
+        collection_id: uuid::Uuid,
+        operation: String,
+        input: serde_json::Value,
+    ) -> Result<serde_json::Value, ConnectError> {
+        let weight_bytes = serde_json::to_vec(&input)?
+            .len()
+            .saturating_add(operation.len())
+            .saturating_add(1024);
+        let class = classify_operation(&operation, Some(&input));
+        let permit = self
+            .admission()
+            .admit(AdmissionRequest {
+                // Local control is one trusted authority principal. A stable
+                // identity keeps concurrent CLI callers within the same
+                // per-principal limit instead of bypassing it per request.
+                grant_id: uuid::Uuid::nil(),
+                collection_id,
+                class,
+                weight_bytes,
+            })
+            .await
+            .map_err(|_| ConnectError::AuthorityOverloaded)?;
+        tracing::debug!(
+            queue_wait_us = permit.queue_wait_us,
+            "admitted local connector operation"
+        );
+
+        let cancellation = mdbase::OperationCancellation::new();
+        let worker_cancellation = cancellation.clone();
+        let state = Arc::clone(self);
+        let execution = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            state.execute_local_operation(collection_id, &operation, &input, &worker_cancellation)
+        });
+        if class == WorkClass::Mutation {
+            return execution.await.map_err(local_operation_task_error)?;
+        }
+
+        let mut cancel_on_drop = CancelLocalOperationOnDrop(Some(cancellation));
+        let outcome = tokio::time::timeout(execution_timeout(None), execution).await;
+        if outcome.is_ok() {
+            cancel_on_drop.0 = None;
+        }
+        match outcome {
+            Ok(result) => result.map_err(local_operation_task_error)?,
+            Err(_) => Err(ConnectError::OperationCancelled),
+        }
+    }
+}
+
+fn local_operation_task_error(error: tokio::task::JoinError) -> ConnectError {
+    ConnectError::Io(std::io::Error::other(format!(
+        "local collection operation task failed: {error}"
+    )))
+}
+
+struct CancelLocalOperationOnDrop(Option<mdbase::OperationCancellation>);
+
+impl Drop for CancelLocalOperationOnDrop {
+    fn drop(&mut self) {
+        if let Some(cancellation) = self.0.take() {
+            cancellation.cancel();
         }
     }
 }

--- a/crates/connect-agent/src/server/control.rs
+++ b/crates/connect-agent/src/server/control.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::admission::{classify_operation, execution_timeout, AdmissionRequest, WorkClass};
+use crate::operation_executor;
 
 impl AgentState {
     pub(super) async fn execute(self: &Arc<Self>, request: ControlRequest) -> ControlResponse {
@@ -343,7 +344,7 @@ impl AgentState {
         let cancellation = mdbase::OperationCancellation::new();
         let worker_cancellation = cancellation.clone();
         let state = Arc::clone(self);
-        let execution = tokio::task::spawn_blocking(move || {
+        let execution = operation_executor::spawn_blocking(class, move || {
             let _permit = permit;
             state.execute_local_operation(collection_id, &operation, &input, &worker_cancellation)
         });

--- a/crates/connect-agent/src/server/durable_mutations.rs
+++ b/crates/connect-agent/src/server/durable_mutations.rs
@@ -93,7 +93,15 @@ impl AgentState {
                         metrics::lease_takeover(mutation_identifier, recovery.state);
                     }
                     return self.execute_owned_mutation(
-                        context, operation, input, metadata, keys, lease, *recovery, revoked,
+                        context,
+                        operation,
+                        mutation_identifier,
+                        input,
+                        metadata,
+                        keys,
+                        lease,
+                        *recovery,
+                        revoked,
                     );
                 }
                 MutationClaim::Live { .. } => {

--- a/crates/connect-agent/src/server/durable_mutations.rs
+++ b/crates/connect-agent/src/server/durable_mutations.rs
@@ -1,0 +1,116 @@
+use super::{metrics, operation_responses::*, *};
+
+impl AgentState {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn handle_durable_encrypted_mutation(
+        &self,
+        context: &mdbase_connect_protocol::GrantSummary,
+        operation: &str,
+        mutation_identifier: &str,
+        input: &serde_json::Value,
+        metadata: RelayMetadata<'_>,
+        keys: &RelayKeys,
+        application_installation_id: uuid::Uuid,
+        grant_snapshot_digest: String,
+        revoked: bool,
+        execution_state: &OperationExecutionState,
+    ) -> RelayMessage {
+        let Some(input_schema_version) = operation_input_schema_version(operation, input) else {
+            return encrypted_problem_response(
+                keys,
+                metadata,
+                ConnectProblem::new(
+                    "invalid_request",
+                    "The mutation input schema version is not defined.",
+                )
+                .with_operation_outcome(ConnectOperationOutcome::Rejected),
+            );
+        };
+        let Ok(input_digest) = mutation_fingerprint(operation, input) else {
+            return encrypted_problem_response(
+                keys,
+                metadata,
+                ConnectProblem::new(
+                    "invalid_request",
+                    "The mutation input is not canonical I-JSON.",
+                )
+                .with_operation_outcome(ConnectOperationOutcome::Rejected),
+            );
+        };
+        // The timeout and worker race at one atomic boundary. If timeout wins,
+        // this request is provably not sent. If the durable transition wins,
+        // the caller must recover by replaying the exact request identity.
+        if !execution_state.begin_durable_mutation() {
+            return encrypted_problem_response(
+                keys,
+                metadata,
+                ConnectProblem::new(
+                    "operation_cancelled",
+                    "The operation was cancelled before its durable mutation was claimed.",
+                )
+                .with_operation_outcome(ConnectOperationOutcome::NotSent),
+            );
+        }
+        let claim_request = MutationClaimRequest {
+            application_installation_id,
+            grant_id: context.id,
+            request_id: metadata.request_id,
+            operation_kind: mutation_identifier.to_string(),
+            input_schema_version,
+            input_digest,
+            grant_snapshot_digest,
+            allow_new: !revoked,
+        };
+
+        let mut claim = match self.registry.claim_mutation(&claim_request) {
+            Ok(claim) => claim,
+            Err(ConnectError::AccessDenied(message)) if revoked => {
+                return encrypted_problem_response(
+                    keys,
+                    metadata,
+                    ConnectProblem::new("access_denied", message)
+                        .with_details(serde_json::json!({ "request_id": metadata.request_id }))
+                        .with_operation_outcome(ConnectOperationOutcome::NotSent),
+                )
+            }
+            Err(error) => {
+                metrics::claim_error(mutation_identifier, &error);
+                return encrypted_problem_response(keys, metadata, operation_problem(&error));
+            }
+        };
+        for _ in 0..1_000 {
+            match claim {
+                MutationClaim::Terminal { state, receipt } => {
+                    metrics::duplicate_replay(mutation_identifier, state);
+                    return serialized_encrypted_response(
+                        &receipt,
+                        metadata.protocol_version,
+                        metadata.request_id,
+                    );
+                }
+                MutationClaim::Owned { lease, recovery } => {
+                    if lease.fencing_generation > 1 {
+                        metrics::lease_takeover(mutation_identifier, recovery.state);
+                    }
+                    return self.execute_owned_mutation(
+                        context, operation, input, metadata, keys, lease, *recovery, revoked,
+                    );
+                }
+                MutationClaim::Live { .. } => {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                    claim = match self.registry.claim_mutation(&claim_request) {
+                        Ok(claim) => claim,
+                        Err(error) => {
+                            return encrypted_problem_response(
+                                keys,
+                                metadata,
+                                operation_problem(&error),
+                            )
+                        }
+                    };
+                }
+            }
+        }
+        pending_mutation_response(keys, metadata)
+    }
+}

--- a/crates/connect-agent/src/server/files.rs
+++ b/crates/connect-agent/src/server/files.rs
@@ -15,6 +15,18 @@ impl AgentState {
         grant: &mdbase_connect_protocol::GrantSummary,
         input: serde_json::Value,
     ) -> Result<serde_json::Value, ConnectError> {
+        self.file_control_cancellable(grant, input, &mdbase::OperationCancellation::new())
+    }
+
+    pub(super) fn file_control_cancellable(
+        &self,
+        grant: &mdbase_connect_protocol::GrantSummary,
+        input: serde_json::Value,
+        cancellation: &mdbase::OperationCancellation,
+    ) -> Result<serde_json::Value, ConnectError> {
+        cancellation
+            .check()
+            .map_err(|_| ConnectError::OperationCancelled)?;
         let message_type = input
             .get("type")
             .and_then(serde_json::Value::as_str)
@@ -24,7 +36,7 @@ impl AgentState {
                     "File control requires a message type.",
                 )
             })?;
-        match message_type {
+        let result = match message_type {
             "list_files" => {
                 let request: ListFilesRequest = parse_file_control(input)?;
                 let limit = validate_list_request(&request)?;
@@ -55,6 +67,9 @@ impl AgentState {
                 let batch_size = limit.saturating_add(1).clamp(128, 1_001);
                 let mut files = Vec::with_capacity(limit.saturating_add(1));
                 while files.len() <= limit {
+                    cancellation
+                        .check()
+                        .map_err(|_| ConnectError::OperationCancelled)?;
                     let batch = self.registry.indexed_files_page(
                         grant.collection_id,
                         scan_after.as_deref(),
@@ -196,7 +211,13 @@ impl AgentState {
                 "invalid_file_request",
                 "The file control message type is unsupported.",
             )),
+        };
+        if result.is_ok() {
+            cancellation
+                .check()
+                .map_err(|_| ConnectError::OperationCancelled)?;
         }
+        result
     }
 
     pub fn handle_direct_file_upload_frame(
@@ -744,6 +765,26 @@ mod tests {
         );
         assert!(parse_local_file_cursor("Assets/images/one.png").is_err());
         assert!(parse_local_file_cursor("local-v1:0:Assets/images/one.png").is_err());
+    }
+
+    #[test]
+    fn cancelled_file_listing_stops_before_index_work() {
+        let state_dir = tempdir().unwrap();
+        let registry = CollectionRegistry::open(state_dir.path()).unwrap();
+        let watcher = CollectionWatchService::start(registry.clone());
+        let state = AgentState::new(registry, watcher, None);
+        let grant = file_grant(Uuid::new_v4(), vec![FileAction::List]);
+        let cancellation = mdbase::OperationCancellation::new();
+        cancellation.cancel();
+
+        assert!(matches!(
+            state.file_control_cancellable(
+                &grant,
+                serde_json::to_value(list_request()).unwrap(),
+                &cancellation,
+            ),
+            Err(ConnectError::OperationCancelled)
+        ));
     }
 
     #[test]

--- a/crates/connect-agent/src/server/operation_responses.rs
+++ b/crates/connect-agent/src/server/operation_responses.rs
@@ -101,10 +101,25 @@ pub(super) fn local_mutation_evidence(
     registry: &CollectionRegistry,
     collection_id: uuid::Uuid,
     operation: &str,
+    mutation_identifier: &str,
 ) -> Result<serde_json::Value, ConnectError> {
     if matches!(operation, "put_timer" | "cancel_timer" | "reconcile_timers") {
         return Ok(serde_json::json!({
             "kind": "timer_authority",
+            "collection_id": collection_id,
+        }));
+    }
+    // Opening an upload and aborting either transfer direction mutate only
+    // connector-owned transfer-session state. They are idempotent by transfer
+    // ID and do not need a full collection manifest before and after the
+    // journaled operation. On a multi-gigabyte collection that snapshot can
+    // take minutes and expand allocator arenas for a tiny cleanup request.
+    if matches!(
+        mutation_identifier,
+        "file_control:open_file_upload" | "file_control:abort_file_transfer"
+    ) {
+        return Ok(serde_json::json!({
+            "kind": "file_transfer_authority",
             "collection_id": collection_id,
         }));
     }
@@ -235,6 +250,36 @@ fn collection_setup_problem(code: &str, error: &ConnectError) -> ConnectProblem 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transfer_session_mutations_do_not_snapshot_the_collection() {
+        let state = tempfile::tempdir().unwrap();
+        let registry = CollectionRegistry::open(state.path()).unwrap();
+        let missing_collection = uuid::Uuid::new_v4();
+
+        for mutation_identifier in [
+            "file_control:open_file_upload",
+            "file_control:abort_file_transfer",
+        ] {
+            let evidence = local_mutation_evidence(
+                &registry,
+                missing_collection,
+                "file_control",
+                mutation_identifier,
+            )
+            .expect("transfer-only evidence must not open the collection");
+            assert_eq!(evidence["kind"], "file_transfer_authority");
+            assert_eq!(evidence["collection_id"], missing_collection.to_string());
+        }
+
+        assert!(local_mutation_evidence(
+            &registry,
+            missing_collection,
+            "file_control",
+            "file_control:delete_file",
+        )
+        .is_err());
+    }
 
     #[test]
     fn collection_diagnostics_cross_the_connector_boundary() {

--- a/crates/connect-agent/src/server/operations.rs
+++ b/crates/connect-agent/src/server/operations.rs
@@ -5,6 +5,7 @@ impl AgentState {
         origin: &str,
         envelope: mdbase_connect_protocol::EncryptedRelayEnvelope,
         cancellation: &mdbase::OperationCancellation,
+        execution_state: &OperationExecutionState,
     ) -> RelayMessage {
         let origin_matches = self
             .registry
@@ -16,17 +17,22 @@ impl AgentState {
             return encrypted_rejection(envelope.protocol_version, envelope.request_id);
         }
         metrics::direct_operation_transport(envelope.protocol_version);
-        self.handle_encrypted_operation(envelope, cancellation)
+        self.handle_encrypted_operation(envelope, cancellation, execution_state)
     }
 
     pub fn handle_relay_message(&self, message: RelayMessage) -> Option<RelayMessage> {
-        self.handle_relay_message_cancellable(message, &mdbase::OperationCancellation::new())
+        self.handle_relay_message_cancellable(
+            message,
+            &mdbase::OperationCancellation::new(),
+            &OperationExecutionState::default(),
+        )
     }
 
     pub(crate) fn handle_relay_message_cancellable(
         &self,
         message: RelayMessage,
         cancellation: &mdbase::OperationCancellation,
+        execution_state: &OperationExecutionState,
     ) -> Option<RelayMessage> {
         match message {
             RelayMessage::PolicySnapshot {
@@ -334,6 +340,34 @@ impl AgentState {
                         ),
                     });
                 }
+                if operation == "batch" {
+                    return Some(RelayMessage::OperationResponse {
+                        protocol_version,
+                        request_id,
+                        ok: false,
+                        result: None,
+                        problem: Some(
+                            ConnectProblem::new(
+                                "invalid_request",
+                                "Batch operations are available only to the local collection owner.",
+                            )
+                            .with_operation_outcome(ConnectOperationOutcome::Rejected),
+                        ),
+                    });
+                }
+                if let Some(problem) = context.as_ref().and_then(|grant| {
+                    grant
+                        .contracts
+                        .mismatch_problem(&operation, &input, "connector")
+                }) {
+                    return Some(RelayMessage::OperationResponse {
+                        protocol_version,
+                        request_id,
+                        ok: false,
+                        result: None,
+                        problem: Some(problem),
+                    });
+                }
                 if self.registry.paused().unwrap_or(true) {
                     let _ = self.registry.record_activity(
                         application_id,
@@ -427,7 +461,7 @@ impl AgentState {
                 })
             }
             RelayMessage::EncryptedOperationRequest { envelope } => {
-                Some(self.handle_encrypted_operation(envelope, cancellation))
+                Some(self.handle_encrypted_operation(envelope, cancellation, execution_state))
             }
             RelayMessage::RelayHello { .. }
             | RelayMessage::RelayWelcome { .. }
@@ -446,6 +480,7 @@ impl AgentState {
         &self,
         envelope: mdbase_connect_protocol::EncryptedRelayEnvelope,
         cancellation: &mdbase::OperationCancellation,
+        execution_state: &OperationExecutionState,
     ) -> RelayMessage {
         if !mdbase_connect_protocol::SUPPORTED_OPERATION_TRANSPORT_PROTOCOL_VERSIONS
             .contains(&envelope.protocol_version)
@@ -518,6 +553,17 @@ impl AgentState {
         let Ok(input) = serde_json::from_slice::<serde_json::Value>(&plaintext) else {
             return rejected();
         };
+        if envelope.operation == "batch" {
+            return encrypted_problem_response(
+                &keys,
+                metadata,
+                ConnectProblem::new(
+                    "invalid_request",
+                    "Batch operations are available only to the local collection owner.",
+                )
+                .with_operation_outcome(ConnectOperationOutcome::Rejected),
+            );
+        }
         if let Some(problem) =
             context
                 .contracts
@@ -642,6 +688,7 @@ impl AgentState {
                 application_installation_id,
                 grant_snapshot_digest,
                 revoked,
+                execution_state,
             );
         }
 
@@ -655,7 +702,7 @@ impl AgentState {
                 "Remote access is paused on this computer.".to_string(),
             ))
         } else if file_control {
-            self.file_control(&context, input)
+            self.file_control_cancellable(&context, input, cancellation)
         } else {
             self.scoped_operation_cancellable(
                 "encrypted",
@@ -719,105 +766,7 @@ impl AgentState {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn handle_durable_encrypted_mutation(
-        &self,
-        context: &mdbase_connect_protocol::GrantSummary,
-        operation: &str,
-        mutation_identifier: &str,
-        input: &serde_json::Value,
-        metadata: RelayMetadata<'_>,
-        keys: &RelayKeys,
-        application_installation_id: uuid::Uuid,
-        grant_snapshot_digest: String,
-        revoked: bool,
-    ) -> RelayMessage {
-        let Some(input_schema_version) = operation_input_schema_version(operation, input) else {
-            return encrypted_problem_response(
-                keys,
-                metadata,
-                ConnectProblem::new(
-                    "invalid_request",
-                    "The mutation input schema version is not defined.",
-                )
-                .with_operation_outcome(ConnectOperationOutcome::Rejected),
-            );
-        };
-        let Ok(input_digest) = mutation_fingerprint(operation, input) else {
-            return encrypted_problem_response(
-                keys,
-                metadata,
-                ConnectProblem::new(
-                    "invalid_request",
-                    "The mutation input is not canonical I-JSON.",
-                )
-                .with_operation_outcome(ConnectOperationOutcome::Rejected),
-            );
-        };
-        let claim_request = MutationClaimRequest {
-            application_installation_id,
-            grant_id: context.id,
-            request_id: metadata.request_id,
-            operation_kind: mutation_identifier.to_string(),
-            input_schema_version,
-            input_digest,
-            grant_snapshot_digest,
-            allow_new: !revoked,
-        };
-
-        let mut claim = match self.registry.claim_mutation(&claim_request) {
-            Ok(claim) => claim,
-            Err(ConnectError::AccessDenied(message)) if revoked => {
-                return encrypted_problem_response(
-                    keys,
-                    metadata,
-                    ConnectProblem::new("access_denied", message)
-                        .with_details(serde_json::json!({ "request_id": metadata.request_id }))
-                        .with_operation_outcome(ConnectOperationOutcome::NotSent),
-                )
-            }
-            Err(error) => {
-                metrics::claim_error(mutation_identifier, &error);
-                return encrypted_problem_response(keys, metadata, operation_problem(&error));
-            }
-        };
-        for _ in 0..1_000 {
-            match claim {
-                MutationClaim::Terminal { state, receipt } => {
-                    metrics::duplicate_replay(mutation_identifier, state);
-                    return serialized_encrypted_response(
-                        &receipt,
-                        metadata.protocol_version,
-                        metadata.request_id,
-                    );
-                }
-                MutationClaim::Owned { lease, recovery } => {
-                    if lease.fencing_generation > 1 {
-                        metrics::lease_takeover(mutation_identifier, recovery.state);
-                    }
-                    return self.execute_owned_mutation(
-                        context, operation, input, metadata, keys, lease, *recovery, revoked,
-                    );
-                }
-                MutationClaim::Live { .. } => {
-                    std::thread::sleep(std::time::Duration::from_millis(25));
-                    claim = match self.registry.claim_mutation(&claim_request) {
-                        Ok(claim) => claim,
-                        Err(error) => {
-                            return encrypted_problem_response(
-                                keys,
-                                metadata,
-                                operation_problem(&error),
-                            )
-                        }
-                    };
-                }
-            }
-        }
-        pending_mutation_response(keys, metadata)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn execute_owned_mutation(
+    pub(super) fn execute_owned_mutation(
         &self,
         context: &mdbase_connect_protocol::GrantSummary,
         operation: &str,

--- a/crates/connect-agent/src/server/operations.rs
+++ b/crates/connect-agent/src/server/operations.rs
@@ -770,6 +770,7 @@ impl AgentState {
         &self,
         context: &mdbase_connect_protocol::GrantSummary,
         operation: &str,
+        mutation_identifier: &str,
         input: &serde_json::Value,
         metadata: RelayMetadata<'_>,
         keys: &RelayKeys,
@@ -813,8 +814,12 @@ impl AgentState {
             );
         }
 
-        let before = match local_mutation_evidence(&self.registry, context.collection_id, operation)
-        {
+        let before = match local_mutation_evidence(
+            &self.registry,
+            context.collection_id,
+            operation,
+            mutation_identifier,
+        ) {
             Ok(evidence) => evidence,
             Err(error) => {
                 let body = serde_json::json!({
@@ -916,19 +921,23 @@ impl AgentState {
             Err(_) => return pending_mutation_response(keys, metadata),
         };
         if succeeded {
-            let after =
-                match local_mutation_evidence(&self.registry, context.collection_id, operation) {
-                    Ok(evidence) => evidence,
-                    Err(_) => {
-                        return mark_owned_mutation_unknown(
-                            &self.registry,
-                            keys,
-                            metadata,
-                            &lease,
-                            "The mutation returned but post-apply evidence could not be persisted.",
-                        )
-                    }
-                };
+            let after = match local_mutation_evidence(
+                &self.registry,
+                context.collection_id,
+                operation,
+                mutation_identifier,
+            ) {
+                Ok(evidence) => evidence,
+                Err(_) => {
+                    return mark_owned_mutation_unknown(
+                        &self.registry,
+                        keys,
+                        metadata,
+                        &lease,
+                        "The mutation returned but post-apply evidence could not be persisted.",
+                    )
+                }
+            };
             if self
                 .registry
                 .mark_mutation_applied(&lease, Some(&after), Some(&result_metadata))

--- a/crates/connect-agent/src/server/scoped_operations.rs
+++ b/crates/connect-agent/src/server/scoped_operations.rs
@@ -1,21 +1,26 @@
 use super::*;
 
 impl AgentState {
-    pub(super) fn local_operation(
+    pub(super) fn execute_local_operation(
         &self,
         collection_id: uuid::Uuid,
         operation: &str,
         input: &serde_json::Value,
+        cancellation: &mdbase::OperationCancellation,
     ) -> Result<serde_json::Value, ConnectError> {
         let started = Instant::now();
         let synchronize_us = std::cell::Cell::new(0_u64);
-        let result =
-            self.registry
-                .operation_synchronized(collection_id, operation, input, |invalidation| {
-                    let synchronize_started = Instant::now();
-                    self.watcher.synchronize(collection_id, invalidation);
-                    synchronize_us.set(elapsed_us(synchronize_started));
-                });
+        let result = self.registry.operation_synchronized_cancellable(
+            collection_id,
+            operation,
+            input,
+            cancellation,
+            |invalidation| {
+                let synchronize_started = Instant::now();
+                self.watcher.synchronize(collection_id, invalidation);
+                synchronize_us.set(elapsed_us(synchronize_started));
+            },
+        );
         profile_operation("control", operation, started, synchronize_us.get(), &result);
         result
     }
@@ -90,7 +95,7 @@ impl AgentState {
             } else {
                 SyncReplicaMode::ReadOnly
             };
-            let result = self.registry.sync_operation_synchronized(
+            let result = self.registry.sync_operation_synchronized_cancellable(
                 collection_id,
                 input,
                 LocalReplica {
@@ -100,6 +105,7 @@ impl AgentState {
                     allowed_types: Default::default(),
                 },
                 &grant.scope,
+                cancellation,
                 |invalidation| {
                     let synchronize_started = Instant::now();
                     self.watcher.synchronize(collection_id, invalidation);

--- a/crates/connect-agent/src/server/tests.rs
+++ b/crates/connect-agent/src/server/tests.rs
@@ -162,12 +162,12 @@ async fn local_collection_operations_share_admission_without_blocking_control() 
     let state = Arc::new(AgentState::new(registry, watcher, None));
 
     let mut held_reads = Vec::new();
-    for principal in 1..=3 {
+    for principal in 1..=crate::admission::MAX_CONCURRENT_READS {
         held_reads.push(
             state
                 .admission()
                 .admit(AdmissionRequest {
-                    grant_id: Uuid::from_u128(principal),
+                    grant_id: Uuid::from_u128(principal as u128),
                     collection_id: collection.id,
                     class: WorkClass::Foreground,
                     weight_bytes: 1,

--- a/crates/connect-agent/src/server/tests.rs
+++ b/crates/connect-agent/src/server/tests.rs
@@ -79,7 +79,7 @@ async fn rejects_an_unsupported_local_control_protocol() {
     ));
     let registry = CollectionRegistry::open(&test_root).unwrap();
     let watcher = CollectionWatchService::start(registry.clone());
-    let state = AgentState::new(registry, watcher, None);
+    let state = Arc::new(AgentState::new(registry, watcher, None));
     let mut request = ControlRequest::new(ControlCommand::Ping);
     request.protocol_version = LOCAL_CONTROL_PROTOCOL_VERSION + 1;
 
@@ -102,7 +102,7 @@ async fn status_reports_the_running_binary_version_for_upgrade_health_checks() {
     ));
     let registry = CollectionRegistry::open(&test_root).unwrap();
     let watcher = CollectionWatchService::start(registry.clone());
-    let state = AgentState::new(registry, watcher, None);
+    let state = Arc::new(AgentState::new(registry, watcher, None));
 
     let response = state
         .execute(ControlRequest::new(ControlCommand::Status))
@@ -144,6 +144,104 @@ async fn bounds_local_control_request_memory() {
     );
     handler.await.unwrap().unwrap();
     fs::remove_dir_all(test_root).unwrap();
+}
+
+#[tokio::test]
+async fn local_collection_operations_share_admission_without_blocking_control() {
+    use crate::admission::{AdmissionRequest, WorkClass};
+
+    let test_root = std::env::temp_dir().join(format!(
+        "mdbase-connect-local-admission-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let registry = CollectionRegistry::open(test_root.join("state")).unwrap();
+    let collection = registry
+        .create(test_root.join("collection"), Some("Local admission"), "UTC")
+        .unwrap();
+    let watcher = CollectionWatchService::start(registry.clone());
+    let state = Arc::new(AgentState::new(registry, watcher, None));
+
+    let mut held_reads = Vec::new();
+    for principal in 1..=3 {
+        held_reads.push(
+            state
+                .admission()
+                .admit(AdmissionRequest {
+                    grant_id: Uuid::from_u128(principal),
+                    collection_id: collection.id,
+                    class: WorkClass::Foreground,
+                    weight_bytes: 1,
+                })
+                .await
+                .unwrap(),
+        );
+    }
+
+    let queued_state = state.clone();
+    let queued = tokio::spawn(async move {
+        queued_state
+            .execute(ControlRequest::new(ControlCommand::CollectionOperation(
+                mdbase_connect_protocol::CollectionOperationParams {
+                    collection_id: collection.id,
+                    operation: "query".to_string(),
+                    input: serde_json::json!({ "limit": 1 }),
+                },
+            )))
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !queued.is_finished(),
+        "a local read must wait behind the shared read limit"
+    );
+
+    let mutation = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        state.execute(ControlRequest::new(ControlCommand::CollectionOperation(
+            mdbase_connect_protocol::CollectionOperationParams {
+                collection_id: collection.id,
+                operation: "create".to_string(),
+                input: serde_json::json!({
+                    "path": "mutation-capacity.md",
+                    "frontmatter": { "title": "Reserved mutation capacity" },
+                    "body": "The queued local read did not consume this slot."
+                }),
+            },
+        ))),
+    )
+    .await
+    .expect("queued local reads must leave the mutation lane available");
+    assert!(mutation.ok, "{:?}", mutation.error);
+    assert_eq!(mutation.result.unwrap()["valid"], true);
+
+    let ping = tokio::time::timeout(
+        std::time::Duration::from_millis(250),
+        state.execute(ControlRequest::new(ControlCommand::Ping)),
+    )
+    .await
+    .expect("queued collection work must not block local control");
+    assert!(ping.ok);
+
+    drop(held_reads.pop());
+    let response = tokio::time::timeout(std::time::Duration::from_secs(2), queued)
+        .await
+        .expect("the admitted local query must finish")
+        .unwrap();
+    assert!(response.ok, "{:?}", response.error);
+
+    drop(held_reads);
+    fs::remove_dir_all(test_root).unwrap();
+}
+
+#[test]
+fn timeout_and_durable_mutation_use_one_atomic_boundary() {
+    let timeout_first = OperationExecutionState::default();
+    assert!(!timeout_first.begin_timeout());
+    assert!(!timeout_first.begin_durable_mutation());
+
+    let mutation_first = OperationExecutionState::default();
+    assert!(mutation_first.begin_durable_mutation());
+    assert!(mutation_first.begin_timeout());
 }
 
 #[tokio::test]

--- a/crates/connect-cli/src/lib.rs
+++ b/crates/connect-cli/src/lib.rs
@@ -404,7 +404,10 @@ enum CliAuthorityTarget {
     Remote,
 }
 
-#[tokio::main]
+// The daemon's collection concurrency is explicitly capped at four. Keep its
+// async I/O runtime independent of host core count as well, so large response
+// serialization cannot leave one allocator high-water arena per CPU worker.
+#[tokio::main(worker_threads = 4)]
 pub async fn run() -> i32 {
     let raw_arguments = std::env::args_os().collect::<Vec<_>>();
     let requested_json = raw_arguments

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -51,6 +51,7 @@ mod identity;
 mod migrations;
 mod mutation_journal;
 mod operation_execution;
+mod operation_setup;
 mod operations;
 mod receipts;
 mod scope;
@@ -71,8 +72,8 @@ pub use mutation_journal::{
     MutationLease, MutationRecoveryData,
 };
 use operation_execution::{
-    error_message, execute_loaded, execute_loaded_cancellable, has_contract,
-    operation_invalidation, supported_operations,
+    error_message, execute_loaded_cancellable, has_contract, operation_invalidation,
+    supported_operations,
 };
 pub use receipts::AuthorityReceiptDiagnostics;
 use scope::{

--- a/crates/connect-core/src/registry/file_transfers.rs
+++ b/crates/connect-core/src/registry/file_transfers.rs
@@ -19,7 +19,9 @@ use download::{download_staging_path, download_transfer_status, required_downloa
 mod routing;
 use routing::{transfer_direction, transfer_exists, upload_session};
 mod security;
-use security::{set_owner_only_directory, set_owner_only_file};
+use security::{
+    create_or_recover_private_staging_file, create_private_staging_file, set_owner_only_directory,
+};
 
 const STAGING_DIRECTORY: &str = ".mdbase/file-staging";
 const TRANSFER_LIFETIME_HOURS: i64 = 24;
@@ -444,7 +446,10 @@ impl CollectionRegistry {
         let staging_name = format!("{transfer_id}.part");
         let staging_root = ensure_staging_root(Path::new(&registered.path))?;
         let staging = staging_root.join(&staging_name);
-        create_private_staging_file(&staging)?;
+        // The staging file is durable before the transfer row is inserted. If
+        // the process stopped between those steps, exact replay must adopt the
+        // empty private file instead of failing forever on `create_new`.
+        let created_staging = create_or_recover_private_staging_file(&staging)?;
         let created_at = Utc::now();
         let expires_at = created_at + Duration::hours(TRANSFER_LIFETIME_HOURS);
         let (_, inferred_media_type) = classify_media(&request.path);
@@ -473,7 +478,16 @@ impl CollectionRegistry {
             ],
         );
         if let Err(error) = inserted {
-            let _ = remove_file_if_present(&staging);
+            // A concurrent exact open can win after both callers observe no
+            // row. Re-read before cleanup so the losing caller neither removes
+            // the winner's staging file nor turns an idempotent retry into an
+            // error.
+            if transfer_exists(&self.connection()?, transfer_id)? {
+                return self.create_upload_transfer(registered, owner_id, request);
+            }
+            if created_staging {
+                let _ = remove_file_if_present(&staging);
+            }
             return Err(error.into());
         }
         Ok(upload_session(
@@ -845,13 +859,6 @@ fn transfer_staging_path(root: &Path, transfer: &UploadTransfer) -> Result<PathB
         ));
     }
     Ok(ensure_staging_root(root)?.join(expected))
-}
-
-fn create_private_staging_file(path: &Path) -> Result<(), ConnectError> {
-    let file = OpenOptions::new().create_new(true).write(true).open(path)?;
-    set_owner_only_file(path)?;
-    file.sync_all()?;
-    sync_parent(path)
 }
 
 fn hash_exact_file(path: &Path, expected_size: u64) -> Result<String, ConnectError> {

--- a/crates/connect-core/src/registry/file_transfers/security.rs
+++ b/crates/connect-core/src/registry/file_transfers/security.rs
@@ -1,5 +1,41 @@
+use super::{file_error, open_verified_file, sync_parent, verify_open_path};
 use crate::ConnectError;
+use std::fs::OpenOptions;
 use std::path::Path;
+
+pub(super) fn create_or_recover_private_staging_file(path: &Path) -> Result<bool, ConnectError> {
+    match OpenOptions::new().create_new(true).write(true).open(path) {
+        Ok(file) => {
+            set_owner_only_file(path)?;
+            file.sync_all()?;
+            sync_parent(path)?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = std::fs::symlink_metadata(path)?;
+            if metadata.file_type().is_symlink() || !metadata.is_file() || metadata.len() != 0 {
+                return Err(file_error(
+                    "staging_file_invalid",
+                    "An orphan upload staging path is unsafe or contains data.",
+                ));
+            }
+            let file = open_verified_file(path, true)?;
+            set_owner_only_file(path)?;
+            file.sync_all()?;
+            verify_open_path(&file, path)?;
+            sync_parent(path)?;
+            Ok(false)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(super) fn create_private_staging_file(path: &Path) -> Result<(), ConnectError> {
+    let file = OpenOptions::new().create_new(true).write(true).open(path)?;
+    set_owner_only_file(path)?;
+    file.sync_all()?;
+    sync_parent(path)
+}
 
 #[cfg(unix)]
 pub(super) fn set_owner_only_directory(path: &Path) -> Result<(), ConnectError> {

--- a/crates/connect-core/src/registry/file_transfers/tests.rs
+++ b/crates/connect-core/src/registry/file_transfers/tests.rs
@@ -403,6 +403,37 @@ fn upload_open_is_idempotent_and_transfer_ownership_is_exact() {
 }
 
 #[test]
+fn upload_open_recovers_an_empty_orphan_staging_file() {
+    let (_state, root, registry, id) = registered();
+    let request = request("recovered.bin", b"recovered bytes");
+    let staging_root = ensure_staging_root(root.path()).unwrap();
+    let staging = staging_root.join(format!("{}.part", request.transfer_id));
+    fs::write(&staging, []).unwrap();
+
+    let session = registry.open_file_upload(id, owner(), &request).unwrap();
+
+    assert_eq!(session.transfer_id, request.transfer_id);
+    assert!(staging.is_file());
+    assert_eq!(fs::metadata(staging).unwrap().len(), 0);
+}
+
+#[test]
+fn upload_open_rejects_a_nonempty_orphan_staging_file() {
+    let (_state, root, registry, id) = registered();
+    let request = request("unsafe.bin", b"expected bytes");
+    let staging_root = ensure_staging_root(root.path()).unwrap();
+    let staging = staging_root.join(format!("{}.part", request.transfer_id));
+    fs::write(&staging, b"untrusted orphan bytes").unwrap();
+
+    let error = registry
+        .open_file_upload(id, owner(), &request)
+        .unwrap_err();
+
+    assert_eq!(error.code(), "staging_file_invalid");
+    assert_eq!(fs::read(staging).unwrap(), b"untrusted orphan bytes");
+}
+
+#[test]
 fn download_is_revision_pinned_resumable_and_snapshot_backed() {
     let (state, root, registry, id) = registered();
     let mut bytes = vec![0x52; DEFAULT_FILE_CHUNK_BYTES as usize];

--- a/crates/connect-core/src/registry/operation_execution.rs
+++ b/crates/connect-core/src/registry/operation_execution.rs
@@ -20,21 +20,6 @@ pub(super) fn has_contract(
     })
 }
 
-pub(super) fn execute_loaded(
-    collection: &Collection,
-    current_version: &str,
-    operation: &str,
-    input: &Value,
-) -> Result<Value, ConnectError> {
-    execute_loaded_cancellable(
-        collection,
-        current_version,
-        operation,
-        input,
-        &mdbase::OperationCancellation::new(),
-    )
-}
-
 pub(super) fn execute_loaded_cancellable(
     collection: &Collection,
     current_version: &str,
@@ -42,6 +27,9 @@ pub(super) fn execute_loaded_cancellable(
     input: &Value,
     cancellation: &mdbase::OperationCancellation,
 ) -> Result<Value, ConnectError> {
+    cancellation
+        .check()
+        .map_err(|_| ConnectError::OperationCancelled)?;
     if collection.spec_profile() == SpecProfile::V03 {
         if operation == "assess_collection_setup" || operation == "apply_collection_setup" {
             let result = if operation == "assess_collection_setup" {
@@ -69,6 +57,9 @@ pub(super) fn execute_loaded_cancellable(
                     },
                 )
             };
+            cancellation
+                .check()
+                .map_err(|_| ConnectError::OperationCancelled)?;
             return serde_json::to_value(result).map_err(ConnectError::from);
         }
         if operation == "assess_type_pack" || operation == "apply_type_pack" {
@@ -156,6 +147,9 @@ pub(super) fn execute_loaded_cancellable(
                     },
                 ),
             };
+            cancellation
+                .check()
+                .map_err(|_| ConnectError::OperationCancelled)?;
             return serde_json::to_value(result).map_err(ConnectError::from);
         }
         let operations = collection
@@ -184,6 +178,9 @@ pub(super) fn execute_loaded_cancellable(
             "update_type" => operations.update_type(input),
             other => return Err(ConnectError::UnsupportedOperation(other.to_string())),
         };
+        cancellation
+            .check()
+            .map_err(|_| ConnectError::OperationCancelled)?;
         return serde_json::to_value(result).map_err(ConnectError::from);
     }
 
@@ -205,6 +202,9 @@ pub(super) fn execute_loaded_cancellable(
         }
         other => return Err(ConnectError::UnsupportedOperation(other.to_string())),
     };
+    cancellation
+        .check()
+        .map_err(|_| ConnectError::OperationCancelled)?;
     Ok(result)
 }
 

--- a/crates/connect-core/src/registry/operation_setup.rs
+++ b/crates/connect-core/src/registry/operation_setup.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+pub(super) fn add_reviewable_setup_adoptions(
+    setup: &mut mdbase::v03::CollectionSetup,
+    result: &mdbase::v03::OperationResult,
+) -> bool {
+    let adoptions = mdbase_connect_protocol::reviewable_type_pack_adoptions(&result.result);
+    let mut changed = false;
+    for (pack_id, resources) in adoptions {
+        let Some(pack) = setup
+            .provisions
+            .type_packs
+            .iter_mut()
+            .find(|pack| pack.provision.manifest["id"].as_str() == Some(pack_id.as_str()))
+        else {
+            continue;
+        };
+        for (target, current_digest) in resources {
+            changed |= pack
+                .options
+                .adopt_resources
+                .insert(target, current_digest.clone())
+                .as_deref()
+                != Some(current_digest.as_str());
+        }
+    }
+    changed
+}
+
+pub(super) fn type_pack_setup_error(result: &mdbase::v03::OperationResult) -> ConnectError {
+    let message = result
+        .diagnostics
+        .first()
+        .map(|diagnostic| diagnostic.message.clone())
+        .or_else(|| {
+            result.result["resources"]
+                .as_array()
+                .and_then(|resources| {
+                    resources
+                        .iter()
+                        .find(|resource| resource["action"] == "conflict")
+                })
+                .and_then(|resource| resource["reason"].as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "Contract setup was rejected.".to_string());
+    let mut diagnostics = result
+        .diagnostics
+        .iter()
+        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
+        .collect::<Vec<_>>();
+    if diagnostics.is_empty() {
+        diagnostics.push(json!({
+            "code": "collection_setup_conflict",
+            "severity": "error",
+            "message": message,
+        }));
+    }
+    ConnectError::ApplicationSetupRejected {
+        message,
+        diagnostics,
+    }
+}
+
+pub(super) fn required_setup_string(result: &Value, key: &str) -> Result<String, ConnectError> {
+    result[key].as_str().map(str::to_string).ok_or_else(|| {
+        ConnectError::InvalidInput(format!("Collection setup assessment returned no {key}."))
+    })
+}

--- a/crates/connect-core/src/registry/operations.rs
+++ b/crates/connect-core/src/registry/operations.rs
@@ -1,3 +1,6 @@
+use super::operation_setup::{
+    add_reviewable_setup_adoptions, required_setup_string, type_pack_setup_error,
+};
 use super::*;
 use std::collections::BTreeMap;
 impl CollectionRegistry {
@@ -21,6 +24,23 @@ impl CollectionRegistry {
         input: &Value,
         synchronize: impl FnOnce(&CollectionInvalidation),
     ) -> Result<Value, ConnectError> {
+        self.operation_synchronized_cancellable(
+            id,
+            operation,
+            input,
+            &mdbase::OperationCancellation::new(),
+            synchronize,
+        )
+    }
+
+    pub fn operation_synchronized_cancellable(
+        &self,
+        id: Uuid,
+        operation: &str,
+        input: &Value,
+        cancellation: &mdbase::OperationCancellation,
+        synchronize: impl FnOnce(&CollectionInvalidation),
+    ) -> Result<Value, ConnectError> {
         let registered = self.get(id)?;
         assert_local_authority_folder(Path::new(&registered.path))?;
         if operation == "changes" {
@@ -34,7 +54,13 @@ impl CollectionRegistry {
                 return serde_json::to_value(self.describe_loaded(&registered, collection)?)
                     .map_err(ConnectError::from);
             }
-            execute_loaded(collection, &registered.spec_version, operation, input)
+            execute_loaded_cancellable(
+                collection,
+                &registered.spec_version,
+                operation,
+                input,
+                cancellation,
+            )
         };
         let result = if operation == "batch" || is_mutating_operation(operation, input) {
             provider.with_collection(|collection| {
@@ -395,8 +421,27 @@ impl CollectionRegistry {
         &self,
         id: Uuid,
         input: &Value,
+        replica: crate::LocalReplica,
+        scope: &GrantScope,
+        synchronize: impl FnOnce(&CollectionInvalidation),
+    ) -> Result<Value, ConnectError> {
+        self.sync_operation_synchronized_cancellable(
+            id,
+            input,
+            replica,
+            scope,
+            &mdbase::OperationCancellation::new(),
+            synchronize,
+        )
+    }
+
+    pub fn sync_operation_synchronized_cancellable(
+        &self,
+        id: Uuid,
+        input: &Value,
         mut replica: crate::LocalReplica,
         scope: &GrantScope,
+        cancellation: &mdbase::OperationCancellation,
         synchronize: impl FnOnce(&CollectionInvalidation),
     ) -> Result<Value, ConnectError> {
         if scope.access == mdbase_connect_protocol::ApplicationAccess::Contract {
@@ -417,14 +462,23 @@ impl CollectionRegistry {
         let provider = self.provider_for(&registered)?;
         let store = crate::LocalSyncStore::for_registry(self);
         let execute = |collection: &Collection| -> Result<Value, ConnectError> {
+            cancellation
+                .check()
+                .map_err(|_| ConnectError::OperationCancelled)?;
             store.assert_authority_available(id)?;
             replica.allowed_types = self
                 .resolve_scope_types_loaded(&registered, collection, scope)?
                 .unwrap_or_default();
             let snapshot = collection.snapshot()?;
+            cancellation
+                .check()
+                .map_err(|_| ConnectError::OperationCancelled)?;
             store.reconcile(id, &snapshot, &HashMap::new())?;
             let files = self.reconcile_files_loaded(&registered, collection, &snapshot)?;
-            match action {
+            cancellation
+                .check()
+                .map_err(|_| ConnectError::OperationCancelled)?;
+            let result = match action {
                 "open_session" => {
                     let description = self.describe_loaded(&registered, collection)?;
                     let resources = sync_resources(&snapshot, description, &replica.allowed_types);
@@ -520,7 +574,13 @@ impl CollectionRegistry {
                 other => Err(ConnectError::AccessDenied(format!(
                     "Unsupported sync action: {other}"
                 ))),
+            };
+            if result.is_ok() {
+                cancellation
+                    .check()
+                    .map_err(|_| ConnectError::OperationCancelled)?;
             }
+            result
         };
         if action == "mutate" {
             provider.with_collection(execute)
@@ -607,7 +667,13 @@ impl CollectionRegistry {
                 let (input, selector) = resolved_scope
                     .read_input(input)
                     .map_err(contract_scope_error)?;
-                let result = execute_loaded(collection, &registered.spec_version, operation, &input)?;
+                let result = execute_loaded_cancellable(
+                    collection,
+                    &registered.spec_version,
+                    operation,
+                    &input,
+                    cancellation,
+                )?;
                 ensure_result_in_scope(&result, allowed_types)?;
                 resolved_scope
                     .project_result(collection, result, selector.as_ref())
@@ -632,7 +698,13 @@ impl CollectionRegistry {
                     &BTreeSet::new(),
                     allowed_types,
                 )?;
-                let result = execute_loaded(collection, &registered.spec_version, operation, &input)?;
+                let result = execute_loaded_cancellable(
+                    collection,
+                    &registered.spec_version,
+                    operation,
+                    &input,
+                    cancellation,
+                )?;
                 if result.get("valid").and_then(Value::as_bool) != Some(false) {
                     ensure_result_in_scope(&result, allowed_types)?;
                 }
@@ -645,11 +717,12 @@ impl CollectionRegistry {
                     .map_write_input(input, false)
                     .map_err(contract_scope_error)?;
                 let path = required_string(&input, "path")?;
-                let current = execute_loaded(
+                let current = execute_loaded_cancellable(
                     collection,
                     &registered.spec_version,
                     "read",
                     &json!({ "path": path }),
+                    cancellation,
                 )?;
                 ensure_result_in_scope(&current, allowed_types)?;
                 let current_types = result_types(&current);
@@ -675,7 +748,13 @@ impl CollectionRegistry {
                     &current_types,
                     allowed_types,
                 )?;
-                let result = execute_loaded(collection, &registered.spec_version, operation, &input)?;
+                let result = execute_loaded_cancellable(
+                    collection,
+                    &registered.spec_version,
+                    operation,
+                    &input,
+                    cancellation,
+                )?;
                 resolved_scope
                     .project_result(collection, result, Some(&selector))
                     .map_err(contract_scope_error)
@@ -685,11 +764,12 @@ impl CollectionRegistry {
                     .identity_input(input)
                     .map_err(contract_scope_error)?;
                 let path = required_string(&scoped_input, "path")?;
-                let current = execute_loaded(
+                let current = execute_loaded_cancellable(
                     collection,
                     &registered.spec_version,
                     "read",
                     &json!({ "path": path }),
+                    cancellation,
                 )?;
                 ensure_result_in_scope(&current, allowed_types)?;
                 resolved_scope
@@ -699,11 +779,12 @@ impl CollectionRegistry {
                 if let Some(object) = scoped_input.as_object_mut() {
                     object.insert("check_backlinks".to_string(), Value::Bool(false));
                 }
-                execute_loaded(
+                execute_loaded_cancellable(
                     collection,
                     &registered.spec_version,
                     operation,
                     &scoped_input,
+                    cancellation,
                 )
             }
             "rename" => {
@@ -718,11 +799,12 @@ impl CollectionRegistry {
                             .to_string(),
                     ));
                 }
-                let current = execute_loaded(
+                let current = execute_loaded_cancellable(
                     collection,
                     &registered.spec_version,
                     "read",
                     &json!({ "path": from }),
+                    cancellation,
                 )?;
                 ensure_result_in_scope(&current, allowed_types)?;
                 resolved_scope
@@ -740,11 +822,12 @@ impl CollectionRegistry {
                     &current_types,
                     allowed_types,
                 )?;
-                let result = execute_loaded(
+                let result = execute_loaded_cancellable(
                     collection,
                     &registered.spec_version,
                     operation,
                     &scoped_input,
+                    cancellation,
                 )?;
                 resolved_scope
                     .project_result(collection, result, selector.as_ref())
@@ -864,72 +947,4 @@ impl CollectionRegistry {
         debug_assert_eq!(resolved.allowed_types, allowed_types);
         Ok(Some(resolved))
     }
-}
-
-fn add_reviewable_setup_adoptions(
-    setup: &mut mdbase::v03::CollectionSetup,
-    result: &mdbase::v03::OperationResult,
-) -> bool {
-    let adoptions = mdbase_connect_protocol::reviewable_type_pack_adoptions(&result.result);
-    let mut changed = false;
-    for (pack_id, resources) in adoptions {
-        let Some(pack) = setup
-            .provisions
-            .type_packs
-            .iter_mut()
-            .find(|pack| pack.provision.manifest["id"].as_str() == Some(pack_id.as_str()))
-        else {
-            continue;
-        };
-        for (target, current_digest) in resources {
-            changed |= pack
-                .options
-                .adopt_resources
-                .insert(target, current_digest.clone())
-                .as_deref()
-                != Some(current_digest.as_str());
-        }
-    }
-    changed
-}
-
-fn type_pack_setup_error(result: &mdbase::v03::OperationResult) -> ConnectError {
-    let message = result
-        .diagnostics
-        .first()
-        .map(|diagnostic| diagnostic.message.clone())
-        .or_else(|| {
-            result.result["resources"]
-                .as_array()
-                .and_then(|resources| {
-                    resources
-                        .iter()
-                        .find(|resource| resource["action"] == "conflict")
-                })
-                .and_then(|resource| resource["reason"].as_str())
-                .map(str::to_string)
-        })
-        .unwrap_or_else(|| "Contract setup was rejected.".to_string());
-    let mut diagnostics = result
-        .diagnostics
-        .iter()
-        .filter_map(|diagnostic| serde_json::to_value(diagnostic).ok())
-        .collect::<Vec<_>>();
-    if diagnostics.is_empty() {
-        diagnostics.push(json!({
-            "code": "collection_setup_conflict",
-            "severity": "error",
-            "message": message,
-        }));
-    }
-    ConnectError::ApplicationSetupRejected {
-        message,
-        diagnostics,
-    }
-}
-
-fn required_setup_string(result: &Value, key: &str) -> Result<String, ConnectError> {
-    result[key].as_str().map(str::to_string).ok_or_else(|| {
-        ConnectError::InvalidInput(format!("Collection setup assessment returned no {key}."))
-    })
 }

--- a/crates/connect-core/src/registry/tests/file_sync.rs
+++ b/crates/connect-core/src/registry/tests/file_sync.rs
@@ -19,6 +19,35 @@ fn sync(
 }
 
 #[test]
+fn cancelled_sync_reads_stop_before_snapshot_work() {
+    let state = tempdir().unwrap();
+    let root = tempdir().unwrap();
+    fs::write(root.path().join("mdbase.yaml"), "spec_version: 0.3.0\n").unwrap();
+    let registry = CollectionRegistry::open(state.path()).unwrap();
+    let collection = registry.add(root.path()).unwrap();
+    let replica = crate::LocalReplica {
+        id: Uuid::new_v4(),
+        name: "Cancelled mirror".to_string(),
+        mode: mdbase_connect_protocol::SyncReplicaMode::ReadOnly,
+        allowed_types: BTreeSet::new(),
+    };
+    let cancellation = mdbase::OperationCancellation::new();
+    cancellation.cancel();
+
+    assert!(matches!(
+        registry.sync_operation_synchronized_cancellable(
+            collection.id,
+            &json!({"action": "open_session"}),
+            replica,
+            &GrantScope::full_collection(),
+            &cancellation,
+            |_| {},
+        ),
+        Err(ConnectError::OperationCancelled)
+    ));
+}
+
+#[test]
 fn file_snapshots_and_changes_share_the_record_cursor() {
     let state = tempdir().unwrap();
     let root = tempdir().unwrap();

--- a/crates/connect-core/src/registry/tests/operations.rs
+++ b/crates/connect-core/src/registry/tests/operations.rs
@@ -108,6 +108,29 @@ fn generic_operation_uses_v03_envelope() {
 }
 
 #[test]
+fn cancelled_unscoped_reads_stop_before_collection_execution() {
+    let state = tempdir().unwrap();
+    let collection_parent = tempdir().unwrap();
+    let registry = CollectionRegistry::open(state.path()).unwrap();
+    let collection = registry
+        .create(collection_parent.path().join("notes"), Some("Notes"), "UTC")
+        .unwrap();
+    let cancellation = mdbase::OperationCancellation::new();
+    cancellation.cancel();
+
+    assert!(matches!(
+        registry.operation_synchronized_cancellable(
+            collection.id,
+            "query",
+            &json!({"limit": 1}),
+            &cancellation,
+            |_| {},
+        ),
+        Err(ConnectError::OperationCancelled)
+    ));
+}
+
+#[test]
 fn legacy_description_only_advertises_executable_operations() {
     let state = tempdir().unwrap();
     let collection_parent = tempdir().unwrap();

--- a/crates/connect-protocol/src/compatibility.rs
+++ b/crates/connect-protocol/src/compatibility.rs
@@ -164,7 +164,7 @@ impl ConnectContractRequirements {
                 ));
             }
         }
-        if crate::is_mutating_operation(operation, input) {
+        if operation == "batch" || crate::is_mutating_operation(operation, input) {
             let required = self.durable_mutation;
             if required.is_none_or(|version| !supported.durable_mutation.contains(&version)) {
                 return Some(contract_problem(
@@ -188,7 +188,8 @@ pub fn authorization_requires_durable_mutation(
     operations.iter().any(|operation| {
         matches!(
             operation.as_str(),
-            "create_view_source"
+            "batch"
+                | "create_view_source"
                 | "update_view_source"
                 | "delete_view_source"
                 | "create"
@@ -259,14 +260,16 @@ mod tests {
     #[test]
     fn mutations_fail_not_sent_without_durable_mutation_support() {
         let requirements = ConnectContractRequirements::current(false);
-        let problem = requirements
-            .mismatch_problem("create", &serde_json::json!({}), "connector")
-            .expect("mutation must require durable recovery");
-        assert_eq!(problem.code, "durable_mutation_unsupported");
-        assert_eq!(
-            problem.operation_outcome,
-            Some(ConnectOperationOutcome::NotSent)
-        );
+        for operation in ["create", "batch"] {
+            let problem = requirements
+                .mismatch_problem(operation, &serde_json::json!({}), "connector")
+                .expect("mutation must require durable recovery");
+            assert_eq!(problem.code, "durable_mutation_unsupported");
+            assert_eq!(
+                problem.operation_outcome,
+                Some(ConnectOperationOutcome::NotSent)
+            );
+        }
     }
 
     #[test]

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.63"
+version = "0.1.0-beta.64"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.63" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.64" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.63",
+  "version": "0.1.0-beta.64",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -121,7 +121,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.63",
+        version: "0.1.0-beta.64",
         capabilities: [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES],
         contract_support: CONNECT_CONTRACT_SUPPORT
       },


### PR DESCRIPTION
## Summary

- release the verified containment as `0.1.0-beta.64`
- route local collection work through bounded admission with two stable read workers, foreground/background priority, reserved mutation capacity, and per-grant/per-collection limits
- hold read permits through relay, loopback, and local-control response delivery so large serialized bodies remain bounded
- cancel expired reads between bounded phases while preserving durable mutation completion
- make timeout versus durable-mutation entry one atomic boundary: timeout-winning requests are provably `not_sent`; durable-boundary winners recover by exact request replay
- avoid whole-collection authority snapshots for idempotent transfer-session open/abort housekeeping while retaining manifest evidence for collection-changing file mutations
- recover an empty orphan upload staging file after the fsync/row-insert crash window, while rejecting unsafe or non-empty orphans
- bound scheduler identity maps and fail legacy remote mutations closed without the durable mutation protocol axis

This is the scale-safe containment boundary around the current synchronous collection engine. Replay-blob isolation, binary object transport, and the separately recorded per-collection runtime remain explicit follow-up architecture work.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (including 127 core and 66 daemon tests)
- `pnpm version:check`
- `pnpm check:release-readiness`
- `pnpm check:architecture`
- `pnpm check:operations`
- `pnpm check:problems`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- Server CI: 9/9 pass, including previous-release upgrade/OAuth, prior-provider recovery, hosted provider, interoperability, and Linux/macOS/Windows durability
- Desktop release PR matrix: all Linux, macOS Intel/Apple Silicon, Windows, Windows Store, and release regression smokes pass
- same-profile beta63→beta64 reopen: all SQLite integrity checks remain `ok`; both collection IDs, 22-grant contract split, migration ledgers, and mutation-journal counts remain exact
- deployed Reader: 2,834 items loaded twice and an existing note opened
- 45,709,415-byte relayed EPUB: 44/44 ranges returned HTTP 200 and the deployed Editor reached SDK completion/digest verification
- binary staging RSS: 178,196 KiB cold, 433,688 KiB peak, 363,472 KiB after 30 seconds idle; no daemon WARN/ERROR/deadline lines
- contention: 16/16 full-body Reader queries returned 1,507 records, 20/20 health probes passed, and a dry-run mutation completed in 108 ms while eight reads were in flight; 465,904 KiB high-water, below 512 MiB

Production is intentionally untouched. The next release steps are exact-main image publication, beta64 tagging, SDK consumer staging updates, exact staging deployment, and the remaining fresh live matrix.