### PR TITLE
Bound hosted mirror synchronization

### DIFF
--- a/crates/connect-agent/src/mirrors.rs
+++ b/crates/connect-agent/src/mirrors.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
+use std::future::Future;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, RwLock};
@@ -27,6 +28,8 @@ use tokio::time::Instant;
 use uuid::Uuid;
 
 const SYNC_INTERVAL: Duration = Duration::from_secs(5);
+const MIRROR_SYNC_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const MIRROR_SLOW_OPERATION_WARNING: Duration = Duration::from_secs(60);
 const MAX_BACKGROUND_BACKOFF: Duration = Duration::from_secs(5 * 60);
 const TOKEN_RENEWAL_WINDOW_SECONDS: i64 = 24 * 60 * 60;
 
@@ -153,7 +156,7 @@ pub struct MirrorManager {
     secrets: SystemSecretStore,
     credential_store_error: Option<String>,
     entries: RwLock<Vec<MirrorRegistryEntry>>,
-    syncing: StdMutex<HashSet<Uuid>>,
+    syncing: StdMutex<HashMap<Uuid, MirrorOperationState>>,
     operation_finished: Notify,
     errors: RwLock<HashMap<Uuid, String>>,
 }

--- a/crates/connect-agent/src/mirrors/runtime.rs
+++ b/crates/connect-agent/src/mirrors/runtime.rs
@@ -28,7 +28,7 @@ impl MirrorManager {
             secrets: SystemSecretStore::new(state_dir),
             credential_store_error,
             entries: RwLock::new(entries),
-            syncing: StdMutex::new(HashSet::new()),
+            syncing: StdMutex::new(HashMap::new()),
             operation_finished: Notify::new(),
             errors: RwLock::new(HashMap::new()),
         }))
@@ -47,6 +47,7 @@ impl MirrorManager {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
+                        manager.warn_slow_operations();
                         let entries = manager.entries();
                         let actionable = entries
                             .iter()

--- a/crates/connect-agent/src/mirrors/support.rs
+++ b/crates/connect-agent/src/mirrors/support.rs
@@ -1,8 +1,14 @@
 use super::*;
 
+pub(super) struct MirrorOperationState {
+    pub(super) kind: &'static str,
+    pub(super) started_at: Instant,
+    pub(super) warned_slow: bool,
+}
+
 pub(super) struct MirrorOperationGuard<'a> {
     pub(super) replica_id: Uuid,
-    pub(super) syncing: &'a StdMutex<HashSet<Uuid>>,
+    pub(super) syncing: &'a StdMutex<HashMap<Uuid, MirrorOperationState>>,
     pub(super) operation_finished: &'a Notify,
 }
 
@@ -22,12 +28,37 @@ impl Default for BackgroundRetry {
 
 impl Drop for MirrorOperationGuard<'_> {
     fn drop(&mut self) {
-        self.syncing
+        let state = self
+            .syncing
             .lock()
             .expect("mirror sync lock poisoned")
             .remove(&self.replica_id);
+        if let Some(state) = state {
+            tracing::debug!(
+                replica_id = %self.replica_id,
+                operation = state.kind,
+                elapsed_ms = u64::try_from(state.started_at.elapsed().as_millis())
+                    .unwrap_or(u64::MAX),
+                "hosted mirror operation finished"
+            );
+        }
         self.operation_finished.notify_one();
     }
+}
+
+pub(super) async fn with_mirror_operation_timeout<T, F>(
+    timeout: Duration,
+    operation: F,
+) -> Result<T, ConnectError>
+where
+    F: Future<Output = Result<T, ConnectError>>,
+{
+    tokio::time::timeout(timeout, operation).await.map_err(|_| {
+        mirror_error(
+            "mirror_sync_timeout",
+            "Hosted mirror synchronization exceeded its bounded operation deadline and will resume from its durable checkpoint.",
+        )
+    })?
 }
 
 pub(super) fn read_registry(path: &Path) -> Result<Vec<MirrorRegistryEntry>, ConnectError> {

--- a/crates/connect-agent/src/mirrors/synchronization.rs
+++ b/crates/connect-agent/src/mirrors/synchronization.rs
@@ -36,7 +36,7 @@ impl MirrorManager {
             .syncing
             .lock()
             .expect("mirror sync lock poisoned")
-            .contains(&entry.replica_id);
+            .contains_key(&entry.replica_id);
         Ok(MirrorSummary {
             collection_id: entry.collection_id,
             replica_id: entry.replica_id,
@@ -77,7 +77,7 @@ impl MirrorManager {
         entry: MirrorRegistryEntry,
         skip_if_busy: bool,
     ) -> Result<(), ConnectError> {
-        let _guard = self.begin_operation(entry.replica_id, skip_if_busy)?;
+        let _guard = self.begin_operation_named(entry.replica_id, skip_if_busy, "sync")?;
         self.sync_entry_exclusive(entry).await
     }
 
@@ -85,10 +85,16 @@ impl MirrorManager {
         &self,
         entry: MirrorRegistryEntry,
     ) -> Result<(), ConnectError> {
-        let result = async {
+        let started_at = Instant::now();
+        tracing::debug!(
+            replica_id = %entry.replica_id,
+            timeout_seconds = MIRROR_SYNC_TIMEOUT.as_secs(),
+            "hosted mirror synchronization started"
+        );
+        let result = with_mirror_operation_timeout(MIRROR_SYNC_TIMEOUT, async {
             let mirror = self.mirror(&entry).await?;
             mirror.sync().await.map_err(from_mirror)
-        }
+        })
         .await;
         match &result {
             Ok(()) => {
@@ -104,6 +110,19 @@ impl MirrorManager {
                     .insert(entry.replica_id, error.to_string());
             }
         }
+        match &result {
+            Ok(()) => tracing::debug!(
+                replica_id = %entry.replica_id,
+                elapsed_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "hosted mirror synchronization completed"
+            ),
+            Err(error) => tracing::warn!(
+                replica_id = %entry.replica_id,
+                code = error.code(),
+                elapsed_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "hosted mirror synchronization stopped"
+            ),
+        }
         result
     }
 
@@ -112,8 +131,17 @@ impl MirrorManager {
         replica_id: Uuid,
         skip_if_busy: bool,
     ) -> Result<MirrorOperationGuard<'_>, ConnectError> {
+        self.begin_operation_named(replica_id, skip_if_busy, "exclusive")
+    }
+
+    pub(super) fn begin_operation_named(
+        &self,
+        replica_id: Uuid,
+        skip_if_busy: bool,
+        kind: &'static str,
+    ) -> Result<MirrorOperationGuard<'_>, ConnectError> {
         let mut syncing = self.syncing.lock().expect("mirror sync lock poisoned");
-        if !syncing.insert(replica_id) {
+        if syncing.contains_key(&replica_id) {
             return Err(mirror_error(
                 if skip_if_busy {
                     "mirror_sync_skipped"
@@ -123,11 +151,40 @@ impl MirrorManager {
                 "This mirror is already synchronizing.",
             ));
         }
+        syncing.insert(
+            replica_id,
+            MirrorOperationState {
+                kind,
+                started_at: Instant::now(),
+                warned_slow: false,
+            },
+        );
+        tracing::debug!(
+            replica_id = %replica_id,
+            operation = kind,
+            "hosted mirror operation started"
+        );
         Ok(MirrorOperationGuard {
             replica_id,
             syncing: &self.syncing,
             operation_finished: &self.operation_finished,
         })
+    }
+
+    pub(super) fn warn_slow_operations(&self) {
+        let mut syncing = self.syncing.lock().expect("mirror sync lock poisoned");
+        for (replica_id, state) in syncing.iter_mut() {
+            let elapsed = state.started_at.elapsed();
+            if !state.warned_slow && elapsed >= MIRROR_SLOW_OPERATION_WARNING {
+                state.warned_slow = true;
+                tracing::warn!(
+                    replica_id = %replica_id,
+                    operation = state.kind,
+                    elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                    "hosted mirror operation is still active"
+                );
+            }
+        }
     }
 
     pub(super) async fn begin_operation_waiting(

--- a/crates/connect-agent/src/mirrors/tests.rs
+++ b/crates/connect-agent/src/mirrors/tests.rs
@@ -137,3 +137,55 @@ fn unavailable_mirror_summary_is_structured_and_local_to_one_replica() {
     );
     assert_eq!(summary.pending, 0);
 }
+
+#[tokio::test]
+async fn aborting_an_operation_releases_the_mirror_guard() {
+    let temporary = tempfile::tempdir().unwrap();
+    let registry = CollectionRegistry::open(temporary.path()).unwrap();
+    let manager = MirrorManager::open(temporary.path(), registry, None, None).unwrap();
+    let replica_id = Uuid::new_v4();
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let running = manager.clone();
+    let task = tokio::spawn(async move {
+        let _guard = running
+            .begin_operation_named(replica_id, false, "abort-test")
+            .unwrap();
+        started_tx.send(()).unwrap();
+        std::future::pending::<()>().await;
+    });
+
+    started_rx.await.unwrap();
+    assert_eq!(
+        manager
+            .begin_operation(replica_id, false)
+            .err()
+            .unwrap()
+            .code(),
+        "mirror_busy"
+    );
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+
+    let _replacement = manager.begin_operation(replica_id, false).unwrap();
+}
+
+#[tokio::test]
+async fn timed_out_sync_future_releases_the_mirror_guard() {
+    let temporary = tempfile::tempdir().unwrap();
+    let registry = CollectionRegistry::open(temporary.path()).unwrap();
+    let manager = MirrorManager::open(temporary.path(), registry, None, None).unwrap();
+    let replica_id = Uuid::new_v4();
+
+    let result = async {
+        let _guard = manager.begin_operation_named(replica_id, false, "timeout-test")?;
+        with_mirror_operation_timeout(
+            Duration::from_millis(10),
+            std::future::pending::<Result<(), ConnectError>>(),
+        )
+        .await
+    }
+    .await;
+    assert_eq!(result.unwrap_err().code(), "mirror_sync_timeout");
+
+    let _replacement = manager.begin_operation(replica_id, false).unwrap();
+}

--- a/crates/connect-mirror/src/transport.rs
+++ b/crates/connect-mirror/src/transport.rs
@@ -1,4 +1,8 @@
 use super::*;
+use std::time::Duration;
+
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+const HTTP_READ_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 #[async_trait]
 pub trait SyncTransport: Send + Sync {
@@ -48,6 +52,20 @@ fn ensure_tls_crypto_provider() {
 
 impl HttpSyncTransport {
     pub fn new(sync_url: &str, replica_token: impl Into<String>) -> Result<Self, MirrorError> {
+        Self::new_with_timeouts(
+            sync_url,
+            replica_token,
+            HTTP_CONNECT_TIMEOUT,
+            HTTP_READ_TIMEOUT,
+        )
+    }
+
+    fn new_with_timeouts(
+        sync_url: &str,
+        replica_token: impl Into<String>,
+        connect_timeout: Duration,
+        read_timeout: Duration,
+    ) -> Result<Self, MirrorError> {
         ensure_tls_crypto_provider();
         let endpoint = Url::parse(sync_url).map_err(|_| {
             MirrorError::new(
@@ -93,6 +111,8 @@ impl HttpSyncTransport {
             + "/files";
         let client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(connect_timeout)
+            .read_timeout(read_timeout)
             .build()
             .map_err(|error| {
                 MirrorError::new(
@@ -132,16 +152,14 @@ impl HttpSyncTransport {
             request = request.json(body);
         }
         let response = request.send().await.map_err(|error| {
-            MirrorError::new(
-                "mirror_offline",
-                format!("Hosted authority is unavailable: {error}"),
-            )
+            transport_error(error, "mirror_offline", "Hosted authority is unavailable")
         })?;
         let status = response.status();
         let value = response.json::<Value>().await.map_err(|error| {
-            MirrorError::new(
+            transport_error(
+                error,
                 "invalid_sync_response",
-                format!("Hosted authority returned invalid JSON: {error}"),
+                "Hosted authority returned invalid JSON",
             )
         })?;
         if !status.is_success() {
@@ -182,6 +200,17 @@ impl HttpSyncTransport {
             )
             .await;
     }
+}
+
+fn transport_error(error: reqwest::Error, fallback_code: &str, context: &str) -> MirrorError {
+    MirrorError::new(
+        if error.is_timeout() {
+            "mirror_transport_timeout"
+        } else {
+            fallback_code
+        },
+        format!("{context}: {error}"),
+    )
 }
 
 #[async_trait]
@@ -422,10 +451,7 @@ impl HttpSyncTransport {
                 upload = upload.header(&name, &value);
             }
             let response = upload.send().await.map_err(|error| {
-                MirrorError::new(
-                    "file_upload_failed",
-                    format!("Object upload failed: {error}"),
-                )
+                transport_error(error, "file_upload_failed", "Object upload failed")
             })?;
             if !response.status().is_success() {
                 return Err(MirrorError::new(
@@ -534,10 +560,7 @@ impl HttpSyncTransport {
                 .send()
                 .await
                 .map_err(|error| {
-                    MirrorError::new(
-                        "mirror_offline",
-                        format!("Hosted authority is unavailable: {error}"),
-                    )
+                    transport_error(error, "mirror_offline", "Hosted authority is unavailable")
                 })?;
             if !response.status().is_success() {
                 let status = response.status();
@@ -565,9 +588,10 @@ impl HttpSyncTransport {
             }
             let mut received = 0_u64;
             while let Some(bytes) = response.chunk().await.map_err(|error| {
-                MirrorError::new(
+                transport_error(
+                    error,
                     "file_download_failed",
-                    format!("Could not read the hosted file response: {error}"),
+                    "Could not read the hosted file response",
                 )
             })? {
                 received = received.checked_add(bytes.len() as u64).ok_or_else(|| {
@@ -860,5 +884,31 @@ mod tests {
                 "invalid_sync_url"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn stalled_authority_request_returns_a_typed_transport_timeout() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let authority_id = Uuid::new_v4();
+        let transport = HttpSyncTransport::new_with_timeouts(
+            &format!("http://{address}/v1/authorities/{authority_id}/sync"),
+            "token",
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+        )
+        .unwrap();
+
+        let error = tokio::time::timeout(Duration::from_secs(2), transport.open_session())
+            .await
+            .expect("the transport must enforce its own shorter timeout")
+            .unwrap_err();
+        assert_eq!(error.code, "mirror_transport_timeout");
+        server.abort();
+        assert!(server.await.unwrap_err().is_cancelled());
     }
 }


### PR DESCRIPTION
## Summary

- bound hosted sync transport connection and read waits
- bound an entire mirror synchronization attempt while preserving resumable journal state
- retain active-operation kind/start metadata and emit one privacy-safe warning for a genuinely long-running operation
- return typed `mirror_transport_timeout` and `mirror_sync_timeout` outcomes

This fixes the staging failure mode where a mirror could remain `syncing=true` indefinitely and reject manual recovery with `mirror_busy` until the daemon restarted.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p mdbase-connect-daemon -p mdbase-connect --all-targets -- -D warnings`
- `cargo test -p mdbase-connect-daemon -p mdbase-connect` (129 passed)
- `cargo test --workspace`
- `fnm exec --using v24.13.0 pnpm typecheck`
- `fnm exec --using v24.13.0 pnpm test`
- `fnm exec --using v24.13.0 pnpm e2e`

The new non-responsive loopback-server test proves the transport deadline and RAII guard cleanup. Staging live hosted/binary/restart tests will be repeated after this is released as the next prerelease; production is intentionally out of scope.