### PR TITLE
Define coordinated local collection runtime execution contract

### DIFF
--- a/.ops/tasks/Coordinated local collection runtime simplification.md
+++ b/.ops/tasks/Coordinated local collection runtime simplification.md
@@ -1,8 +1,8 @@
 ---
 title: Coordinated local collection runtime simplification
-status: planned
+status: in_progress
 priority: high
-owner: unassigned
+owner: codex
 tags:
   - architecture
   - mdbase-rs
@@ -15,7 +15,7 @@ tags:
   - caching
   - observability
 created_at: 2026-08-11T18:24:43+10:00
-updated_at: 2026-08-11T18:24:43+10:00
+updated_at: 2026-08-11T23:48:00+10:00
 type: task
 ---
 
@@ -556,16 +556,71 @@ unrelated view-model, import, or transport redesign.
 | Generation semantics become a distributed consensus mechanism | Keep generations local and opaque; they order one authority's snapshots and changes, not multiple authorities globally. |
 | Performance work expands without evidence | Use existing phase timings and soak history; omit compiled plans or transaction-journal changes when measurements do not justify them. |
 
+## Implementation evidence — 2026-08-11
+
+The user approved this program for implementation while staging acceptance
+continues. Production remains on beta55. Beta64 is the frozen compatibility and
+performance baseline; NATS replacement and a production rollout remain out of
+scope for this phase.
+
+Phase 0 is complete and published for review:
+
+- provider contract, executable fixtures, and reproducible baseline:
+  `callumalpass/mdbase-rs#48` at `2454cb2`;
+- Connect execution, persistence, and cutover ADR:
+  `mdbase-dev/mdbase-connect#250` at `719ab9c` before this registry update;
+- the contract passed six independent red-team passes with no remaining P0/P1
+  contradiction.
+
+The accepted contract fixes the implementation boundaries before behavior changes:
+
+- host claim, application request, commit, event, and collection generation
+  identities are separate and crash-resolvable;
+- all blocking provider/feed work receives one deadline-bearing operation context;
+- preparation is cancellable, a pre-commit rejection is a durable final outcome,
+  and only the fsynced commit transition transfers settlement ownership to mdbase;
+- exact normalized changes are paged and digest-bound, including explicit body
+  change metadata;
+- mdbase owns a durable, singleton, fenced pull/ack feed and the only application
+  change writer after an explicit per-collection cutover;
+- transfer intent/receipt/ack handling is crash-idempotent, and baseline feed
+  initialization sets every cursor and watermark explicitly;
+- Connect does not retain a dual writer or permanent compatibility runtime after
+  a collection cuts over.
+
+The current-main release baseline used mdbase source `a363419` and Connect
+`d4138fb9`. Both 2,000- and 10,000-record workloads passed correctness, 160 mixed
+requests per concurrency scenario, and 1,600 soak requests with zero errors. The
+10,000-record provider mutation mean was 4,125.60 ms and same-collection mixed
+throughput was 2.53 requests/s, while between-request RSS/PSS stayed flat at roughly
+76,652/74,012 KiB. This points at repeated coordination/rebuild work as the primary
+provider-runtime cost in the harness rather than an unbounded provider-memory leak.
+
+Beta64 staging heavy testing also found a separate hosted-mirror liveness problem:
+an HTTP sync transport that stopped making progress could hold the mirror RAII guard
+indefinitely, leaving `syncing=true` and manual recovery at `mirror_busy` until daemon
+restart. Draft `mdbase-dev/mdbase-connect#249` at `5dec13c` adds bounded connect/read
+and whole-sync deadlines, typed timeout outcomes, resumable journal settlement, and
+abort/timeout cleanup tests. It passed the complete Rust workspace, formatting,
+clippy, TypeScript typecheck/tests, and local daemon/relay E2E path. It still requires
+a new prerelease and deployed hosted/binary/restart staging acceptance before merge
+to any production rollout.
+
+Next implementation step: land the provider contract, create a clean mdbase-rs
+worktree from that merge, and implement Phase 1 outcomes/feed primitives without
+changing the public Connect/NATS wire. Carry the baseline harness forward as a
+correctness and comparative-observation tool, not a fixed timing gate.
+
 ## Handoff
 
-Begin with Phase 0 in mdbase-rs: draft the provider-level
-`ExecutionOutcome`, `ChangeSet`, and generation contract beside the current
-`OperationRequest`/`OperationResult` types. Use create, update, delete, rename
-with reference updates, view-source mutation, and one external edit as the API
-review fixtures.
+Begin Phase 1 in mdbase-rs from the merged provider contract. Implement the
+accepted identities, preparation/outcome states, normalized paged changes, and
+durable feed primitives behind current public behavior. Preserve the existing
+Connect path until fixtures and crash/cancellation tests prove the provider
+boundary; then pin the exact mdbase revision into a new Connect worktree.
 
-Do not start by changing Connect's scheduler. The executor becomes simpler once
-mdbase can return exact changes and own one coherent collection runtime. After
-the API fixture is accepted, implement outcome production without changing the
-existing Connect path, pin it into a Connect branch, and only then replace and
-delete the duplicate watcher/invalidation path.
+Do not start with a second Connect scheduler or a dual watcher. Phase 4 introduces
+the per-collection executor only when it can cut each collection atomically to the
+provider feed and delete the legacy inference/watcher writer. Keep production on
+beta55 until the new prerelease passes direct, relay, hosted, migration, binary,
+large-vault, contention, cancellation, and deployed-consumer staging acceptance.

--- a/.ops/tasks/Coordinated local collection runtime simplification.md
+++ b/.ops/tasks/Coordinated local collection runtime simplification.md
@@ -1,0 +1,571 @@
+---
+title: Coordinated local collection runtime simplification
+status: planned
+priority: high
+owner: unassigned
+tags:
+  - architecture
+  - mdbase-rs
+  - connector
+  - runtime
+  - reliability
+  - performance
+  - scalability
+  - cancellation
+  - caching
+  - observability
+created_at: 2026-08-11T18:24:43+10:00
+updated_at: 2026-08-11T18:24:43+10:00
+type: task
+---
+
+# Coordinated local collection runtime simplification
+
+## Outcome
+
+Make one long-lived mdbase runtime the canonical local execution boundary for
+each registered collection, and make Connect a thin authority and scheduling
+layer around that runtime.
+
+The work should improve reliability, latency, bounded memory use, and scaling
+to larger and more numerous collections by removing duplicated discovery,
+watching, invalidation, and execution machinery. Performance is a consequence
+of clearer ownership and less repeated work; it is not a reason to weaken
+durability, authorization, or Markdown-as-source-of-truth guarantees.
+
+The target is not a rewrite. Each phase should introduce one stronger primitive,
+move its current callers onto it, and delete the mechanism it replaces. Avoid a
+permanent compatibility layer between two local runtime models.
+
+## Scope and repository map
+
+| Repository | Responsibility in the target architecture |
+| --- | --- |
+| `mdbase-rs` | Canonical collection semantics, filesystem transactions and recovery, collection generations, exact change sets, watching external edits, query/cache/index semantics, snapshots, and cooperative operation cancellation. |
+| `mdbase-connect` | Application authorization, grant enforcement, admission and fairness, durable application request identity/outcomes, relay and loopback routing, application-facing retry metadata, and lifecycle management of local collection runtimes. |
+
+Connect must not duplicate mdbase mutation semantics, infer changes by decoding
+operation-specific JSON, or ask a second watcher to rediscover a mutation that
+mdbase just performed. mdbase must not acquire Connect concepts such as grants,
+applications, relay policy, or request retry behavior.
+
+The existing NATS-based transport remains in place. Transport replacement is
+not part of this program.
+
+## Architectural principles
+
+1. **One owner per concern.** mdbase owns collection state transitions;
+   Connect owns authority and application request state transitions.
+2. **One runtime per active local collection.** The runtime owns the provider,
+   external-change watcher, generation, and rebuildable indexes for its
+   lifetime.
+3. **Known changes are applied, not rediscovered.** Successful mdbase mutations
+   return their exact change set. Watchers exist for external changes and
+   recovery reconciliation.
+4. **Canonical data and derived state remain distinct.** Markdown and durable
+   mdbase transaction evidence are authoritative. Query caches, link indexes,
+   and compiled plans are bounded, disposable, and rebuildable.
+5. **Prepare can be cancelled; commit must finish.** Expensive read work and
+   mutation preparation cooperate with deadlines. Once a durable filesystem
+   commit begins, it completes or recovers independently of whether the caller
+   is still waiting.
+6. **Bounded work is explicit.** Queueing, concurrency, cache residency, and
+   snapshot lifetime have deliberate limits. Increasing timeouts or queue sizes
+   is not a substitute for removing redundant work.
+7. **Simple failure states beat clever concurrency.** Prefer ordered mutation
+   execution, immutable read generations, and idempotent recovery over broad
+   shared-state synchronization.
+8. **Every new abstraction pays for itself by deletion.** A collection runtime,
+   execution outcome, or mutation plan is complete only when its duplicated
+   watcher, inference, shadow-copy, or task-spawning path is removed.
+
+## Target architecture
+
+```text
+application
+    |
+    v
+Connect SDK request coordinator
+    |
+    v
+Connect transport + grant enforcement
+    |
+    v
+per-collection executor
+  - ordered mutation lane
+  - bounded foreground read lane
+  - bounded background lane
+    |
+    v
+mdbase FilesystemRuntime
+  - provider and operation gate
+  - collection generation
+  - transaction/recovery engine
+  - external-change watcher
+  - rebuildable query/link indexes
+    |
+    v
+canonical Markdown collection
+
+mdbase ExecutionOutcome
+    |
+    +--> Connect durable request receipt
+    +--> Connect change journal / notifications
+    +--> mdbase incremental cache update
+```
+
+There should be no second Connect-owned collection watcher in the completed
+architecture. There should also be no unbounded fan-out from an incoming
+request to the general Tokio blocking pool.
+
+## Existing foundations
+
+Preserve and build on the work already shipped:
+
+- mdbase query memory is bounded for metadata pages and long-running queries
+  accept cooperative cancellation (`mdbase-rs` tree pinned by Connect at
+  `ca71aeb`).
+- Connect has bounded admission, per-grant fairness, absolute deadlines,
+  cooperative query cancellation, and durable mutation outcomes across client
+  deadlines (`f5b0ff7b` and `b1ba9e67`).
+- Connect has payload-free daemon profiling, admission/RSS observations, and a
+  long-lived read/query soak (`29eb42d` and `8ff69e8`).
+- mdbase has crash-recoverable collection transactions and a caller-owned
+  staged mutation API.
+
+This program should consolidate those foundations rather than introduce a
+parallel execution framework.
+
+## Phase 0 — freeze boundaries and measure the current path
+
+### Contract work
+
+1. Write a short cross-repository ADR defining:
+   - `CollectionGeneration`;
+   - `ExecutionOutcome` and `ChangeSet`;
+   - mdbase filesystem transaction identity versus Connect application request
+     identity;
+   - mutation prepare/commit/cancel semantics;
+   - known mutation changes versus external watcher changes;
+   - generation-pinned reads and expiration; and
+   - which state is authoritative, durable support state, or rebuildable cache.
+2. Draft the Rust API before changing Connect. The API should be useful to any
+   mdbase host and contain no Connect-specific types.
+3. Decide whether a commit identifier must survive process restart. If so, it
+   is an opaque mdbase transaction identifier and must not contain paths or
+   record content.
+4. Define one normalized external-change shape that can represent create,
+   update, delete, rename, and collection-control changes without losing the
+   revisions mdbase needs for cache invalidation.
+
+### Baseline observations
+
+Record the current release-mode behavior on at least 2,000 and 10,000 synthetic
+records:
+
+- create, update, delete, rename, and reference-updating rename;
+- 200-row library query and sequential pagination;
+- concurrent and mixed daemon workloads;
+- cache refresh and rebuild phase timings;
+- mutation execution versus watcher synchronization time;
+- RSS through a 1,600-request soak; and
+- two active collections under concurrent load.
+
+Performance results remain informational. Correctness and boundedness are
+release requirements; fixed latency or RSS thresholds are not.
+
+### Exit evidence
+
+- The ADR is reviewed in both repositories.
+- The proposed mdbase API can express every current canonical mutation and
+  watcher event without Connect decoding operation-specific result fields.
+- Baseline reports are retained through the existing performance observation
+  machinery.
+- No implementation phase begins with an unresolved ownership question.
+
+## Phase 1 — return canonical mdbase execution outcomes
+
+Implement provider-level types along these lines, with final names chosen in
+the mdbase-rs API review:
+
+```rust
+struct ExecutionOutcome {
+    result: OperationResult,
+    generation: CollectionGeneration,
+    changes: ChangeSet,
+    commit_id: Option<CommitId>,
+}
+
+enum ChangeSet {
+    None,
+    Records(Vec<RecordChange>),
+    Resources(Vec<ResourceChange>),
+    CollectionWide,
+}
+```
+
+### mdbase-rs
+
+1. Make operation execution return the generation observed or produced by the
+   operation and the exact canonical affected resources.
+2. Keep `OperationResult` as the portable semantic result. Keep generation,
+   commit, and local invalidation metadata in the provider/runtime outcome
+   rather than automatically expanding the public wire schema.
+3. Replace host-side calls to `OperationRequest::affected_paths()` with the
+   engine-produced change set. Retain the current helper only as an internal
+   construction aid until every operation emits exact changes.
+4. Cover single mutations, atomic batches, reference-updating rename, type and
+   view-source changes, dry runs, invalid operations, and no-op results.
+5. Prove that change sets never report paths outside the collection and that
+   invalid operations cannot advance generation.
+
+### mdbase-connect preparation
+
+1. Add an adapter that consumes `ExecutionOutcome` while leaving the existing
+   runtime active.
+2. Record the outcome's generation and opaque commit identity in privacy-safe
+   diagnostics where useful, but do not persist paths or content in the
+   application request journal.
+3. Add conformance fixtures proving direct mdbase execution and Connect's
+   adapter agree on result and invalidation semantics.
+
+### Deletion requirement
+
+When Connect cuts over in Phase 4, delete its operation-specific invalidation
+inference. Do not retain both outcome consumption and JSON-result inference.
+
+## Phase 2 — make ordinary mutations sparse
+
+The canonical single-record mutation path currently creates a collection-wide
+shadow working copy before committing a small write. Replace this gradually
+with explicit mutation plans.
+
+### mdbase-rs
+
+1. Introduce an internal `MutationPlan` containing exact revision
+   preconditions, planned writes/deletes/renames, and the resulting `ChangeSet`.
+2. Refactor create, update, and delete first. They should validate and render
+   only their affected record, then use the existing crash-recoverable
+   transaction layer to commit the exact write set.
+3. Refactor rename after the reverse-link candidate work in Phase 3 is
+   available. A rename plan includes the source, destination, and only records
+   whose references actually change.
+4. Keep complete atomic batch semantics. Replace the full copied collection
+   with a sparse copy-on-write overlay only after single-operation planning is
+   stable; do not combine the two behavioral changes in one patch.
+5. Make mutation preparation cooperatively cancellable. Once the transaction
+   journal enters commit, finish or recover the commit even if the host's
+   cancellation token is set.
+6. Keep mdbase transaction recovery and Connect request recovery separate:
+   mdbase proves the filesystem write set; Connect proves what happened to one
+   authorized application request.
+
+### Transaction simplification investigation
+
+The transaction journal currently checkpoints progress after each applied
+entry. Evaluate an idempotent recovery model based on each entry's exact before
+and after revision:
+
+- current equals before: apply the planned entry;
+- current equals after: the entry is already applied;
+- current equals neither: stop with a typed interference/manual-recovery
+  outcome.
+
+Adopt the simpler prepared/committing/committed journal only if crash injection
+proves it at every entry boundary on Linux, macOS, and Windows. Otherwise keep
+the current journal; sparse write sets still deliver most of the architectural
+and performance benefit.
+
+### Exit evidence
+
+- Single-record create/update/delete cost no longer grows with the total number
+  of collection records.
+- Existing revision, validation, crash recovery, and atomicity semantics remain
+  unchanged.
+- A cancellation during preparation performs no write; cancellation after
+  commit begins cannot strand an incomplete unowned transaction.
+- The old full-shadow path is removed for migrated operations.
+
+## Phase 3 — make cache and link maintenance incremental
+
+### mdbase-rs runtime and cache
+
+1. Add `apply_changes(ChangeSet)` for known successful mutations and
+   `apply_external_changes(...)` for watcher-originated changes.
+2. Re-index only affected records/resources and advance the cache generation in
+   the same rebuildable cache transaction.
+3. Stop walking every collection record to prove cache freshness before every
+   query. Full scans remain startup/recovery/reconciliation tools.
+4. Replace per-operation control-folder stamp walks with runtime generation
+   invalidation. Retain an explicit full control-resource reconciliation path.
+5. Treat cache corruption or a generation mismatch as a typed reason to
+   rebuild, never as permission to change or delete canonical Markdown.
+
+### Reverse-link candidates
+
+1. Extend the reconstructible link index with canonical resolved target path or
+   record identity, source revision, location, field, and raw target.
+2. Use that index to select candidate sources for backlinks and
+   reference-updating rename.
+3. Re-parse and semantically verify each candidate before changing it. The
+   index is an accelerator, not the final authority.
+4. Fall back to a full scan when the index is absent, stale, or cannot represent
+   an ambiguous link safely.
+
+### Exit evidence
+
+- A warm unchanged query does not perform a collection-wide filesystem scan.
+- A one-record external edit re-indexes that record and produces the same query
+  result as a clean full rebuild.
+- A known mutation updates the cache from its `ChangeSet` without waiting for a
+  watcher round trip.
+- Reference-updating rename work scales primarily with actual candidate
+  references rather than total records.
+- Rebuilding the cache from Markdown produces the same generation-visible
+  results as incremental maintenance.
+
+## Phase 4 — cut Connect over to one per-collection executor
+
+### mdbase-connect
+
+1. Replace registry-owned provider handles plus the separate
+   `CollectionWatchService` with one runtime handle per active local collection.
+2. Put a small `CollectionExecutor` around that runtime. It owns:
+   - one ordered mutation lane;
+   - a bounded foreground read lane;
+   - a bounded background/sync lane;
+   - deadline-aware queued work; and
+   - lifecycle state for open, idle, unavailable, rebuilding, and closing.
+3. Keep authorization and admission before execution. Admission protects the
+   daemon globally; the executor provides collection-local ordering, fairness,
+   and lifecycle ownership.
+4. Stop spawning an independent general blocking-pool job for every admitted
+   request. Use stable bounded workers owned by the executor and preserve
+   responsiveness across collections.
+5. On a successful mutation, consume `ExecutionOutcome` directly:
+   - advance the Connect mutation journal state;
+   - persist the application-facing final receipt;
+   - append the local change journal entry;
+   - deliver runtime notifications; and
+   - return the response.
+6. Feed normalized external changes from the mdbase runtime through the same
+   change-journal and notification path, with generation/revision deduplication.
+7. Preserve the existing distinction between reserved mutation capacity,
+   foreground reads, background work, and grant fairness. Do not replace known
+   admission guarantees with a generic actor mailbox.
+
+### Deletion requirement
+
+Delete:
+
+- Connect's separate per-collection watcher supervisor and workers;
+- synchronous post-mutation watcher rescans;
+- Connect's operation-result invalidation inference; and
+- redundant provider lifecycle paths in `CollectionRegistry`.
+
+Do not declare Phase 4 complete while both old and new runtime paths can serve
+normal authority requests.
+
+### Exit evidence
+
+- Known mutations have no watcher-synchronization phase in their request
+  latency.
+- External editor changes still produce durable ordered Connect change events.
+- One slow collection cannot occupy every local execution worker.
+- Active and queued counts return to zero after cancellation, timeout, runtime
+  close, and daemon shutdown.
+- Restart tests recover both the mdbase filesystem transaction and the Connect
+  application request outcome without duplicating the logical mutation.
+
+## Phase 5 — coordinate application request pressure
+
+The daemon should remain bounded, but applications should avoid creating work
+that is already obsolete before it reaches the collection executor.
+
+### mdbase-connect SDK
+
+1. Add one request coordinator per selected connection, not one per UI
+   component.
+2. Bound foreground concurrency to the authority's advertised/recommended
+   capacity.
+3. Coalesce identical in-flight reads and queries where request identity and
+   result semantics permit it.
+4. Support latest-wins cancellation for explicitly replaceable query families,
+   such as library search/filter refreshes. Do not apply latest-wins semantics
+   implicitly to mutations.
+5. Keep mutations in an ordered request lane and preserve their durable pending
+   recovery handles.
+6. Return structured retry timing for genuine overload and make retries consume
+   the caller's original overall request budget.
+7. Distinguish privacy-safe metrics for queue-full rejection, queue deadline,
+   execution deadline, cancellation, and policy synchronization delay.
+
+### Exit evidence
+
+- Rapidly changing a query does not leave stale requests occupying all
+  per-grant capacity.
+- The coordinator has one state owner and does not introduce a second session
+  or cache model.
+- Existing applications remain free to issue independent queries when they are
+  genuinely concurrent.
+- Durable mutations are never coalesced, silently cancelled, or retried under a
+  new request identity.
+
+## Phase 6 — generation-pinned pagination and bounded runtime residency
+
+Do this after the simpler runtime and incremental cache are established.
+
+### mdbase-rs
+
+1. Add optional generation-pinned query pagination with an opaque cursor,
+   deterministic tie-breaker, and typed expiration when the requested
+   generation is no longer available.
+2. Keep offset/limit compatibility only where still required; migrate
+   controlled consumers to cursor paging and then decide whether the old path
+   should remain public.
+3. Cache compiled query or saved-view plans only when profiling demonstrates a
+   meaningful repeated compilation cost. Key plans by canonical query/view
+   digest and every semantic generation that can invalidate them.
+
+### mdbase-connect
+
+1. Add explicit per-runtime accounting for parsed/indexed state, query cache,
+   link index, and active snapshots using mdbase-provided measurements where
+   possible.
+2. Bound the number of resident collection runtimes and idle-evict clean,
+   inactive runtimes through the same lifecycle owner.
+3. Reopen an evicted runtime from canonical Markdown and rebuildable support
+   state without changing collection identity or application grants.
+4. Exercise concurrent workloads across more collections than the residency
+   limit so eviction, reopening, and fairness are observable.
+
+### Exit evidence
+
+- Pagination does not duplicate or skip records within a retained generation.
+- Expired generations fail explicitly instead of silently mixing snapshots.
+- Long-lived daemon memory remains bounded as collections are opened, idled,
+  evicted, and reopened.
+- Plan caching is omitted if measurements do not justify its complexity.
+
+## Verification strategy
+
+### mdbase-rs correctness
+
+- Change-set conformance for every canonical mutator and dry-run/error path.
+- Sparse mutation equivalence against the existing shadow implementation while
+  the migration is under test.
+- Crash injection before prepare, after durable prepare, at each commit entry,
+  after commit, and during cleanup.
+- External modification at every revision/precondition boundary.
+- Incremental cache versus clean-rebuild differential tests.
+- Reverse-link candidate versus full-scan differential tests, including
+  ambiguous names, relative links, IDs, embeds, and frontmatter links.
+- Cancellation at bounded intervals through query, view, snapshot, link-graph,
+  rename discovery, and batch preparation.
+
+### mdbase-connect correctness
+
+- Direct loopback and relay execution against the same runtime semantics.
+- Process termination at every mdbase-commit/Connect-receipt boundary followed
+  by exact request replay.
+- Watcher failure/restart and external edit ordering.
+- Disk-full and cache-corruption recovery without canonical content loss.
+- Queue deadline and execution deadline while other grants and collections
+  continue making progress.
+- Runtime eviction/reopen with stable collection identity and grant behavior.
+- Daemon shutdown with no active or queued operation left unowned.
+
+### Performance visibility
+
+Extend the existing non-gating observations rather than adding pass/fail
+budgets:
+
+- mutation preparation, commit, cache application, journal/receipt completion,
+  and total latency;
+- executor queue time by work class and collection;
+- cache full scans, incremental updates, rebuilds, and hit rate;
+- rename candidate count versus total records;
+- active/idle runtime count and estimated resident bytes;
+- single- and multi-collection daemon soak checkpoints; and
+- library page, rapid replacement, pagination, mutation, and mixed workloads.
+
+Record source commits from both repositories in each observation so results
+remain attributable across a coordinated pin change.
+
+## Delivery and review order
+
+1. Land the ADR and API types in mdbase-rs without changing behavior.
+2. Land exact `ExecutionOutcome` production and conformance tests in mdbase-rs.
+3. Land sparse create/update/delete as reviewable mdbase-rs changes.
+4. Land incremental cache application and reverse-link candidates separately.
+5. Pin that reviewed mdbase-rs revision in a Connect branch.
+6. Add the Connect executor and outcome adapter, then cut normal local authority
+   traffic over in one reviewed change series.
+7. Delete the old Connect watcher/inference/provider lifecycle in the same
+   release train.
+8. Add SDK request coordination only after the executor's observable capacity
+   and cancellation behavior are stable.
+9. Add generation-pinned pagination and runtime residency bounds as follow-up
+   slices, retaining only complexity justified by the recorded workloads.
+10. Promote one coordinated candidate through staging, crash/recovery suites,
+    consumer acceptance, and the non-gating performance observations.
+
+Correctness changes, performance changes, and large module moves should remain
+separate commits where possible. Do not combine this architecture program with
+unrelated view-model, import, or transport redesign.
+
+## Acceptance criteria
+
+1. Each active local collection has one mdbase runtime and one Connect
+   executor; Connect has no second collection watcher.
+2. Connect consumes an exact mdbase `ExecutionOutcome` and no longer infers
+   mutation invalidation from operation-specific JSON.
+3. Create, update, and delete use sparse mutation plans rather than a
+   collection-wide shadow copy.
+4. Known mutations update derived indexes directly and do not wait for watcher
+   rediscovery.
+5. External edits flow through the same generation-aware change path and remain
+   recoverable after watcher or daemon restart.
+6. Warm queries avoid a collection-wide freshness scan; full reconciliation is
+   explicit and recoverable.
+7. Reference-updating rename uses a verified reverse-link candidate set with a
+   safe full-scan fallback.
+8. Cancellation can stop expensive preparation and reads, while a begun commit
+   always finishes or recovers to a typed durable state.
+9. Per-collection execution and SDK coordination prevent stale read/query
+   bursts from starving mutations or unrelated collections.
+10. Cursor pagination is stable within a retained generation and fails
+    explicitly when that generation expires.
+11. Runtime and cache residency remain bounded as multiple collections cycle
+    through active and idle states.
+12. NATS remains the transport architecture for this program.
+13. Performance history shows the effects without introducing latency or memory
+    release gates.
+14. The completed implementation deletes the duplicate watcher, invalidation,
+    shadow-copy, and general task-fan-out paths it replaces.
+
+## Risks and controls
+
+| Risk | Control |
+| --- | --- |
+| Cross-repository contract drift | Pin exact mdbase revisions; run shared outcome/change-set fixtures in both repositories; record both commits in profiling output. |
+| Cache treated as authority | Keep caches reconstructible; differential-test incremental state against clean rebuilds; fall back safely on generation mismatch. |
+| Mutation optimization weakens durability | Preserve exact revision preconditions and crash recovery; migrate one operation class at a time; require crash injection before deleting the shadow path. |
+| A collection actor becomes a new monolith | Keep the executor limited to scheduling and lifecycle; collection semantics stay in mdbase; retain separate bounded lanes rather than one opaque mailbox. |
+| Dual runtime paths linger | Put deletion requirements and exit evidence in every phase; do not ship a permanent feature flag or compatibility facade. |
+| Generation semantics become a distributed consensus mechanism | Keep generations local and opaque; they order one authority's snapshots and changes, not multiple authorities globally. |
+| Performance work expands without evidence | Use existing phase timings and soak history; omit compiled plans or transaction-journal changes when measurements do not justify them. |
+
+## Handoff
+
+Begin with Phase 0 in mdbase-rs: draft the provider-level
+`ExecutionOutcome`, `ChangeSet`, and generation contract beside the current
+`OperationRequest`/`OperationResult` types. Use create, update, delete, rename
+with reference updates, view-source mutation, and one external edit as the API
+review fixtures.
+
+Do not start by changing Connect's scheduler. The executor becomes simpler once
+mdbase can return exact changes and own one coherent collection runtime. After
+the API fixture is accepted, implement outcome production without changing the
+existing Connect path, pin it into a Connect branch, and only then replace and
+delete the duplicate watcher/invalidation path.

--- a/docs/decisions/0009-collection-runtime-execution-contract.md
+++ b/docs/decisions/0009-collection-runtime-execution-contract.md
@@ -1,6 +1,6 @@
 # ADR 0009: Cross-repository collection runtime execution contract
 
-- Status: proposed (Phase 0 API audit)
+- Status: accepted (Phase 0 contract review)
 - Date: 2026-08-11
 - Connect baseline: `d4138fb93ea0606d141139c96062136fee1cd409`
 - mdbase-rs baseline: `ca71aeb5b375c98de1cb5631ddffe6f89c264672`
@@ -43,12 +43,47 @@ struct CollectionGeneration {
 }
 
 struct CommitId(Uuid); // opaque mdbase filesystem-transaction identity
+struct HostClaimId([u8; 32]); // opaque host-generated recovery token
+struct ChangeEventId(Uuid); // durable provider-feed identity
+struct ChangeWatermark(u64); // durable provider-feed ordering
+struct OperationDeadline(Instant); // process-local absolute monotonic deadline
+struct OperationContext<'a> {
+    cancellation: &'a OperationCancellation,
+    deadline: OperationDeadline,
+}
+struct ChangeFeedOwnerId([u8; 32]); // secret singleton host-feed capability
+struct ChangeFeedTransferId(Uuid); // host-generated durable idempotency identity
+struct ReadCursor { /* opaque provider snapshot pin and ordering state */ }
+struct ChangeFeed { /* opaque fenced handle for the current owner process */ }
+struct ChangeFeedBaseline {
+    fencing_epoch: u64,
+    acknowledged_through: ChangeWatermark,
+    feed_head: ChangeWatermark,
+}
+struct ChangeFeedTransferIntent {
+    id: ChangeFeedTransferId,
+    current: ChangeFeedOwnerId,
+    next: ChangeFeedOwnerId,
+    expected_acked_through: ChangeWatermark,
+}
+struct ChangeFeedTransferReceipt {
+    id: ChangeFeedTransferId,
+    fencing_epoch: u64,
+    acknowledged_through: ChangeWatermark,
+    feed_head: ChangeWatermark,
+}
+
+enum PreparationOutcome {
+    NoMutation(ExecutionOutcome),
+    Prepared(PreparedMutation),
+}
 
 struct ExecutionOutcome {
     result: OperationResult,
     generation: CollectionGeneration,
     changes: ChangeSet,
     commit_id: Option<CommitId>,
+    change_event: Option<(ChangeEventId, ChangeWatermark)>,
 }
 
 enum ChangeSet {
@@ -57,16 +92,24 @@ enum ChangeSet {
     CollectionWide { reason: RebuildReason },
 }
 
+enum RebuildReason {
+    RecoveryReconciliation,
+    ExternalChangeUncertain,
+    ControlResourceChange,
+    ChangeFeedRetentionGap,
+}
+
 // One immutable mdbase-owned representation with bounded page iteration.
 // Large known batches may be journal-backed rather than copied into Connect.
 struct ChangeBatch { /* exact count, digest, bounded page reader */ }
 ```
 
 `RecordChange` identifies created, updated, deleted, or renamed records and carries
-the canonical path plus before/after revisions where available. A rename is one
+the canonical path, before/after revisions and canonical type sets, plus exact
+changed frontmatter field paths and a body-change marker. A rename is one
 logical change with its reference updates represented in the same atomic outcome;
 callers must not reconstruct it from operation-specific JSON. `ResourceChange`
-identifies configuration, type-definition, contract, view-source, and other
+identifies configuration, type-definition, contract, view-source, binary/file, and other
 collection resources. An exact batch is consumed in bounded pages from one
 immutable mdbase-owned representation, so a large atomic batch or
 reference-updating rename is not copied into an unbounded `Vec` in every host
@@ -76,13 +119,16 @@ cannot be narrowed safely; it is not an overflow fallback for a known mutation.
 The provider also emits an external event using the same normalized `ChangeSet`:
 
 ```rust
-struct ExternalChange {
+struct RuntimeChangeEvent {
+    event_id: ChangeEventId,
+    watermark: ChangeWatermark,
     generation: CollectionGeneration,
     changes: ChangeSet,
-    origin: ExternalChangeOrigin,
+    origin: ChangeOrigin,
+    commit_id: Option<CommitId>,
 }
 
-enum ExternalChangeOrigin { Filesystem, RecoveryReconciliation }
+enum ChangeOrigin { KnownMutation, Filesystem, RecoveryReconciliation }
 ```
 
 The event may have no `CommitId`: an external editor is not an application request
@@ -94,17 +140,52 @@ The provider operation is split into an opaque prepared mutation and an outcome:
 
 ```rust
 trait CollectionRuntime {
-    fn read(&self, request: ReadRequest, pin: Option<CollectionGeneration>)
+    fn read(&self, request: ReadRequest, context: &OperationContext<'_>)
         -> Result<ReadOutcome, RuntimeError>;
-    fn prepare(&self, request: MutationRequest, cancel: &Cancellation)
-        -> Result<PreparedMutation, RuntimeError>;
-    fn commit(&self, prepared: PreparedMutation)
-        -> Result<ExecutionOutcome, RuntimeError>;
-    fn cancel(&self, prepared: PreparedMutation) -> Result<CancelOutcome, RuntimeError>;
-    fn resolve_commit(&self, commit_id: &CommitId)
+    fn open_read(&self, request: ReadRequest, context: &OperationContext<'_>)
+        -> Result<ReadPage, RuntimeError>;
+    fn read_page(&self, cursor: &ReadCursor, context: &OperationContext<'_>)
+        -> Result<ReadPage, RuntimeError>;
+    fn release_read(&self, cursor: ReadCursor, context: &OperationContext<'_>)
+        -> Result<(), RuntimeError>;
+    fn prepare(&self, request: MutationRequest, claim: &HostClaimId,
+               context: &OperationContext<'_>)
+        -> Result<PreparationOutcome, RuntimeError>;
+    fn attach_prepared(&self, claim: &HostClaimId, context: &OperationContext<'_>)
+        -> Result<Option<PreparedMutation>, RuntimeError>;
+    fn commit(&self, prepared: &PreparedMutation, context: &OperationContext<'_>)
+        -> Result<CommitAttempt, RuntimeError>;
+    fn cancel(&self, prepared: &PreparedMutation, context: &OperationContext<'_>)
+        -> Result<CancelOutcome, RuntimeError>;
+    fn resolve_commit(&self, commit_id: &CommitId, context: &OperationContext<'_>)
         -> Result<Option<DurableCommitState>, RuntimeError>;
-    fn recv_external_change(&self, timeout: Duration)
-        -> Result<Option<ExternalChange>, RuntimeError>;
+    fn resolve_claim(&self, claim: &HostClaimId, context: &OperationContext<'_>)
+        -> Result<Option<(CommitId, DurableCommitState)>, RuntimeError>;
+    fn change_page(&self, batch: &ChangeBatch, after: Option<ChangePageCursor>,
+                   limit: usize, context: &OperationContext<'_>)
+        -> Result<ChangePage, RuntimeError>;
+    fn open_change_feed(&self, owner: &ChangeFeedOwnerId,
+                        context: &OperationContext<'_>)
+        -> Result<ChangeFeed, RuntimeError>;
+    fn transfer_change_feed(&self, intent: &ChangeFeedTransferIntent,
+                            context: &OperationContext<'_>)
+        -> Result<(ChangeFeed, ChangeFeedTransferReceipt), RuntimeError>;
+    fn ack_change_feed_transfer(&self, transfer: &ChangeFeedTransferId,
+                                context: &OperationContext<'_>)
+        -> Result<(), RuntimeError>;
+    fn establish_change_feed_baseline(&self, feed: &ChangeFeed,
+                                      context: &OperationContext<'_>)
+        -> Result<ChangeFeedBaseline, RuntimeError>;
+    fn read_change_events(&self, feed: &ChangeFeed,
+                          after: Option<ChangeWatermark>, limit: usize,
+                          context: &OperationContext<'_>)
+        -> Result<RuntimeChangeEventPage, RuntimeError>;
+    fn ack_change_events(&self, feed: &ChangeFeed, through: ChangeWatermark,
+                         context: &OperationContext<'_>)
+        -> Result<(), RuntimeError>;
+    fn ack_commit_resolution(&self, commit_id: &CommitId,
+                             context: &OperationContext<'_>)
+        -> Result<(), RuntimeError>;
 }
 
 impl PreparedMutation {
@@ -114,8 +195,25 @@ impl PreparedMutation {
 enum DurableCommitState {
     Prepared,
     Committing,
-    Committed { changes: ChangeSet },
+    Committed { outcome: ExecutionOutcome },
+    RejectedBeforeCommit { rejection: CommitRejection },
     CancelledBeforeCommit,
+    NeedsManualRecovery,
+}
+
+struct CommitRejection { /* versioned canonical semantic failure, no content */ }
+
+enum CommitAttempt {
+    Committed(ExecutionOutcome),
+    RejectedBeforeCommit { rejection: CommitRejection },
+    SettlementPending { commit_id: CommitId },
+}
+
+enum CancelOutcome {
+    CancelledBeforeCommit,
+    AlreadyCommitStarted,
+    AlreadyCommitted(ExecutionOutcome),
+    AlreadyRejected(CommitRejection),
     NeedsManualRecovery,
 }
 ```
@@ -123,30 +221,83 @@ enum DurableCommitState {
 These signatures are intentionally conceptual. `prepare` may validate, resolve
 references, calculate the exact change set, and stage the durable transaction. It is
 cancellable until the canonical write boundary. A successful prepared handle exposes
-its `CommitId` only after the mdbase prepared journal is durable. Connect must persist
-the application-request-to-commit association before calling `commit`; the identifier
-cannot first appear in the post-commit outcome.
+its `CommitId` only after the mdbase prepared journal is durable. Before calling
+`prepare`, Connect generates an unguessable `HostClaimId` and durably records request
+ID -> host claim. The provider stores only that opaque token plus a canonical mutation
+digest. It does not acquire a Connect request or grant type. Connect augments its row
+with `CommitId` before calling `commit`; the transaction identifier cannot first
+appear in the post-commit outcome.
 
-`commit` owns the durable boundary: once canonical writes begin, it ignores caller
-cancellation and completes or recovers the transaction. A lost response after that
-boundary is `outcome_unknown`/pending at the Connect layer, never evidence that the
-request was not sent. `cancel` is idempotent: before commit it releases an unclaimed
-prepared transaction (`CancelledBeforeCommit`); after durable commit it reports
-`AlreadyCommitted` and returns or permits recovery of the outcome.
+Every potentially blocking provider call receives one process-local
+`OperationContext` with an absolute monotonic deadline and cooperative cancellation
+token. Provider runtime/journal/feed gates use cancellable, bounded acquisition; the
+current blocking `RwLock::read`/`write` seam is not sufficient. Connect applies the
+same absolute request deadline before provider entry, but it does not assume that its
+executor can bound a gate wait inside a generic mdbase host. Feed ownership conflict
+returns a typed error rather than waiting for the other owner. Feed
+open/transfer/baseline/read/ack, batch paging, cursor release, and resolution calls
+are all bounded by a context.
+
+Invalid/precondition-failed work, dry runs, and semantic no-ops return
+`PreparationOutcome::NoMutation` with `ChangeSet::None` and no commit/event identity.
+Connect finalizes that result and removes its unused claim. Only `Prepared` enters
+the cross-journal hand-off below.
+
+`commit` owns the durable boundary. Its context bounds runtime-gate/journal-lock
+acquisition before the phase transition. Expiry there returns typed
+`commit_not_started` and leaves the journal `Prepared`, allowing Connect to retry or
+cancel the same durable request according to its journal. Once the fsynced
+`Committing` transition wins, canonical settlement ignores caller cancellation and
+completes or recovers the transaction. If the foreground context expires during
+settlement, the provider returns `SettlementPending { commit_id }`; its durable
+worker continues without retaining the caller task or Connect permits. A lost
+response after that boundary is `outcome_unknown`/pending at the Connect layer,
+never evidence that the request was not sent. `cancel` is idempotent: before commit
+it releases a prepared transaction (`CancelledBeforeCommit`); after durable commit
+it reports `AlreadyCommitted` and returns or permits recovery of the outcome.
 
 The durable hand-off is therefore:
 
-1. mdbase prepares and returns a durable opaque `CommitId`;
-2. Connect records request ID → `CommitId` in its application journal;
-3. Connect asks mdbase to commit; and
+1. Connect durably records request ID -> new opaque host claim;
+2. mdbase prepares that claim and returns a durable opaque `CommitId`;
+3. Connect records claim -> `CommitId` and asks mdbase to commit; and
 4. Connect records the final application receipt after commit or recovery resolves.
 
-After restart, `resolve_commit` distinguishes prepared, committing, committed,
-cancelled-before-commit, and manual-recovery states. mdbase proves its filesystem
-write set; Connect independently proves what happened to the authorized application
-request. An unclaimed orphan prepared before step 2 may be discarded without a
-canonical write. A claimed prepared transaction is resolved from both journals and
-must not be guessed from elapsed time.
+If Connect stops before step 2, `resolve_claim` is absent and the same request/claim
+may prepare. If it stops after step 2 but before copying `CommitId`, `resolve_claim`
+returns the prepared transaction. Reusing one claim with a different mutation digest
+is `claim_mismatch`. After restart, `resolve_claim`/`resolve_commit` distinguish
+prepared, committing, committed, rejected-before-commit, cancelled-before-commit,
+and manual-recovery states. mdbase proves its filesystem write set or its durable
+pre-write rejection; Connect independently proves what happened to the authorized
+application request. A claimed prepared transaction is never guessed from elapsed
+time or discarded merely because the host has not copied `CommitId`.
+When the durable state is `Prepared`, `attach_prepared(claim)` reconstructs a new
+process-local handle from the journal so recovery can commit or cancel; it does not
+prepare again. Later states are resolved without requiring the lost handle.
+
+Before `prepare` returns, the fsynced provider journal contains schema version, host
+claim, commit ID, versioned mutation digest, stable event ID, and exact batch
+count/digest/backing reference. The winning `Prepared -> Committing` transition runs
+under the runtime ordering gate, rechecks filesystem preconditions, assigns the
+then-next generation and watermark, and fsyncs them with `Committing` before the
+first canonical write. Preparation does not hold that gate or reserve ordering gaps
+while waiting for Connect. Recovery uses the descriptor to append or find the same
+event before reporting success, including a crash after the final file write.
+
+If the commit-time recheck observes an external edit or another failed precondition,
+the same journal lock atomically records `RejectedBeforeCommit` with a versioned
+canonical `CommitRejection`, releases the reserved event/batch backing, and fsyncs
+that final state without assigning a generation/watermark or changing canonical
+files. Claim and commit identity continue resolving to the same rejection until
+Connect has durably finalized and acknowledged the original request's semantic
+conflict receipt. Connect never maps this to cancellation, `not_sent`, or an absent
+claim, and never retries it under a new application request identity.
+
+The generation stored with `Committing` is historical to that runtime epoch. After a
+restart, recovery preserves commit/event/watermark/batch identity but reports the
+recovered observation in the new runtime epoch; it never revives an old generation
+pin. Connect deduplicates effects by provider event ID, not generation equality.
 
 The mdbase `CommitId` is the filesystem transaction identity and must remain
 recoverable across process termination for as long as its journal or bounded
@@ -154,7 +305,48 @@ completed marker is needed to resolve a claimed Connect request. It is distinct 
 the Connect application request ID. Connect stores the `CommitId` only in private
 local durable request support state; it must never substitute one identity for the
 other, use it as a grant identifier, or expose it to an application or transport as
-a path/content locator.
+a path/content locator. After its final receipt and derived change rows are durable,
+Connect acknowledges commit resolution and the associated provider watermark so
+mdbase may retire bounded support state.
+
+Connect may remove a pre-prepare host claim only after `resolve_claim` is absent and
+it has durably finalized the application request as `not_sent`. mdbase never
+age-evicts claimed prepared/committing/unresolved-committed or unacknowledged
+rejected state; it backpressures new preparation until Connect cancels, resolves and
+acknowledges, or an explicit audited abandonment operation proves no write began.
+
+Claims are collection-local; a movable filesystem root is not part of the digest.
+Version 1 claim digests are SHA-256 over RFC 8785/JCS of spec profile, operation
+name, normalized input, and explicit preconditions. Version 1 batch digests hash the
+canonically ordered normalized change items. The provider
+review defines the exact ordering; both repositories share fixtures for digest and
+page boundaries rather than independently serializing them.
+
+Cancellation has two clocks. The operation context stops provider gate acquisition,
+validation, preparation, feed work, and a provider transaction while it remains
+durably `Prepared`. The same absolute application deadline also stops waiting for a
+response. Once mdbase durably records `Committing`, settlement continues in a
+background recovery task that does not inherit the caller token or its foreground
+deadline.
+
+Provider `commit` and `cancel` use the same transaction lock and durably
+compare-and-set `Prepared` to `Committing`, `RejectedBeforeCommit`, or
+`CancelledBeforeCommit`. The fsynced phase transition is the linearization point.
+The winner is idempotent; the loser returns the exact durable winning state. Two
+reattached callers therefore cannot both cross the boundary.
+
+| State observed when the deadline/cancellation wins | Connect response |
+| --- | --- |
+| before prepare | `operation_cancelled` with `not_sent` |
+| prepared and provider confirms `CancelledBeforeCommit` | `operation_cancelled` with `not_sent` |
+| provider reports `RejectedBeforeCommit` | final semantic failure for the original request; never cancellation or an absent claim |
+| cancel/commit race is unresolved | pending/`outcome_unknown`; never `not_sent` |
+| provider reports `Committing` or `Committed` | final outcome when available, otherwise pending/`outcome_unknown` |
+
+Thus the outer deadline never labels a durable mutation `not_sent` merely because
+the foreground handler stopped waiting. Reads remain cancellable throughout. Every
+queue and provider wait is bounded, and durable settlement cannot retain a global,
+per-grant, or collection-executor permit after foreground execution has detached.
 
 ### Admission and collection-executor ownership
 
@@ -178,6 +370,313 @@ worker while its requests merely wait. The implementation may centralize the fai
 budget arbiter, but it must not replace the explicit collection lanes with a generic
 unbounded actor mailbox.
 
+### Durable change feed and bounded batches
+
+Known commits and external/recovery observations share a durable, pull-based mdbase
+feed. Each event has an opaque `ChangeEventId` and monotonic `ChangeWatermark` that
+survive a runtime-epoch restart. The per-collection Connect runtime persists one
+random, unguessable `ChangeFeedOwnerId` secret capability; it is never exposed as a
+public identifier. `open_change_feed` fences a stale process handle and rejects a
+different owner until explicit lifecycle transfer. This is a singleton consumer
+contract, not a shared destructive cursor. Connect pages the feed, stages and
+finalizes derived rows, then monotonically acknowledges the provider watermark.
+Redelivery after a crash is idempotent. The provider's completed commit marker
+includes the same event identity, so the direct mutation outcome and later feed
+replay cannot create two app events.
+
+Opening the same owner increments the provider's durable fencing epoch; the returned
+`ChangeFeed` carries that epoch, Connect stores it as `consumer_epoch`, and every
+read/ack verifies it. For transfer, Connect first durably records an unguessable
+`ChangeFeedTransferId`, current/next owner capabilities, and the exact expected
+acknowledged head. `transfer_change_feed` atomically persists that intent/result and
+installs the next owner/epoch. A retry with the exact tuple returns the same receipt
+whether the provider still has the old owner or has already installed the next;
+anything else is `change_feed_transfer_mismatch`. Connect durably installs the
+receipt in its feed state, then calls `ack_change_feed_transfer`. The provider retains
+one completed receipt and rejects another transfer until that acknowledgement.
+Acknowledgement atomically leaves a bounded tombstone for the last acknowledged
+transfer ID, and repeating acknowledgement for that ID succeeds. A crash after
+provider acknowledgement but before Connect deletes `connect_installed` therefore
+repeats acknowledgement and completes cleanup; a crash on either side of the
+provider/SQLite boundary resumes forward without losing the usable capability. Loss
+of the old secret requires a user-confirmed
+administrative rebaseline that creates a continuity barrier; normal startup cannot
+seize the feed.
+
+Before first provider cutover, `establish_change_feed_baseline` starts native
+observation and atomically persists the authoritative watcher snapshot/feed head
+under the runtime ordering gate. It is idempotent for that owner. Any startup race or
+uncertainty creates the stable reconciliation epoch, so Connect can resume
+`provider_baselining` after a crash without an observation gap. The returned
+acknowledged watermark equals the feed head; its fencing epoch is the current opened
+handle's epoch. After the initial baseline is durable, a retry returns that same
+watermark/snapshot receipt even if a later external event is already pending; the
+later event remains the first post-baseline event. Watermarks use checked succession
+and never wrap.
+
+The provider assigns known-commit and accepted-watcher generations/watermarks under
+one runtime ordering gate. A prepared transaction does not retain that gate while
+waiting for Connect; only its commit transition and filesystem settlement do.
+
+Acknowledgement is contiguous. Equal or older acknowledgements are idempotent;
+ahead-of-head or gap-skipping acknowledgement is `invalid_change_ack`. Reading after
+head is empty. Reading before retained history creates/returns the live
+`change_feed_reset_required` reconciliation barrier; it never advances silently.
+
+No semantic event crosses an unbounded Rust channel. A capacity-one coalescing wake
+signal may tell Connect to pull; the durable feed remains authoritative. Watcher
+startup, backend/scan failure, or external edit pressure durably sets one versioned
+provider reconciliation epoch with a stable event ID. Its state is
+`Required -> Reconciling -> EventDurable -> Acknowledged`. Failed scans return the
+same epoch to `Required`; restart from `Reconciling` retries it; restart from
+`EventDurable` replays the same event. A successful scan atomically installs a
+pending watcher snapshot, appends exact changes where safe or one
+`CollectionWide(RecoveryReconciliation)` event, and records `EventDurable`. Only
+provider-feed acknowledgement promotes that pending snapshot and clears the marker.
+Activity after the durable event starts a following dirty epoch. Runtime health
+reports this state as degraded instead of silently logging and losing the obligation.
+
+An exact `ChangeBatch` has a digest, count, bounded page size, and one provider-owned
+backing representation. Claimed known mutations reserve batch/event capacity before
+durable prepare; exhaustion is `runtime_capacity_exhausted` before any canonical
+write. External pressure cannot be rejected, so it coalesces behind a durable
+collection-wide reconciliation marker held in a separately reserved emergency slot
+and bounded descriptor area that ordinary batches cannot consume. Failure to persist
+that emergency marker makes runtime health terminal/unavailable rather than claiming
+continuity. Referenced known batches remain available
+until both commit resolution and their provider watermark are acknowledged. Active
+batches are never silently evicted. A process-local handle may expire, but reopening
+an unacknowledged event reconstructs it from durable backing. Backing retires only
+after acknowledgement; a later stale handle receives typed `change_batch_expired`.
+
+Retention is finite and configuration exposes limits for pending events, metadata
+bytes, active batch handles, page size, and acknowledged-state age. Unacknowledged
+state does not age-evict and therefore backpressures new preparation. The implementation must test those
+limits with deliberately tiny capacities. This is admission/backpressure policy, not
+a second scheduler and not a reason to copy large change vectors into Connect.
+
+### Connect persistence, scope, and privacy
+
+Provider metadata is private authority support state. The Connect cutover migration
+is additive and preserves every existing application cursor:
+
+```sql
+CREATE TABLE collection_runtime_feed_state (
+  collection_id TEXT PRIMARY KEY,
+  feed_owner_id TEXT NOT NULL,
+  consumer_epoch INTEGER NOT NULL,
+  next_expected_watermark INTEGER NOT NULL,
+  processed_through INTEGER NOT NULL,
+  acknowledged_through INTEGER NOT NULL
+);
+
+CREATE TABLE collection_runtime_feed_transfers (
+  collection_id TEXT PRIMARY KEY,
+  transfer_id TEXT NOT NULL UNIQUE,
+  current_owner_id TEXT NOT NULL,
+  next_owner_id TEXT NOT NULL,
+  expected_acked_through INTEGER NOT NULL,
+  state TEXT NOT NULL CHECK (
+    state IN ('intent', 'provider_transferred', 'connect_installed')
+  ),
+  provider_consumer_epoch INTEGER,
+  provider_acknowledged_through INTEGER,
+  provider_feed_head INTEGER
+);
+
+CREATE TABLE collection_runtime_cutovers (
+  collection_id TEXT PRIMARY KEY,
+  state TEXT NOT NULL CHECK (
+    state IN ('legacy', 'stopping_legacy', 'provider_baselining', 'provider')
+  ),
+  legacy_last_cursor INTEGER,
+  continuity_barrier_cursor INTEGER,
+  provider_feed_owner_id TEXT,
+  provider_consumer_epoch INTEGER,
+  provider_baseline_watermark INTEGER
+);
+
+CREATE TABLE collection_runtime_events (
+  collection_id TEXT NOT NULL,
+  provider_event_id TEXT NOT NULL,
+  provider_watermark INTEGER NOT NULL,
+  origin TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('staging', 'complete')),
+  expected_item_count INTEGER NOT NULL,
+  batch_digest TEXT NOT NULL,
+  next_item_index INTEGER NOT NULL DEFAULT 0,
+  first_application_cursor INTEGER,
+  last_application_cursor INTEGER,
+  processed_at TEXT,
+  PRIMARY KEY (collection_id, provider_event_id),
+  UNIQUE (collection_id, provider_watermark)
+);
+
+CREATE TABLE collection_runtime_event_items (
+  collection_id TEXT NOT NULL,
+  provider_event_id TEXT NOT NULL,
+  item_index INTEGER NOT NULL,
+  event_type TEXT NOT NULL,
+  private_payload TEXT NOT NULL,
+  item_digest TEXT NOT NULL,
+  application_cursor INTEGER,
+  PRIMARY KEY (collection_id, provider_event_id, item_index),
+  UNIQUE (collection_id, application_cursor)
+);
+
+CREATE TABLE collection_change_heads (
+  collection_id TEXT PRIMARY KEY,
+  head INTEGER NOT NULL
+);
+
+CREATE TABLE collection_runtime_continuity_barriers (
+  collection_id TEXT NOT NULL,
+  cursor INTEGER NOT NULL,
+  provider_event_id TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  PRIMARY KEY (collection_id, cursor),
+  UNIQUE (collection_id, provider_event_id)
+);
+```
+
+Feed transfer is a four-step idempotent hand-off. Connect inserts `intent` before
+calling mdbase. It writes the exact provider receipt and changes the row to
+`provider_transferred`; retrying the provider with the stored tuple is safe if a
+crash precedes that write. In one SQLite transaction it then verifies the receipt's
+acknowledged watermark against feed state, replaces `feed_owner_id` and
+`consumer_epoch`, and marks `connect_installed` without changing the existing
+processed/acknowledged watermark. Finally it acknowledges the transfer receipt to
+mdbase and deletes the intent row. Provider acknowledgement is idempotent for its
+bounded last-acknowledged tombstone. Restart resumes from any recorded state; a crash
+after the provider transfer but before SQLite therefore still has both owner
+capabilities and the idempotency ID, while a crash after SQLite but before provider
+ack repeats only acknowledgement. Owner capabilities are protected local support
+state and never logged, transported, or returned to applications.
+
+`next_expected_watermark` is the only event Connect may stage; the singleton adapter
+never works ahead of a gap. Each bounded `change_page` is verified against its page
+cursor and inserted into `collection_runtime_event_items` in a short immediate
+transaction. A page must begin exactly at `next_item_index`; an earlier page is an
+idempotent replay only when every item digest matches, while a later page is rejected
+as `invalid_change_page`. Updating staged rows and `next_item_index` is one SQLite
+transaction. After the exact item count and canonical rolling digest match the
+provider descriptor, one final SQLite
+transaction allocates a contiguous application-cursor range, uses ordered
+`INSERT ... SELECT` to append the existing `collection_changes` rows without a Rust
+`Vec`, marks the event complete, and advances `processed_through` and
+`next_expected_watermark`. `collection_change_heads` is seeded from each collection's
+existing `MAX(cursor)` and becomes the sole allocator/current-cursor source. A
+zero-item or `CollectionWide` event increments that head and inserts only a row in
+`collection_runtime_continuity_barriers`; no synthetic row enters
+`collection_changes`.
+
+For storage, `CollectionWide` uses `expected_item_count = 0`. Its version 1
+descriptor is exactly the JCS object
+`{"schema_version":1,"kind":"collection_wide","reason":<reason>}`, and
+`batch_digest` is its SHA-256 digest. The closed version 1 reason strings are
+`recovery_reconciliation`, `external_change_uncertain`,
+`control_resource_change`, and `change_feed_retention_gap`; future reasons require a
+new descriptor schema version.
+Exact type sets are deduplicated and UTF-8 byte sorted; changed fields are
+deduplicated canonical JSON Pointers in the same ordering. Each normalized record
+item includes an explicit JSON boolean `body_changed`; it is never a field sentinel
+and participates in item/batch hashing.
+
+A crash during page staging resumes at the highest contiguous `next_item_index`. A
+crash before the final transaction exposes no partial application event. A crash
+after it finds a complete primary key and only advances/repairs
+`acknowledged_through` after provider acknowledgement. The provider watermark may be
+acknowledged only when every earlier event is complete. No existing
+`collection_changes` row or cursor is rewritten. The final migration may add foreign
+keys/indexes, but it must preserve the explicit feed-state row, page idempotency,
+digest check, finalization atomicity, and cursor continuity rules.
+
+Cutover is per collection and has exactly one application-change writer:
+
+1. `legacy`: the existing Connect watcher is the sole writer. Provider outcomes may
+   be observed in shadow mode but neither the direct handler nor provider feed writes
+   application changes.
+2. Under the collection executor and SQLite writer gate, Connect enters
+   `stopping_legacy`, stops and joins that collection's legacy watcher, drains its
+   already-produced events, then in one transaction records `legacy_last_cursor`,
+   allocates a private continuity barrier, and enters `provider_baselining`. After
+   this commit the legacy path is permanently fenced from `append_changes`.
+3. While collection operations are paused, Connect persists a newly generated
+   `provider_feed_owner_id` in the `provider_baselining` cutover row, opens that same
+   owner, and asks mdbase to idempotently establish the feed-owner baseline and
+   watcher snapshot under its runtime ordering gate. Any uncertainty becomes the same
+   durable reconciliation epoch/barrier mechanism. A crash repeats open/baseline with
+   the stored owner; the watermark/snapshot baseline is unchanged even though the
+   reopened handle has a newer fencing epoch. If a post-baseline event arrived before
+   the crash, the repeated baseline still succeeds and leaves that event pending.
+4. Connect requires `baseline.acknowledged_through == baseline.feed_head`. In one
+   SQLite transaction it inserts `collection_runtime_feed_state` with
+   `feed_owner_id = provider_feed_owner_id`, `consumer_epoch = baseline.fencing_epoch`,
+   `processed_through = acknowledged_through = baseline.feed_head`, and
+   `next_expected_watermark = checked(baseline.feed_head + 1)`; records
+   `provider_consumer_epoch` and `provider_baseline_watermark`; and enters `provider`.
+   A checked-successor failure is terminal and never wraps. Only after this commit
+   does the provider feed become the sole application-change writer and collection
+   service resume. A crash before the transaction repeats step 3; a crash after it
+   observes the complete `provider` state and never re-baselines.
+
+Crash recovery resumes the recorded state forward; it never enables both writers.
+An in-flight legacy database transaction finishes before step 2's writer-gate
+transaction, and no new legacy event is admitted afterward. Rollback to legacy, if
+needed during development, first stops the provider consumer and allocates another
+continuity barrier. This intentionally trades one scoped refresh at beta cutover for
+a simple no-gap/no-duplicate ownership boundary.
+
+In `provider` state, the provider-feed finalizer is the sole writer of
+`collection_changes`, including changes caused by a foreground mutation. The direct
+mutation handler durably stores its application receipt with private commit/event
+identity and sends only a coalescing feed wake-up; it never appends change rows. It
+may return the mutation result before the feed event becomes visible, because reads
+already observe committed collection state and the resumable changes stream is
+eventually advanced by the durable feed. A caller that explicitly waits for change
+visibility waits on the event's `complete` row with a bounded deadline. After a crash
+between receipt and finalization, replay of that event ID stages/finalizes the rows
+once; after the reverse ordering, receipt recovery joins the same event ID.
+
+Application-facing change payload v2 contains only a schema version, normalized
+event kind, collection-relative visible `path`/`from`, opaque before/after revisions,
+matched authorized types, changed-field names, and an optional reset reason. It never
+contains record snapshots, bodies/frontmatter, absolute paths, `CommitId`,
+`HostClaimId`, provider event identity/watermark, transaction paths, grant IDs, or
+application request IDs. Existing v1 rows remain readable during the additive
+migration.
+
+Connect projects each completed provider batch against the current grant at
+read/delivery time. A
+rename wholly inside a contract scope remains a rename; one leaving scope becomes a
+delete, one entering scope becomes a create, and one wholly outside scope is absent.
+For contract-scoped grants, resource changes that could alter type/scope semantics
+become a private continuity barrier; resource paths are not disclosed.
+`CollectionWide` is likewise stored only as a private barrier. An application whose
+cursor crosses it receives the existing content-free `reset: true` page result and
+refreshes through its authorized query/read projection; it does not receive a
+synthetic event saying that unrelated content changed. This necessarily reveals only
+that continuity cannot be proved, the same fact already exposed by retention reset.
+The authorization snapshot is always the current grant when `changes` is read or a
+delayed notification is evaluated; historical authorization never widens delivery.
+
+The migrated `changes()` implementation consults the earliest private barrier after
+the caller's `after` cursor before selecting visible rows. If one exists, it returns
+no event payloads, `reset: true`, and the current `collection_change_heads.head`, so
+the application's subsequent authorized refresh establishes continuity at the live
+head. Barrier rows are never serialized as `CollectionChange`. Normal retention
+prunes them only with the same reset boundary used for old change rows; a caller from
+before retained history still receives `reset: true`.
+
+Runtime notification criteria are evaluated locally against authorized normalized
+events. A collection-wide barrier never directly triggers a push criterion. The
+authority first reconciles the criterion's current authorized projection against its
+last evaluation snapshot and signals only an actual authorized match; until that
+finishes notification health is degraded/retryable. The cloud path remains the
+existing content-free signal ID, grant ID, criterion ID, and opaque application
+cursor; no provider-feed metadata crosses the control plane. This ADR therefore
+changes neither notification transport nor NATS privacy boundaries.
+
 ### Generation and pinned reads
 
 Every successful runtime state transition returns a `CollectionGeneration`. The
@@ -185,18 +684,31 @@ generation is opaque to Connect and SDK consumers except for equality and cursor
 pinning. A paginated read may request a generation pin. If that generation is no
 longer available (including after a runtime restart), the provider returns a typed
 `generation_expired` result; it must not silently mix records from two snapshots.
-Phase 0 does not require durable snapshot retention. A restart creates a new opaque
-runtime epoch, and rebuildable caches/indexes are reconstructed from authoritative
-state.
+Creating a cursor atomically pins the immutable query/index snapshot used by the
+first `open_read` page. `ReadPage.next` is an opaque `ReadCursor`; `read_page` both
+uses and renews its idle lease, and `release_read` ends it explicitly. Replaying one
+cursor token before expiry returns the same page/next token, making response loss
+safe. Connect never
+reconstructs a cursor from a generation or reissues a later page as a new read.
+Mutations may advance the active generation without altering that pin.
+Pins have finite count/byte budgets, idle leases, hard lifetimes, and explicit
+release; admission fails with `cursor_capacity_exhausted` rather than evicting a live
+pin. Lease expiry, runtime close/restart, or a non-retainable rebuild returns
+`generation_expired`. Phase 0 does not require durable snapshot retention. A restart
+creates a new opaque runtime epoch, and rebuildable caches/indexes are reconstructed
+from authoritative state. Recovered durable commits/events keep their stable IDs and
+watermarks but are observed at a generation in this new epoch; any historical
+generation retained in a receipt remains non-pageable audit metadata.
 
 ### State ownership
 
 | State | Owner | Classification and rule |
 | --- | --- | --- |
 | Markdown records, files, configuration, type/contract definitions, view sources | mdbase-rs | Authoritative collection state; filesystem transactions are the only write path. |
-| Transaction journal, staged entries, `CommitId`, bounded completed resolution markers | mdbase-rs | Durable support state; recover before accepting conflicting work and retain resolution long enough for claimed Connect requests. |
+| Transaction journal, staged entries, opaque host claim, `CommitId`, bounded completed resolution markers | mdbase-rs | Durable support state; recover before accepting conflicting work and retain resolution until the host acknowledges its receipt. |
+| Provider change event IDs/watermarks, reconciliation marker, acknowledged watcher snapshot, exact batch backing | mdbase-rs | Durable support state; replay until monotonic acknowledgement and never silently discard known changes. |
 | Parsed collection, query/link indexes, compiled plans, watcher snapshot, runtime epoch | mdbase-rs | Rebuildable state; no caller treats it as collection truth. |
-| Accounts, grants, scopes, application identity, request IDs/receipts/outcomes | Connect | Authoritative application/control-plane state; separate from collection truth. |
+| Accounts, grants, scopes, application identity, request IDs/host claims/commit associations/receipts/outcomes | Connect | Authoritative application/control-plane state; host claim and commit ID remain private recovery metadata separate from collection truth. |
 | Connect notification/change cursor derived from provider outcomes | Connect | Durable application support state; derived from provider `ChangeSet`, never a second collection authority. |
 | NATS envelopes and transport retry metadata | Connect/protocol | Transport concern only; no semantic change in Phase 0. |
 
@@ -213,6 +725,9 @@ phases:
 | `crates/connect-agent/src/server/scoped_operations.rs:3-131` | Agent invokes the registry and then calls `watcher.synchronize` for local and sync operations. | Consume provider outcomes and publish normalized changes; do not rescan after known mutations. |
 | `crates/connect-agent/src/watcher.rs:18-26,39-96` | A separate supervisor owns refresh/synchronize commands. | The duplicate watcher is temporary compatibility code and is removed only after the provider event stream is live. |
 | `crates/connect-agent/src/watcher.rs:145-242` | Each collection has a `CollectionWatcher` worker; explicit `rescan`/`rescan_paths` and filesystem events are persisted separately. | mdbase-rs becomes the single watcher/runtime owner and emits normalized external changes. |
+| `crates/connect-agent/src/watcher.rs:45-49,99-103,179-193` | Supervisor, runtime-event, and per-worker command paths use unbounded channels. | Replace semantic delivery with the durable provider pull/ack feed; any wake channel is bounded and coalescing. |
+| `crates/connect-agent/src/watcher.rs:208-215,223-231,277-280` | Rescan, watcher-stop, and persistence failures are logged while the worker can continue or exit without a durable retry obligation. | Provider persists `reconciliation_required`, exposes degraded health, and clears it only after acknowledged reconciliation. |
+| `crates/connect-agent/src/runtime_notifications.rs:23-30,45-50` | Notification event and timer command inputs are unbounded; a rejected runtime event is only logged. | Change events are replayed from durable Connect rows; timer commands receive a separate finite command policy. |
 | `crates/connect-agent/src/server/files.rs:141-155,191-208` | File move/delete/upload commit call `watcher.rescan` after registry mutation. | File operations use `ResourceChange`/record changes from the same provider outcome. |
 | `crates/connect-agent/src/server.rs:73-75,198-203` | `AgentState` owns the watcher and refreshes it from the collection registry. | Connect lifecycle owns registration, but provider lifecycle owns collection runtime/watch state after migration. |
 
@@ -223,13 +738,28 @@ operation to an expected outcome. The adapter must preserve these mappings:
 
 | Fixture | Provider outcome | Connect behavior |
 | --- | --- | --- |
-| Create record | `RecordChange::Created`, new generation, `Some(CommitId)` | Persist application outcome and commit metadata; publish the exact created change. |
+| Create record | `RecordChange::Created`, new generation, `Some(CommitId)` | Persist receipt/commit/event metadata; wake the sole feed finalizer, which publishes the exact created change once. |
 | Update record | `RecordChange::Updated` with before/after revision | Persist and publish revisioned change; no path rescan. |
 | Delete record | `RecordChange::Deleted` with prior revision | Persist and publish deletion; no inferred invalidation. |
 | Rename with reference updates | Atomic `Renamed` plus verified reference updates in one `ChangeSet` | Deliver one outcome/change batch; do not decode `references_updated` from JSON. |
 | View-source mutation | `ResourceChange::ViewSource`, unless provider cannot prove narrower scope | Rebuild affected view/query state according to resource kind; do not force collection-wide invalidation by default. |
-| External edit | `ExternalChangeOrigin::Filesystem`, normalized record/resource changes, and no application request ID | Advance local change/notification cursors and reconcile; never manufacture an app receipt or commit ID. |
+| External edit | `ChangeOrigin::Filesystem`, normalized record/resource changes, and no application request ID | Advance local change/notification cursors and reconcile; never manufacture an app receipt or commit ID. |
 | Dry-run, invalid, or no-op | `ChangeSet::None`, no commit ID, no generation advance for rejected work | Return validation result without notification or cache invalidation. |
+| Cursor across concurrent mutation | Every page reads the first page's pinned generation | Preserve the opaque provider cursor; never reissue the page against current state. |
+| Cursor expiry/restart | Typed `generation_expired` | Return the versioned refresh condition; do not hide it with an automatic mixed-snapshot retry. |
+| Cancellation before commit | Durable `CancelledBeforeCommit` | Only then return `operation_cancelled`/`not_sent` and retire the host claim. |
+| Cancellation at/after commit boundary | Committing/committed state remains recoverable | Detach foreground wait, retain durable settlement, and return pending/`outcome_unknown` when final state is unavailable. |
+| Crash after provider prepare | `resolve_claim` finds the same commit | Reconcile request -> claim -> commit without manufacturing a second mutation. |
+| Crash after last file write | Recovery appends/finds journal's exact event descriptor | Persist one exact event and final receipt; never infer collection-wide effects. |
+| Cancel/commit race | One durable provider phase transition wins | Map only confirmed cancellation to `not_sent`; otherwise settle the same commit. |
+| Partial large-batch staging | Replayed pages retain item indexes and digests | Keep rows private until count/digest finalization; resume without duplicating app cursors. |
+| Direct receipt before feed finalization | Same provider event remains pending | Return the mutation receipt; replay/finalize the event once after restart without a second direct write. |
+| Grant narrows after a canonical event is staged | Provider event remains private authority support state | Project only through the current narrowed grant; prove no previously staged path, type, field, or resource metadata can be read through `changes()`. |
+| Crash after provider feed transfer before SQLite receipt | Exact transfer tuple returns the same provider receipt | Resume the persisted intent, install the next owner/epoch once, acknowledge the provider receipt, and retain a usable fenced handle. |
+| Crash after provider baseline before feed-state insert | Same owner returns the same watermark/snapshot baseline | Initialize processed/acknowledged at the baseline head and next expected at its checked successor; never replay pre-baseline events. |
+| Watcher failure/restart gap | Durable collection-wide reconciliation event | Persist one private continuity barrier; return scoped `reset: true` only when a current grant crosses it. |
+| Repeated reconciliation retry | Stable provider epoch/event identity | Do not create duplicate barriers or notification evaluations. |
+| External rename without proof | Delete plus create | Apply scope projection to each side; never infer an identity from timing alone. |
 
 The mdbase-rs review document additionally records current implementation evidence:
 `src/runtime/provider.rs:18-25,135-243,245-297`,
@@ -271,15 +801,27 @@ and recovery tests; then removal of `operation_invalidation` and the watcher
 supervisor/rescans after cutover evidence. Performance observations are informative
 for the task but are not claimed by this documentation-only Phase 0 audit.
 
-## Open review questions
+The current transaction journal cannot satisfy this contract unchanged. Phase 1
+must version/migrate its descriptor to add host claim/digest, stable event identity,
+exact batch backing, commit-time generation/watermark ordering, cancelled state, and
+acknowledged completed markers before Connect enables any provider cutover. Old
+profiles recover their v1 journals with existing semantics first; only then may new
+v2 preparation be admitted.
 
-- Should `CollectionGeneration` be persisted across restart, or should the runtime
-  epoch always invalidate outstanding pins? This draft chooses invalidation because
-  Phase 0 does not promise snapshot retention.
-- Which provider error name and wire representation should encode
-  `generation_expired` and `outcome_unknown` across all transports?
-- Should exact external changes be batched by filesystem debounce interval or by
-  transaction/recovery boundary? Either choice must preserve generation ordering.
-- Which file operations are represented as `ResourceChange` versus record changes?
-  The provider must decide once and expose the result, rather than requiring Connect
-  to infer it.
+## Resolved review choices
+
+- A runtime restart creates a new generation epoch and expires outstanding snapshot
+  pins. Persisting snapshots across restart is outside this task.
+- Provider errors use stable semantic names including `generation_expired`,
+  `cursor_capacity_exhausted`, `change_batch_expired`, `runtime_capacity_exhausted`,
+  `claim_mismatch`, and commit states. Their versioned application wire mapping is a
+  later compatibility phase; Phase 0 does not change transport envelopes.
+- One known atomic commit is one provider change event. External changes observed by
+  one successful debounced final-state comparison are one event. Startup/recovery is
+  a separate event boundary. Events are never merged across an acknowledged
+  watermark.
+- A configured record file is a `RecordChange`. Collection configuration, types,
+  contracts, and saved-view sources use their explicit `ResourceChange` kinds. Other
+  files, including binary objects managed by the file API, use `ResourceChange::File`.
+  An external rename is emitted only when identity is provable; otherwise it is a
+  delete plus create.

--- a/docs/decisions/0009-collection-runtime-execution-contract.md
+++ b/docs/decisions/0009-collection-runtime-execution-contract.md
@@ -1,0 +1,285 @@
+# ADR 0009: Cross-repository collection runtime execution contract
+
+- Status: proposed (Phase 0 API audit)
+- Date: 2026-08-11
+- Connect baseline: `d4138fb93ea0606d141139c96062136fee1cd409`
+- mdbase-rs baseline: `ca71aeb5b375c98de1cb5631ddffe6f89c264672`
+- Companion provider review: `mdbase-rs/docs/architecture/collection-runtime-api-phase0.md`
+- Companion fixtures: `mdbase-rs/docs/architecture/collection-runtime-api-fixtures.json`
+
+## Context
+
+Collection semantics currently cross the repository boundary as an operation result
+plus Connect-side invalidation hints. mdbase-rs owns the collection, filesystem
+transaction, cache, and watcher behavior, while Connect owns authorization, grants,
+admission, application request receipts, routing, and lifecycle. The current
+boundary does not carry a generation, an exact change set, or the filesystem
+transaction identity. Consequently Connect infers invalidation from JSON and asks a
+second watcher service to rescan after a successful operation.
+
+The Phase 0 task, `Coordinated local collection runtime simplification.md`, requires
+the provider to become the semantic owner. This ADR records the API and ownership
+contract before any implementation or scheduler/NATS change. It does not change
+runtime behavior.
+
+## Decision
+
+Define one provider-neutral execution contract in mdbase-rs. Connect adapts its
+authorization and durable application-request machinery to that contract; it does
+not reinterpret collection operation JSON or maintain a second collection watcher.
+The mdbase-rs API review and fixtures are the normative provider-level draft. The
+following names and invariants are the cross-repository agreement.
+
+### Provider result types
+
+The provider exposes the following conceptual Rust types. Exact module placement and
+serialization are implementation details to be resolved in the provider PR; these
+types must not include grant, application, or transport state.
+
+```rust
+struct CollectionGeneration {
+    runtime_epoch: Uuid,
+    sequence: u64,
+}
+
+struct CommitId(Uuid); // opaque mdbase filesystem-transaction identity
+
+struct ExecutionOutcome {
+    result: OperationResult,
+    generation: CollectionGeneration,
+    changes: ChangeSet,
+    commit_id: Option<CommitId>,
+}
+
+enum ChangeSet {
+    None,
+    Exact(ChangeBatch),
+    CollectionWide { reason: RebuildReason },
+}
+
+// One immutable mdbase-owned representation with bounded page iteration.
+// Large known batches may be journal-backed rather than copied into Connect.
+struct ChangeBatch { /* exact count, digest, bounded page reader */ }
+```
+
+`RecordChange` identifies created, updated, deleted, or renamed records and carries
+the canonical path plus before/after revisions where available. A rename is one
+logical change with its reference updates represented in the same atomic outcome;
+callers must not reconstruct it from operation-specific JSON. `ResourceChange`
+identifies configuration, type-definition, contract, view-source, and other
+collection resources. An exact batch is consumed in bounded pages from one
+immutable mdbase-owned representation, so a large atomic batch or
+reference-updating rename is not copied into an unbounded `Vec` in every host
+layer. `CollectionWide` is reserved for reconciliation or an external change that
+cannot be narrowed safely; it is not an overflow fallback for a known mutation.
+
+The provider also emits an external event using the same normalized `ChangeSet`:
+
+```rust
+struct ExternalChange {
+    generation: CollectionGeneration,
+    changes: ChangeSet,
+    origin: ExternalChangeOrigin,
+}
+
+enum ExternalChangeOrigin { Filesystem, RecoveryReconciliation }
+```
+
+The event may have no `CommitId`: an external editor is not an application request
+and does not have a Connect transaction identity.
+
+### Prepare, commit, and cancel
+
+The provider operation is split into an opaque prepared mutation and an outcome:
+
+```rust
+trait CollectionRuntime {
+    fn read(&self, request: ReadRequest, pin: Option<CollectionGeneration>)
+        -> Result<ReadOutcome, RuntimeError>;
+    fn prepare(&self, request: MutationRequest, cancel: &Cancellation)
+        -> Result<PreparedMutation, RuntimeError>;
+    fn commit(&self, prepared: PreparedMutation)
+        -> Result<ExecutionOutcome, RuntimeError>;
+    fn cancel(&self, prepared: PreparedMutation) -> Result<CancelOutcome, RuntimeError>;
+    fn resolve_commit(&self, commit_id: &CommitId)
+        -> Result<Option<DurableCommitState>, RuntimeError>;
+    fn recv_external_change(&self, timeout: Duration)
+        -> Result<Option<ExternalChange>, RuntimeError>;
+}
+
+impl PreparedMutation {
+    fn commit_id(&self) -> &CommitId; // available after durable prepare
+}
+
+enum DurableCommitState {
+    Prepared,
+    Committing,
+    Committed { changes: ChangeSet },
+    CancelledBeforeCommit,
+    NeedsManualRecovery,
+}
+```
+
+These signatures are intentionally conceptual. `prepare` may validate, resolve
+references, calculate the exact change set, and stage the durable transaction. It is
+cancellable until the canonical write boundary. A successful prepared handle exposes
+its `CommitId` only after the mdbase prepared journal is durable. Connect must persist
+the application-request-to-commit association before calling `commit`; the identifier
+cannot first appear in the post-commit outcome.
+
+`commit` owns the durable boundary: once canonical writes begin, it ignores caller
+cancellation and completes or recovers the transaction. A lost response after that
+boundary is `outcome_unknown`/pending at the Connect layer, never evidence that the
+request was not sent. `cancel` is idempotent: before commit it releases an unclaimed
+prepared transaction (`CancelledBeforeCommit`); after durable commit it reports
+`AlreadyCommitted` and returns or permits recovery of the outcome.
+
+The durable hand-off is therefore:
+
+1. mdbase prepares and returns a durable opaque `CommitId`;
+2. Connect records request ID → `CommitId` in its application journal;
+3. Connect asks mdbase to commit; and
+4. Connect records the final application receipt after commit or recovery resolves.
+
+After restart, `resolve_commit` distinguishes prepared, committing, committed,
+cancelled-before-commit, and manual-recovery states. mdbase proves its filesystem
+write set; Connect independently proves what happened to the authorized application
+request. An unclaimed orphan prepared before step 2 may be discarded without a
+canonical write. A claimed prepared transaction is resolved from both journals and
+must not be guessed from elapsed time.
+
+The mdbase `CommitId` is the filesystem transaction identity and must remain
+recoverable across process termination for as long as its journal or bounded
+completed marker is needed to resolve a claimed Connect request. It is distinct from
+the Connect application request ID. Connect stores the `CommitId` only in private
+local durable request support state; it must never substitute one identity for the
+other, use it as a grant identifier, or expose it to an application or transport as
+a path/content locator.
+
+### Admission and collection-executor ownership
+
+Global/per-grant admission and the future per-collection executor are two bounded
+stages with one deadline, not two independent schedulers that each believe they own
+execution. Admission may reserve bounded queue accounting, but a request waiting for
+its collection lane must not hold a global worker/read/mutation execution permit.
+
+The collection lane marks only its runnable head work. A shared fair execution-budget
+arbiter grants the existing global, work-class, and per-grant execution capacity at
+the point the collection can start it. Only then does the executor enter mdbase's
+runtime gate. Permit order is therefore queue slot → runnable collection head →
+shared execution budget → mdbase runtime gate. Cancellation or deadline expiry has
+one owner at each state transition and releases every later reservation in reverse
+order. Mutation commit ownership transfers to mdbase at the durable boundary and is
+the sole exception to caller cancellation.
+
+This preserves the current reserved mutation, foreground-read, background, and
+per-grant guarantees without allowing a slow collection to consume every global
+worker while its requests merely wait. The implementation may centralize the fair
+budget arbiter, but it must not replace the explicit collection lanes with a generic
+unbounded actor mailbox.
+
+### Generation and pinned reads
+
+Every successful runtime state transition returns a `CollectionGeneration`. The
+generation is opaque to Connect and SDK consumers except for equality and cursor
+pinning. A paginated read may request a generation pin. If that generation is no
+longer available (including after a runtime restart), the provider returns a typed
+`generation_expired` result; it must not silently mix records from two snapshots.
+Phase 0 does not require durable snapshot retention. A restart creates a new opaque
+runtime epoch, and rebuildable caches/indexes are reconstructed from authoritative
+state.
+
+### State ownership
+
+| State | Owner | Classification and rule |
+| --- | --- | --- |
+| Markdown records, files, configuration, type/contract definitions, view sources | mdbase-rs | Authoritative collection state; filesystem transactions are the only write path. |
+| Transaction journal, staged entries, `CommitId`, bounded completed resolution markers | mdbase-rs | Durable support state; recover before accepting conflicting work and retain resolution long enough for claimed Connect requests. |
+| Parsed collection, query/link indexes, compiled plans, watcher snapshot, runtime epoch | mdbase-rs | Rebuildable state; no caller treats it as collection truth. |
+| Accounts, grants, scopes, application identity, request IDs/receipts/outcomes | Connect | Authoritative application/control-plane state; separate from collection truth. |
+| Connect notification/change cursor derived from provider outcomes | Connect | Durable application support state; derived from provider `ChangeSet`, never a second collection authority. |
+| NATS envelopes and transport retry metadata | Connect/protocol | Transport concern only; no semantic change in Phase 0. |
+
+## Current-main evidence
+
+The audit found the following existing seams that the contract replaces in later
+phases:
+
+| Current path | Evidence | Contract implication |
+| --- | --- | --- |
+| `crates/connect-core/src/registry/operations.rs:36-76` | Local operations select `with_collection` for batch/mutations and `with_collection_read` otherwise; successful mutation calls a synchronization callback. | Provider must return the exact outcome and changes so this callback becomes an adapter, not a second semantic path. |
+| `crates/connect-core/src/registry/operations.rs:379-417` | Scoped operations repeat the same mutation/read split and invalidation callback. | Authorization remains Connect-owned; collection effects move behind the provider contract. |
+| `crates/connect-core/src/registry/operation_execution.rs:477-515` | `operation_invalidation` decodes `OperationResult`, calls `OperationRequest::affected_paths`, and falls back to `All` for legacy/unknown envelopes. | Remove operation-specific JSON/path inference after cutover; preserve `CollectionWide` as an explicit provider result. |
+| `crates/connect-agent/src/server/scoped_operations.rs:3-131` | Agent invokes the registry and then calls `watcher.synchronize` for local and sync operations. | Consume provider outcomes and publish normalized changes; do not rescan after known mutations. |
+| `crates/connect-agent/src/watcher.rs:18-26,39-96` | A separate supervisor owns refresh/synchronize commands. | The duplicate watcher is temporary compatibility code and is removed only after the provider event stream is live. |
+| `crates/connect-agent/src/watcher.rs:145-242` | Each collection has a `CollectionWatcher` worker; explicit `rescan`/`rescan_paths` and filesystem events are persisted separately. | mdbase-rs becomes the single watcher/runtime owner and emits normalized external changes. |
+| `crates/connect-agent/src/server/files.rs:141-155,191-208` | File move/delete/upload commit call `watcher.rescan` after registry mutation. | File operations use `ResourceChange`/record changes from the same provider outcome. |
+| `crates/connect-agent/src/server.rs:73-75,198-203` | `AgentState` owns the watcher and refreshes it from the collection registry. | Connect lifecycle owns registration, but provider lifecycle owns collection runtime/watch state after migration. |
+
+## Fixture and API-review coverage
+
+The companion JSON fixture file is deliberately provider-neutral and maps each
+operation to an expected outcome. The adapter must preserve these mappings:
+
+| Fixture | Provider outcome | Connect behavior |
+| --- | --- | --- |
+| Create record | `RecordChange::Created`, new generation, `Some(CommitId)` | Persist application outcome and commit metadata; publish the exact created change. |
+| Update record | `RecordChange::Updated` with before/after revision | Persist and publish revisioned change; no path rescan. |
+| Delete record | `RecordChange::Deleted` with prior revision | Persist and publish deletion; no inferred invalidation. |
+| Rename with reference updates | Atomic `Renamed` plus verified reference updates in one `ChangeSet` | Deliver one outcome/change batch; do not decode `references_updated` from JSON. |
+| View-source mutation | `ResourceChange::ViewSource`, unless provider cannot prove narrower scope | Rebuild affected view/query state according to resource kind; do not force collection-wide invalidation by default. |
+| External edit | `ExternalChangeOrigin::Filesystem`, normalized record/resource changes, and no application request ID | Advance local change/notification cursors and reconcile; never manufacture an app receipt or commit ID. |
+| Dry-run, invalid, or no-op | `ChangeSet::None`, no commit ID, no generation advance for rejected work | Return validation result without notification or cache invalidation. |
+
+The mdbase-rs review document additionally records current implementation evidence:
+`src/runtime/provider.rs:18-25,135-243,245-297`,
+`src/runtime/filesystem.rs:12-65`,
+`src/runtime/operation.rs:84-136`, and
+`src/transactions.rs:63-97,203-242,287-384`. Those references show why the
+provider API must own the operation gate, transaction recovery, and normalized
+change production before Connect can remove its duplicate watcher.
+
+## Compatibility and migration rules
+
+1. Introduce the provider result behind an additive internal API. Keep the current
+   operation envelope as an adapter while both sides migrate.
+2. Preserve old profiles by rebuilding generation/index state from authoritative
+   files and recovering any durable transaction journal before serving requests.
+3. Treat a missing portable result envelope as a compatibility condition during the
+   adapter period, not as proof of a particular path change. The adapter may use a
+   conservative collection-wide rebuild until the provider contract is available.
+4. Keep provider generation, change, and commit metadata inside the authority/runtime
+   adapter in the current phases. Existing relay, loopback, hosted, and direct
+   application responses do not expose `CommitId`. Generation enters a versioned
+   application wire contract only when generation-pinned pagination is implemented;
+   it does not require a NATS framing redesign.
+5. A generation-expired cursor is a typed refresh/retry condition. A commit outcome
+   that is not yet known remains pending/unknown until the provider or recovery
+   reports it; it is not retried as a new mutation without the original application
+   request identity.
+
+## Phased implementation boundary
+
+Phase 0 is complete when both repositories have reviewed this contract, the API
+fixtures pass review, and the ownership/identity decisions are accepted. This
+change intentionally does not implement behavior, alter the Connect scheduler,
+change admission/fairness, modify NATS, or remove the watcher.
+
+The subsequent implementation order is: provider types and outcome production in
+mdbase-rs; a Connect adapter that consumes outcomes and external events; compatibility
+and recovery tests; then removal of `operation_invalidation` and the watcher
+supervisor/rescans after cutover evidence. Performance observations are informative
+for the task but are not claimed by this documentation-only Phase 0 audit.
+
+## Open review questions
+
+- Should `CollectionGeneration` be persisted across restart, or should the runtime
+  epoch always invalidate outstanding pins? This draft chooses invalidation because
+  Phase 0 does not promise snapshot retention.
+- Which provider error name and wire representation should encode
+  `generation_expired` and `outcome_unknown` across all transports?
+- Should exact external changes be batched by filesystem debounce interval or by
+  transaction/recovery boundary? Either choice must preserve generation ordering.
+- Which file operations are represented as `ResourceChange` versus record changes?
+  The provider must decide once and expose the result, rather than requiring Connect
+  to infer it.


### PR DESCRIPTION
## Summary

Freeze the Connect-side execution contract for the coordinated local collection runtime simplification before source cutover.

The ADR defines:

- deadline and cancellation ownership across Connect and the provider
- pre-commit versus post-commit mutation outcomes
- single-writer feed finalization and durable acknowledgements
- crash-idempotent transfer intent/receipt/ack handling
- per-collection legacy-to-provider cutover without dual writers
- private staging barriers, emergency reconciliation capacity, and recovery states

## Review status

The contract has completed six independent red-team passes, including generation/fencing, digest paging, crash windows, transfer acknowledgement races, initialization, and cutover invariants. No P0/P1 issues remain.

This PR is documentation-only. Runtime source implementation begins against the accepted contract after the paired mdbase provider PR lands.