### PR TITLE
Negotiate legacy hosted query pagination in beta67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.1.0-beta.67
+
+Beta.67 restores hosted-authority query compatibility while keeping
+generation-pinned cursor pagination as the preferred SDK path.
+
+- The SDK now treats its first automatic cursor request as a read-only
+  capability probe. If an authority rejects the optional pagination field, it
+  retries that first page with legacy offset pagination and keeps later pages
+  on the legacy path.
+- Explicit cursor requests remain strict: they are never silently downgraded,
+  so callers asking for generation-pinned semantics still receive the
+  authority's typed incompatibility response.
+
 ## 0.1.0-beta.66
 
 Beta.66 hardens the coordinated runtime introduced in beta.65 against

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "async-trait",
  "axum",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "async-trait",
  "axum",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.66"
+version = "0.1.0-beta.67"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -442,6 +442,86 @@ describe("provider-neutral collection client", () => {
     ]);
   });
 
+  it("falls back to legacy offset pages when an authority rejects the automatic cursor probe", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const records = ["one.md", "two.md", "three.md"].map((path) => ({
+      path,
+      frontmatter: {},
+      types: []
+    }));
+    const client = new MdbaseCollectionClient({
+      async operation<Result>(_operation: string, input: unknown) {
+        const query = input as { offset: number; limit: number; pagination?: string };
+        calls.push(query);
+        if (query.pagination === "cursor") {
+          return {
+            valid: false,
+            diagnostics: [{
+              severity: "error",
+              code: "invalid_query",
+              message: "Additional properties are not allowed ('pagination' was unexpected)."
+            }],
+            result: {}
+          } as Result;
+        }
+        const results = records.slice(query.offset, query.offset + query.limit);
+        return {
+          valid: true,
+          diagnostics: [],
+          result: {
+            results,
+            meta: {
+              total_count: records.length,
+              has_more: query.offset + results.length < records.length
+            }
+          }
+        } as Result;
+      }
+    });
+    const loaded: string[] = [];
+
+    for await (const outcome of client.queryPages({}, {
+      firstPageSize: 1,
+      pageSize: 2
+    })) {
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) loaded.push(...outcome.value.results.map(({ path }) => path));
+    }
+
+    expect(loaded).toEqual(["one.md", "two.md", "three.md"]);
+    expect(calls).toEqual([
+      { limit: 1, offset: 0, pagination: "cursor" },
+      { limit: 1, offset: 0 },
+      { limit: 2, offset: 1 }
+    ]);
+  });
+
+  it("does not downgrade an explicit cursor request", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const client = new MdbaseCollectionClient({
+      async operation<Result>(_operation: string, input: unknown) {
+        calls.push(input as Record<string, unknown>);
+        return {
+          valid: false,
+          diagnostics: [{
+            severity: "error",
+            code: "invalid_query",
+            message: "Cursor pagination is unavailable."
+          }],
+          result: {}
+        } as Result;
+      }
+    });
+
+    const iterator = client.queryPages({ pagination: "cursor" });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { ok: false, problem: { code: "operation_invalid" } }
+    });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    expect(calls).toEqual([{ limit: 200, offset: 0, pagination: "cursor" }]);
+  });
+
   it("uses generation cursors and releases an abandoned iterator", async () => {
     const calls: Array<Record<string, unknown>> = [];
     const client = new MdbaseCollectionClient({

--- a/packages/client/src/query-pagination.ts
+++ b/packages/client/src/query-pagination.ts
@@ -46,7 +46,16 @@ export async function* coordinatedQueryPages<Frontmatter extends JsonObject>(
     try {
       while (!options.signal?.aborted) {
         const pageCursor = cursor;
-        const queried = await query({
+        const pageRequestOptions = {
+          signal: options.signal,
+          timeoutMs: options.pageTimeoutMs,
+          coordination: { ...options.coordination, coalesce: false }
+        };
+        const automaticCursorProbe = pageNumber === 0
+          && requestedCursor === undefined
+          && requestedPagination === undefined
+          && requestedSnapshot === undefined;
+        let queried = await query({
           ...criteria,
           limit: pageNumber === 0 ? firstPageSize : pageSize,
           ...(cursorMode
@@ -58,14 +67,25 @@ export async function* coordinatedQueryPages<Frontmatter extends JsonObject>(
                   ? { pagination: "cursor" as const }
                   : {})
               }),
-          ...(!cursorMode && !snapshot && requestedPagination === undefined
+          ...(!cursorMode && !snapshot && automaticCursorProbe
             ? { pagination: "cursor" as const }
             : {})
-        }, {
-          signal: options.signal,
-          timeoutMs: options.pageTimeoutMs,
-          coordination: { ...options.coordination, coalesce: false }
-        });
+        }, pageRequestOptions);
+        // Cursor pagination is a read-only capability probe for authorities
+        // predating generation cursors. Retry the first page without that
+        // optional field only when the authority rejected the operation
+        // schema; explicit cursor requests remain strict.
+        if (
+          automaticCursorProbe
+          && !queried.ok
+          && queried.problem.code === "operation_invalid"
+        ) {
+          queried = await query({
+            ...criteria,
+            limit: firstPageSize,
+            offset
+          }, pageRequestOptions);
+        }
         if (!queried.ok) {
           yield queried;
           return;

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.66" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.67" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.66",
+  "version": "0.1.0-beta.67",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -121,7 +121,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.66",
+        version: "0.1.0-beta.67",
         capabilities: [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES],
         contract_support: CONNECT_CONTRACT_SUPPORT
       },


### PR DESCRIPTION
## What changed

- Treat the SDK's first automatic generation-cursor request as a read-only capability probe.
- If an authority rejects that optional field with `operation_invalid`, retry the first page once without `pagination` and continue with legacy offset paging.
- Keep explicit cursor requests strict and never silently downgrade them.
- Prepare the coordinated packages as `0.1.0-beta.67`.

## Why

The beta66 deployed Pickle and Editor apps automatically send `pagination: "cursor"`. Staging hosted-provider requests return HTTP 200 but a canonical `invalid_query` diagnostic because the hosted v0.3 query schema rejects `pagination` as an additional property. This prevented hosted inbox/library queries after otherwise successful OAuth and collection setup.

The fallback belongs in the shared SDK because the hosted authority is stateless across the local-runtime generation cursor contract, and all `queryAll()` consumers were affected. The retry is limited to a safe read-only automatic probe; explicit callers retain exact cursor semantics.

## Validation

- Rust: `cargo fmt --all --check`, workspace clippy with warnings denied, complete workspace tests (including 136 Connect core, 70 daemon, 69 hosted-provider, and 63 mirror tests).
- TypeScript: complete workspace test suite (including 199 SDK, 311 server, and 270 Editor tests), full typecheck and builds.
- Release: beta67 version check, release readiness, architecture check, and package consumer audit.
- Browser: non-extractable storage persistence and accessibility suites.
- Regression tests cover successful legacy fallback and strict explicit-cursor failure.

Production remains untouched; this is for staging validation.
