### PR TITLE
Bound offline desktop refresh pressure

### DIFF
--- a/.github/workflows/editor-pages.yml
+++ b/.github/workflows/editor-pages.yml
@@ -129,7 +129,10 @@ jobs:
         env:
           MDBASE_EDITOR_ORIGIN: https://editor-staging.mdbase.dev
           MDBASE_EDITOR_BASE_PATH: /
+          MDBASE_CONNECT_URL: https://connect-staging.mdbase.dev
           VITE_MDBASE_CONNECT_URL: https://connect-staging.mdbase.dev
+      - name: Verify staging editor manifest
+        run: node apps/editor/scripts/verify-deployment-manifest.mjs apps/editor/dist/.well-known/mdbase-app.json https://editor-staging.mdbase.dev/ https://connect-staging.mdbase.dev
       - name: Deploy staging editor
         run: npx --yes --package wrangler@4.114.0 wrangler pages deploy apps/editor/dist --project-name=mdbase-editor --branch=staging
         env:
@@ -143,7 +146,7 @@ jobs:
           CLOUDFLARE_PAGES_PROJECT: mdbase-editor
           CLOUDFLARE_PAGES_DOMAIN: editor-staging.mdbase.dev
       - name: Verify staging custom domain
-        run: node apps/editor/scripts/verify-deployment-manifest.mjs https://editor-staging.mdbase.dev/.well-known/mdbase-app.json https://editor-staging.mdbase.dev/
+        run: node apps/editor/scripts/verify-deployment-manifest.mjs https://editor-staging.mdbase.dev/.well-known/mdbase-app.json https://editor-staging.mdbase.dev/ https://connect-staging.mdbase.dev
         env:
           MDBASE_MANIFEST_VERIFY_ATTEMPTS: 12
           MDBASE_MANIFEST_VERIFY_DELAY_MS: 5000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.0-beta.68
+
+Beta.68 keeps the desktop control plane responsive when the operating-system
+credential store is temporarily unavailable.
+
+- Desktop refreshes are single-flight, so timer and user-triggered refreshes
+  share one bounded request instead of multiplying concurrent control work.
+- A locked or unavailable credential store is represented as a typed offline
+  hosted snapshot. Repeated hosted polls are served locally for a 30-second
+  retry window, while unrelated failures remain visible.
+
 ## 0.1.0-beta.67
 
 Beta.67 restores hosted-authority query compatibility while keeping

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "async-trait",
  "axum",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -10,6 +10,7 @@ await build({
     "src/main/deep-link.ts",
     "src/main/editor-url.ts",
     "src/main/electron-update-backend.ts",
+    "src/main/hosted-snapshot.ts",
     "src/main/release-source.ts",
     "src/main/update-coordinator.ts",
     "src/main/update-download.ts",

--- a/apps/desktop/src/main/hosted-snapshot.ts
+++ b/apps/desktop/src/main/hosted-snapshot.ts
@@ -1,0 +1,64 @@
+export interface HostedControlSnapshot {
+  online: boolean;
+  hosted_collections_available: boolean;
+  hosted_collections: unknown[];
+  grants: unknown[];
+  pending_authorizations: unknown[];
+}
+
+const credentialStoreUnavailable = (error: unknown): boolean => (
+  error instanceof Error
+  && "code" in error
+  && error.code === "credential_store_unavailable"
+);
+
+const offlineSnapshot = (): HostedControlSnapshot => ({
+  online: false,
+  hosted_collections_available: false,
+  hosted_collections: [],
+  grants: [],
+  pending_authorizations: []
+});
+
+interface HostedSnapshotLoaderOptions {
+  retryAfterMs?: number;
+  now?: () => number;
+}
+
+/**
+ * A hosted snapshot is status data, so a known unavailable credential store is
+ * represented as an offline snapshot rather than a rejected Electron IPC call.
+ * Repeated polls are served locally during a short retry cooldown. Other
+ * failures remain visible to the renderer and preserve its last snapshot.
+ */
+export function createHostedSnapshotLoader(
+  request: () => Promise<HostedControlSnapshot>,
+  options: HostedSnapshotLoaderOptions = {}
+): () => Promise<HostedControlSnapshot> {
+  const retryAfterMs = options.retryAfterMs ?? 30_000;
+  const now = options.now ?? Date.now;
+  let retryAt = 0;
+  let inFlight: Promise<HostedControlSnapshot> | undefined;
+
+  return () => {
+    if (now() < retryAt) return Promise.resolve(offlineSnapshot());
+    if (inFlight) return inFlight;
+
+    const pending = (async () => {
+      try {
+        const snapshot = await request();
+        retryAt = 0;
+        return snapshot;
+      } catch (error) {
+        if (!credentialStoreUnavailable(error)) throw error;
+        retryAt = now() + retryAfterMs;
+        return offlineSnapshot();
+      }
+    })();
+    const tracked = pending.finally(() => {
+      if (inFlight === tracked) inFlight = undefined;
+    });
+    inFlight = tracked;
+    return tracked;
+  };
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -20,6 +20,7 @@ import { AgentControlError, requestAgent } from "./control-client";
 import { routeForDeepLink, shouldRegisterDeepLinks } from "./deep-link";
 import { buildEditorUrl } from "./editor-url";
 import { ElectronUpdateBackend } from "./electron-update-backend";
+import { createHostedSnapshotLoader, type HostedControlSnapshot } from "./hosted-snapshot";
 import { selectiveSyncPolicy } from "./selective-sync-input";
 import { createTrayImage } from "./tray-image";
 import { UpdateCoordinator } from "./update-coordinator";
@@ -158,6 +159,10 @@ async function chooseFolder(): Promise<string | null> {
 }
 
 function registerIpc(): void {
+  const loadHostedSnapshot = createHostedSnapshotLoader(
+    () => requestReadyAgent<HostedControlSnapshot>("hosted.snapshot", undefined, 30_000)
+  );
+
   ipcMain.handle("connect:status", async (event) => {
     trustedIpc(event);
     return requestReadyAgent("status");
@@ -516,7 +521,7 @@ function registerIpc(): void {
   });
   ipcMain.handle("connect:hosted:snapshot", async (event) => {
     trustedIpc(event);
-    return requestReadyAgent("hosted.snapshot", undefined, 30_000);
+    return loadHostedSnapshot();
   });
   ipcMain.handle("connect:hosted:create", async (event, input: unknown) => {
     trustedIpc(event);

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -15,6 +15,7 @@ import { Collections } from "./collections-view";
 import { presentConnection } from "./connection-state.mjs";
 import { RequestPermissionChoices } from "./authorization-components";
 import { ConnectionProgress, Overview } from "./overview-view";
+import { singleFlight } from "./single-flight.mjs";
 import {
   AccessControl,
   Empty,
@@ -94,7 +95,7 @@ function App() {
   const [mirrorTarget, setMirrorTarget] = useState<string | null>(null);
   const [navigationOpen, setNavigationOpen] = useState(false);
 
-  const refresh = useCallback(async (quiet = false) => {
+  const runRefresh = useCallback(async (quiet = false) => {
     try {
       const results = await Promise.allSettled([
         window.mdbaseConnect.status().then(setStatus),
@@ -116,6 +117,7 @@ function App() {
       if (!quiet) setError(message(refreshError));
     }
   }, []);
+  const refresh = useMemo(() => singleFlight(runRefresh), [runRefresh]);
 
   useEffect(() => {
     void refresh();

--- a/apps/desktop/src/renderer/single-flight.mts
+++ b/apps/desktop/src/renderer/single-flight.mts
@@ -1,0 +1,21 @@
+/**
+ * Coalesce overlapping refresh requests onto one in-flight operation. The next
+ * interval tick will refresh again after settlement, so callers do not need an
+ * unbounded queue of stale polling work.
+ */
+export function singleFlight<Arguments extends unknown[], Result>(
+  operation: (...arguments_: Arguments) => Promise<Result>
+): (...arguments_: Arguments) => Promise<Result> {
+  let active: Promise<Result> | null = null;
+  return (...arguments_: Arguments) => {
+    if (active) return active;
+    let current: Promise<Result>;
+    current = Promise.resolve()
+      .then(() => operation(...arguments_))
+      .finally(() => {
+        if (active === current) active = null;
+      });
+    active = current;
+    return current;
+  };
+}

--- a/apps/desktop/test/hosted-snapshot.test.mjs
+++ b/apps/desktop/test/hosted-snapshot.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { createHostedSnapshotLoader } = require("../dist/main/hosted-snapshot.js");
+
+test("concurrent hosted snapshot callers share one main-process request", async () => {
+  let requestCount = 0;
+  let resolveRequest;
+  const snapshot = {
+    online: true,
+    hosted_collections_available: true,
+    hosted_collections: [],
+    grants: [],
+    pending_authorizations: []
+  };
+  const loadHostedSnapshot = createHostedSnapshotLoader(() => {
+    requestCount += 1;
+    if (requestCount > 1) return Promise.resolve(snapshot);
+    return new Promise((resolve) => { resolveRequest = resolve; });
+  });
+
+  const first = loadHostedSnapshot();
+  const second = loadHostedSnapshot();
+  assert.equal(first, second);
+  assert.equal(requestCount, 1);
+
+  resolveRequest(snapshot);
+  assert.deepEqual(await Promise.all([first, second]), [snapshot, snapshot]);
+  assert.equal(requestCount, 1);
+
+  assert.equal(await loadHostedSnapshot(), snapshot);
+  assert.equal(requestCount, 2);
+});
+
+test("credential-store degradation becomes a typed offline snapshot with a retry cooldown", async () => {
+  const error = Object.assign(new Error("Login keyring is locked."), {
+    code: "credential_store_unavailable"
+  });
+  let currentTime = 1_000;
+  let requestCount = 0;
+  const snapshot = {
+    online: true,
+    hosted_collections_available: true,
+    hosted_collections: [{ id: "collection" }],
+    grants: [],
+    pending_authorizations: []
+  };
+  const loadHostedSnapshot = createHostedSnapshotLoader(async () => {
+    requestCount += 1;
+    if (requestCount === 1) throw error;
+    return snapshot;
+  }, {
+    retryAfterMs: 30_000,
+    now: () => currentTime
+  });
+
+  assert.deepEqual(await loadHostedSnapshot(), {
+    online: false,
+    hosted_collections_available: false,
+    hosted_collections: [],
+    grants: [],
+    pending_authorizations: []
+  });
+  assert.equal(requestCount, 1);
+
+  currentTime += 29_999;
+  assert.equal((await loadHostedSnapshot()).online, false);
+  assert.equal(requestCount, 1);
+
+  currentTime += 1;
+  assert.equal(await loadHostedSnapshot(), snapshot);
+  assert.equal(requestCount, 2);
+});
+
+test("hosted snapshot preserves successes and unrelated failures", async () => {
+  const snapshot = {
+    online: true,
+    hosted_collections_available: true,
+    hosted_collections: [{ id: "collection" }],
+    grants: [],
+    pending_authorizations: []
+  };
+  const loadSuccess = createHostedSnapshotLoader(async () => snapshot);
+  assert.equal(await loadSuccess(), snapshot);
+
+  const failure = new Error("Connect service unavailable");
+  let requestCount = 0;
+  const loadFailure = createHostedSnapshotLoader(async () => {
+    requestCount += 1;
+    throw failure;
+  });
+  await assert.rejects(loadFailure(), (error) => error === failure);
+  await assert.rejects(loadFailure(), (error) => error === failure);
+  assert.equal(requestCount, 2);
+});

--- a/apps/desktop/test/single-flight.test.mjs
+++ b/apps/desktop/test/single-flight.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { singleFlight } from "../src/renderer/single-flight.mts";
+
+test("overlapping refreshes share one operation and capacity is released", async () => {
+  const calls = [];
+  let release;
+  const refresh = singleFlight(async (quiet) => {
+    calls.push(quiet);
+    if (calls.length === 1) await new Promise((resolve) => { release = resolve; });
+    return calls.length;
+  });
+
+  const first = refresh(false);
+  const overlapping = refresh(true);
+  assert.equal(first, overlapping);
+  await Promise.resolve();
+  assert.deepEqual(calls, [false]);
+  release();
+  assert.equal(await first, 1);
+
+  assert.equal(await refresh(true), 2);
+  assert.deepEqual(calls, [false, true]);
+});
+
+test("a rejected refresh does not wedge later refreshes", async () => {
+  let attempts = 0;
+  const refresh = singleFlight(async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("offline");
+    return "online";
+  });
+
+  await assert.rejects(refresh(), /offline/);
+  assert.equal(await refresh(), "online");
+  assert.equal(attempts, 2);
+});

--- a/apps/editor/scripts/verify-deployment-manifest.mjs
+++ b/apps/editor/scripts/verify-deployment-manifest.mjs
@@ -3,23 +3,31 @@ import { fileURLToPath } from "node:url";
 
 const source = process.argv[2];
 const expectedHomepage = process.argv[3];
+const expectedConnectOrigin = process.argv[4];
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   if (!source || !expectedHomepage) {
-    throw new Error("Usage: node scripts/verify-deployment-manifest.mjs <path-or-url> <expected-homepage>");
+    throw new Error(
+      "Usage: node scripts/verify-deployment-manifest.mjs <path-or-url> <expected-homepage> [expected-connect-origin]"
+    );
   }
-  await verifyManifest(source, expectedHomepage, {
+  await verifyManifest(source, expectedHomepage, expectedConnectOrigin, {
     attempts: positiveInteger(process.env.MDBASE_MANIFEST_VERIFY_ATTEMPTS, 1),
     delayMs: nonNegativeInteger(process.env.MDBASE_MANIFEST_VERIFY_DELAY_MS, 0)
   });
 }
 
-export async function verifyManifest(source, expectedHomepage, { attempts = 1, delayMs = 0 } = {}) {
+export async function verifyManifest(
+  source,
+  expectedHomepage,
+  expectedConnectOrigin,
+  { attempts = 1, delayMs = 0 } = {}
+) {
   let failure;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
       const manifest = await loadManifest(source, attempt);
-      assertEditorManifest(manifest, expectedHomepage);
+      assertEditorManifest(manifest, expectedHomepage, expectedConnectOrigin);
       console.log(`Verified editor file access in ${source}`);
       return;
     } catch (error) {
@@ -30,7 +38,7 @@ export async function verifyManifest(source, expectedHomepage, { attempts = 1, d
   throw failure;
 }
 
-export function assertEditorManifest(manifest, expectedHomepage) {
+export function assertEditorManifest(manifest, expectedHomepage, expectedConnectOrigin) {
   const required = manifest?.requirements?.capabilities?.required;
   const actions = manifest?.requirements?.files?.actions;
   const scope = manifest?.requirements?.files?.scope;
@@ -39,6 +47,13 @@ export function assertEditorManifest(manifest, expectedHomepage) {
   if (manifest?.homepage !== expectedHomepage) problems.push(`homepage must be ${expectedHomepage}`);
   if (!Array.isArray(manifest?.redirect_uris) || manifest.redirect_uris[0] !== expectedHomepage) {
     problems.push(`first redirect URI must be ${expectedHomepage}`);
+  }
+  if (expectedConnectOrigin) {
+    const callback = new URL(expectedHomepage);
+    callback.searchParams.set("server", new URL(expectedConnectOrigin).origin);
+    if (!manifest?.redirect_uris?.includes(callback.href)) {
+      problems.push(`redirect URIs must include ${callback.href}`);
+    }
   }
   if (manifest?.requirements?.access !== "full_collection") problems.push("access must be full_collection");
   if (!Array.isArray(required) || !required.includes("files.list")) problems.push("files.list capability is required");

--- a/apps/editor/scripts/verify-deployment-manifest.test.mjs
+++ b/apps/editor/scripts/verify-deployment-manifest.test.mjs
@@ -8,6 +8,19 @@ test("accepts collection-wide binary file access", () => {
   assert.doesNotThrow(() => assertEditorManifest(manifest(), homepage));
 });
 
+test("accepts the exact configured Connect callback", () => {
+  const value = manifest();
+  value.redirect_uris.push("https://editor.mdbase.dev/?server=https%3A%2F%2Fconnect-staging.mdbase.dev");
+  assert.doesNotThrow(() => assertEditorManifest(value, homepage, "https://connect-staging.mdbase.dev"));
+});
+
+test("rejects a deployment without the configured Connect callback", () => {
+  assert.throws(
+    () => assertEditorManifest(manifest(), homepage, "https://connect-staging.mdbase.dev"),
+    /redirect URIs must include/
+  );
+});
+
 for (const [name, mutate, expected] of [
   ["file capabilities", (value) => { value.requirements.capabilities.required = []; }, /files\.list capability/],
   ["file actions", (value) => { delete value.requirements.files; }, /file list action/],

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "async-trait",
  "axum",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "async-trait",
  "axum",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.67"
+version = "0.1.0-beta.68"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/deploy-editor-dev.mjs
+++ b/scripts/deploy-editor-dev.mjs
@@ -25,6 +25,7 @@ export async function deployDevelopmentEditor(environment, run = runCommand) {
     ...environment,
     MDBASE_EDITOR_ORIGIN: developmentDeployment.editorOrigin,
     MDBASE_EDITOR_BASE_PATH: "/",
+    MDBASE_CONNECT_URL: developmentDeployment.connectOrigin,
     VITE_MDBASE_CONNECT_URL: developmentDeployment.connectOrigin
   };
 
@@ -34,7 +35,8 @@ export async function deployDevelopmentEditor(environment, run = runCommand) {
     await run("node", [
       "apps/editor/scripts/verify-deployment-manifest.mjs",
       "apps/editor/dist/.well-known/mdbase-app.json",
-      `${developmentDeployment.editorOrigin}/`
+      `${developmentDeployment.editorOrigin}/`,
+      developmentDeployment.connectOrigin
     ], deploymentEnvironment);
     await run("pnpm", [
       "dlx",
@@ -48,7 +50,8 @@ export async function deployDevelopmentEditor(environment, run = runCommand) {
     await run("node", [
       "apps/editor/scripts/verify-deployment-manifest.mjs",
       `${developmentDeployment.editorOrigin}/.well-known/mdbase-app.json`,
-      `${developmentDeployment.editorOrigin}/`
+      `${developmentDeployment.editorOrigin}/`,
+      developmentDeployment.connectOrigin
     ], {
       ...deploymentEnvironment,
       MDBASE_MANIFEST_VERIFY_ATTEMPTS: "12",

--- a/scripts/deploy-editor-dev.test.mjs
+++ b/scripts/deploy-editor-dev.test.mjs
@@ -10,7 +10,14 @@ test("builds and deploys the editor against the same-site staging control plane"
 
   const build = calls.find(({ args }) => args.includes("mdbase-editor") && args.includes("build"));
   assert.equal(build.environment.MDBASE_EDITOR_ORIGIN, developmentDeployment.editorOrigin);
+  assert.equal(build.environment.MDBASE_CONNECT_URL, developmentDeployment.connectOrigin);
   assert.equal(build.environment.VITE_MDBASE_CONNECT_URL, developmentDeployment.connectOrigin);
+
+  const manifestChecks = calls.filter(({ args }) => args.includes("apps/editor/scripts/verify-deployment-manifest.mjs"));
+  assert.equal(manifestChecks.length, 2);
+  for (const check of manifestChecks) {
+    assert.equal(check.args.at(-1), developmentDeployment.connectOrigin);
+  }
 
   const deploy = calls.find(({ args }) => args.includes("wrangler@4.114.0"));
   assert.ok(deploy);

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.67" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.68" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.67",
+  "version": "0.1.0-beta.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -121,7 +121,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.67",
+        version: "0.1.0-beta.68",
         capabilities: [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES],
         contract_support: CONNECT_CONTRACT_SUPPORT
       },


### PR DESCRIPTION
## Summary

- coalesce overlapping desktop refreshes in the renderer and again at the hosted-snapshot IPC boundary
- map only credential_store_unavailable to a typed offline snapshot and serve repeated polls locally for a 30-second retry window
- preserve unrelated failures and release single-flight capacity after success or rejection
- advance the coordinated workspace release identity to 0.1.0-beta.68
- generate and verify the exact Editor staging OAuth callback so server-selecting staging links remain authorized

## Verification

- pnpm typecheck
- pnpm test
- pnpm --filter @mdbase/connect-desktop typecheck
- pnpm --filter @mdbase/connect-desktop build
- pnpm --filter @mdbase/connect-desktop test (59/59)
- pnpm check:architecture
- pnpm version:check v0.1.0-beta.68
- full Rust workspace tests, formatting, and clippy with warnings denied
- Editor typecheck, build, 270 tests, deployment-contract tests, bundle budget, and CSP checks
- live beta68 Electron shell against the preserved staging profile
- independent Luna heavy-vault, binary, relay, hosted-app, cancellation, contention, and memory observations

## Rollout

Draft until CI and cross-platform desktop preflight pass. Desktop update rollout is pinned to 0%. Production remains untouched. After merge, beta68 will be tagged and exercised in staging before any production decision.