### PR TITLE
Prepare beta71 hosted point-read candidate

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -65,6 +65,7 @@ jobs:
           if git diff --quiet "$parent" "$SOURCE_COMMIT" -- \
             Cargo.toml \
             apps/portal \
+            config \
             crates \
             deploy/docker/Cargo.lock.hosted-provider \
             deploy/docker/Dockerfile.hosted-provider \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,23 @@
 
 ## Unreleased
 
+## 0.1.0-beta.71
+
+Beta.71 begins the bounded hosted execution rollout and adds direct hosted CLI
+access without weakening the encrypted authority boundary.
+
 - The unified CLI can authorize a direct, per-collection hosted connection and
   execute portable data commands against the hosted authority without a local
   filesystem mirror. Hosted requests use short-lived provider capabilities,
   grant-bound P-256 proofs, automatic credential refresh, and the same explicit
   revocation model as other applications. Account login alone still cannot read
   collection contents.
+- Hosted point reads now fetch and decrypt exactly one record by stable identity
+  or keyed path token, compile canonical resource semantics through `mdbase-rs`,
+  and avoid the legacy collection-wide decrypted working set.
+- A published execution-budget manifest, privacy-safe memory and scan metrics,
+  deterministic large fixtures, and temporary working-set admission limits make
+  the remaining compatibility path explicit and bounded during migration.
 
 ## 0.1.0-beta.70
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "async-trait",
  "axum",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "async-trait",
  "axum",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "async-trait",
  "axum",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.70"
+version = "0.1.0-beta.71"
 dependencies = [
  "chrono",
  "mdbase",

--- a/deploy/docker/Dockerfile.hosted-provider
+++ b/deploy/docker/Dockerfile.hosted-provider
@@ -17,6 +17,7 @@ COPY Cargo.toml ./
 # published revision above so a dirty sibling cannot affect the image graph.
 COPY deploy/docker/Cargo.lock.hosted-provider ./Cargo.lock
 COPY crates crates
+COPY config config
 COPY templates templates
 RUN --mount=type=cache,id=hosted-provider-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=hosted-provider-cargo-git,target=/usr/local/cargo/git/db,sharing=locked \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.70" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.71" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.70",
+  "version": "0.1.0-beta.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -121,7 +121,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.70",
+        version: "0.1.0-beta.71",
         capabilities: [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES],
         contract_support: CONNECT_CONTRACT_SUPPORT
       },


### PR DESCRIPTION
Prepares the first bounded-hosted-execution staging candidate as beta.71. Copies the published execution-budget manifest into the minimal provider image build context, makes manifest changes trigger signed image publication, and synchronizes all Rust/TypeScript package versions. The exact provider Docker build passes locally.