### PR TITLE
Guard desktop output stream failures

### DIFF
--- a/apps/desktop/scripts/build-main.mjs
+++ b/apps/desktop/scripts/build-main.mjs
@@ -11,6 +11,7 @@ await build({
     "src/main/editor-url.ts",
     "src/main/electron-update-backend.ts",
     "src/main/hosted-snapshot.ts",
+    "src/main/process-output.ts",
     "src/main/release-source.ts",
     "src/main/update-coordinator.ts",
     "src/main/update-download.ts",

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -21,10 +21,13 @@ import { routeForDeepLink, shouldRegisterDeepLinks } from "./deep-link";
 import { buildEditorUrl } from "./editor-url";
 import { ElectronUpdateBackend } from "./electron-update-backend";
 import { createHostedSnapshotLoader, type HostedControlSnapshot } from "./hosted-snapshot";
+import { guardDesktopProcessOutput } from "./process-output";
 import { selectiveSyncPolicy } from "./selective-sync-input";
 import { createTrayImage } from "./tray-image";
 import { UpdateCoordinator } from "./update-coordinator";
 import { UpdateStateStore } from "./update-state";
+
+guardDesktopProcessOutput();
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;

--- a/apps/desktop/src/main/process-output.ts
+++ b/apps/desktop/src/main/process-output.ts
@@ -1,0 +1,23 @@
+type OutputStream = Pick<NodeJS.WriteStream, "on">;
+
+/**
+ * A desktop application's lifetime must not depend on the terminal or launcher
+ * that happened to start it. Linux desktop launchers can leave stdout and
+ * stderr attached to pipes whose readers later exit. Any subsequent console
+ * write then emits a stream error (usually EPIPE), which would otherwise crash
+ * Electron's main process while it is reporting an unrelated IPC failure.
+ */
+export function guardDesktopProcessOutput(
+  stdout: OutputStream = process.stdout,
+  stderr: OutputStream = process.stderr
+): void {
+  ignoreOutputErrors(stdout);
+  ignoreOutputErrors(stderr);
+}
+
+function ignoreOutputErrors(stream: OutputStream): void {
+  stream.on("error", () => {
+    // Diagnostic output is best-effort for a GUI process. There is nowhere
+    // safer to report a failed output stream, so keep the application alive.
+  });
+}

--- a/apps/desktop/test/process-output.test.mjs
+++ b/apps/desktop/test/process-output.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const { guardDesktopProcessOutput } = require("../dist/main/process-output.js");
+
+test("closed launcher output pipes do not crash the desktop process", () => {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  guardDesktopProcessOutput(stdout, stderr);
+
+  assert.doesNotThrow(() => {
+    stdout.emit("error", Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+    stderr.emit("error", Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+  });
+  assert.equal(stdout.listenerCount("error"), 1);
+  assert.equal(stderr.listenerCount("error"), 1);
+});


### PR DESCRIPTION
## What changed

- install stdout and stderr error handlers at Electron main-process startup
- treat GUI diagnostic output as best-effort when a launcher-owned pipe closes
- include the output guard as a testable desktop build entry
- add a regression test for closed launcher pipes

## Why

On Linux, a desktop launcher can leave the Electron process attached to stdout or stderr pipes whose readers later exit. When Electron reports an unrelated IPC rejection with `console.error`, the write emits `EPIPE` and crashes the main process, masking the original error with a JavaScript exception dialog.

## Impact

A closed diagnostic pipe no longer crashes mdbase connect or hides the actionable request error. Connector request and authorization semantics are unchanged.

## Validation

- `pnpm --filter @mdbase/connect-desktop typecheck`
- `pnpm --filter @mdbase/connect-desktop test` — 60 tests passed
