### PR TITLE
feat(hosted): activate Candidate B collections atomically

### DIFF
--- a/crates/connect-hosted-provider/migrations/0059_hosted_execution_model_activation.sql
+++ b/crates/connect-hosted-provider/migrations/0059_hosted_execution_model_activation.sql
@@ -1,0 +1,12 @@
+-- Initial Candidate B activation is prepared while legacy execution remains
+-- available. Projection completion atomically binds the complete generation,
+-- switches the execution model, and clears this durable intent.
+ALTER TABLE hosted_provider_collections
+  ADD COLUMN pending_hosted_execution_model text
+    CHECK (pending_hosted_execution_model IS NULL
+      OR pending_hosted_execution_model = 'candidate_b');
+
+CREATE INDEX hosted_provider_collections_projection_activation_idx
+  ON hosted_provider_collections (updated_at, id)
+  WHERE state = 'active'
+    AND pending_hosted_execution_model = 'candidate_b';

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -46,6 +46,7 @@ mod accounts;
 mod authentication;
 mod authority_import_files;
 mod files;
+mod projections;
 
 use accounts::account_routes;
 use authentication::{bearer, request_origin, request_proof};
@@ -54,6 +55,7 @@ use authority_import_files::{
     prepare_authority_import_file_part,
 };
 use files::file_routes;
+use projections::projection_routes;
 
 const MAX_BODY_BYTES: usize = 3 * 1024 * 1024;
 // Record imports are paged, but a page can contain several large canonical
@@ -109,18 +111,6 @@ struct RotateTokenRequest {
 #[derive(Debug, Deserialize)]
 struct CompactRequest {
     through: u64,
-}
-
-#[derive(Debug, Deserialize)]
-struct ActivateCandidateBRequest {
-    expected_head: u64,
-    expected_resource_revision: String,
-    confirmation: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct AdvanceProjectionRequest {
-    generation_id: Uuid,
 }
 
 #[derive(Debug, Deserialize)]
@@ -203,6 +193,7 @@ pub fn app(state: AppState) -> Router {
         .max_age(std::time::Duration::from_secs(600));
     let internal = Router::new()
         .merge(account_routes())
+        .merge(projection_routes())
         .route("/internal/v1/protocol-usage", get(protocol_usage))
         .route(
             "/internal/v1/collections/{collection_id}",
@@ -211,18 +202,6 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/internal/v1/collections/{collection_id}/usage",
             get(collection_usage),
-        )
-        .route(
-            "/internal/v1/collections/{collection_id}/projection",
-            get(projection_status),
-        )
-        .route(
-            "/internal/v1/collections/{collection_id}/projection/activate-candidate-b",
-            post(activate_candidate_b),
-        )
-        .route(
-            "/internal/v1/collections/{collection_id}/projection/advance",
-            post(advance_projection),
         )
         .route(
             "/internal/v1/collections/{collection_id}/replicas",
@@ -426,59 +405,6 @@ async fn collection_usage(
     state.authorize_internal(&headers)?;
     let usage = state.provider.collection_usage(collection_id).await?;
     Ok(Json(json!({ "usage": usage })))
-}
-
-async fn projection_status(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Path(collection_id): Path<Uuid>,
-) -> ApiResult<Json<Value>> {
-    state.authorize_internal(&headers)?;
-    let status = state.provider.projection_status(collection_id).await?;
-    Ok(Json(json!({ "projection": status })))
-}
-
-async fn activate_candidate_b(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Path(collection_id): Path<Uuid>,
-    Json(input): Json<ActivateCandidateBRequest>,
-) -> ApiResult<Json<Value>> {
-    state.authorize_internal(&headers)?;
-    let expected_confirmation = format!(
-        "activate-candidate-b:{collection_id}:{}:{}",
-        input.expected_head, input.expected_resource_revision
-    );
-    if input.confirmation != expected_confirmation {
-        return Err(ApiError::bad_request(
-            "projection_activation_confirmation_invalid",
-            "The Candidate B activation confirmation does not match the expected binding.",
-        ));
-    }
-    let status = state
-        .provider
-        .request_candidate_b_activation(
-            collection_id,
-            input.expected_head,
-            input.expected_resource_revision,
-        )
-        .await?;
-    Ok(Json(json!({ "projection": status })))
-}
-
-async fn advance_projection(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Path(collection_id): Path<Uuid>,
-    Json(input): Json<AdvanceProjectionRequest>,
-) -> ApiResult<Json<Value>> {
-    state.authorize_internal(&headers)?;
-    let batch = state
-        .provider
-        .advance_projection_generation(collection_id, input.generation_id)
-        .await?;
-    let status = state.provider.projection_status(collection_id).await?;
-    Ok(Json(json!({ "batch": batch, "projection": status })))
 }
 
 async fn protocol_usage(

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -112,6 +112,18 @@ struct CompactRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct ActivateCandidateBRequest {
+    expected_head: u64,
+    expected_resource_revision: String,
+    confirmation: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvanceProjectionRequest {
+    generation_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
 struct ProvisionTypePacksRequest {
     type_packs: Vec<TypePackProvision>,
     installed_by: String,
@@ -199,6 +211,18 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/internal/v1/collections/{collection_id}/usage",
             get(collection_usage),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/projection",
+            get(projection_status),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/projection/activate-candidate-b",
+            post(activate_candidate_b),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/projection/advance",
+            post(advance_projection),
         )
         .route(
             "/internal/v1/collections/{collection_id}/replicas",
@@ -402,6 +426,59 @@ async fn collection_usage(
     state.authorize_internal(&headers)?;
     let usage = state.provider.collection_usage(collection_id).await?;
     Ok(Json(json!({ "usage": usage })))
+}
+
+async fn projection_status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let status = state.provider.projection_status(collection_id).await?;
+    Ok(Json(json!({ "projection": status })))
+}
+
+async fn activate_candidate_b(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<ActivateCandidateBRequest>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let expected_confirmation = format!(
+        "activate-candidate-b:{collection_id}:{}:{}",
+        input.expected_head, input.expected_resource_revision
+    );
+    if input.confirmation != expected_confirmation {
+        return Err(ApiError::bad_request(
+            "projection_activation_confirmation_invalid",
+            "The Candidate B activation confirmation does not match the expected binding.",
+        ));
+    }
+    let status = state
+        .provider
+        .request_candidate_b_activation(
+            collection_id,
+            input.expected_head,
+            input.expected_resource_revision,
+        )
+        .await?;
+    Ok(Json(json!({ "projection": status })))
+}
+
+async fn advance_projection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<AdvanceProjectionRequest>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let batch = state
+        .provider
+        .advance_projection_generation(collection_id, input.generation_id)
+        .await?;
+    let status = state.provider.projection_status(collection_id).await?;
+    Ok(Json(json!({ "batch": batch, "projection": status })))
 }
 
 async fn protocol_usage(

--- a/crates/connect-hosted-provider/src/http/projections.rs
+++ b/crates/connect-hosted-provider/src/http/projections.rs
@@ -1,0 +1,94 @@
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::error::{ApiError, ApiResult};
+
+use super::AppState;
+
+#[derive(Debug, Deserialize)]
+struct ActivateCandidateBRequest {
+    expected_head: u64,
+    expected_resource_revision: String,
+    confirmation: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvanceProjectionRequest {
+    generation_id: Uuid,
+}
+
+pub(super) fn projection_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/internal/v1/collections/{collection_id}/projection",
+            get(projection_status),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/projection/activate-candidate-b",
+            post(activate_candidate_b),
+        )
+        .route(
+            "/internal/v1/collections/{collection_id}/projection/advance",
+            post(advance_projection),
+        )
+}
+
+async fn projection_status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let status = state.provider.projection_status(collection_id).await?;
+    Ok(Json(json!({ "projection": status })))
+}
+
+async fn activate_candidate_b(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<ActivateCandidateBRequest>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let expected_confirmation = format!(
+        "activate-candidate-b:{collection_id}:{}:{}",
+        input.expected_head, input.expected_resource_revision
+    );
+    if input.confirmation != expected_confirmation {
+        return Err(ApiError::bad_request(
+            "projection_activation_confirmation_invalid",
+            "The Candidate B activation confirmation does not match the expected binding.",
+        ));
+    }
+    let status = state
+        .provider
+        .request_candidate_b_activation(
+            collection_id,
+            input.expected_head,
+            input.expected_resource_revision,
+        )
+        .await?;
+    Ok(Json(json!({ "projection": status })))
+}
+
+async fn advance_projection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(collection_id): Path<Uuid>,
+    Json(input): Json<AdvanceProjectionRequest>,
+) -> ApiResult<Json<Value>> {
+    state.authorize_internal(&headers)?;
+    let batch = state
+        .provider
+        .advance_projection_generation(collection_id, input.generation_id)
+        .await?;
+    let status = state.provider.projection_status(collection_id).await?;
+    Ok(Json(json!({ "batch": batch, "projection": status })))
+}

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -106,7 +106,7 @@ pub use lifecycle_states::{ProviderAuthorityImportState, ProviderAuthorityTransf
 use operation_context::RecordOperationContext;
 use persistence::*;
 use policy::*;
-pub use projections::{HostedProjectionBatch, HostedProjectionGeneration};
+pub use projections::{HostedProjectionBatch, HostedProjectionGeneration, HostedProjectionStatus};
 
 const SNAPSHOT_PAGE_SIZE: i64 = 200;
 const DATABASE_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -106,7 +106,7 @@ pub use lifecycle_states::{ProviderAuthorityImportState, ProviderAuthorityTransf
 use operation_context::RecordOperationContext;
 use persistence::*;
 use policy::*;
-pub use projections::{HostedProjectionBatch, HostedProjectionGeneration, HostedProjectionStatus};
+pub use projections::{HostedProjectionBatch, HostedProjectionGeneration};
 
 const SNAPSHOT_PAGE_SIZE: i64 = 200;
 const DATABASE_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);

--- a/crates/connect-hosted-provider/src/provider/projections.rs
+++ b/crates/connect-hosted-provider/src/provider/projections.rs
@@ -120,10 +120,6 @@ impl HostedProvider {
         let execution_model: String = row.get("hosted_execution_model");
         let pending_execution_model: Option<String> = row.get("pending_hosted_execution_model");
         if let Some(expected) = activation.as_ref() {
-            if execution_model == "candidate_b" {
-                transaction.rollback().await?;
-                return Ok(None);
-            }
             let current_head = number(row.get::<i64, _>("head"), "collection head")?;
             let current_resource_revision: String = row.get("resource_revision");
             if current_head != expected.head
@@ -139,6 +135,10 @@ impl HostedProvider {
                     "expected_resource_revision": expected.resource_revision,
                     "actual_resource_revision": current_resource_revision,
                 })));
+            }
+            if execution_model == "candidate_b" {
+                transaction.rollback().await?;
+                return Ok(None);
             }
         }
         if activation.is_some() && pending_execution_model.as_deref() == Some("candidate_b") {

--- a/crates/connect-hosted-provider/src/provider/projections.rs
+++ b/crates/connect-hosted-provider/src/provider/projections.rs
@@ -41,6 +41,23 @@ pub struct HostedProjectionBatch {
     pub phase_advanced: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct HostedProjectionStatus {
+    pub collection_id: Uuid,
+    pub execution_model: String,
+    pub pending_execution_model: Option<String>,
+    pub head: u64,
+    pub resource_revision: String,
+    pub active_generation_id: Option<Uuid>,
+    pub building_generation: Option<HostedProjectionGeneration>,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateBActivationExpectation {
+    head: u64,
+    resource_revision: String,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ActiveProjectionChange {
     pub record_id: Uuid,
@@ -72,10 +89,21 @@ impl HostedProvider {
         collection_id: Uuid,
         supersede_building: bool,
     ) -> ApiResult<Option<HostedProjectionGeneration>> {
+        self.start_projection_generation_with_expectation(collection_id, supersede_building, None)
+            .await
+    }
+
+    async fn start_projection_generation_with_expectation(
+        &self,
+        collection_id: Uuid,
+        supersede_building: bool,
+        activation: Option<CandidateBActivationExpectation>,
+    ) -> ApiResult<Option<HostedProjectionGeneration>> {
         let generation_id = Uuid::new_v4();
         let mut transaction = self.pool.begin().await?;
         let row = sqlx::query(
-            r#"SELECT head, resource_revision, wrapped_data_key, resources_ciphertext
+            r#"SELECT head, resource_revision, wrapped_data_key, resources_ciphertext,
+                      hosted_execution_model, pending_hosted_execution_model
                FROM hosted_provider_collections
                WHERE id = $1 AND state = 'active'
                FOR UPDATE"#,
@@ -89,6 +117,48 @@ impl HostedProvider {
                 "Hosted collection not found.",
             )
         })?;
+        let execution_model: String = row.get("hosted_execution_model");
+        let pending_execution_model: Option<String> = row.get("pending_hosted_execution_model");
+        if let Some(expected) = activation.as_ref() {
+            if execution_model == "candidate_b" {
+                transaction.rollback().await?;
+                return Ok(None);
+            }
+            let current_head = number(row.get::<i64, _>("head"), "collection head")?;
+            let current_resource_revision: String = row.get("resource_revision");
+            if current_head != expected.head
+                || current_resource_revision != expected.resource_revision
+            {
+                return Err(ApiError::conflict(
+                    "projection_activation_binding_changed",
+                    "The collection head or resource revision changed before activation.",
+                )
+                .with_details(json!({
+                    "expected_head": expected.head,
+                    "actual_head": current_head,
+                    "expected_resource_revision": expected.resource_revision,
+                    "actual_resource_revision": current_resource_revision,
+                })));
+            }
+        }
+        if activation.is_some() && pending_execution_model.as_deref() == Some("candidate_b") {
+            let building = sqlx::query(
+                r#"SELECT generation_id, target_catalog_revision,
+                          projection_format_version, semantic_engine_version,
+                          source_head, phase, status, lease_fencing_generation
+                   FROM hosted_provider_projection_generations
+                   WHERE collection_id = $1 AND status = 'building'
+                   ORDER BY created_at DESC, generation_id DESC LIMIT 1"#,
+            )
+            .bind(collection_id)
+            .fetch_optional(&mut *transaction)
+            .await?;
+            if let Some(building) = building {
+                let generation = projection_generation_from_row(collection_id, &building)?;
+                transaction.rollback().await?;
+                return Ok(Some(generation));
+            }
+        }
         if !supersede_building {
             // Recovery selects missing work without locking every candidate.
             // Recheck after taking the collection lock so a stale selection
@@ -177,12 +247,23 @@ impl HostedProvider {
         .bind(PROJECTION_LEASE_SECONDS)
         .execute(&mut *transaction)
         .await?;
-        sqlx::query(
-            "UPDATE hosted_provider_collections SET hosted_execution_model = 'candidate_b' WHERE id = $1",
-        )
-        .bind(collection_id)
-        .execute(&mut *transaction)
-        .await?;
+        if activation.is_some() {
+            sqlx::query(
+                r#"UPDATE hosted_provider_collections
+                   SET pending_hosted_execution_model = 'candidate_b', updated_at = now()
+                   WHERE id = $1 AND hosted_execution_model = 'legacy'"#,
+            )
+            .bind(collection_id)
+            .execute(&mut *transaction)
+            .await?;
+        } else if pending_execution_model.as_deref() != Some("candidate_b") {
+            sqlx::query(
+                "UPDATE hosted_provider_collections SET hosted_execution_model = 'candidate_b' WHERE id = $1",
+            )
+            .bind(collection_id)
+            .execute(&mut *transaction)
+            .await?;
+        }
         transaction.commit().await?;
         Ok(Some(HostedProjectionGeneration {
             collection_id,
@@ -197,6 +278,118 @@ impl HostedProvider {
         }))
     }
 
+    /// Record an initial Candidate B activation intent without changing the
+    /// readable execution model. The complete projection generation is bound
+    /// and activated atomically by the resolution completion transaction.
+    pub async fn request_candidate_b_activation(
+        &self,
+        collection_id: Uuid,
+        expected_head: u64,
+        expected_resource_revision: String,
+    ) -> ApiResult<HostedProjectionStatus> {
+        self.start_projection_generation_with_expectation(
+            collection_id,
+            false,
+            Some(CandidateBActivationExpectation {
+                head: expected_head,
+                resource_revision: expected_resource_revision,
+            }),
+        )
+        .await?;
+        self.projection_status(collection_id).await
+    }
+
+    pub async fn projection_status(
+        &self,
+        collection_id: Uuid,
+    ) -> ApiResult<HostedProjectionStatus> {
+        let row = sqlx::query(
+            r#"SELECT collection.hosted_execution_model,
+                      collection.pending_hosted_execution_model,
+                      collection.head, collection.resource_revision,
+                      collection.active_projection_generation_id,
+                      generation.generation_id, generation.target_catalog_revision,
+                      generation.projection_format_version,
+                      generation.semantic_engine_version, generation.source_head,
+                      generation.phase, generation.status,
+                      generation.lease_fencing_generation
+               FROM hosted_provider_collections collection
+               LEFT JOIN LATERAL (
+                 SELECT generation_id, target_catalog_revision,
+                        projection_format_version, semantic_engine_version,
+                        source_head, phase, status, lease_fencing_generation
+                 FROM hosted_provider_projection_generations
+                 WHERE collection_id = collection.id AND status = 'building'
+                 ORDER BY created_at DESC, generation_id DESC LIMIT 1
+               ) generation ON true
+               WHERE collection.id = $1 AND collection.state = 'active'"#,
+        )
+        .bind(collection_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::not_found(
+                "hosted_collection_not_found",
+                "Hosted collection not found.",
+            )
+        })?;
+        Ok(HostedProjectionStatus {
+            collection_id,
+            execution_model: row.get("hosted_execution_model"),
+            pending_execution_model: row.get("pending_hosted_execution_model"),
+            head: number(row.get::<i64, _>("head"), "collection head")?,
+            resource_revision: row.get("resource_revision"),
+            active_generation_id: row.get("active_projection_generation_id"),
+            building_generation: projection_generation_from_joined_row(collection_id, &row)?,
+        })
+    }
+
+    /// Advance exactly one bounded batch for the named generation. Callers
+    /// must re-read status after every call; this never loops to completion.
+    pub async fn advance_projection_generation(
+        &self,
+        collection_id: Uuid,
+        generation_id: Uuid,
+    ) -> ApiResult<HostedProjectionBatch> {
+        let row = sqlx::query(
+            r#"SELECT generation.phase
+               FROM hosted_provider_projection_generations generation
+               JOIN hosted_provider_collections collection
+                 ON collection.id = generation.collection_id
+               WHERE generation.collection_id = $1
+                 AND generation.generation_id = $2
+                 AND generation.status = 'building'
+                 AND collection.state = 'active'
+                 AND (
+                   collection.hosted_execution_model = 'candidate_b'
+                   OR collection.pending_hosted_execution_model = 'candidate_b'
+                 )"#,
+        )
+        .bind(collection_id)
+        .bind(generation_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| {
+            ApiError::conflict(
+                "projection_generation_not_building",
+                "The requested projection generation is not the current building generation.",
+            )
+        })?;
+        let phase: String = row.get("phase");
+        if phase == "projection" {
+            self.project_generation_batch(collection_id, generation_id, MAX_PROJECTION_BATCH)
+                .await
+        } else if phase == "resolution" {
+            self.resolve_generation_batch(collection_id, generation_id, MAX_PROJECTION_BATCH)
+                .await
+        } else {
+            Err(ApiError::conflict(
+                "projection_generation_phase_invalid",
+                "The projection generation has an invalid phase.",
+            ))
+        }
+    }
+
     /// Advance a bounded number of opted-in projection rebuilds. A missing
     /// generation is recreated from exact authority, while live leases remain
     /// fenced to their current owner. One call performs at most one bounded
@@ -207,9 +400,13 @@ impl HostedProvider {
             r#"SELECT collection.id
                FROM hosted_provider_collections collection
                WHERE collection.state = 'active'
-                 AND collection.hosted_execution_model = 'candidate_b'
                  AND (
-                   collection.active_projection_generation_id IS NULL
+                   collection.hosted_execution_model = 'candidate_b'
+                   OR collection.pending_hosted_execution_model = 'candidate_b'
+                 )
+                 AND (
+                   collection.pending_hosted_execution_model = 'candidate_b'
+                   OR collection.active_projection_generation_id IS NULL
                    OR EXISTS (
                      SELECT 1
                      FROM hosted_provider_record_projections projection
@@ -278,7 +475,10 @@ impl HostedProvider {
                JOIN hosted_provider_collections collection
                  ON collection.id = generation.collection_id
                WHERE collection.state = 'active'
-                 AND collection.hosted_execution_model = 'candidate_b'
+                 AND (
+                   collection.hosted_execution_model = 'candidate_b'
+                   OR collection.pending_hosted_execution_model = 'candidate_b'
+                 )
                  AND generation.status = 'building'
                  AND (
                    generation.lease_owner IS NULL
@@ -341,6 +541,75 @@ impl HostedProvider {
         }
         Ok(advanced)
     }
+}
+
+fn projection_generation_from_row(
+    collection_id: Uuid,
+    row: &sqlx::postgres::PgRow,
+) -> ApiResult<HostedProjectionGeneration> {
+    Ok(HostedProjectionGeneration {
+        collection_id,
+        generation_id: row.get("generation_id"),
+        catalog_revision: row.get("target_catalog_revision"),
+        projection_format_version: u32::try_from(number(
+            row.get::<i32, _>("projection_format_version").into(),
+            "projection format version",
+        )?)
+        .map_err(|_| ApiError::internal("Projection format version is outside u32 range."))?,
+        semantic_engine_version: row.get("semantic_engine_version"),
+        source_head: number(row.get::<i64, _>("source_head"), "projection source head")?,
+        phase: row.get("phase"),
+        status: row.get("status"),
+        lease_fencing_generation: number(
+            row.get::<i64, _>("lease_fencing_generation"),
+            "projection lease fence",
+        )?,
+    })
+}
+
+fn projection_generation_from_joined_row(
+    collection_id: Uuid,
+    row: &sqlx::postgres::PgRow,
+) -> ApiResult<Option<HostedProjectionGeneration>> {
+    let Some(generation_id) = row.get::<Option<Uuid>, _>("generation_id") else {
+        return Ok(None);
+    };
+    let required = |name: &str| {
+        row.try_get::<Option<String>, _>(name)
+            .map_err(ApiError::from)?
+            .ok_or_else(|| ApiError::internal("A building projection generation was incomplete."))
+    };
+    let format_version = row
+        .get::<Option<i32>, _>("projection_format_version")
+        .ok_or_else(|| {
+            ApiError::internal("A building projection generation omitted its format.")
+        })?;
+    Ok(Some(HostedProjectionGeneration {
+        collection_id,
+        generation_id,
+        catalog_revision: required("target_catalog_revision")?,
+        projection_format_version: u32::try_from(number(
+            i64::from(format_version),
+            "projection format version",
+        )?)
+        .map_err(|_| ApiError::internal("Projection format version is outside u32 range."))?,
+        semantic_engine_version: required("semantic_engine_version")?,
+        source_head: number(
+            row.get::<Option<i64>, _>("source_head").ok_or_else(|| {
+                ApiError::internal("A building projection generation omitted its source head.")
+            })?,
+            "projection source head",
+        )?,
+        phase: required("phase")?,
+        status: required("status")?,
+        lease_fencing_generation: number(
+            row.get::<Option<i64>, _>("lease_fencing_generation")
+                .ok_or_else(|| {
+                    ApiError::internal("A building projection generation omitted its lease fence.")
+                })?,
+            "projection lease fence",
+        )?,
+    }))
 }
 
 include!("projections/batches.rs");

--- a/crates/connect-hosted-provider/src/provider/projections.rs
+++ b/crates/connect-hosted-provider/src/provider/projections.rs
@@ -50,6 +50,8 @@ pub struct HostedProjectionStatus {
     pub resource_revision: String,
     pub active_generation_id: Option<Uuid>,
     pub building_generation: Option<HostedProjectionGeneration>,
+    pub latest_terminal_generation_id: Option<Uuid>,
+    pub latest_terminal_error_code: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -157,6 +159,40 @@ impl HostedProvider {
                 let generation = projection_generation_from_row(collection_id, &building)?;
                 transaction.rollback().await?;
                 return Ok(Some(generation));
+            }
+            let terminal_error: Option<String> = sqlx::query_scalar(
+                r#"SELECT last_error_code
+                   FROM hosted_provider_projection_generations
+                   WHERE collection_id = $1 AND status = 'abandoned'
+                     AND last_error_code IN (
+                       'projection_record_too_large',
+                       'projection_authority_invalid',
+                       'projection_semantic_failure',
+                       'projection_state_invalid'
+                     )
+                     AND source_head = $2
+                     AND source_resource_revision = $3
+                     AND projection_format_version = $4
+                     AND semantic_engine_version = $5
+                   ORDER BY updated_at DESC, generation_id DESC LIMIT 1"#,
+            )
+            .bind(collection_id)
+            .bind(row.get::<i64, _>("head"))
+            .bind(row.get::<String, _>("resource_revision"))
+            .bind(i64::from(
+                mdbase::runtime::SEMANTIC_PROJECTION_FORMAT_VERSION,
+            ))
+            .bind(mdbase::VERSION)
+            .fetch_optional(&mut *transaction)
+            .await?
+            .flatten();
+            if let Some(error_code) = terminal_error {
+                return Err(ApiError::new(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "projection_activation_quarantined",
+                    "Candidate B activation is quarantined until exact authority or the semantic catalog changes.",
+                )
+                .with_details(json!({ "generation_error_code": error_code })));
             }
         }
         if !supersede_building {
@@ -312,7 +348,9 @@ impl HostedProvider {
                       generation.projection_format_version,
                       generation.semantic_engine_version, generation.source_head,
                       generation.phase, generation.status,
-                      generation.lease_fencing_generation
+                      generation.lease_fencing_generation,
+                      terminal.generation_id AS terminal_generation_id,
+                      terminal.last_error_code AS terminal_error_code
                FROM hosted_provider_collections collection
                LEFT JOIN LATERAL (
                  SELECT generation_id, target_catalog_revision,
@@ -322,6 +360,12 @@ impl HostedProvider {
                  WHERE collection_id = collection.id AND status = 'building'
                  ORDER BY created_at DESC, generation_id DESC LIMIT 1
                ) generation ON true
+               LEFT JOIN LATERAL (
+                 SELECT generation_id, last_error_code
+                 FROM hosted_provider_projection_generations
+                 WHERE collection_id = collection.id AND status = 'abandoned'
+                 ORDER BY updated_at DESC, generation_id DESC LIMIT 1
+               ) terminal ON true
                WHERE collection.id = $1 AND collection.state = 'active'"#,
         )
         .bind(collection_id)
@@ -341,6 +385,8 @@ impl HostedProvider {
             resource_revision: row.get("resource_revision"),
             active_generation_id: row.get("active_projection_generation_id"),
             building_generation: projection_generation_from_joined_row(collection_id, &row)?,
+            latest_terminal_generation_id: row.get("terminal_generation_id"),
+            latest_terminal_error_code: row.get("terminal_error_code"),
         })
     }
 

--- a/crates/connect-hosted-provider/src/provider/projections/batches.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/batches.rs
@@ -785,6 +785,16 @@ impl HostedProvider {
                        active_projection_format_version = $4,
                        active_semantic_engine_version = $5,
                        active_projection_generation_id = $2,
+                       hosted_execution_model = CASE
+                         WHEN pending_hosted_execution_model = 'candidate_b'
+                           THEN 'candidate_b'
+                         ELSE hosted_execution_model
+                       END,
+                       pending_hosted_execution_model = CASE
+                         WHEN pending_hosted_execution_model = 'candidate_b'
+                           THEN NULL
+                         ELSE pending_hosted_execution_model
+                       END,
                        updated_at = now()
                    WHERE id = $1 AND state = 'active' AND head = $6
                    "#,

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -257,6 +257,169 @@ async fn candidate_b_projection_rebuild_abandons_an_oversized_first_record() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
+async fn candidate_b_initial_activation_keeps_legacy_until_atomic_completion() {
+    let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
+        .expect("MDBASE_PROJECTION_DATABASE_URL is required");
+    let fixture = FileLifecycleFixture::new(&database_url).await;
+    let binding = sqlx::query(
+        "SELECT head, resource_revision FROM hosted_provider_collections WHERE id = $1",
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    let head = u64::try_from(binding.get::<i64, _>("head")).unwrap();
+    let resource_revision: String = binding.get("resource_revision");
+
+    let stale = fixture
+        .provider
+        .request_candidate_b_activation(fixture.collection_id, head + 1, resource_revision.clone())
+        .await
+        .unwrap_err();
+    assert_eq!(stale.code, "projection_activation_binding_changed");
+
+    let requested = fixture
+        .provider
+        .request_candidate_b_activation(fixture.collection_id, head, resource_revision.clone())
+        .await
+        .unwrap();
+    assert_eq!(requested.execution_model, "legacy");
+    assert_eq!(
+        requested.pending_execution_model.as_deref(),
+        Some("candidate_b")
+    );
+    let generation_id = requested.building_generation.unwrap().generation_id;
+
+    // A retry is idempotent and does not supersede the authorized generation.
+    let retried = fixture
+        .provider
+        .request_candidate_b_activation(fixture.collection_id, head, resource_revision)
+        .await
+        .unwrap();
+    assert_eq!(
+        retried.building_generation.unwrap().generation_id,
+        generation_id
+    );
+
+    for _ in 0..8 {
+        let before = fixture
+            .provider
+            .projection_status(fixture.collection_id)
+            .await
+            .unwrap();
+        if before.execution_model == "candidate_b" {
+            break;
+        }
+        assert_eq!(before.execution_model, "legacy");
+        fixture
+            .provider
+            .advance_projection_generation(fixture.collection_id, generation_id)
+            .await
+            .unwrap();
+    }
+    let complete = fixture
+        .provider
+        .projection_status(fixture.collection_id)
+        .await
+        .unwrap();
+    assert_eq!(complete.execution_model, "candidate_b");
+    assert!(complete.pending_execution_model.is_none());
+    assert_eq!(complete.active_generation_id, Some(generation_id));
+    assert!(complete.building_generation.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
+async fn candidate_b_pending_activation_recovers_after_a_concurrent_legacy_write() {
+    let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
+        .expect("MDBASE_PROJECTION_DATABASE_URL is required");
+    let fixture = FileLifecycleFixture::new(&database_url).await;
+    let binding = sqlx::query(
+        "SELECT head, resource_revision FROM hosted_provider_collections WHERE id = $1",
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    let requested = fixture
+        .provider
+        .request_candidate_b_activation(
+            fixture.collection_id,
+            u64::try_from(binding.get::<i64, _>("head")).unwrap(),
+            binding.get("resource_revision"),
+        )
+        .await
+        .unwrap();
+    let stale_generation = requested.building_generation.unwrap().generation_id;
+    let replica = sqlx::query(
+        "SELECT id, scope_epoch FROM hosted_provider_replicas WHERE collection_id = $1",
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    put(
+        &fixture,
+        replica.get("id"),
+        u64::try_from(replica.get::<i64, _>("scope_epoch")).unwrap(),
+        Uuid::now_v7(),
+        None,
+        "concurrent.md",
+        "A write while legacy remains readable.\n",
+    )
+    .await;
+    let mut stale_code = None;
+    for _ in 0..4 {
+        match fixture
+            .provider
+            .advance_projection_generation(fixture.collection_id, stale_generation)
+            .await
+        {
+            Ok(_) => {}
+            Err(error) => {
+                stale_code = Some(error.code);
+                break;
+            }
+        }
+    }
+    assert_eq!(
+        stale_code.as_deref(),
+        Some("projection_source_head_changed")
+    );
+    let still_legacy = fixture
+        .provider
+        .projection_status(fixture.collection_id)
+        .await
+        .unwrap();
+    assert_eq!(still_legacy.execution_model, "legacy");
+    assert_eq!(
+        still_legacy.pending_execution_model.as_deref(),
+        Some("candidate_b")
+    );
+
+    for _ in 0..16 {
+        fixture
+            .provider
+            .recover_projection_generations(1)
+            .await
+            .unwrap();
+        let status = fixture
+            .provider
+            .projection_status(fixture.collection_id)
+            .await
+            .unwrap();
+        if status.execution_model == "candidate_b" {
+            assert!(status.pending_execution_model.is_none());
+            assert!(status.active_generation_id.is_some());
+            return;
+        }
+        assert_eq!(status.execution_model, "legacy");
+    }
+    panic!("pending Candidate B activation did not recover within its bounded test loop");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
 async fn candidate_b_projection_rebuild_quarantines_an_oversized_semantic_projection() {
     let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
         .expect("MDBASE_PROJECTION_DATABASE_URL is required");

--- a/crates/connect-protocol/src/lib.rs
+++ b/crates/connect-protocol/src/lib.rs
@@ -42,10 +42,12 @@ pub const RELAY_INCOMPATIBLE_CLOSE_CODE: u16 = 4406;
 pub const MINIMUM_CONNECTOR_VERSION: &str = "0.1.0-beta.33";
 pub const HOSTED_PROVIDER_REQUIRED_CAPABILITIES: &[&str] =
     &["durable-mutation-journal-v1", "durable-file-lifecycle-v1"];
+pub const HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY: &str = "candidate-b-activation-v1";
 pub const HOSTED_PROVIDER_CAPABILITIES: &[&str] = &[
     "durable-mutation-journal-v1",
     "durable-file-lifecycle-v1",
     "mutation-replay-after-credential-retirement-v1",
+    HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY,
 ];
 pub const CONTRACT_SETUP_CAPABILITY: &str = "contract-setup-v1";
 pub const FILE_RELAY_CAPABILITY: &str = "file-relay-v1";

--- a/docs/architecture/hosted-projection-migration.md
+++ b/docs/architecture/hosted-projection-migration.md
@@ -55,8 +55,11 @@ the default is `legacy`. In Candidate B mode, a newly created provider collectio
 must complete this bounded protocol before its control-plane catalogue row is
 inserted or returned to a consumer. Completed authority imports use the same gate:
 the provider import receipt remains replayable while Connect resumes bounded
-activation calls, and the control-plane transfer stays `activating` until the
-complete Candidate B generation is visible.
+activation calls. A request that exhausts its 16 one-batch advances returns an
+explicit HTTP 202 `activating` response; the same fenced completion request is
+safe to resume while the periodic provider worker also advances it. The
+control-plane transfer stays `activating` until the complete Candidate B generation
+is visible.
 
 ## Physical state
 

--- a/docs/architecture/hosted-projection-migration.md
+++ b/docs/architecture/hosted-projection-migration.md
@@ -44,8 +44,9 @@ stale, cancelled, or restarted build therefore never exposes a half-projected
 collection and never removes the legacy path.
 
 The internal activation protocol is `candidate-b-activation-v1`. Status returns
-only execution/binding state, head, resource revision, and the current building
-generation. Activation requires the expected head, expected resource revision, and
+only execution/binding state, head, resource revision, the current building
+generation, and bounded metadata for the latest terminal generation. Activation
+requires the expected head, expected resource revision, and
 an exact `activate-candidate-b:<collection>:<head>:<revision>` confirmation. A retry
 returns the existing authorized generation instead of superseding it. Advance names
 that generation and executes exactly one bounded projection or resolution batch.

--- a/docs/architecture/hosted-projection-migration.md
+++ b/docs/architecture/hosted-projection-migration.md
@@ -16,6 +16,7 @@ Snapshot mtime cursor index: `crates/connect-hosted-provider/migrations/0055_sna
 Versioned query-receipt compression: `crates/connect-hosted-provider/migrations/0056_query_receipt_compression.sql`
 Immutable receipt ownership: `crates/connect-hosted-provider/migrations/0057_query_receipt_identity_immutability.sql`
 Guarded digest binding: `crates/connect-hosted-provider/migrations/0058_projection_digest_write_guard.sql`
+Atomic activation intent: `crates/connect-hosted-provider/migrations/0059_hosted_execution_model_activation.sql`
 
 ## Compatibility strategy
 
@@ -32,10 +33,27 @@ is installed only if the collection head and catalog still equal that source
 snapshot at completion. Otherwise the generation is abandoned and retried.
 Migration 0036 adds an explicit `legacy | candidate_b` execution-model gate with a
 `legacy` default. Existing collections therefore keep their recoverable path when
-the additive schema and dual-capable binary deploy. Starting the first explicitly
-authorized generation opts only that collection into Candidate B. Maintenance
-recreates missing generations and advances one bounded fenced batch at a time only
-for opted-in collections.
+the additive schema and dual-capable binary deploy. Requesting the first explicitly
+authorized generation writes a durable
+`pending_hosted_execution_model = 'candidate_b'` intent but leaves the collection
+on `legacy`. Maintenance recreates missing generations and advances one bounded
+fenced batch at a time for active or pending collections. Only the generation's
+completion transaction binds the fully resolved snapshot, changes
+`hosted_execution_model` to `candidate_b`, and clears the pending intent. A failed,
+stale, cancelled, or restarted build therefore never exposes a half-projected
+collection and never removes the legacy path.
+
+The internal activation protocol is `candidate-b-activation-v1`. Status returns
+only execution/binding state, head, resource revision, and the current building
+generation. Activation requires the expected head, expected resource revision, and
+an exact `activate-candidate-b:<collection>:<head>:<revision>` confirmation. A retry
+returns the existing authorized generation instead of superseding it. Advance names
+that generation and executes exactly one bounded projection or resolution batch.
+The control plane may set
+`MDBASE_CONNECT_NEW_HOSTED_EXECUTION_MODEL=candidate_b` for an isolated environment;
+the default is `legacy`. In Candidate B mode, a newly created provider collection
+must complete this bounded protocol before its control-plane catalogue row is
+inserted or returned to a consumer.
 
 ## Physical state
 
@@ -45,6 +63,10 @@ for opted-in collections.
 - `active_projection_format_version`;
 - `active_semantic_engine_version`; and
 - `active_projection_generation_id`.
+
+Migration 0059 additionally adds nullable `pending_hosted_execution_model`. The
+only non-null value is `candidate_b`; it records authorization to rebuild and
+survives process restart or source-head races without changing query routing.
 
 They are either all null or all present. Existing encrypted exact records remain
 unchanged and authoritative.
@@ -397,8 +419,10 @@ leaves only the successor returned by the committed response/retry receipt path.
 
 ## Code rollback
 
-Before production activation, rollback is simply the previous binary; all new rows
-remain unused and no canonical state changed. During an isolated activated staging
+Before production activation, rollback is a code rollback; all new rows remain
+derived and no canonical state changed. A pre-0059 binary ignores a pending
+activation and continues routing that collection through `legacy`; it does not
+recover the intent, and a later 0059-aware deployment resumes it. During an isolated activated staging
 test, an operator may invalidate query cursors and atomically null all four
 collection binding fields to return traffic to the encrypted exact path while
 retaining generation-scoped projection rows for diagnosis.

--- a/docs/architecture/hosted-projection-migration.md
+++ b/docs/architecture/hosted-projection-migration.md
@@ -53,7 +53,10 @@ The control plane may set
 `MDBASE_CONNECT_NEW_HOSTED_EXECUTION_MODEL=candidate_b` for an isolated environment;
 the default is `legacy`. In Candidate B mode, a newly created provider collection
 must complete this bounded protocol before its control-plane catalogue row is
-inserted or returned to a consumer.
+inserted or returned to a consumer. Completed authority imports use the same gate:
+the provider import receipt remains replayable while Connect resumes bounded
+activation calls, and the control-plane transfer stays `activating` until the
+complete Candidate B generation is visible.
 
 ## Physical state
 

--- a/docs/architecture/hosted-queryable-execution.md
+++ b/docs/architecture/hosted-queryable-execution.md
@@ -276,10 +276,12 @@ edge replacement, and record-revision CAS make restart safe. Rebuild failure aff
 optimization only: exact authority remains available, subject to the same bounded
 fallback and fail-closed authorization rules.
 
-Provider startup awaits one bounded recovery pass for at most 20 Candidate B
-generations before binding the HTTP listener. The pass can create a missing
+Provider startup awaits one bounded recovery pass for at most 20 active or durably
+pending Candidate B generations before binding the HTTP listener. The pass can create a missing
 generation and advances at most one bounded projection or resolution batch per
-selected collection; it does not turn global readiness into a wait for every tenant
+selected collection. Pending initial activation remains routed through legacy until
+the complete generation is bound atomically; recovery cannot expose partial state.
+The startup pass does not turn global readiness into a wait for every tenant
 rebuild to complete. Terminal semantic or ciphertext faults remain quarantined,
 while an unexpected database or recovery error fails startup instead of advertising
 a ready process that has not attempted recovery. The periodic bounded worker resumes

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -42,9 +42,12 @@ export const HOSTED_PROVIDER_REQUIRED_CAPABILITIES = [
   "durable-mutation-journal-v1",
   "durable-file-lifecycle-v1"
 ] as const;
+export const HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY =
+  "candidate-b-activation-v1" as const;
 export const HOSTED_PROVIDER_CAPABILITIES = [
   ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
-  "mutation-replay-after-credential-retirement-v1"
+  "mutation-replay-after-credential-retirement-v1",
+  HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY
 ] as const;
 export const RELAY_CAPABILITIES = [
   ...RELAY_REQUIRED_CAPABILITIES,

--- a/services/server/src/authority-adoption.test.ts
+++ b/services/server/src/authority-adoption.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
 import {
+  HostedProviderResponseError,
   HostedProviderUnavailableError,
   type HostedProviderClient
 } from "./hosted-provider.js";
@@ -57,6 +58,13 @@ describe("portable local collection adoption", () => {
         completionAttempts += 1;
         if (completionAttempts === 1) {
           throw new HostedProviderUnavailableError(new Error("response lost after commit"));
+        }
+        if (completionAttempts === 2) {
+          throw new HostedProviderResponseError(
+            409,
+            "projection_activation_pending",
+            "Candidate B projection is still building."
+          );
         }
         return {
           id: transferId,
@@ -199,6 +207,15 @@ describe("portable local collection adoption", () => {
       headers: { authorization: `Bearer ${secret}` },
       payload: { ...completion, manifest_digest: "c".repeat(64) }
     })).statusCode).toBe(409);
+
+    const projectionPending = await app.inject({
+      method: "POST",
+      url: `/v1/authority-adoptions/${adoptionId}/complete`,
+      headers: { authorization: `Bearer ${secret}` },
+      payload: completion
+    });
+    expect(projectionPending.statusCode, projectionPending.body).toBe(202);
+    expect(projectionPending.json()).toEqual({ status: "activating" });
 
     const completed = await app.inject({
       method: "POST",

--- a/services/server/src/authority-transfer.test.ts
+++ b/services/server/src/authority-transfer.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
 import {
+  HostedProviderResponseError,
   HostedProviderUnavailableError,
   type HostedProviderClient
 } from "./hosted-provider.js";
@@ -454,6 +455,13 @@ describe("local-to-hosted authority transfer", () => {
         if (completionAttempts === 1) {
           throw new HostedProviderUnavailableError(new Error("response lost"));
         }
+        if (completionAttempts === 2) {
+          throw new HostedProviderResponseError(
+            409,
+            "projection_activation_pending",
+            "Candidate B projection is still building."
+          );
+        }
         return {
           id: transferId,
           collection_id: collectionId,
@@ -572,6 +580,23 @@ describe("local-to-hosted authority transfer", () => {
         source_head: 7
       }
     })).statusCode).toBe(409);
+
+    const projectionPending = await app.inject({
+      method: "POST",
+      url: `/v1/connectors/authority-transfers/${transferId}/complete`,
+      headers: { authorization: `Bearer ${connectorToken}` },
+      payload: {
+        manifest_digest: manifestDigest,
+        source_revision: sourceRevision,
+        source_head: 7
+      }
+    });
+    expect(projectionPending.statusCode, projectionPending.body).toBe(202);
+    expect(projectionPending.json()).toEqual({
+      status: "activating",
+      collection_id: collectionId,
+      authority_epoch: 2
+    });
 
     const completed = await app.inject({
       method: "POST",

--- a/services/server/src/features/authority-adoption/routes.ts
+++ b/services/server/src/features/authority-adoption/routes.ts
@@ -442,11 +442,22 @@ export function registerAuthorityAdoptionRoutes(
           ));
         }
       }
-      const completed = await options.hostedProvider.completeAuthorityImport(
-        adoption.id,
-        input.manifest_digest,
-        input.source_revision
-      );
+      let completed;
+      try {
+        completed = await options.hostedProvider.completeAuthorityImport(
+          adoption.id,
+          input.manifest_digest,
+          input.source_revision
+        );
+      } catch (error) {
+        if (
+          error instanceof HostedProviderResponseError
+          && error.code === "projection_activation_pending"
+        ) {
+          return reply.code(202).send({ status: "activating" });
+        }
+        throw error;
+      }
       if (
         completed.id !== adoption.id
         || completed.collection_id !== adoption.collection_id

--- a/services/server/src/features/authority-transfer/local-to-hosted-routes.ts
+++ b/services/server/src/features/authority-transfer/local-to-hosted-routes.ts
@@ -237,11 +237,26 @@ export function registerLocalToHostedTransferRoutes(
           input
         );
       }
-      const completed = await options.hostedProvider.completeAuthorityImport(
-        transferId,
-        input.manifest_digest,
-        input.source_revision
-      );
+      let completed;
+      try {
+        completed = await options.hostedProvider.completeAuthorityImport(
+          transferId,
+          input.manifest_digest,
+          input.source_revision
+        );
+      } catch (error) {
+        if (
+          error instanceof HostedProviderResponseError
+          && error.code === "projection_activation_pending"
+        ) {
+          return reply.code(202).send({
+            status: "activating",
+            collection_id: transfer.hosted_collection_id,
+            authority_epoch: Number(transfer.next_authority_epoch)
+          });
+        }
+        throw error;
+      }
       if (
         completed.id !== transferId
         || completed.collection_id !== transfer.hosted_collection_id

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -112,6 +112,47 @@ describe("hosted provider control client", () => {
       .resolves.toEqual(active);
   });
 
+  it("does not return a completed authority import before Candidate B is active", async () => {
+    const completed = {
+      id: "transfer",
+      collection_id: "collection",
+      authority_epoch: 2,
+      state: "completed",
+      manifest_digest: "sha256:manifest",
+      source_revision: "source-v1",
+      source_head: 42,
+      contracts: [],
+      expires_at: "2026-08-18T00:00:00Z"
+    };
+    const active = {
+      collection_id: "collection",
+      execution_model: "candidate_b",
+      pending_execution_model: null,
+      head: 42,
+      resource_revision: "catalog-v1",
+      active_generation_id: "generation",
+      building_generation: null
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify(completed)))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ projection: active })));
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret",
+      newCollectionExecutionModel: "candidate_b"
+    });
+
+    await expect(provider.completeAuthorityImport(
+      "transfer",
+      "sha256:manifest",
+      "source-v1"
+    )).resolves.toEqual(completed);
+    expect(fetchMock.mock.calls.map(([url, init]) => [url, init?.method])).toEqual([
+      ["https://provider.example/internal/v1/authority-imports/transfer", "POST"],
+      ["https://provider.example/internal/v1/collections/collection/projection", "GET"]
+    ]);
+  });
+
   it("uses only the internal bearer credential and expected provider document", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(undefined, { status: 201 })

--- a/services/server/src/hosted-provider.test.ts
+++ b/services/server/src/hosted-provider.test.ts
@@ -25,6 +25,93 @@ function readinessDocument(contractSupport: ConnectContractSupport = CONNECT_CON
 }
 
 describe("hosted provider control client", () => {
+  it("activates new Candidate B collections before returning them to the control plane", async () => {
+    const legacy = {
+      collection_id: "collection",
+      execution_model: "legacy",
+      pending_execution_model: null,
+      head: 0,
+      resource_revision: "catalog-v1",
+      active_generation_id: null,
+      building_generation: null
+    };
+    const building = {
+      ...legacy,
+      pending_execution_model: "candidate_b",
+      building_generation: {
+        collection_id: "collection",
+        generation_id: "generation",
+        source_head: 0,
+        phase: "projection",
+        status: "building"
+      }
+    };
+    const active = {
+      ...legacy,
+      execution_model: "candidate_b",
+      active_generation_id: "generation"
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(undefined, { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ projection: legacy })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ projection: building })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ projection: active })));
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret",
+      newCollectionExecutionModel: "candidate_b"
+    });
+
+    await provider.createCollection("account", "collection", "blank", "Notes", "UTC");
+
+    expect(fetchMock.mock.calls.map(([url, init]) => [url, init?.method])).toEqual([
+      ["https://provider.example/internal/v1/collections", "POST"],
+      ["https://provider.example/internal/v1/collections/collection/projection", "GET"],
+      [
+        "https://provider.example/internal/v1/collections/collection/projection/activate-candidate-b",
+        "POST"
+      ],
+      [
+        "https://provider.example/internal/v1/collections/collection/projection/advance",
+        "POST"
+      ]
+    ]);
+    expect(fetchMock.mock.calls[2]?.[1]?.body).toBe(JSON.stringify({
+      expected_head: 0,
+      expected_resource_revision: "catalog-v1",
+      confirmation: "activate-candidate-b:collection:0:catalog-v1"
+    }));
+  });
+
+  it("reconciles an activation batch whose successful response was lost", async () => {
+    const active = {
+      collection_id: "collection",
+      execution_model: "candidate_b",
+      pending_execution_model: null,
+      head: 0,
+      resource_revision: "catalog-v1",
+      active_generation_id: "generation",
+      building_generation: null
+    };
+    vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("response lost after commit"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: {
+          code: "projection_generation_not_building",
+          message: "The generation completed."
+        }
+      }), { status: 409 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ projection: active })));
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret",
+      newCollectionExecutionModel: "candidate_b"
+    });
+
+    await expect(provider.advanceProjection("collection", "generation"))
+      .resolves.toEqual(active);
+  });
+
   it("uses only the internal bearer credential and expected provider document", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(undefined, { status: 201 })
@@ -174,6 +261,21 @@ describe("hosted provider control client", () => {
     const provider = new HostedProviderClient({
       url: "https://provider.example",
       internalToken: "internal-secret"
+    });
+    await expect(provider.ready()).rejects.toBeInstanceOf(HostedProviderUnavailableError);
+  });
+
+  it("requires the versioned activation capability only when new Candidate B collections are enabled", async () => {
+    const document = readinessDocument();
+    document.provider.capabilities = [...HOSTED_PROVIDER_REQUIRED_CAPABILITIES];
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      JSON.stringify(document),
+      { status: 200 }
+    ));
+    const provider = new HostedProviderClient({
+      url: "https://provider.example",
+      internalToken: "internal-secret",
+      newCollectionExecutionModel: "candidate_b"
     });
     await expect(provider.ready()).rejects.toBeInstanceOf(HostedProviderUnavailableError);
   });

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -265,7 +265,7 @@ export class HostedProviderClient {
       timezone
     });
     if (this.newCollectionExecutionModel === "candidate_b") {
-      await this.activateCandidateBCollection(collectionId);
+      await this.activateCandidateBCollection(collectionId, false);
     }
   }
 
@@ -328,12 +328,15 @@ export class HostedProviderClient {
     }
   }
 
-  private async activateCandidateBCollection(collectionId: string): Promise<void> {
+  private async activateCandidateBCollection(
+    collectionId: string,
+    resumable: boolean
+  ): Promise<void> {
     let status = await this.projectionStatus(collectionId);
     if (status.execution_model === "candidate_b" && status.active_generation_id) return;
     status = await this.requestCandidateBActivation(collectionId, status);
-    // Creation-time collections contain no user records. Keep the loop finite
-    // so a provider regression cannot hold a control-plane request forever.
+    // Keep every control-plane request finite. Large authority imports resume
+    // the same fenced generation through an explicit typed pending response.
     for (let batch = 0; batch < 16; batch += 1) {
       if (status.execution_model === "candidate_b" && status.active_generation_id) return;
       const generationId = status.building_generation?.generation_id;
@@ -345,6 +348,13 @@ export class HostedProviderClient {
         );
       }
       status = await this.advanceProjection(collectionId, generationId);
+    }
+    if (resumable) {
+      throw new HostedProviderResponseError(
+        409,
+        "projection_activation_pending",
+        "Candidate B activation is still building; resume the same fenced authority import."
+      );
     }
     throw new HostedProviderResponseError(
       503,
@@ -641,7 +651,7 @@ export class HostedProviderClient {
       { manifest_digest: manifestDigest, source_revision: sourceRevision }
     ) as AuthorityImport;
     if (this.newCollectionExecutionModel === "candidate_b") {
-      await this.activateCandidateBCollection(completed.collection_id);
+      await this.activateCandidateBCollection(completed.collection_id, true);
     }
     return completed;
   }

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -40,6 +40,8 @@ export interface HostedProjectionStatus {
   resource_revision: string;
   active_generation_id: string | null;
   building_generation: HostedProjectionGenerationStatus | null;
+  latest_terminal_generation_id?: string | null;
+  latest_terminal_error_code?: string | null;
 }
 
 export interface HostedReplicaEnrollment {
@@ -263,7 +265,7 @@ export class HostedProviderClient {
       timezone
     });
     if (this.newCollectionExecutionModel === "candidate_b") {
-      await this.activateNewCandidateBCollection(collectionId);
+      await this.activateCandidateBCollection(collectionId);
     }
   }
 
@@ -326,7 +328,7 @@ export class HostedProviderClient {
     }
   }
 
-  private async activateNewCandidateBCollection(collectionId: string): Promise<void> {
+  private async activateCandidateBCollection(collectionId: string): Promise<void> {
     let status = await this.projectionStatus(collectionId);
     if (status.execution_model === "candidate_b" && status.active_generation_id) return;
     status = await this.requestCandidateBActivation(collectionId, status);
@@ -633,11 +635,15 @@ export class HostedProviderClient {
     manifestDigest: string,
     sourceRevision: string
   ): Promise<AuthorityImport> {
-    return await this.request(
+    const completed = await this.request(
       "POST",
       `/internal/v1/authority-imports/${encodeURIComponent(transferId)}`,
       { manifest_digest: manifestDigest, source_revision: sourceRevision }
     ) as AuthorityImport;
+    if (this.newCollectionExecutionModel === "candidate_b") {
+      await this.activateCandidateBCollection(completed.collection_id);
+    }
+    return completed;
   }
 
   async abortAuthorityImport(transferId: string): Promise<AuthorityImport> {

--- a/services/server/src/hosted-provider.ts
+++ b/services/server/src/hosted-provider.ts
@@ -10,6 +10,7 @@ import type {
 } from "@mdbase-dev/connect-protocol";
 import {
   CONNECT_CONTRACT_SUPPORT,
+  HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY,
   HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
   type ConnectContractSupport
 } from "@mdbase-dev/connect-protocol";
@@ -20,6 +21,25 @@ export interface HostedProviderConfig {
   url: string;
   publicUrl?: string;
   internalToken: string;
+  newCollectionExecutionModel?: "legacy" | "candidate_b";
+}
+
+export interface HostedProjectionGenerationStatus {
+  collection_id: string;
+  generation_id: string;
+  source_head: number;
+  phase: "projection" | "resolution";
+  status: "building";
+}
+
+export interface HostedProjectionStatus {
+  collection_id: string;
+  execution_model: "legacy" | "candidate_b";
+  pending_execution_model: "candidate_b" | null;
+  head: number;
+  resource_revision: string;
+  active_generation_id: string | null;
+  building_generation: HostedProjectionGenerationStatus | null;
 }
 
 export interface HostedReplicaEnrollment {
@@ -135,11 +155,13 @@ export class HostedProviderClient {
   readonly url: string;
   private readonly endpointUrl: string;
   private readonly internalToken: string;
+  private readonly newCollectionExecutionModel: "legacy" | "candidate_b";
 
   constructor(config: HostedProviderConfig) {
     this.endpointUrl = new URL(config.url).origin;
     this.url = new URL(config.publicUrl ?? config.url).origin;
     this.internalToken = config.internalToken;
+    this.newCollectionExecutionModel = config.newCollectionExecutionModel ?? "legacy";
   }
 
   async ready(): Promise<void> {
@@ -155,6 +177,8 @@ export class HostedProviderClient {
         || !HOSTED_PROVIDER_REQUIRED_CAPABILITIES.every(
           (required) => capabilities.includes(required)
         )
+        || (this.newCollectionExecutionModel === "candidate_b"
+          && !capabilities.includes(HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY))
         || !hostedContractSupportMatches(result.provider?.contract_support)) {
       throw new HostedProviderUnavailableError(
         new Error("Hosted provider capability report is incompatible.")
@@ -238,6 +262,93 @@ export class HostedProviderClient {
       display_name: displayName,
       timezone
     });
+    if (this.newCollectionExecutionModel === "candidate_b") {
+      await this.activateNewCandidateBCollection(collectionId);
+    }
+  }
+
+  async projectionStatus(collectionId: string): Promise<HostedProjectionStatus> {
+    const result = await this.request(
+      "GET",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/projection`
+    ) as { projection?: HostedProjectionStatus } | undefined;
+    return requiredProjectionStatus(result?.projection);
+  }
+
+  async requestCandidateBActivation(
+    collectionId: string,
+    expected: Pick<HostedProjectionStatus, "head" | "resource_revision">
+  ): Promise<HostedProjectionStatus> {
+    const confirmation = [
+      "activate-candidate-b",
+      collectionId,
+      String(expected.head),
+      expected.resource_revision
+    ].join(":");
+    const result = await this.request(
+      "POST",
+      `/internal/v1/collections/${encodeURIComponent(collectionId)}/projection/activate-candidate-b`,
+      {
+        expected_head: expected.head,
+        expected_resource_revision: expected.resource_revision,
+        confirmation
+      }
+    ) as { projection?: HostedProjectionStatus } | undefined;
+    return requiredProjectionStatus(result?.projection);
+  }
+
+  async advanceProjection(
+    collectionId: string,
+    generationId: string
+  ): Promise<HostedProjectionStatus> {
+    try {
+      const result = await this.request(
+        "POST",
+        `/internal/v1/collections/${encodeURIComponent(collectionId)}/projection/advance`,
+        { generation_id: generationId }
+      ) as { projection?: HostedProjectionStatus } | undefined;
+      return requiredProjectionStatus(result?.projection);
+    } catch (error) {
+      // A bounded batch may commit while its HTTP response is lost. The retry
+      // then observes a completed generation. Reconcile only that exact ID;
+      // never reinterpret another generation as success.
+      if (
+        error instanceof HostedProviderResponseError
+        && error.code === "projection_generation_not_building"
+      ) {
+        const status = await this.projectionStatus(collectionId);
+        if (
+          status.execution_model === "candidate_b"
+          && status.active_generation_id === generationId
+        ) return status;
+      }
+      throw error;
+    }
+  }
+
+  private async activateNewCandidateBCollection(collectionId: string): Promise<void> {
+    let status = await this.projectionStatus(collectionId);
+    if (status.execution_model === "candidate_b" && status.active_generation_id) return;
+    status = await this.requestCandidateBActivation(collectionId, status);
+    // Creation-time collections contain no user records. Keep the loop finite
+    // so a provider regression cannot hold a control-plane request forever.
+    for (let batch = 0; batch < 16; batch += 1) {
+      if (status.execution_model === "candidate_b" && status.active_generation_id) return;
+      const generationId = status.building_generation?.generation_id;
+      if (!generationId) {
+        throw new HostedProviderResponseError(
+          503,
+          "projection_activation_stalled",
+          "Candidate B activation has no building projection generation."
+        );
+      }
+      status = await this.advanceProjection(collectionId, generationId);
+    }
+    throw new HostedProviderResponseError(
+      503,
+      "projection_activation_budget_exceeded",
+      "Candidate B activation exceeded its bounded creation-time batch budget."
+    );
   }
 
   async renameCollection(collectionId: string, displayName: string): Promise<void> {
@@ -590,6 +701,43 @@ function hostedContractSupportMatches(value: unknown): value is ConnectContractS
     && includes("authorization_binding", CONNECT_CONTRACT_SUPPORT.authorization_binding)
     && includes("semantic_capabilities", CONNECT_CONTRACT_SUPPORT.semantic_capabilities)
     && includes("durable_mutation", CONNECT_CONTRACT_SUPPORT.durable_mutation);
+}
+
+function requiredProjectionStatus(value: unknown): HostedProjectionStatus {
+  if (!value || typeof value !== "object") {
+    throw new HostedProviderResponseError(
+      502,
+      "invalid_provider_response",
+      "Hosted projection status was missing from the provider response."
+    );
+  }
+  const status = value as Record<string, unknown>;
+  const building = status.building_generation;
+  if (
+    typeof status.collection_id !== "string"
+    || !["legacy", "candidate_b"].includes(String(status.execution_model))
+    || !(status.pending_execution_model === null
+      || status.pending_execution_model === "candidate_b")
+    || !Number.isSafeInteger(status.head)
+    || typeof status.resource_revision !== "string"
+    || !(status.active_generation_id === null
+      || typeof status.active_generation_id === "string")
+    || !(building === null || (
+      typeof building === "object"
+      && typeof (building as Record<string, unknown>).generation_id === "string"
+      && ["projection", "resolution"].includes(
+        String((building as Record<string, unknown>).phase)
+      )
+      && (building as Record<string, unknown>).status === "building"
+    ))
+  ) {
+    throw new HostedProviderResponseError(
+      502,
+      "invalid_provider_response",
+      "Hosted projection status was malformed."
+    );
+  }
+  return value as HostedProjectionStatus;
 }
 
 export class HostedProviderResponseError extends Error {

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -287,6 +287,22 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: "x".repeat(40)
     });
     expect(value.hostedProvider?.url).toBe("http://127.0.0.1:8790");
+    expect(value.hostedProvider?.newCollectionExecutionModel).toBe("legacy");
+
+    const candidateB = runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_HOSTED_COLLECTIONS: "1",
+      MDBASE_CONNECT_HOSTED_PROVIDER_URL: "http://127.0.0.1:8790",
+      MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: "x".repeat(40),
+      MDBASE_CONNECT_NEW_HOSTED_EXECUTION_MODEL: "candidate_b"
+    });
+    expect(candidateB.hostedProvider?.newCollectionExecutionModel).toBe("candidate_b");
+    expect(() => hostedProviderConfigFromEnv({
+      MDBASE_CONNECT_HOSTED_PROVIDER_URL: "https://provider.example",
+      MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: "x".repeat(40),
+      MDBASE_CONNECT_NEW_HOSTED_EXECUTION_MODEL: "unknown"
+    })).toThrow(/legacy or candidate_b/);
 
     const dockerDevelopment = runtimeConfigFromEnv({
       PUBLIC_URL: "http://localhost:8787",
@@ -333,7 +349,8 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: "x".repeat(40)
     })).toEqual({
       url: "https://provider.example",
-      internalToken: "x".repeat(40)
+      internalToken: "x".repeat(40),
+      newCollectionExecutionModel: "legacy"
     });
     expect(() => hostedProviderConfigFromEnv({
       MDBASE_CONNECT_HOSTED_PROVIDER_URL: "https://provider.example"

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -356,12 +356,21 @@ export function hostedProviderConfigFromEnv(
     env.MDBASE_CONNECT_HOSTED_PROVIDER_PUBLIC_URL?.trim() ?? "";
   const internalToken =
     env.MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN?.trim() ?? "";
+  const newCollectionExecutionModel =
+    env.MDBASE_CONNECT_NEW_HOSTED_EXECUTION_MODEL?.trim() || "legacy";
+  if (!["legacy", "candidate_b"].includes(newCollectionExecutionModel)) {
+    throw new Error(
+      "MDBASE_CONNECT_NEW_HOSTED_EXECUTION_MODEL must be legacy or candidate_b."
+    );
+  }
   if (!url && !publicUrl && !internalToken) return null;
   return validateHostedProviderConfig(
     {
       url,
       ...(publicUrl ? { publicUrl } : {}),
-      internalToken
+      internalToken,
+      newCollectionExecutionModel:
+        newCollectionExecutionModel as "legacy" | "candidate_b"
     },
     env.MDBASE_CONNECT_ALLOW_INSECURE_HOSTED_PROVIDER === "1",
     env.MDBASE_CONNECT_DEV_AUTH === "1"


### PR DESCRIPTION
## Summary
- persist guarded Candidate B activation intent while legacy execution remains readable
- atomically bind the complete projection and switch execution models at completion
- expose versioned internal status/start/one-batch advance endpoints
- opt new collections into Candidate B only when explicitly configured, before control-plane exposure
- reconcile lost completion responses against the exact generation ID

## Validation
- hosted-provider unit suite: 105 passed, 3 environment-gated ignored
- disposable PostgreSQL: atomic activation and concurrent-write recovery regressions passed
- server suite: 318 passed
- provider tests compile and TypeScript typecheck pass

## Rollout boundary
Defaults remain legacy. This does not activate or migrate existing production data.