### PR TITLE
Allow resolved projection exact fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.1.0-beta.75
+
+Beta.75 allows a projection generation to activate when a canonically parsed
+record intentionally requires exact fallback, while continuing to require
+complete relationship resolution and valid projection digests. This prevents
+the production cutover indexer from repeatedly rebuilding collections that
+contain malformed Markdown or body-dependent computed fields. Query execution
+still treats those rows as projection-incomplete and uses bounded exact fallback;
+authorization classification remains fail-closed.
+
 ## 0.1.0-beta.74
 
 Beta.74 replaces the unreleased Candidate B migration history with the final

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-hosted-provider/src/provider/projections.rs
+++ b/crates/connect-hosted-provider/src/provider/projections.rs
@@ -480,9 +480,11 @@ impl HostedProvider {
             && row
                 .get::<Option<String>, _>("active_semantic_engine_version")
                 .as_deref()
-                == Some(mdbase::VERSION)
-            && row.get::<Option<i64>, _>("active_integrity_epoch")
-                == row.get::<Option<i64>, _>("active_integrity_verified_epoch");
+                == Some(mdbase::VERSION);
+        // A current, complete generation is operationally ready even when its
+        // integrity epoch cannot be globally projection-trusted. Query setup
+        // uses the distinct verified-epoch proof to select bounded exact
+        // fallback for semantic-incomplete or otherwise untrusted rows.
         Ok(HostedProjectionStatus {
             collection_id,
             ready,

--- a/crates/connect-hosted-provider/src/provider/projections/activation.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/activation.rs
@@ -445,7 +445,19 @@ impl HostedProvider {
         if prior_integrity_verified {
             let verified = sqlx::query(
                 r#"UPDATE hosted_provider_projection_generations
-                   SET integrity_verified_epoch = integrity_epoch, updated_at = now()
+                   SET integrity_verified_epoch = CASE
+                         WHEN NOT EXISTS (
+                           SELECT 1
+                           FROM hosted_provider_record_projections projection
+                           WHERE projection.collection_id = $1
+                             AND projection.generation_id = $2
+                             AND projection.valid_to_sequence IS NULL
+                             AND (NOT projection.semantic_complete
+                                  OR NOT projection.resolution_complete)
+                         ) THEN integrity_epoch
+                         ELSE 0
+                       END,
+                       updated_at = now()
                    WHERE collection_id = $1 AND generation_id = $2 AND status = 'complete'"#,
             )
             .bind(collection_id)

--- a/crates/connect-hosted-provider/src/provider/projections/batches.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/batches.rs
@@ -767,7 +767,10 @@ impl HostedProvider {
                         OR p.semantic_engine_version <> $6
                         OR NOT hosted_provider_projection_digest_valid(
                           p.projection_digest, p.projection_observed_digest)
-                        OR NOT p.semantic_complete
+                        -- Semantic incompleteness is a valid, durable exact-fallback
+                        -- state (for example malformed Markdown or a body-dependent
+                        -- computed field). Only unfinished relationship resolution
+                        -- means the generation has not completed its build.
                         OR NOT p.resolution_complete
                      UNION ALL
                      SELECT 1 FROM hosted_provider_record_projections p
@@ -883,7 +886,6 @@ impl HostedProvider {
                        WHERE projection.collection_id = $1
                          AND projection.generation_id = $2
                          AND projection.valid_to_sequence IS NULL
-                         AND projection.semantic_complete
                          AND projection.resolution_complete
                      )
                      ELSE resolved_records + $7

--- a/crates/connect-hosted-provider/src/provider/projections/batches.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/batches.rs
@@ -891,7 +891,19 @@ impl HostedProvider {
                      ELSE resolved_records + $7
                    END,
                    status = CASE WHEN $8 THEN 'complete' ELSE status END,
-                   integrity_verified_epoch = CASE WHEN $8 THEN integrity_epoch ELSE integrity_verified_epoch END,
+                   integrity_verified_epoch = CASE
+                     WHEN $8 AND NOT EXISTS (
+                       SELECT 1
+                       FROM hosted_provider_record_projections projection
+                       WHERE projection.collection_id = $1
+                         AND projection.generation_id = $2
+                         AND projection.valid_to_sequence IS NULL
+                         AND (NOT projection.semantic_complete
+                              OR NOT projection.resolution_complete)
+                     ) THEN integrity_epoch
+                     WHEN $8 THEN 0
+                     ELSE integrity_verified_epoch
+                   END,
                    completed_at = CASE WHEN $8 THEN now() ELSE completed_at END,
                    lease_owner = NULL,
                    lease_expires_at = NULL,

--- a/crates/connect-hosted-provider/src/provider/projections/indexing.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/indexing.rs
@@ -254,7 +254,6 @@ impl HostedProvider {
                          AND projection.generation_id =
                              collection.active_projection_generation_id
                          AND projection.valid_to_sequence IS NULL
-                         AND projection.semantic_complete
                          AND projection.resolution_complete) AS resolved_records,
                       (SELECT count(*)::bigint
                        FROM hosted_provider_record_projections projection
@@ -444,7 +443,20 @@ async fn verify_projection_derived_rows_in(
                     continue;
                 }
             };
-            if !projection.is_current_for(catalog_revision, engine_version)
+            // `is_current_for` deliberately rejects semantic-incomplete rows so
+            // query evaluators cannot trust them. Index verification must still
+            // validate the remainder of that envelope: incompleteness is the
+            // durable signal that selects exact fallback, not malformed derived
+            // storage. Temporarily toggling only that flag exercises every other
+            // mdbase-rs currentness and structural-digest invariant.
+            let envelope_current = if projection.facts.semantic_complete {
+                projection.is_current_for(catalog_revision, engine_version)
+            } else {
+                let mut fallback_envelope = projection.clone();
+                fallback_envelope.facts.semantic_complete = true;
+                fallback_envelope.is_current_for(catalog_revision, engine_version)
+            };
+            if !envelope_current
                 || i64::from(projection.facts.format_version) != i64::from(format_version)
             {
                 verification.semantic_envelopes_valid = false;

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -637,6 +637,94 @@ async fn projection_indexing_binds_only_after_atomic_completion() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
+async fn projection_indexing_activates_resolved_exact_fallback_rows() {
+    let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
+        .expect("MDBASE_PROJECTION_DATABASE_URL is required");
+    let fixture = FileLifecycleFixture::new(&database_url).await;
+    let replica = sqlx::query(
+        "SELECT id, scope_epoch FROM hosted_provider_replicas WHERE collection_id = $1",
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    let incomplete_id = Uuid::now_v7();
+    put(
+        &fixture,
+        replica.get("id"),
+        u64::try_from(replica.get::<i64, _>("scope_epoch")).unwrap(),
+        incomplete_id,
+        None,
+        "notes/malformed.md",
+        "A deliberately malformed [[relationship.\n",
+    )
+    .await;
+    make_collection_unindexed(&fixture).await;
+    let binding = sqlx::query(
+        "SELECT head, resource_revision FROM hosted_provider_collections WHERE id = $1",
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    let status = fixture
+        .provider
+        .request_projection_indexing(
+            fixture.collection_id,
+            u64::try_from(binding.get::<i64, _>("head")).unwrap(),
+            binding.get("resource_revision"),
+        )
+        .await
+        .unwrap();
+    let generation_id = status.building_generation.unwrap().generation_id;
+
+    for _ in 0..16 {
+        if fixture
+            .provider
+            .projection_status(fixture.collection_id)
+            .await
+            .unwrap()
+            .ready
+        {
+            break;
+        }
+        fixture
+            .provider
+            .advance_projection_generation(fixture.collection_id, generation_id)
+            .await
+            .unwrap();
+    }
+
+    let complete = fixture
+        .provider
+        .projection_status(fixture.collection_id)
+        .await
+        .unwrap();
+    assert!(complete.ready);
+    let fallback_row = sqlx::query(
+        r#"SELECT semantic_complete, resolution_complete
+           FROM hosted_provider_record_projections
+           WHERE collection_id = $1 AND generation_id = $2 AND record_id = $3
+             AND valid_to_sequence IS NULL"#,
+    )
+    .bind(fixture.collection_id)
+    .bind(generation_id)
+    .bind(incomplete_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    assert!(!fallback_row.get::<bool, _>("semantic_complete"));
+    assert!(fallback_row.get::<bool, _>("resolution_complete"));
+    let verification = fixture
+        .provider
+        .verify_projection_index(fixture.collection_id)
+        .await
+        .unwrap();
+    assert!(verification.verified, "{:?}", verification.failures);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
 async fn idempotent_collection_create_waits_for_a_projection_lease_handoff() {
     let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
         .expect("MDBASE_PROJECTION_DATABASE_URL is required");
@@ -8239,6 +8327,21 @@ async fn make_collection_unindexed(fixture: &FileLifecycleFixture) {
     .execute(&mut *transaction)
     .await
     .unwrap();
+    sqlx::query("DELETE FROM hosted_provider_record_relationships WHERE collection_id = $1")
+        .bind(fixture.collection_id)
+        .execute(&mut *transaction)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM hosted_provider_record_resolution_keys WHERE collection_id = $1")
+        .bind(fixture.collection_id)
+        .execute(&mut *transaction)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM hosted_provider_record_projections WHERE collection_id = $1")
+        .bind(fixture.collection_id)
+        .execute(&mut *transaction)
+        .await
+        .unwrap();
     sqlx::query("DELETE FROM hosted_provider_projection_generations WHERE collection_id = $1")
         .bind(fixture.collection_id)
         .execute(&mut *transaction)

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -715,6 +715,46 @@ async fn projection_indexing_activates_resolved_exact_fallback_rows() {
     .unwrap();
     assert!(!fallback_row.get::<bool, _>("semantic_complete"));
     assert!(fallback_row.get::<bool, _>("resolution_complete"));
+    let integrity = sqlx::query(
+        r#"SELECT integrity_epoch, integrity_verified_epoch
+           FROM hosted_provider_projection_generations
+           WHERE collection_id = $1 AND generation_id = $2"#,
+    )
+    .bind(fixture.collection_id)
+    .bind(generation_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    assert_ne!(
+        integrity.get::<i64, _>("integrity_epoch"),
+        integrity.get::<i64, _>("integrity_verified_epoch"),
+        "semantic-incomplete rows must keep exact fallback enabled"
+    );
+    let (_, application_token) = register_query_application(&fixture, Vec::new()).await;
+    let result = fixture
+        .provider
+        .operation(
+            fixture.collection_id,
+            &application_token,
+            "query",
+            Uuid::new_v4(),
+            json!({
+                "where": "file.inFolder('notes')",
+                "include_body": true,
+                "limit": 10,
+                "order_by": [{"field": "file.path"}]
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result["valid"], true);
+    assert_eq!(result["result"]["meta"]["total_count"], 1);
+    assert_eq!(result["result"]["results"][0]["path"], "notes/malformed.md");
+    assert_eq!(
+        result["result"]["results"][0]["body"],
+        "A deliberately malformed [[relationship.\n"
+    );
     let verification = fixture
         .provider
         .verify_projection_index(fixture.collection_id)

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.74"
+version = "0.1.0-beta.75"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.74" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.75" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.74",
+  "version": "0.1.0-beta.75",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -122,7 +122,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.74",
+        version: "0.1.0-beta.75",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary

- lets fully resolved projection generations activate when mdbase-rs intentionally marks individual rows semantically incomplete
- preserves semantic_complete=false as the exact-fallback/fail-closed signal
- verifies every other mdbase-rs envelope, structural digest, relationship, resolution-key, and row-digest invariant
- adds a PostgreSQL regression using malformed Markdown
- prepares v0.1.0-beta.75 for the production recovery

## Production root cause

The Candidate B cutover repeatedly rebuilt one collection because 173 resolved records legitimately require exact fallback (malformed Markdown or body-dependent computed fields). The completion check incorrectly interpreted semantic incompleteness as unfinished relationship resolution.

## Safety

Projected query paths still require semantic_complete=true. Exact classification for authorization remains fail-closed when semantic evidence is incomplete. Only generation activation and aggregate verification now distinguish resolved exact-fallback rows from unfinished rows.

## Validation

- release-version consistency and immutable lock parity
- 110 hosted-provider unit tests passed
- four focused PostgreSQL projection-indexing tests passed
- new malformed-Markdown activation regression passed
- cargo fmt and git diff checks passed

Independent semantic, database, and security reviews are in progress.