### PR TITLE
Separate projection integrity from exact fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.1.0-beta.76
+
+Beta.76 separates derived-state integrity verification from semantic exact
+fallback. A fully verified generation may contain records that mdbase-rs marks
+semantic-incomplete; query initialization detects those rows independently and
+keeps them on bounded canonical exact evaluation. This preserves both the final
+cutover integrity gate and complete query results.
+
 ## 0.1.0-beta.75
 
 Beta.75 allows a projection generation to activate when a canonically parsed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-hosted-provider/src/provider/operation_queries/bindings.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/bindings.rs
@@ -367,7 +367,9 @@ fn collection_projection_integrity_verified(collection: &PgRow) -> ApiResult<boo
         .get::<Option<i64>, _>("projection_integrity_verified_epoch")
         .map(|value| number(value, "verified projection integrity epoch"))
         .transpose()?;
-    Ok(epoch.is_some() && epoch == verified)
+    let semantic_fallback_exists =
+        collection.get::<bool, _>("projection_semantic_fallback_exists");
+    Ok(epoch.is_some() && epoch == verified && !semantic_fallback_exists)
 }
 
 fn enforce_hosted_query_scan_budget(state: &HostedQueryState) -> ApiResult<()> {

--- a/crates/connect-hosted-provider/src/provider/operation_queries/provider_impl.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/provider_impl.rs
@@ -326,7 +326,16 @@ impl HostedProvider {
                       active_semantic_engine_version, active_projection_generation_id,
                       active_projection_head,
                       generation.integrity_epoch AS projection_integrity_epoch,
-                      generation.integrity_verified_epoch AS projection_integrity_verified_epoch
+                      generation.integrity_verified_epoch AS projection_integrity_verified_epoch,
+                      EXISTS (
+                        SELECT 1
+                        FROM hosted_provider_record_projections projection
+                        WHERE projection.collection_id = collection.id
+                          AND projection.generation_id = collection.active_projection_generation_id
+                          AND projection.valid_to_sequence IS NULL
+                          AND (NOT projection.semantic_complete
+                               OR NOT projection.resolution_complete)
+                      ) AS projection_semantic_fallback_exists
                FROM hosted_provider_collections collection
                LEFT JOIN hosted_provider_projection_generations generation
                  ON generation.collection_id = collection.id

--- a/crates/connect-hosted-provider/src/provider/projections/activation.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/activation.rs
@@ -445,19 +445,7 @@ impl HostedProvider {
         if prior_integrity_verified {
             let verified = sqlx::query(
                 r#"UPDATE hosted_provider_projection_generations
-                   SET integrity_verified_epoch = CASE
-                         WHEN NOT EXISTS (
-                           SELECT 1
-                           FROM hosted_provider_record_projections projection
-                           WHERE projection.collection_id = $1
-                             AND projection.generation_id = $2
-                             AND projection.valid_to_sequence IS NULL
-                             AND (NOT projection.semantic_complete
-                                  OR NOT projection.resolution_complete)
-                         ) THEN integrity_epoch
-                         ELSE 0
-                       END,
-                       updated_at = now()
+                   SET integrity_verified_epoch = integrity_epoch, updated_at = now()
                    WHERE collection_id = $1 AND generation_id = $2 AND status = 'complete'"#,
             )
             .bind(collection_id)

--- a/crates/connect-hosted-provider/src/provider/projections/batches.rs
+++ b/crates/connect-hosted-provider/src/provider/projections/batches.rs
@@ -891,19 +891,7 @@ impl HostedProvider {
                      ELSE resolved_records + $7
                    END,
                    status = CASE WHEN $8 THEN 'complete' ELSE status END,
-                   integrity_verified_epoch = CASE
-                     WHEN $8 AND NOT EXISTS (
-                       SELECT 1
-                       FROM hosted_provider_record_projections projection
-                       WHERE projection.collection_id = $1
-                         AND projection.generation_id = $2
-                         AND projection.valid_to_sequence IS NULL
-                         AND (NOT projection.semantic_complete
-                              OR NOT projection.resolution_complete)
-                     ) THEN integrity_epoch
-                     WHEN $8 THEN 0
-                     ELSE integrity_verified_epoch
-                   END,
+                   integrity_verified_epoch = CASE WHEN $8 THEN integrity_epoch ELSE integrity_verified_epoch END,
                    completed_at = CASE WHEN $8 THEN now() ELSE completed_at END,
                    lease_owner = NULL,
                    lease_expires_at = NULL,

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -725,10 +725,10 @@ async fn projection_indexing_activates_resolved_exact_fallback_rows() {
     .fetch_one(&fixture.pool)
     .await
     .unwrap();
-    assert_ne!(
+    assert_eq!(
         integrity.get::<i64, _>("integrity_epoch"),
         integrity.get::<i64, _>("integrity_verified_epoch"),
-        "semantic-incomplete rows must keep exact fallback enabled"
+        "derived-state verification remains independent from exact fallback"
     );
     let (_, application_token) = register_query_application(&fixture, Vec::new()).await;
     let result = fixture

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.75"
+version = "0.1.0-beta.76"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.75" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.76" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.75",
+  "version": "0.1.0-beta.76",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -122,7 +122,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.75",
+        version: "0.1.0-beta.76",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
Preserves the final derived-state integrity epoch proof while independently detecting semantic-incomplete active rows at query initialization. Those rows force bounded canonical exact fallback without making a fully verified generation fail the final database cutover gate.

Validation: release consistency, lockfile equality, 110 hosted-provider unit tests, four focused PostgreSQL lifecycle tests, and the malformed-record query regression.