### PR TITLE
Read Pickle request attachments

### DIFF
--- a/packages/pickle/src/index.test.ts
+++ b/packages/pickle/src/index.test.ts
@@ -82,6 +82,7 @@ const contract = {
 
 describe("Pickle contract adapter", () => {
   it("pins every type-pack resource to its exact embedded document", async () => {
+    expect(PICKLE_TYPE_PACK_PROVISION.manifest.version).toBe("1.1.0");
     const documents = new Map(
       PICKLE_TYPE_PACK_PROVISION.resources.map((resource) => [
         resource.source,
@@ -102,6 +103,72 @@ describe("Pickle contract adapter", () => {
         ).join("")}`
       );
     }
+  });
+
+  it("reads Markdown attachments from typed records", async () => {
+    const read = vi.fn(async () =>
+      connectSuccess({
+        path: "attachments/req-one/1-context.md",
+        types: ["pickle_attachment"],
+        frontmatter: {
+          type: "pickle_attachment",
+          request_id: "req-one",
+          filename: "context.md",
+          content_type: "text/markdown",
+          size_bytes: 9,
+          sha256: `sha256:${"0".repeat(64)}`
+        },
+        body: "# Context"
+      })
+    );
+    const files = {
+      list: vi.fn(async function* () { yield* []; }),
+      download: vi.fn()
+    };
+    const pickle = new PickleCollection({ read, files } as never);
+
+    const content = await pickle.readAttachment({
+      path: "attachments/req-one/1-context.md",
+      filename: "1-context.md"
+    });
+
+    expect(content).toMatchObject({
+      filename: "context.md",
+      mediaType: "text/markdown",
+      size: 9
+    });
+    expect(await content?.blob.text()).toBe("# Context");
+    expect(files.list).not.toHaveBeenCalled();
+  });
+
+  it("reads binary attachments through the file API", async () => {
+    const descriptor = {
+      fileId: "file-1",
+      path: "attachments/req-one/2-report.pdf",
+      revision: "one",
+      contentDigest: `sha256:${"0".repeat(64)}`,
+      size: 3,
+      mediaType: "application/pdf",
+      mediaClass: "pdf",
+      modifiedAt: "2026-08-17T00:00:00Z"
+    } as const;
+    const files = {
+      list: vi.fn(async function* () { yield descriptor; }),
+      download: vi.fn(async () => new Blob(["pdf"], { type: "application/pdf" }))
+    };
+    const pickle = new PickleCollection({ files } as never);
+
+    const content = await pickle.readAttachment({
+      path: descriptor.path,
+      filename: "report.pdf"
+    });
+
+    expect(content).toMatchObject({
+      filename: "report.pdf",
+      mediaType: "application/pdf",
+      size: 3
+    });
+    expect(files.download).toHaveBeenCalledWith(descriptor, {});
   });
 
   it("derives lifecycle from response links and writes a typed response", async () => {

--- a/packages/pickle/src/index.ts
+++ b/packages/pickle/src/index.ts
@@ -3,6 +3,7 @@ import {
   MdbaseConnectError,
   type CollectionContractDescriptor,
   type CollectionDescription,
+  type CollectionFileDescriptor,
   type CollectionTypeDescriptor,
   type JsonObject,
   type RecordDocument,
@@ -16,6 +17,7 @@ import { PICKLE_REQUEST_CONTRACT_DIGEST } from "./resources.js";
 
 export {
   PICKLE_ACK_RESPONSE_TYPE_DOCUMENT,
+  PICKLE_ATTACHMENT_TYPE_DOCUMENT,
   PICKLE_APPROVAL_RESPONSE_TYPE_DOCUMENT,
   PICKLE_REQUEST_CONTRACT_DOCUMENT,
   PICKLE_REQUEST_CONTRACT_DIGEST,
@@ -86,6 +88,14 @@ export interface PickleAttachment {
   filename: string;
 }
 
+export interface PickleAttachmentContent {
+  path: string;
+  filename: string;
+  mediaType: string;
+  size: number;
+  blob: Blob;
+}
+
 export interface PickleResponse {
   path: string;
   type: string;
@@ -149,6 +159,11 @@ export interface PickleClient {
     input: Parameters<MdbaseConnection<PickleFrontmatter>["create"]>[0],
     options?: ConnectRequestOptions
   ): ReturnType<MdbaseConnection<PickleFrontmatter>["create"]>;
+  read(
+    input: Parameters<MdbaseConnection<PickleFrontmatter>["read"]>[0],
+    options?: ConnectRequestOptions
+  ): ReturnType<MdbaseConnection<PickleFrontmatter>["read"]>;
+  files: MdbaseConnection<PickleFrontmatter>["files"];
   pendingMutations<Result = unknown>(): readonly PendingMutation<Result>[];
   pendingMutation<Result = unknown>(
     requestId: string
@@ -310,6 +325,52 @@ export class PickleCollection {
       requestOptions
     );
     return responseSubmission(created);
+  }
+
+  async readAttachment(
+    attachment: PickleAttachment,
+    options: ConnectRequestOptions = {}
+  ): Promise<PickleAttachmentContent | null> {
+    const path = attachment.path.replace(/^\/+/, "");
+    if (isMarkdownPath(path)) {
+      const outcome = await this.connect.read({ path }, options);
+      if (outcome.ok) {
+        const frontmatter = outcome.value.frontmatter;
+        if (stringField(frontmatter, "type") === "pickle_attachment") {
+          const body = outcome.value.body ?? "";
+          const filename = stringField(frontmatter, "filename") || attachment.filename;
+          const mediaType = stringField(frontmatter, "content_type") || "text/markdown";
+          return {
+            path,
+            filename,
+            mediaType,
+            size: new TextEncoder().encode(body).byteLength,
+            blob: new Blob([body], { type: mediaType })
+          };
+        }
+      }
+    }
+    const separator = path.lastIndexOf("/");
+    const folder = separator < 0 ? undefined : path.slice(0, separator);
+    let match: CollectionFileDescriptor | null = null;
+    for await (const file of this.connect.files.list({
+      ...options,
+      ...(folder ? { folder } : {})
+    })) {
+      if (file.path === path) {
+        match = file;
+        break;
+      }
+    }
+    if (!match) return null;
+    const blob = await this.connect.files.download(match, options);
+    return {
+      path,
+      filename: attachment.filename,
+      mediaType: match.mediaType || blob.type || "application/octet-stream",
+      size: match.size,
+      blob
+    };
   }
 
   pendingResponses(): readonly PicklePendingResponse[] {
@@ -595,6 +656,10 @@ function validFieldPath(value: string): boolean {
 
 function trimSlashes(value: string): string {
   return value.replace(/^\/+|\/+$/g, "");
+}
+
+function isMarkdownPath(path: string): boolean {
+  return /\.(?:md|markdown|mdown|mkd|mkdn)$/i.test(path);
 }
 
 function asObject(value: unknown): JsonObject | undefined {

--- a/packages/pickle/src/resources.ts
+++ b/packages/pickle/src/resources.ts
@@ -210,11 +210,37 @@ lifecycle:
 ---
 `;
 
+export const PICKLE_ATTACHMENT_TYPE_DOCUMENT = `---
+kind: mdbase.type
+name: pickle_attachment
+version: 1
+description: Markdown content attached to a Pickle request.
+schema:
+  dialect: json-schema-2020-12
+  value:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    type: object
+    additionalProperties: true
+    required: [request_id, filename, content_type, size_bytes, sha256]
+    properties:
+      type: { const: pickle_attachment }
+      request_id: { type: string, minLength: 1 }
+      filename: { type: string, minLength: 1 }
+      content_type: { type: string, minLength: 1 }
+      size_bytes: { type: integer, minimum: 0 }
+      sha256: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+      created_at: { type: string, format: date-time }
+collection:
+  display:
+    name_field: filename
+---
+`;
+
 export const PICKLE_TYPE_PACK_PROVISION = {
   manifest: {
     kind: "mdbase.type-pack",
     id: "pickle.requests",
-    version: "1.0.0",
+    version: "1.1.0",
     name: "Pickle requests",
     description: "Pickle request and response record types.",
     resources: [
@@ -245,6 +271,13 @@ export const PICKLE_TYPE_PACK_PROVISION = {
         source: "types/pickle_response_ack.md",
         target: "_types/pickle_response_ack.md",
         digest: "sha256:2530c8d21bb711889f20e0d096045cb6c9a7618583b1e2afff7ada72367de41f"
+      },
+      {
+        kind: "type",
+        mode: "seed",
+        source: "types/pickle_attachment.md",
+        target: "_types/pickle_attachment.md",
+        digest: "sha256:67f14eeee2c126e99d8b37b7508fa148955b924367e2d2941b1793d1c814ec25"
       }
     ]
   },
@@ -264,6 +297,10 @@ export const PICKLE_TYPE_PACK_PROVISION = {
     {
       source: "types/pickle_response_ack.md",
       document: PICKLE_ACK_RESPONSE_TYPE_DOCUMENT
+    },
+    {
+      source: "types/pickle_attachment.md",
+      document: PICKLE_ATTACHMENT_TYPE_DOCUMENT
     }
   ],
   provides: [{


### PR DESCRIPTION
Adds attachment reading to the Pickle package.

## What

- New `pickle_attachment` mdbase type (`request_id`, `filename`, `content_type`, `size_bytes`, `sha256`, `created_at`), seeded as `_types/pickle_attachment.md`.
- `PickleCollection.readAttachment(attachment, options)` returning `PickleAttachmentContent | null`.
  - Markdown paths resolve through a typed record read and return a text `Blob`.
  - Other paths fall back to the collection file API.
  - No match returns `null` rather than throwing.
- `PickleClient` now exposes `read` and `files`, which `readAttachment` requires.

## Note for review

The type pack advances `1.0.0 -> 1.1.0` and seeds a new type. A semantic catalog change clears the projection binding and starts a rebuild, so this should land deliberately rather than alongside unrelated provisioning changes.

The declared pack digest was recomputed from the document and matches (`sha256:67f14eee...`).

## Verification

- `pnpm --filter @mdbase-dev/pickle test` — 8 passed, including one test per resolution branch.
- `tsc --noEmit` clean.