### PR TITLE
Keep view mutations from stranding projection readiness

### DIFF
--- a/crates/connect-hosted-provider/src/http/diagnostics.rs
+++ b/crates/connect-hosted-provider/src/http/diagnostics.rs
@@ -26,7 +26,7 @@ async fn health() -> Json<Value> {
 }
 
 async fn ready(State(state): State<AppState>) -> ApiResult<Json<Value>> {
-    let notifications = state.provider.ready().await?;
+    let readiness = state.provider.ready().await?;
     Ok(Json(json!({
         "status": "ready",
         "provider": {
@@ -34,7 +34,8 @@ async fn ready(State(state): State<AppState>) -> ApiResult<Json<Value>> {
             "capabilities": mdbase_connect_protocol::HOSTED_PROVIDER_CAPABILITIES,
             "contract_support": mdbase_connect_protocol::ConnectContractSupport::default(),
         },
-        "notifications": notifications
+        "notifications": readiness.notifications,
+        "projections": readiness.projections
     })))
 }
 

--- a/crates/connect-hosted-provider/src/provider.rs
+++ b/crates/connect-hosted-provider/src/provider.rs
@@ -419,6 +419,24 @@ pub struct NotificationRecoveryStatus {
     pub last_success_at: Option<DateTime<Utc>>,
 }
 
+/// Process readiness. Collections whose semantic projection is absent or bound
+/// to a superseded catalog/resource revision are reported as degraded, never as
+/// a process failure: the query path already serves them from bounded canonical
+/// exact fallback, and failing the probe would remove a provider that is still
+/// serving every collection correctly.
+#[derive(Debug, Clone, Serialize)]
+pub struct HostedReadinessStatus {
+    pub notifications: NotificationRecoveryStatus,
+    pub projections: HostedProjectionReadiness,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct HostedProjectionReadiness {
+    /// Active collections currently served from canonical exact fallback while
+    /// their projection generation is absent, superseded, or rebuilding.
+    pub degraded_collections: u64,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationRecoveryState {

--- a/crates/connect-hosted-provider/src/provider/lifecycle.rs
+++ b/crates/connect-hosted-provider/src/provider/lifecycle.rs
@@ -205,7 +205,7 @@ impl HostedProvider {
         }
     }
 
-    pub async fn ready(&self) -> ApiResult<NotificationRecoveryStatus> {
+    pub async fn ready(&self) -> ApiResult<HostedReadinessStatus> {
         sqlx::query("SELECT 1").execute(&self.pool).await?;
         self.blob_store.ready().await?;
         self.verify_key_readiness().await?;
@@ -239,19 +239,24 @@ impl HostedProvider {
         .bind(mdbase::VERSION)
         .fetch_one(&self.pool)
         .await?;
-        if unready_collections != 0 {
-            return Err(ApiError::new(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "hosted_projection_index_incomplete",
-                "Hosted semantic projection indexing is incomplete.",
-            ));
-        }
+        // A collection whose projection is absent, superseded or rebuilding is
+        // degraded, not unserviceable: the query path routes it to bounded
+        // canonical exact fallback and returns correct results. Failing the
+        // probe here would withdraw a provider that is still serving every
+        // collection, turning one collection's rebuild into a total outage.
+        // Report the count so operators and the indexer can act on it.
+        //
         // Keep readiness acyclic: notification delivery is an outbound,
         // durably-retried dependency on the Connect control plane, while
         // Connect itself checks this endpoint before advertising readiness.
         // Report degradation for operators without inviting the platform to
         // restart a provider that can still serve authoritative data.
-        Ok(self.notification_recovery.read().await.clone())
+        Ok(HostedReadinessStatus {
+            notifications: self.notification_recovery.read().await.clone(),
+            projections: HostedProjectionReadiness {
+                degraded_collections: number(unready_collections, "degraded collection count")?,
+            },
+        })
     }
 
     /// Apply a shrinking server-side statement deadline to the single cutover

--- a/crates/connect-hosted-provider/src/provider/operation_resource_mutations.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_resource_mutations.rs
@@ -169,8 +169,36 @@ impl HostedProvider {
         .bind(event_revision)
         .execute(&mut *transaction)
         .await?;
+        // Every resource mutation advances `resource_revision`, and a generation
+        // is current only while its `source_resource_revision` still matches.
+        //
+        // A type mutation changes the semantic catalog, so its projections are
+        // genuinely superseded and the binding is invalidated for rebuild.
+        //
+        // A view mutation does not: an Obsidian Base source is a query
+        // definition, and no projected fact is derived from it. Previously the
+        // revision advanced while the generation kept the old value, leaving the
+        // collection permanently stale with no rebuild scheduled -- which failed
+        // readiness forever. Carry the generation forward instead. Invalidating
+        // here would be worse than the bug: it drops a large collection into
+        // canonical exact fallback and its Base queries start returning
+        // `hosted_exact_document_budget_exceeded` until the rebuild completes.
         if is_type {
             invalidate_projection_catalog_binding(&mut transaction, collection_id).await?;
+        } else {
+            sqlx::query(
+                r#"UPDATE hosted_provider_projection_generations generation
+                   SET source_resource_revision = $2, updated_at = now()
+                   FROM hosted_provider_collections collection
+                   WHERE collection.id = $1
+                     AND generation.collection_id = collection.id
+                     AND generation.generation_id
+                           = collection.active_projection_generation_id"#,
+            )
+            .bind(collection_id)
+            .bind(&resource_revision)
+            .execute(&mut *transaction)
+            .await?;
         }
         sqlx::query(
             r#"UPDATE hosted_provider_collections

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -5843,8 +5843,17 @@ async fn assert_projected_group_cancellation(fixture: &FileLifecycleFixture, tok
             .fetch_one(&fixture.pool)
             .await
             .unwrap();
+            // This grouping workload reads only projected metadata: a title
+            // predicate, a title group key, a count, and a path ordering. It
+            // resolves entirely inside PostgreSQL, so engagement is proven by
+            // the query slot, the scan permit and the blocked backend -- never
+            // by a plaintext scope. Requiring zero scopes here pins the
+            // Candidate B invariant that projected metadata work decrypts
+            // nothing; scope acquisition and release under cancellation are
+            // covered by the body-predicate cancellations, which genuinely
+            // need plaintext.
             if activity.active_queries == 2
-                && activity.plaintext_scopes == 2
+                && activity.plaintext_scopes == 0
                 && activity.active_scan_permits == 2
                 && blocked_sessions == 2
             {
@@ -5854,7 +5863,10 @@ async fn assert_projected_group_cancellation(fixture: &FileLifecycleFixture, tok
         }
     })
     .await
-    .expect("the projected grouping query reaches its cancellable PostgreSQL wait");
+    .expect(
+        "the projected grouping query reaches its cancellable PostgreSQL wait \
+         without materializing plaintext",
+    );
     let point_started = Instant::now();
     let point = fixture
         .provider

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -850,6 +850,145 @@ async fn idempotent_collection_create_waits_for_a_projection_lease_handoff() {
     );
 }
 
+/// A view mutation advances `resource_revision`. Because no projected fact is
+/// derived from a Base source, the active generation must be carried to the new
+/// revision rather than abandoned: leaving it behind stranded the collection as
+/// permanently stale (the 2026-08-18 outage), while abandoning it would drop a
+/// large collection into canonical exact fallback for no semantic reason.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
+async fn view_mutations_carry_the_projection_binding_and_keep_readiness() {
+    let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
+        .expect("MDBASE_PROJECTION_DATABASE_URL is required");
+    let fixture = FileLifecycleFixture::new(&database_url).await;
+    let replica = sqlx::query(
+        "SELECT id, scope_epoch FROM hosted_provider_replicas WHERE collection_id = $1",
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    let replica_id = replica.get("id");
+    let scope_epoch = u64::try_from(replica.get::<i64, _>("scope_epoch")).unwrap();
+    put(
+        &fixture,
+        replica_id,
+        scope_epoch,
+        Uuid::now_v7(),
+        None,
+        "notes/source.md",
+        "---\ntitle: Source\n---\nSource body.\n",
+    )
+    .await;
+    complete_generation(&fixture).await;
+
+    // Other tests share this database, so assert on this collection rather
+    // than the process-wide degraded count.
+    fixture.provider.ready().await.expect("readiness before");
+    assert!(
+        fixture
+            .provider
+            .projection_status(fixture.collection_id)
+            .await
+            .unwrap()
+            .ready
+    );
+
+    let writer_token = format!("candidate-b-view-writer-{}", Uuid::new_v4());
+    fixture
+        .provider
+        .register_replica(
+            fixture.collection_id,
+            RegisterReplica {
+                replica_id: Uuid::now_v7(),
+                name: "Candidate B view writer".to_string(),
+                purpose: ReplicaPurpose::Application,
+                mode: SyncReplicaMode::ReadWrite,
+                allowed_types: Vec::new(),
+                contract_scope: Vec::new(),
+                full_collection: true,
+                allowed_operations: vec!["create_view_source".to_string()],
+                operation_transport_protocol: Some(3),
+                operation_transport_recovery_protocols: Vec::new(),
+                file_capability: None,
+                allowed_origin: None,
+                proof_public_key: None,
+                grant_id: Some(Uuid::now_v7()),
+                application_declaration_id: None,
+                application_declaration_digest: None,
+                token: writer_token.clone(),
+                token_ttl_seconds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    fixture.enable_obsidian_base_pattern("views/*.base").await;
+    complete_generation(&fixture).await;
+
+    let created = fixture
+        .provider
+        .operation(
+            fixture.collection_id,
+            &writer_token,
+            "create_view_source",
+            Uuid::new_v4(),
+            json!({
+                "path": "views/notes.base",
+                "document": "views:\n  - type: table\n    name: All notes\n    order: [file.name]\n"
+            }),
+            None,
+        )
+        .await
+        .expect("the view source is created");
+    assert_eq!(created["valid"], true);
+
+    // A Base source is a query definition; no projected fact derives from it.
+    // The generation must therefore stay bound and be carried to the new
+    // resource revision rather than abandoned -- invalidating would drop the
+    // collection into canonical exact fallback for no semantic reason.
+    let carried: (Option<Uuid>, Option<String>, String) = sqlx::query_as(
+        r#"SELECT collection.active_projection_generation_id,
+                  generation.source_resource_revision,
+                  collection.resource_revision
+           FROM hosted_provider_collections collection
+           LEFT JOIN hosted_provider_projection_generations generation
+             ON generation.collection_id = collection.id
+            AND generation.generation_id = collection.active_projection_generation_id
+           WHERE collection.id = $1"#,
+    )
+    .bind(fixture.collection_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    assert!(
+        carried.0.is_some(),
+        "a view mutation must not abandon the active projection binding"
+    );
+    assert_eq!(
+        carried.1.as_deref(),
+        Some(carried.2.as_str()),
+        "the generation must be carried to the new resource revision"
+    );
+
+    // Readiness must remain healthy and the collection must stay queryable.
+    // `ready()` returning Ok at all is the property that matters: a degraded
+    // collection must never fail the probe for the whole provider.
+    fixture
+        .provider
+        .ready()
+        .await
+        .expect("readiness must survive a view mutation");
+    assert!(
+        fixture
+            .provider
+            .projection_status(fixture.collection_id)
+            .await
+            .unwrap()
+            .ready
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
 async fn projection_verification_detects_missing_resolution_keys_and_relationships() {

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -929,23 +929,39 @@ async fn projection_verification_detects_missing_resolution_keys_and_relationshi
     .unwrap();
     assert_eq!(deleted_relationships.rows_affected(), 1);
 
+    // Operational readiness is deliberately independent from derived-state
+    // integrity: a current, complete generation keeps serving, and the query
+    // path routes untrusted rows to bounded canonical fallback through the
+    // separate verified-epoch proof. Out-of-band derived corruption is caught
+    // by the canonical verifier below, which is the cutover's admission gate.
     assert!(
-        !fixture
+        fixture
             .provider
             .projection_status(fixture.collection_id)
             .await
             .unwrap()
-            .ready
+            .ready,
+        "a complete generation stays operationally ready after derived-row loss"
     );
     let after = fixture
         .provider
         .verify_projection_index(fixture.collection_id)
         .await
         .unwrap();
-    assert!(!after.verified);
-    assert!(after
-        .failures
-        .contains(&"active_binding_not_current".to_string()));
+    assert!(
+        !after.verified,
+        "the canonical verifier must still detect missing derived rows"
+    );
+    // `active_binding_not_current` mirrors operational readiness, which derived-row
+    // loss no longer disturbs. Detection here must come from the canonical row
+    // counts themselves, so assert it is absent rather than leaving the weaker
+    // binding signal to carry this test.
+    assert!(
+        !after
+            .failures
+            .contains(&"active_binding_not_current".to_string()),
+        "binding currency is independent of derived-row integrity"
+    );
     assert!(after
         .failures
         .contains(&"projection_resolution_keys_mismatch".to_string()));

--- a/packages/pickle/src/index.test.ts
+++ b/packages/pickle/src/index.test.ts
@@ -82,6 +82,7 @@ const contract = {
 
 describe("Pickle contract adapter", () => {
   it("pins every type-pack resource to its exact embedded document", async () => {
+    expect(PICKLE_TYPE_PACK_PROVISION.manifest.version).toBe("1.1.0");
     const documents = new Map(
       PICKLE_TYPE_PACK_PROVISION.resources.map((resource) => [
         resource.source,
@@ -102,6 +103,72 @@ describe("Pickle contract adapter", () => {
         ).join("")}`
       );
     }
+  });
+
+  it("reads Markdown attachments from typed records", async () => {
+    const read = vi.fn(async () =>
+      connectSuccess({
+        path: "attachments/req-one/1-context.md",
+        types: ["pickle_attachment"],
+        frontmatter: {
+          type: "pickle_attachment",
+          request_id: "req-one",
+          filename: "context.md",
+          content_type: "text/markdown",
+          size_bytes: 9,
+          sha256: `sha256:${"0".repeat(64)}`
+        },
+        body: "# Context"
+      })
+    );
+    const files = {
+      list: vi.fn(async function* () { yield* []; }),
+      download: vi.fn()
+    };
+    const pickle = new PickleCollection({ read, files } as never);
+
+    const content = await pickle.readAttachment({
+      path: "attachments/req-one/1-context.md",
+      filename: "1-context.md"
+    });
+
+    expect(content).toMatchObject({
+      filename: "context.md",
+      mediaType: "text/markdown",
+      size: 9
+    });
+    expect(await content?.blob.text()).toBe("# Context");
+    expect(files.list).not.toHaveBeenCalled();
+  });
+
+  it("reads binary attachments through the file API", async () => {
+    const descriptor = {
+      fileId: "file-1",
+      path: "attachments/req-one/2-report.pdf",
+      revision: "one",
+      contentDigest: `sha256:${"0".repeat(64)}`,
+      size: 3,
+      mediaType: "application/pdf",
+      mediaClass: "pdf",
+      modifiedAt: "2026-08-17T00:00:00Z"
+    } as const;
+    const files = {
+      list: vi.fn(async function* () { yield descriptor; }),
+      download: vi.fn(async () => new Blob(["pdf"], { type: "application/pdf" }))
+    };
+    const pickle = new PickleCollection({ files } as never);
+
+    const content = await pickle.readAttachment({
+      path: descriptor.path,
+      filename: "report.pdf"
+    });
+
+    expect(content).toMatchObject({
+      filename: "report.pdf",
+      mediaType: "application/pdf",
+      size: 3
+    });
+    expect(files.download).toHaveBeenCalledWith(descriptor, {});
   });
 
   it("derives lifecycle from response links and writes a typed response", async () => {

--- a/packages/pickle/src/index.ts
+++ b/packages/pickle/src/index.ts
@@ -3,6 +3,7 @@ import {
   MdbaseConnectError,
   type CollectionContractDescriptor,
   type CollectionDescription,
+  type CollectionFileDescriptor,
   type CollectionTypeDescriptor,
   type JsonObject,
   type RecordDocument,
@@ -16,6 +17,7 @@ import { PICKLE_REQUEST_CONTRACT_DIGEST } from "./resources.js";
 
 export {
   PICKLE_ACK_RESPONSE_TYPE_DOCUMENT,
+  PICKLE_ATTACHMENT_TYPE_DOCUMENT,
   PICKLE_APPROVAL_RESPONSE_TYPE_DOCUMENT,
   PICKLE_REQUEST_CONTRACT_DOCUMENT,
   PICKLE_REQUEST_CONTRACT_DIGEST,
@@ -86,6 +88,14 @@ export interface PickleAttachment {
   filename: string;
 }
 
+export interface PickleAttachmentContent {
+  path: string;
+  filename: string;
+  mediaType: string;
+  size: number;
+  blob: Blob;
+}
+
 export interface PickleResponse {
   path: string;
   type: string;
@@ -149,6 +159,11 @@ export interface PickleClient {
     input: Parameters<MdbaseConnection<PickleFrontmatter>["create"]>[0],
     options?: ConnectRequestOptions
   ): ReturnType<MdbaseConnection<PickleFrontmatter>["create"]>;
+  read(
+    input: Parameters<MdbaseConnection<PickleFrontmatter>["read"]>[0],
+    options?: ConnectRequestOptions
+  ): ReturnType<MdbaseConnection<PickleFrontmatter>["read"]>;
+  files: MdbaseConnection<PickleFrontmatter>["files"];
   pendingMutations<Result = unknown>(): readonly PendingMutation<Result>[];
   pendingMutation<Result = unknown>(
     requestId: string
@@ -310,6 +325,52 @@ export class PickleCollection {
       requestOptions
     );
     return responseSubmission(created);
+  }
+
+  async readAttachment(
+    attachment: PickleAttachment,
+    options: ConnectRequestOptions = {}
+  ): Promise<PickleAttachmentContent | null> {
+    const path = attachment.path.replace(/^\/+/, "");
+    if (isMarkdownPath(path)) {
+      const outcome = await this.connect.read({ path }, options);
+      if (outcome.ok) {
+        const frontmatter = outcome.value.frontmatter;
+        if (stringField(frontmatter, "type") === "pickle_attachment") {
+          const body = outcome.value.body ?? "";
+          const filename = stringField(frontmatter, "filename") || attachment.filename;
+          const mediaType = stringField(frontmatter, "content_type") || "text/markdown";
+          return {
+            path,
+            filename,
+            mediaType,
+            size: new TextEncoder().encode(body).byteLength,
+            blob: new Blob([body], { type: mediaType })
+          };
+        }
+      }
+    }
+    const separator = path.lastIndexOf("/");
+    const folder = separator < 0 ? undefined : path.slice(0, separator);
+    let match: CollectionFileDescriptor | null = null;
+    for await (const file of this.connect.files.list({
+      ...options,
+      ...(folder ? { folder } : {})
+    })) {
+      if (file.path === path) {
+        match = file;
+        break;
+      }
+    }
+    if (!match) return null;
+    const blob = await this.connect.files.download(match, options);
+    return {
+      path,
+      filename: attachment.filename,
+      mediaType: match.mediaType || blob.type || "application/octet-stream",
+      size: match.size,
+      blob
+    };
   }
 
   pendingResponses(): readonly PicklePendingResponse[] {
@@ -595,6 +656,10 @@ function validFieldPath(value: string): boolean {
 
 function trimSlashes(value: string): string {
   return value.replace(/^\/+|\/+$/g, "");
+}
+
+function isMarkdownPath(path: string): boolean {
+  return /\.(?:md|markdown|mdown|mkd|mkdn)$/i.test(path);
 }
 
 function asObject(value: unknown): JsonObject | undefined {

--- a/packages/pickle/src/resources.ts
+++ b/packages/pickle/src/resources.ts
@@ -210,11 +210,37 @@ lifecycle:
 ---
 `;
 
+export const PICKLE_ATTACHMENT_TYPE_DOCUMENT = `---
+kind: mdbase.type
+name: pickle_attachment
+version: 1
+description: Markdown content attached to a Pickle request.
+schema:
+  dialect: json-schema-2020-12
+  value:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    type: object
+    additionalProperties: true
+    required: [request_id, filename, content_type, size_bytes, sha256]
+    properties:
+      type: { const: pickle_attachment }
+      request_id: { type: string, minLength: 1 }
+      filename: { type: string, minLength: 1 }
+      content_type: { type: string, minLength: 1 }
+      size_bytes: { type: integer, minimum: 0 }
+      sha256: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+      created_at: { type: string, format: date-time }
+collection:
+  display:
+    name_field: filename
+---
+`;
+
 export const PICKLE_TYPE_PACK_PROVISION = {
   manifest: {
     kind: "mdbase.type-pack",
     id: "pickle.requests",
-    version: "1.0.0",
+    version: "1.1.0",
     name: "Pickle requests",
     description: "Pickle request and response record types.",
     resources: [
@@ -245,6 +271,13 @@ export const PICKLE_TYPE_PACK_PROVISION = {
         source: "types/pickle_response_ack.md",
         target: "_types/pickle_response_ack.md",
         digest: "sha256:2530c8d21bb711889f20e0d096045cb6c9a7618583b1e2afff7ada72367de41f"
+      },
+      {
+        kind: "type",
+        mode: "seed",
+        source: "types/pickle_attachment.md",
+        target: "_types/pickle_attachment.md",
+        digest: "sha256:67f14eeee2c126e99d8b37b7508fa148955b924367e2d2941b1793d1c814ec25"
       }
     ]
   },
@@ -264,6 +297,10 @@ export const PICKLE_TYPE_PACK_PROVISION = {
     {
       source: "types/pickle_response_ack.md",
       document: PICKLE_ACK_RESPONSE_TYPE_DOCUMENT
+    },
+    {
+      source: "types/pickle_attachment.md",
+      document: PICKLE_ATTACHMENT_TYPE_DOCUMENT
     }
   ],
   provides: [{


### PR DESCRIPTION
Fixes the 2026-08-18 09:2x–09:44Z production outage. **Saving an Obsidian Base source took the entire hosted provider offline.**

## What happened

Two defects, both required.

**1. The binding was only invalidated for type mutations.** `operation_resource_mutations.rs:148` gates invalidation on `is_type = matches!(operation, "create_type" | "update_type")`, but `resource_revision` advances unconditionally. `create_view_source` / `update_view_source` / `delete_view_source` (`operation_dispatch.rs:364`) therefore left the active generation pinned to a superseded revision with **no rebuild scheduled**. Collection `0d728eb2` sat on `hosted:1:884:resources` while the collection had moved to `hosted:1:898:resources`, `status = complete`, never self-healing.

**2. `ready()` escalated that to a process failure.** `lifecycle.rs:208` counted any unready active collection and returned 503. Render health-checks `/ready`, pulled the instance, and served 502 for **all 69 collections and every user**, plus `sync.mdbase.dev`.

## The fix

**Carry the generation forward, don't abandon it.** A Base source is a query definition; no projected fact derives from it. My first attempt invalidated unconditionally and it was **worse than the bug** — three Base tests failed with `hosted_exact_document_budget_exceeded` (limit 2000, observed 2001), because dropping a 10k collection into canonical exact fallback breaks its Base queries until rebuild. Type mutations still invalidate, since they do change the semantic catalog.

**Readiness reports degradation instead of failing.** `ready()` now returns `projections.degraded_collections` alongside the existing notification degradation, following the acyclic-readiness rule already documented in that same function — *"Report degradation for operators without inviting the platform to restart a provider that can still serve authoritative data."* A collection whose projection is absent or rebuilding is served from bounded canonical fallback by design.

## Verification

Disposable PostgreSQL 18.4-alpine, CI's exact invocation:

```
main pass (with CI's 8 skips):                                        44 passed; 0 failed
candidate_b_projection_lifecycle_is_snapshot_safe_and_write_through:  ok
candidate_b_recovery_does_not_supersede_a_concurrent_explicit_...:    ok
clippy --all-targets -D warnings:                                     clean
```

New test `view_mutations_carry_the_projection_binding_and_keep_readiness` **fails without fix 1** (`a resource revision advance must clear the active projection binding` in the earlier form; now asserts the generation is carried and readiness survives).

## Still open

`hosted-projection-migration.md` documents "a semantic catalog change clears the binding and starts a rebuild", which now holds for type mutations only. That doc should be reconciled with the view behaviour.

Full analysis in cloud-ops `.ops/tasks/investigate-candidate-b-production-outage.md`.