### PR TITLE
Follow the editor theme in the rendered Google button

### DIFF
--- a/apps/editor/src/GoogleIdentityButton.tsx
+++ b/apps/editor/src/GoogleIdentityButton.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { ConnectManagementClient } from "@mdbase/connect-management";
 import { observeProviderWidth } from "@mdbase/connect-ui/provider-button";
+import { observeTheme, resolveDarkTheme } from "@mdbase/connect-ui/theme";
 
 interface GoogleAccountsApi {
   accounts: {
@@ -14,7 +15,7 @@ interface GoogleAccountsApi {
       }): void;
       renderButton(element: HTMLElement, config: {
         type: "standard";
-        theme: "outline";
+        theme: "outline" | "filled_black";
         size: "large";
         text: "continue_with";
         shape: "rectangular";
@@ -78,22 +79,23 @@ export function GoogleIdentityButton({ client, purpose, onComplete, onError }: {
   }, [attempt, client, onComplete, onError, purpose]);
 
   useEffect(() => observeProviderWidth(container.current, setWidth), []);
+  const dark = useSyncExternalStore(observeTheme, () => resolveDarkTheme(), () => false);
 
-  // Google draws the button itself at a fixed pixel width, so the only way to
-  // keep it aligned with the controls around it is to ask for it again.
+  // Google draws the button itself at a fixed pixel width and bakes the palette
+  // in, so the only way to follow the surrounding chrome is to ask for it again.
   useEffect(() => {
     if (!google || !width || !button.current) return;
     button.current.replaceChildren();
     google.accounts.id.renderButton(button.current, {
       type: "standard",
-      theme: "outline",
+      theme: dark ? "filled_black" : "outline",
       size: "large",
       text: "continue_with",
       shape: "rectangular",
       logo_alignment: "left",
       width
     });
-  }, [google, width]);
+  }, [dark, google, width]);
 
   const ready = Boolean(google && width);
   return <div ref={container} className={`connect-google-provider ${busy ? "busy" : ""}`} aria-busy={busy}>

--- a/packages/ui/theme.test.ts
+++ b/packages/ui/theme.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { loadThemePreference, normalizeThemePreference, saveThemePreference } from "./theme.ts";
+import { loadThemePreference, normalizeThemePreference, observeTheme, resolveDarkTheme, saveThemePreference } from "./theme.ts";
 
 test("normalizes unsupported theme preferences to system", () => {
   assert.equal(normalizeThemePreference("sepia"), "system");
@@ -26,4 +26,34 @@ test("loads and saves a local theme preference", () => {
 
   saveThemePreference("system", storage, root);
   assert.equal(loadThemePreference(storage), "system");
+});
+
+test("resolves the applied theme ahead of the system preference", () => {
+  const root = (theme?: string) => ({ dataset: theme ? { theme } : {} }) as unknown as HTMLElement;
+
+  assert.equal(resolveDarkTheme(root("dark")), true);
+  assert.equal(resolveDarkTheme(root("light")), false);
+  // No data-theme means "system", which is light here because Node has no matchMedia.
+  assert.equal(resolveDarkTheme(root()), false);
+});
+
+test("stops observing the theme once released", () => {
+  const observed: HTMLElement[] = [];
+  let disconnected = 0;
+  class MutationObserverStub {
+    observe(target: HTMLElement) { observed.push(target); }
+    disconnect() { disconnected += 1; }
+  }
+  const previous = globalThis.MutationObserver;
+  globalThis.MutationObserver = MutationObserverStub as unknown as typeof MutationObserver;
+
+  try {
+    const root = {} as HTMLElement;
+    const release = observeTheme(() => {}, root);
+    assert.deepEqual(observed, [root]);
+    release();
+    assert.equal(disconnected, 1);
+  } finally {
+    globalThis.MutationObserver = previous;
+  }
 });


### PR DESCRIPTION
Google bakes its palette into the button it draws, and the editor asked for the outline theme unconditionally — a white button with a light border, which sits as a bright block on the dark canvas.

`resolveDarkTheme` and `observeTheme` landed in `@mdbase/connect-ui/theme` with beta77 (#282) but had no call sites. This wires them up:

- `theme` widens from the `"outline"` literal to `"outline" | "filled_black"`.
- `useSyncExternalStore(observeTheme, resolveDarkTheme)` tracks the applied theme. The helpers read `data-theme` off the document element, so they work regardless of which module set it — the editor keeps its own local `src/theme.ts` rather than the shared one.
- `dark` joins the render effect's inputs alongside `width`, so the button follows a live theme switch.

Also covers `resolveDarkTheme` and `observeTheme`, which had no tests.

The portal is deliberately untouched: its button is `filled_blue`, which Google intends for both light and dark backgrounds.

Editor typecheck clean, 283 editor tests pass, `packages/ui` 18 pass.