### PR TITLE
Bound the Playwright browser install

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -124,7 +124,12 @@ jobs:
       - run: pnpm build
       # Browser-only provider boundaries run alongside the slower Rust and
       # system suites instead of extending their critical path.
+      # `--with-deps` pulls system packages from distribution mirrors, so a
+      # slow or unresponsive mirror hangs this step rather than failing it.
+      # Bound it: an unbounded install burned 75 minutes of a job whose whole
+      # successful run is normally under 18.
       - run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 10
       - run: pnpm test:browser-storage
       - run: pnpm test:accessibility
       - run: pnpm typecheck
@@ -246,7 +251,12 @@ jobs:
       - run: cargo build --locked --workspace
       # The local system suite launches Chromium even though the standalone
       # browser-storage and accessibility checks run in the parallel Node job.
+      # `--with-deps` pulls system packages from distribution mirrors, so a
+      # slow or unresponsive mirror hangs this step rather than failing it.
+      # Bound it: an unbounded install burned 75 minutes of a job whose whole
+      # successful run is normally under 18.
       - run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 10
       # Exercise the local connector/browser request path in normal CI as well
       # as the durable hosted-provider path below.
       - run: node test/system/run.mjs --suite local --no-prepare


### PR DESCRIPTION
`playwright install --with-deps` pulls system packages from distribution mirrors, so a slow or unresponsive mirror **hangs** the step rather than failing it. There was no timeout.

On 2026-08-19 the `hosted-provider` job spent **75 minutes** on that download — in a job whose successful runs finish in under 18 — and did the same again on a re-run. GitHub Actions itself was fully operational throughout, and the `node` job cleared the identical step, so this is a mirror problem that the workflow had no defence against.

Both call sites (`:127` and `:249`) are now bounded at ten minutes, matching the `timeout-minutes: 20` already used by the desktop suite step in the same job. A slow mirror now fails fast and can be retried rather than silently consuming an hour of CI.

## The install is required and stays

I checked whether `hosted-provider` needed Chromium at all. It does — the workflow comment was accurate:

| Suite | Script | Browser references |
|---|---|---|
| `local` | `scripts/e2e.mjs` | 8 |
| `provider` | `scripts/hosted-provider-e2e.mjs` | 4 |
| `relay` | `scripts/relay-e2e.mjs` | 0 |
| `files-adversarial` | `scripts/hosted-file-adversarial-e2e.mjs` | 0 |

Two of the four suites in that job drive Chromium, so removing the install is not an option.

## Possible follow-up

Caching `~/.cache/ms-playwright` keyed on the Playwright version would skip the download on most runs and make mirror availability irrelevant rather than merely bounded. Left out here to keep this change small and obviously correct.