### PR TITLE
Cache the browser install and retry retryable generation starts

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -124,12 +124,26 @@ jobs:
       - run: pnpm build
       # Browser-only provider boundaries run alongside the slower Rust and
       # system suites instead of extending their critical path.
-      # `--with-deps` pulls system packages from distribution mirrors, so a
-      # slow or unresponsive mirror hangs this step rather than failing it.
-      # Bound it: an unbounded install burned 75 minutes of a job whose whole
-      # successful run is normally under 18.
-      - run: pnpm exec playwright install --with-deps chromium
+      # `--with-deps` pulls system packages from distribution mirrors. On
+      # 2026-08-19 azure.archive.ubuntu.com served 21 MB of font packages at
+      # under 50 KB/s, hanging the step for 75 minutes before it was bounded.
+      #
+      # Cache the browser so most runs never contact a mirror at all, and keep
+      # the timeout so a cache miss on a slow day fails fast instead of
+      # silently consuming an hour.
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+      # The system dependencies are font packages that the runner image
+      # already carries; only a cache miss needs them refreshed.
+      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
         timeout-minutes: 10
+      - if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install chromium
+        timeout-minutes: 5
       - run: pnpm test:browser-storage
       - run: pnpm test:accessibility
       - run: pnpm typecheck
@@ -251,12 +265,26 @@ jobs:
       - run: cargo build --locked --workspace
       # The local system suite launches Chromium even though the standalone
       # browser-storage and accessibility checks run in the parallel Node job.
-      # `--with-deps` pulls system packages from distribution mirrors, so a
-      # slow or unresponsive mirror hangs this step rather than failing it.
-      # Bound it: an unbounded install burned 75 minutes of a job whose whole
-      # successful run is normally under 18.
-      - run: pnpm exec playwright install --with-deps chromium
+      # `--with-deps` pulls system packages from distribution mirrors. On
+      # 2026-08-19 azure.archive.ubuntu.com served 21 MB of font packages at
+      # under 50 KB/s, hanging the step for 75 minutes before it was bounded.
+      #
+      # Cache the browser so most runs never contact a mirror at all, and keep
+      # the timeout so a cache miss on a slow day fails fast instead of
+      # silently consuming an hour.
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+      # The system dependencies are font packages that the runner image
+      # already carries; only a cache miss needs them refreshed.
+      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
         timeout-minutes: 10
+      - if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install chromium
+        timeout-minutes: 5
       # Exercise the local connector/browser request path in normal CI as well
       # as the durable hosted-provider path below.
       - run: node test/system/run.mjs --suite local --no-prepare

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -8517,11 +8517,24 @@ async fn register_query_application(
 }
 
 async fn complete_generation(fixture: &FileLifecycleFixture) -> Uuid {
-    let generation = fixture
-        .provider
-        .start_projection_generation(fixture.collection_id)
-        .await
-        .unwrap();
+    // The provider types transaction conflicts as `provider_database_retryable`
+    // and tells the caller to retry. A helper that unwraps them instead asserts
+    // a stronger contract than production offers, and fails on ordinary
+    // contention: the 230k fixture flaked exactly this way on a deadlock during
+    // generation start.
+    let generation = loop {
+        match fixture
+            .provider
+            .start_projection_generation(fixture.collection_id)
+            .await
+        {
+            Ok(generation) => break generation,
+            Err(error) if error.code == "provider_database_retryable" => {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(error) => panic!("projection generation start failed: {error:?}"),
+        }
+    };
     loop {
         let batch = match fixture
             .provider


### PR DESCRIPTION
Two CI reliability fixes, both from failures seen today.

## Cache the Playwright browser

The install depends on distribution mirrors. On 2026-08-19 `azure.archive.ubuntu.com` served 21 MB of font packages at under 50 KB/s:

```
11:16:29  Need to get 21.1 MB of archives
11:16:35  Get:2 fonts-ipafont-gothic  [3513 kB]
11:19:51  Get:3 fonts-freefont-ttf    [5641 kB]   ← 3m16s for one package
11:25:19  Get:4 fonts-tlwg-loma-otf   [107 kB]    ← 5m28s more
11:26:07  ERROR: timed out after 10 minutes
```

Unbounded, it hung a job for **75 minutes** whose successful runs finish in under 18. Bounded (#285), it fails cleanly but still cannot pass while the mirror is slow.

Caching `~/.cache/ms-playwright` on the lockfile hash means most runs never contact a mirror at all. The timeout stays, so a cache miss on a bad day fails fast rather than silently consuming an hour. Only a cache miss needs `--with-deps` — the system dependencies are font packages the runner image already carries.

## Retry retryable generation starts

`complete_generation` unwrapped `start_projection_generation`. The provider explicitly types transaction conflicts as retryable:

```
ApiError { status: 503, code: "provider_database_retryable",
  message: "The hosted provider database transaction conflicted. Retry the request.",
  details: {"retry_class": "deadlock"} }
```

Unwrapping that asserts a stronger contract than production offers, and fails on ordinary contention — the 230k fixture flaked exactly that way on #286. The helper already retried `projection_lease_unavailable`; it now also retries this code, and still panics on anything else.

## Verification

```
main pass (CI's 8 skips):  45 passed; 0 failed
cargo fmt --all --check:   clean
```