### PR TITLE
Give the browser cache-miss path room to populate

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -137,10 +137,14 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       # The system dependencies are font packages that the runner image
-      # already carries; only a cache miss needs them refreshed.
+      # already carries; only a cache miss needs them refreshed. A miss must be
+      # able to finish even on a slow mirror, or the cache never populates and
+      # every run pays the same cost -- so this path gets a wider budget than
+      # the cached path. It is still bounded: the 2026-08-19 hang ran 75
+      # minutes unbounded.
       - if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
-        timeout-minutes: 10
+        timeout-minutes: 30
       - if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install chromium
         timeout-minutes: 5
@@ -278,10 +282,14 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       # The system dependencies are font packages that the runner image
-      # already carries; only a cache miss needs them refreshed.
+      # already carries; only a cache miss needs them refreshed. A miss must be
+      # able to finish even on a slow mirror, or the cache never populates and
+      # every run pays the same cost -- so this path gets a wider budget than
+      # the cached path. It is still bounded: the 2026-08-19 hang ran 75
+      # minutes unbounded.
       - if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
-        timeout-minutes: 10
+        timeout-minutes: 30
       - if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install chromium
         timeout-minutes: 5


### PR DESCRIPTION
Follow-up to #287.

The cache only helps once populated, and a miss still contacts the distribution mirror. With both paths capped at ten minutes, the miss could never complete while `azure.archive.ubuntu.com` was slow — so the cache never populated, and every run kept paying the same cost.

The miss path now gets thirty minutes. The cached path keeps its short bound, and that is the path almost every run will take once the cache exists. Still bounded: the unbounded version ran **75 minutes** on 2026-08-19.