### PR TITLE
release: prepare beta79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+## 0.1.0-beta.79
+
+Beta.79 fixes a durable write race in the engine and a credential expiry that
+never decoded.
+
+- The runtime transaction commit path now rejects a commit against a path
+  another commit owns but has not settled. Settlement runs after the commit lock
+  is released, so a committed-but-unsettled transaction was invisible to the
+  precondition check and two writers could both take commit points against one
+  baseline. Whichever settled second found a revision matching neither its
+  before nor its intended state, stranded its journal as needing manual
+  recovery, and that journal then failed every later collection open — so an
+  ordinary lost write race could leave a collection unopenable. The loser is now
+  rejected before taking a commit point, reporting a concurrent modification
+  conflict, which is what it is.
+- `storage.credential_expires_at` in the hosted provider diagnostics surface
+  reported no expiry for every temporary credential. The session token is
+  standard base64 of `jwt/<header>.<claims>.<signature>` rather than a bare JWT,
+  so its claims were never read and an expiring credential was indistinguishable
+  from a permanent one. That is the field the surface exists to provide, and it
+  failed in the direction of false reassurance.
+
+Note for operators: a modest increase in concurrent modification conflicts is
+expected and correct. Races that previously succeeded and then stranded now
+surface as conflicts instead. A sustained rate against a small set of paths is
+the signal worth investigating, not the aggregate change.
+
 ## 0.1.0-beta.78
 
 Beta.78 adds a diagnostics surface to the hosted provider.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.78"
+version = "0.1.0-beta.79"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.78" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.79" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.78",
+  "version": "0.1.0-beta.79",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -122,7 +122,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.78",
+        version: "0.1.0-beta.79",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
Ships two fixes, one of which changes durable write-path behaviour.

## Engine: unsettled-path commit race

Settlement runs after the commit lock is released, so a committed-but-unsettled transaction was invisible to the precondition check. Two writers could both take commit points against one baseline:

```
A: [lock] recheck ok                     -> phase=Committing -> [unlock]
B: [lock] recheck sees the OLD revision  -> phase=Committing -> [unlock]
A: [lock] settle -> path rewritten
B: [lock] settle -> matches neither before nor intended
```

B stranded its journal as `NeedsManualRecovery`, and `recover_pending` then failed on it at **every later `Collection::open`**. An ordinary lost write race could leave a collection unopenable until someone deleted the transaction directory by hand.

B is now rejected before taking a commit point, reporting `concurrent_modification`. (callumalpass/mdbase-rs#54, pinned via #291.)

## Diagnostics: credential expiry never decoded

`storage.credential_expires_at` reported **no expiry for every temporary credential** — staging and lab read as permanent, days before they expire. The session token is standard base64 of `jwt/<header>.<claims>.<signature>`, not a bare JWT, so the claims were never read. `None` also means "permanent credential", so the broken case was indistinguishable from the healthy one. (#289.)

## Also on main since beta.78

#290 adds `pnpm check:workspace-pins`, a developer preflight comparing sibling checkouts against pinned revisions. No runtime effect.

## Operator note

**A modest rise in `concurrent_modification` is expected and correct.** Races that previously succeeded and then stranded now surface as conflicts. The signal worth investigating is a sustained rate against a small set of paths, not the aggregate change.

One behaviour change to know: a stale `Committing` journal now blocks commits to its paths until recovery settles it, where previously those commits proceeded and stranded. Visible and self-healing on reopen, versus silent and terminal — but new. Tracked in cloud-ops#205.

## Verification

- mdbase-rs#54: 7/7 including three OSes and live PostgreSQL; its regression tests fail without the fix.
- #291 (engine bump alone): 9/9 including `hosted-provider`, the job hosting the `unified_cli` race this fixes.
- #289 and #290: 9/9 each on the fixed engine.
- `node scripts/check-release-version.mjs` — consistent at 0.1.0-beta.79.