### PR TITLE
CI: promote exact qualified artifacts

### DIFF
--- a/.github/workflows/ci-observability.yml
+++ b/.github/workflows/ci-observability.yml
@@ -1,0 +1,64 @@
+name: Server CI timings
+
+on:
+  workflow_run:
+    workflows: [Server CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Capture one bounded jobs snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
+          UPDATED_AT: ${{ github.event.workflow_run.updated_at }}
+        run: |
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" \
+            >job-pages.json
+          jq -n \
+            --arg run_id "$RUN_ID" --arg head_sha "$HEAD_SHA" \
+            --arg event "$SOURCE_EVENT" --arg conclusion "$CONCLUSION" \
+            --arg started_at "$STARTED_AT" --arg updated_at "$UPDATED_AT" \
+            --slurpfile pages job-pages.json '
+              def seconds($start; $end):
+                if ($start == null or $end == null) then null
+                else (($end | fromdateiso8601) - ($start | fromdateiso8601)) end;
+              ($pages | map(.[]?.jobs // []) | add) as $jobs
+              | {schema_version:1,run_id:($run_id|tonumber),head_sha:$head_sha,
+                  event:$event,conclusion:$conclusion,started_at:$started_at,
+                  completed_at:$updated_at,
+                  duration_seconds:seconds($started_at;$updated_at),
+                  jobs:[$jobs[] | {id,name,status,conclusion,run_attempt,
+                    started_at,completed_at,
+                    duration_seconds:seconds(.started_at;.completed_at),
+                    steps:[.steps[]? | {number,name,status,conclusion,
+                      started_at,completed_at,
+                      duration_seconds:seconds(.started_at;.completed_at)}]}]}
+            ' >server-ci-timings.json
+          {
+            echo '## Server CI timing report'
+            echo
+            echo '| Job | Result | Seconds | Attempt |'
+            echo '|---|---:|---:|---:|'
+            jq -r '.jobs | sort_by(-(.duration_seconds // 0))[]
+              | "| \(.name) | \(.conclusion // .status) | \(.duration_seconds // "-") | \(.run_attempt // 1) |"' \
+              server-ci-timings.json
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-ci-timings-${{ github.event.workflow_run.id }}
+          path: server-ci-timings.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,6 +19,7 @@ on:
       - "pnpm-workspace.yaml"
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -30,6 +31,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     name: ${{ matrix.label }}
     permissions:
+      actions: read
       contents: read
       id-token: write
     strategy:
@@ -70,6 +72,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: mdbase-connect
+
+      - name: Require exact full Server CI qualification
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci/verify-qualified-commit "$GITHUB_SHA"
 
       - id: version
         shell: bash
@@ -212,8 +220,6 @@ jobs:
             pnpm check:release-readiness -- --stable
           fi
       - run: pnpm build
-      - run: pnpm typecheck
-      - run: pnpm test
       - run: pnpm --filter @mdbase/connect-desktop make
 
       - name: Verify macOS release mode

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,7 +24,9 @@ permissions:
 
 concurrency:
   group: desktop-release-${{ github.ref }}
-  cancel-in-progress: false
+  # Tag publication must finish once started. Pull-request regressions are
+  # replaceable and should not make every superseded commit wait its turn.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -22,6 +22,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -49,6 +50,21 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - name: Verify exact Server CI qualification
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          scripts/ci/verify-qualified-commit
+          "$SOURCE_COMMIT"
+          "${{ github.event.workflow_run.id }}"
+
+      - name: Verify manually republished source qualification
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci/verify-qualified-commit "$SOURCE_COMMIT"
+
       - id: diff
         name: Detect managed runtime changes
         run: |
@@ -69,6 +85,7 @@ jobs:
             crates \
             deploy/docker/Cargo.lock.hosted-provider \
             deploy/docker/Dockerfile.hosted-provider \
+            deploy/docker/Dockerfile.client \
             deploy/docker/Dockerfile.mcp \
             deploy/docker/Dockerfile.server \
             deploy/docker/mdbase-rs-revision \
@@ -112,6 +129,9 @@ jobs:
           - component: mcp
             package: mdbase-connect-mcp
             dockerfile: deploy/docker/Dockerfile.mcp
+          - component: client
+            package: mdbase-connect-client
+            dockerfile: deploy/docker/Dockerfile.client
     env:
       IMAGE: ghcr.io/mdbase-dev/${{ matrix.package }}
 
@@ -149,6 +169,25 @@ jobs:
           dockerfile: deploy/docker/Dockerfile.hosted-provider
           skip-extraction: ${{ steps.hosted-provider-cache.outputs.cache-hit }}
 
+      - name: Restore client Cargo cache mounts
+        if: matrix.component == 'client'
+        id: client-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: client-cache-mounts
+          key: client-cargo-${{ hashFiles('deploy/docker/Cargo.lock.hosted-provider', 'deploy/docker/mdbase-rs-revision') }}-${{ env.SOURCE_COMMIT }}
+          restore-keys: |
+            client-cargo-${{ hashFiles('deploy/docker/Cargo.lock.hosted-provider', 'deploy/docker/mdbase-rs-revision') }}-
+
+      - name: Inject client Cargo cache mounts
+        if: matrix.component == 'client'
+        uses: reproducible-containers/buildkit-cache-dance@5b81f4d29dc8397a7d341dba3aeecc7ec54d6361 # v3.3.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: client-cache-mounts
+          dockerfile: deploy/docker/Dockerfile.client
+          skip-extraction: ${{ steps.client-cache.outputs.cache-hit }}
+
       - id: build
         name: Build and push immutable image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -166,6 +205,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.package }}
           provenance: mode=max
           sbom: true
+
+      - name: Smoke-test the published client image
+        if: matrix.component == 'client'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          expected=$(jq -r .version package.json)
+          actual=$(docker run --rm "$IMAGE@$DIGEST" --version)
+          grep -F -- "$expected" <<<"$actual"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,6 +7,7 @@ on:
       - "v*"
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -14,11 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     permissions:
+      actions: read
       contents: read
       id-token: write
 
     steps:
       - uses: actions/checkout@v7
+
+      - id: qualification
+        name: Require exact full Server CI qualification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci/verify-qualified-commit "$GITHUB_SHA"
 
       - uses: pnpm/action-setup@v6
 
@@ -49,7 +57,6 @@ jobs:
       - name: Verify trusted-publisher bootstrap
         run: pnpm check:npm-bootstrap
 
-      - run: pnpm install --frozen-lockfile
       - run: pnpm version:check
 
       - name: Enforce release-readiness gates
@@ -62,17 +69,14 @@ jobs:
           esac
 
       - run: pnpm check:architecture
-      - run: pnpm build
-      - run: pnpm typecheck
-      - run: pnpm test
-      - run: pnpm package:audit
 
-      - name: Pack public packages
-        run: |
-          mkdir -p "$RUNNER_TEMP/npm-packages"
-          while IFS=$'\t' read -r PACKAGE_NAME PACKAGE_DIR; do
-            pnpm --dir "$PACKAGE_DIR" pack --pack-destination "$RUNNER_TEMP/npm-packages"
-          done < <(node scripts/public-packages.mjs)
+      - name: Download qualified package tarballs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: qualified-npm-packages
+          path: ${{ runner.temp }}/npm-packages
+          run-id: ${{ steps.qualification.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Publish packages
         env:

--- a/.github/workflows/publish-staging-images.yml
+++ b/.github/workflows/publish-staging-images.yml
@@ -39,7 +39,8 @@ jobs:
     outputs:
       mdbase_rs_revision: ${{ steps.source.outputs.mdbase_rs_revision }}
     steps:
-      - name: Require an open, green, exact pull-request head
+      - id: qualification
+        name: Require an open, fully qualified, exact pull-request head
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -63,6 +64,7 @@ jobs:
               and .head.sha == $commit
               and .head.repo.full_name == $repository
             ' >/dev/null <<<"$pull"
+          jq -e 'any(.labels[]?; .name == "ci:full")' >/dev/null <<<"$pull"
 
           runs=$(gh run list \
             --repo "$GITHUB_REPOSITORY" \
@@ -70,14 +72,16 @@ jobs:
             --commit "$SOURCE_COMMIT" \
             --event pull_request \
             --limit 20 \
-            --json status,conclusion,headSha,event,url)
-          jq -e --arg commit "$SOURCE_COMMIT" '
-            any(.[];
+            --json databaseId,status,conclusion,headSha,event,url)
+          run_id=$(jq -er --arg commit "$SOURCE_COMMIT" '
+            [.[] | select(
               .headSha == $commit
               and .event == "pull_request"
               and .status == "completed"
-              and .conclusion == "success")
-            ' >/dev/null <<<"$runs"
+              and .conclusion == "success")]
+            | sort_by(.databaseId) | last | .databaseId
+            ' <<<"$runs")
+          echo "run_id=$run_id" >>"$GITHUB_OUTPUT"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -91,6 +95,15 @@ jobs:
           revision=$(tr -d '\r\n' <deploy/docker/mdbase-rs-revision)
           [[ $revision =~ ^[0-9a-f]{40}$ ]]
           echo "mdbase_rs_revision=$revision" >>"$GITHUB_OUTPUT"
+
+      - name: Verify the full qualification artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          scripts/ci/verify-qualified-commit
+          "$SOURCE_COMMIT"
+          "${{ steps.qualification.outputs.run_id }}"
+          pull_request
 
   publish:
     needs: authorize
@@ -114,6 +127,9 @@ jobs:
           - component: mcp
             package: mdbase-connect-mcp
             dockerfile: deploy/docker/Dockerfile.mcp
+          - component: client
+            package: mdbase-connect-client
+            dockerfile: deploy/docker/Dockerfile.client
     env:
       IMAGE: ghcr.io/mdbase-dev/${{ matrix.package }}
 
@@ -154,6 +170,25 @@ jobs:
           dockerfile: deploy/docker/Dockerfile.hosted-provider
           skip-extraction: ${{ steps.hosted-provider-cache.outputs.cache-hit }}
 
+      - name: Restore client Cargo cache mounts
+        if: matrix.component == 'client'
+        id: client-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: client-cache-mounts
+          key: staging-client-cargo-${{ hashFiles('deploy/docker/Cargo.lock.hosted-provider', 'deploy/docker/mdbase-rs-revision') }}-${{ env.SOURCE_COMMIT }}
+          restore-keys: |
+            staging-client-cargo-${{ hashFiles('deploy/docker/Cargo.lock.hosted-provider', 'deploy/docker/mdbase-rs-revision') }}-
+
+      - name: Inject client Cargo cache mounts
+        if: matrix.component == 'client'
+        uses: reproducible-containers/buildkit-cache-dance@5b81f4d29dc8397a7d341dba3aeecc7ec54d6361 # v3.3.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: client-cache-mounts
+          dockerfile: deploy/docker/Dockerfile.client
+          skip-extraction: ${{ steps.client-cache.outputs.cache-hit }}
+
       - id: build
         name: Build immutable staging image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -172,6 +207,14 @@ jobs:
           cache-to: type=gha,mode=max,scope=candidate-b-staging-${{ matrix.package }}
           provenance: mode=max
           sbom: true
+
+      - name: Smoke-test the candidate client image
+        if: matrix.component == 'client'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          expected=$(jq -r .version package.json)
+          docker run --rm "$IMAGE@$DIGEST" --version | grep -F -- "$expected"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -13,13 +15,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify:
+    name: Select qualification depth
+    runs-on: ubuntu-24.04
+    outputs:
+      run_full: ${{ steps.depth.outputs.run_full }}
+      upstream_run_id: ${{ steps.depth.outputs.upstream_run_id }}
+    steps:
+      - id: depth
+        name: Reuse only an exact merge-queue qualification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            if jq -e 'any(.pull_request.labels[]?; .name == "ci:full")' \
+              "$GITHUB_EVENT_PATH" >/dev/null
+            then
+              echo 'run_full=true' >>"$GITHUB_OUTPUT"
+            else
+              echo 'run_full=false' >>"$GITHUB_OUTPUT"
+            fi
+            echo 'upstream_run_id=' >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == merge_group ]]; then
+            echo 'run_full=true' >>"$GITHUB_OUTPUT"
+            echo 'upstream_run_id=' >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          runs=$(gh api --method GET \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/server-ci.yml/runs" \
+            --field head_sha="$GITHUB_SHA" --field event=merge_group \
+            --field status=completed)
+          upstream=$(jq -r --arg sha "$GITHUB_SHA" '
+            [.workflow_runs[] | select(
+              .head_sha == $sha and .event == "merge_group"
+              and .conclusion == "success"
+            )] | sort_by(.run_number) | last | .id // empty' <<<"$runs")
+          if [[ -n $upstream ]]; then
+            echo 'run_full=false' >>"$GITHUB_OUTPUT"
+            echo "upstream_run_id=$upstream" >>"$GITHUB_OUTPUT"
+          else
+            echo 'run_full=true' >>"$GITHUB_OUTPUT"
+            echo 'upstream_run_id=' >>"$GITHUB_OUTPUT"
+          fi
+
   windows-filesystem:
     name: Filesystem durability (${{ matrix.os }})
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        os: [macos-15, windows-2025]
     defaults:
       run:
         working-directory: mdbase-connect
@@ -54,6 +103,8 @@ jobs:
 
   runtime-testbed:
     name: Runtime interoperability testbed
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -104,6 +155,8 @@ jobs:
           --timeout-ms 120000
 
   node:
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -132,6 +185,7 @@ jobs:
       # the timeout so a cache miss on a slow day fails fast instead of
       # silently consuming an hour.
       - uses: actions/cache@v4
+        if: needs.classify.outputs.run_full == 'true'
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -142,19 +196,39 @@ jobs:
       # every run pays the same cost -- so this path gets a wider budget than
       # the cached path. It is still bounded: the 2026-08-19 hang ran 75
       # minutes unbounded.
-      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - if: needs.classify.outputs.run_full == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
         timeout-minutes: 30
-      - if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - if: needs.classify.outputs.run_full == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install chromium
         timeout-minutes: 5
-      - run: pnpm test:browser-storage
-      - run: pnpm test:accessibility
+      - if: needs.classify.outputs.run_full == 'true'
+        run: pnpm test:browser-storage
+      - if: needs.classify.outputs.run_full == 'true'
+        run: pnpm test:accessibility
       - run: pnpm typecheck
       - run: pnpm test
-      - run: pnpm package:audit
+      - if: needs.classify.outputs.run_full == 'true'
+        run: pnpm package:audit
+      - name: Pack qualified public packages
+        if: needs.classify.outputs.run_full == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/npm-packages"
+          while IFS=$'\t' read -r package_name package_dir; do
+            pnpm --dir "$package_dir" pack \
+              --pack-destination "$RUNNER_TEMP/npm-packages"
+          done < <(node scripts/public-packages.mjs)
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: needs.classify.outputs.run_full == 'true'
+        with:
+          name: qualified-npm-packages
+          path: ${{ runner.temp }}/npm-packages/*.tgz
+          if-no-files-found: error
+          retention-days: 90
 
-  server-container:
+  server-container-full:
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -167,8 +241,26 @@ jobs:
           MDBASE_CONNECT_E2E_BUILD=0
           node test/system/run.mjs --suite container --no-prepare
 
+  server-container:
+    needs: [classify, server-container-full]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Preserve the required check during migration
+        env:
+          RUN_FULL: ${{ needs.classify.outputs.run_full }}
+          FULL_RESULT: ${{ needs.server-container-full.result }}
+        run: |
+          if [[ "$RUN_FULL" == true ]]; then
+            [[ "$FULL_RESULT" == success ]]
+          else
+            echo 'Container qualification is deferred to the full merge lane.'
+          fi
+
   previous-release-upgrade:
     name: Previous release upgrade and OAuth
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
     services:
       postgres:
@@ -194,6 +286,8 @@ jobs:
 
   previous-provider-upgrade:
     name: Previous provider notification recovery
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
     services:
       postgres:
@@ -217,7 +311,9 @@ jobs:
       - name: Exercise the previous-provider recovery contract
         run: test/upgrade/provider-from-previous
 
-  hosted-provider:
+  hosted-provider-full:
+    needs: classify
+    if: needs.classify.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -303,3 +399,96 @@ jobs:
       # plane uses the same packaged Docker boundary as production.
       - run: node test/system/run.mjs --suite desktop --no-prepare
         timeout-minutes: 20
+
+  hosted-provider:
+    needs: [classify, hosted-provider-full]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Preserve the required check during migration
+        env:
+          RUN_FULL: ${{ needs.classify.outputs.run_full }}
+          FULL_RESULT: ${{ needs.hosted-provider-full.result }}
+        run: |
+          if [[ "$RUN_FULL" == true ]]; then
+            [[ "$FULL_RESULT" == success ]]
+          else
+            echo 'Rust and system qualification is deferred to the full merge lane.'
+          fi
+
+  qualification:
+    name: Qualification
+    if: always()
+    needs:
+      - classify
+      - windows-filesystem
+      - runtime-testbed
+      - node
+      - server-container
+      - server-container-full
+      - previous-release-upgrade
+      - previous-provider-upgrade
+      - hosted-provider
+      - hosted-provider-full
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require the selected qualification lane
+        env:
+          RUN_FULL: ${{ needs.classify.outputs.run_full }}
+          UPSTREAM_RUN_ID: ${{ needs.classify.outputs.upstream_run_id }}
+          WINDOWS: ${{ needs.windows-filesystem.result }}
+          RUNTIME: ${{ needs.runtime-testbed.result }}
+          NODE: ${{ needs.node.result }}
+          CONTAINER: ${{ needs.server-container-full.result }}
+          SERVER_UPGRADE: ${{ needs.previous-release-upgrade.result }}
+          PROVIDER_UPGRADE: ${{ needs.previous-provider-upgrade.result }}
+          PROVIDER: ${{ needs.hosted-provider-full.result }}
+        run: |
+          if [[ "$RUN_FULL" == true ]]; then
+            for result in "$WINDOWS" "$RUNTIME" "$NODE" "$CONTAINER" \
+              "$SERVER_UPGRADE" "$PROVIDER_UPGRADE" "$PROVIDER"
+            do
+              [[ $result == success ]]
+            done
+          elif [[ -z "$UPSTREAM_RUN_ID" ]]; then
+            [[ "$NODE" == success ]]
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Record immutable qualification inputs
+        env:
+          RUN_FULL: ${{ needs.classify.outputs.run_full }}
+          UPSTREAM_RUN_ID: ${{ needs.classify.outputs.upstream_run_id }}
+        run: |
+          kind=fast
+          [[ "$RUN_FULL" == true || -n "$UPSTREAM_RUN_ID" ]] && kind=full
+          tree=$(git rev-parse HEAD^{tree})
+          jq -n \
+            --arg commit "$GITHUB_SHA" \
+            --arg tree "$tree" \
+            --arg kind "$kind" \
+            --arg event "$GITHUB_EVENT_NAME" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg upstream_run_id "$UPSTREAM_RUN_ID" \
+            --arg pnpm_lock_sha256 "$(sha256sum pnpm-lock.yaml | cut -d' ' -f1)" \
+            --arg cargo_lock_sha256 "$(sha256sum deploy/docker/Cargo.lock.hosted-provider | cut -d' ' -f1)" \
+            --arg mdbase_rs_revision "$(tr -d '\r\n' <deploy/docker/mdbase-rs-revision)" \
+            --arg workflow_sha256 "$(sha256sum .github/workflows/server-ci.yml | cut -d' ' -f1)" \
+            '{schema_version:1,qualification:$kind,commit:$commit,tree:$tree,
+              event:$event,run_id:$run_id,
+              upstream_run_id:(if $upstream_run_id == "" then null else $upstream_run_id end),
+              inputs:{pnpm_lock_sha256:$pnpm_lock_sha256,
+                cargo_lock_sha256:$cargo_lock_sha256,
+                mdbase_rs_revision:$mdbase_rs_revision,
+                workflow_sha256:$workflow_sha256}}' \
+            >qualification.json
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: server-qualification
+          path: qualification.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
 
 permissions:

--- a/deploy/docker/Dockerfile.client
+++ b/deploy/docker/Dockerfile.client
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+FROM rust:1.94.0-bookworm AS build
+
+ARG MDBASE_RS_REPOSITORY=https://github.com/callumalpass/mdbase-rs.git
+ARG MDBASE_RS_REVISION
+
+COPY deploy/docker/mdbase-rs-revision /build/mdbase-rs-revision
+RUN revision="${MDBASE_RS_REVISION:-$(tr -d '\r\n' < /build/mdbase-rs-revision)}" \
+ && test -n "$revision" \
+ && git clone --filter=blob:none "$MDBASE_RS_REPOSITORY" /build/mdbase-rs \
+ && git -C /build/mdbase-rs checkout --detach "$revision"
+
+WORKDIR /build/mdbase-connect
+COPY Cargo.toml ./
+COPY deploy/docker/Cargo.lock.hosted-provider ./Cargo.lock
+COPY crates crates
+COPY config config
+COPY templates templates
+RUN --mount=type=cache,id=client-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=client-cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
+    --mount=type=cache,id=client-target,target=/build/mdbase-connect/target,sharing=locked \
+    cargo build --locked --release -p mdbase-cli \
+ && mkdir -p /build/output \
+ && cp target/release/mdbase /build/output/mdbase
+
+FROM debian:bookworm-slim AS runtime
+
+ARG MDBASE_CONNECT_REVISION
+RUN apt-get update \
+ && apt-get install --yes --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --create-home --uid 10001 mdbase
+
+COPY --from=build /build/output/mdbase /usr/local/bin/mdbase
+
+ENV RENDER_GIT_COMMIT=${MDBASE_CONNECT_REVISION}
+USER mdbase
+ENTRYPOINT ["/usr/local/bin/mdbase"]
+CMD ["--help"]

--- a/docs/ci-qualification.md
+++ b/docs/ci-qualification.md
@@ -1,0 +1,54 @@
+# CI qualification and artifact promotion
+
+`Server CI / Qualification` is the stable required check. It separates feedback
+from release qualification without allowing publication to cross an unverified
+trust boundary.
+
+## Lanes
+
+- Ordinary pull requests run the fast Node build, typecheck, architecture, and
+  unit-test lane.
+- Pull requests labelled `ci:full` run the complete cross-platform, Rust,
+  browser, container, upgrade, and system qualification. Isolated staging
+  publication requires this label and verifies the full artifact.
+- Merge-queue commits always run the complete qualification.
+- A push to `main` reuses a successful merge-queue qualification only when its
+  head SHA is exactly the same. If GitHub has no such completed run, all full
+  jobs run again.
+
+The always-present `Qualification` job checks the selected lane and records a
+JSON manifest containing the commit, Git tree, package and Cargo lock hashes,
+the mdbase engine revision, and the Server CI workflow hash. A reused main run
+also records the exact upstream merge-queue run.
+
+## Publication
+
+Server and client images are built after a successful `main` push qualification,
+smoke-tested, signed, and attested at immutable digests. Release preparation
+promotes those digests; it does not rebuild them.
+
+The full Node job packs public npm tarballs only after package audit and retains
+them with its qualification. A tag workflow verifies the exact successful
+`main` qualification and publishes those tarballs unchanged. Desktop release
+jobs verify the same qualification, then perform only the platform-specific
+build, signing, and package verification that cannot be promoted portably.
+
+## Required-check transition
+
+Enable merge queue for `main`, add `Server CI / Qualification` as required, and
+remove the old matrix job names in the same branch-protection update. Keeping an
+old job required after it becomes intentionally skipped will strand pull
+requests in an expected-check state. Do not change branch protection before the
+workflow commit is present on the default branch.
+
+During this transition, the existing required `node`, `server-container`, and
+`hosted-provider` contexts remain present. `node` carries fast PR feedback; the
+other two are compatibility wrappers that require their real heavy job in a
+full lane and explicitly defer it in an ordinary PR lane. Remove those wrappers
+only after branch protection requires `Qualification` instead.
+
+`Server CI timings` makes one paginated jobs request after each completed run,
+uploads machine-readable job and step durations, and writes a longest-first job
+table to the workflow summary. Use this evidence before merging jobs or adding
+retries; a retry should address a classified transient failure, not conceal a
+deterministic one.

--- a/scripts/ci/verify-qualified-commit
+++ b/scripts/ci/verify-qualified-commit
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit=${1:?usage: verify-qualified-commit COMMIT [RUN_ID] [EXPECTED_EVENT]}
+run_id=${2:-}
+expected_event=${3:-push}
+[[ $commit =~ ^[0-9a-f]{40}$ ]] || {
+  printf 'Qualification commit must be a full SHA.\n' >&2
+  exit 2
+}
+command -v gh >/dev/null
+command -v jq >/dev/null
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+if [[ -z $run_id ]]; then
+  runs=$(gh api --method GET \
+    "repos/$GITHUB_REPOSITORY/actions/workflows/server-ci.yml/runs" \
+    --field head_sha="$commit" --field event="$expected_event" --field status=completed)
+  run_id=$(jq -er --arg commit "$commit" --arg event "$expected_event" '
+    [.workflow_runs[] | select(
+      .head_sha == $commit and .event == $event and .conclusion == "success"
+    )] | sort_by(.run_number) | last | .id' <<<"$runs") || {
+    printf 'No successful %s qualification exists for %s.\n' \
+      "$expected_event" "$commit" >&2
+    exit 1
+  }
+fi
+[[ $run_id =~ ^[1-9][0-9]*$ ]] || {
+  printf 'Qualification run ID must be a positive integer.\n' >&2
+  exit 2
+}
+run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+jq -e --arg commit "$commit" --arg event "$expected_event" '
+  .head_sha == $commit and .event == $event and .status == "completed"
+  and .conclusion == "success" and .path == ".github/workflows/server-ci.yml"
+' >/dev/null <<<"$run" || {
+  printf 'Run %s is not a successful exact Server CI %s qualification.\n' \
+    "$run_id" "$expected_event" >&2
+  exit 1
+}
+
+temporary=$(mktemp -d)
+trap 'rm -rf -- "$temporary"' EXIT
+gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+  --name server-qualification --dir "$temporary"
+manifest=$temporary/qualification.json
+[[ -f $manifest && $(git rev-parse HEAD) == "$commit" ]] || {
+  printf 'Qualification artifact or checkout identity is invalid.\n' >&2
+  exit 1
+}
+jq -e \
+  --arg commit "$commit" \
+  --arg tree "$(git rev-parse HEAD^{tree})" \
+  --arg pnpm "$(sha256_file pnpm-lock.yaml)" \
+  --arg cargo "$(sha256_file deploy/docker/Cargo.lock.hosted-provider)" \
+  --arg revision "$(tr -d '\r\n' <deploy/docker/mdbase-rs-revision)" \
+  --arg workflow "$(sha256_file .github/workflows/server-ci.yml)" '
+    .schema_version == 1 and .qualification == "full"
+    and .commit == $commit and .tree == $tree
+    and .inputs.pnpm_lock_sha256 == $pnpm
+    and .inputs.cargo_lock_sha256 == $cargo
+    and .inputs.mdbase_rs_revision == $revision
+    and .inputs.workflow_sha256 == $workflow
+  ' "$manifest" >/dev/null || {
+  printf 'Run %s qualification is not bound to this exact checkout.\n' \
+    "$run_id" >&2
+  exit 1
+}
+artifact_run_id=$(jq -r '.upstream_run_id // .run_id' "$manifest")
+[[ $artifact_run_id =~ ^[1-9][0-9]*$ ]] || {
+  printf 'Qualification artifact does not identify its producing run.\n' >&2
+  exit 1
+}
+if [[ -n ${GITHUB_OUTPUT:-} ]]; then
+  printf 'run_id=%s\nartifact_run_id=%s\n' "$run_id" "$artifact_run_id" \
+    >>"$GITHUB_OUTPUT"
+fi
+printf 'Verified full Server CI qualification run %s for %s.\n' \
+  "$run_id" "$commit"

--- a/scripts/lib/verify-qualified-commit.test.mjs
+++ b/scripts/lib/verify-qualified-commit.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { chmod, cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const verifier = join(repositoryRoot, "scripts/ci/verify-qualified-commit");
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: "utf8", ...options }).trim();
+}
+
+async function sha256(path) {
+  return createHash("sha256").update(await readFile(path)).digest("hex");
+}
+
+test("requires a full qualification bound to the exact checkout", async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "qualified-commit-"));
+  await mkdir(join(fixture, ".github/workflows"), { recursive: true });
+  await mkdir(join(fixture, "deploy/docker"), { recursive: true });
+  await mkdir(join(fixture, "bin"), { recursive: true });
+  await cp(
+    join(repositoryRoot, ".github/workflows/server-ci.yml"),
+    join(fixture, ".github/workflows/server-ci.yml"),
+  );
+  await writeFile(join(fixture, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+  await writeFile(join(fixture, "deploy/docker/Cargo.lock.hosted-provider"), "lock\n");
+  await writeFile(
+    join(fixture, "deploy/docker/mdbase-rs-revision"),
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+  );
+  run("git", ["init", "--quiet"], { cwd: fixture });
+  run("git", ["config", "user.email", "ci@example.test"], { cwd: fixture });
+  run("git", ["config", "user.name", "CI"], { cwd: fixture });
+  run("git", ["add", "."], { cwd: fixture });
+  run("git", ["commit", "--quiet", "-m", "fixture"], { cwd: fixture });
+  const commit = run("git", ["rev-parse", "HEAD"], { cwd: fixture });
+  const tree = run("git", ["rev-parse", "HEAD^{tree}"], { cwd: fixture });
+  const manifest = join(fixture, "qualification.json");
+  await writeFile(
+    manifest,
+    `${JSON.stringify({
+      schema_version: 1,
+      qualification: "full",
+      commit,
+      tree,
+      event: "push",
+      run_id: "321",
+      upstream_run_id: null,
+      inputs: {
+        pnpm_lock_sha256: await sha256(join(fixture, "pnpm-lock.yaml")),
+        cargo_lock_sha256: await sha256(
+          join(fixture, "deploy/docker/Cargo.lock.hosted-provider"),
+        ),
+        mdbase_rs_revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        workflow_sha256: await sha256(join(fixture, ".github/workflows/server-ci.yml")),
+      },
+    })}\n`,
+  );
+  const fakeGh = join(fixture, "bin/gh");
+  await writeFile(
+    fakeGh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ $1 == api && $* == *actions/workflows/server-ci.yml/runs* ]]; then
+  printf '{"workflow_runs":[{"id":321,"head_sha":"%s","event":"push","conclusion":"success","run_number":1}]}\\n' "$TEST_COMMIT"
+elif [[ $1 == api && $* == *actions/runs/321* ]]; then
+  printf '{"head_sha":"%s","event":"push","status":"completed","conclusion":"success","path":".github/workflows/server-ci.yml"}\\n' "$TEST_COMMIT"
+elif [[ $1 == run && $2 == download ]]; then
+  while (($#)); do
+    [[ $1 != --dir ]] || { cp "$TEST_MANIFEST" "$2/qualification.json"; exit 0; }
+    shift
+  done
+  exit 2
+else
+  exit 2
+fi
+`,
+  );
+  await chmod(fakeGh, 0o755);
+  const output = join(fixture, "github-output");
+  const environment = {
+    ...process.env,
+    PATH: `${join(fixture, "bin")}:${process.env.PATH}`,
+    GITHUB_REPOSITORY: "mdbase-dev/mdbase-connect",
+    GITHUB_OUTPUT: output,
+    TEST_COMMIT: commit,
+    TEST_MANIFEST: manifest,
+  };
+  const result = spawnSync(verifier, [commit], {
+    cwd: fixture,
+    env: environment,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(await readFile(output, "utf8"), /artifact_run_id=321/);
+
+  await writeFile(join(fixture, "pnpm-lock.yaml"), "changed\n");
+  const mismatched = spawnSync(verifier, [commit], {
+    cwd: fixture,
+    env: environment,
+    encoding: "utf8",
+  });
+  assert.notEqual(mismatched.status, 0);
+  assert.match(mismatched.stderr, /not bound to this exact checkout/);
+});


### PR DESCRIPTION
## Summary
- split ordinary PR feedback from full merge/main qualification while preserving existing required contexts
- bind qualification evidence to the exact tree, locks, engine revision, and workflow
- publish signed client OCI artifacts and promote qualified npm tarballs instead of rebuilding them at tag time
- add bounded CI timing evidence and remove the duplicated Ubuntu filesystem leg

## Safety
- exact-SHA main reuse falls back to the full suite when merge-queue evidence is absent
- image, npm, desktop, and isolated-staging publication verify full qualification artifacts
- no TaskNotes product or repository changes

## Validation
- `pnpm typecheck`
- `pnpm test` (57 script suites plus all workspace suites)
- `pnpm package:audit`
- client Docker image build and `mdbase --version` smoke test
- actionlint across all workflows
- qualification verifier unit test, including mismatched-lock rejection
