### PR TITLE
release: prepare beta83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## 0.1.0-beta.83
+
+Beta.83 makes Connect onboarding and collection management simpler and more
+consistent across browser applications, the desktop client, and the portal.
+
+- Account-first onboarding now carries the user's intent through pairing,
+  explains existing-folder setup, and ends with durable collection receipts.
+- Applications can opt into a focused popup authorization flow with redirect
+  fallback, isolated-window recovery, and in-place completion in the original
+  application session.
+- Reauthorization clearly separates existing access from newly requested
+  actions, while grant editing remains limited to narrowing or revoking access.
+- Authority transfer uses one consequential approval with readiness, progress,
+  application and replica impact, completion, and retired-authority history.
+- Desktop, Connect management, and transactional approval terminology now
+  distinguishes durable configuration from individual data operations.
+- Windows release qualification now compares canonical repository content so
+  Git's CRLF checkout conversion cannot block an exact qualified commit.
+
 ## 0.1.0-beta.82
 
 Beta.82 keeps hosted saved views usable when an ordinary Markdown record cannot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "async-trait",
  "axum",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.82"
+version = "0.1.0-beta.83"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/ci/verify-qualified-commit
+++ b/scripts/ci/verify-qualified-commit
@@ -13,9 +13,9 @@ command -v jq >/dev/null
 
 sha256_file() {
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | cut -d' ' -f1
+    git cat-file blob "HEAD:$1" | sha256sum | cut -d' ' -f1
   else
-    shasum -a 256 "$1" | cut -d' ' -f1
+    git cat-file blob "HEAD:$1" | shasum -a 256 | cut -d' ' -f1
   fi
 }
 
@@ -55,6 +55,17 @@ manifest=$temporary/qualification.json
   printf 'Qualification artifact or checkout identity is invalid.\n' >&2
   exit 1
 }
+qualified_inputs=(
+  pnpm-lock.yaml
+  deploy/docker/Cargo.lock.hosted-provider
+  deploy/docker/mdbase-rs-revision
+  .github/workflows/server-ci.yml
+)
+git diff --quiet -- "${qualified_inputs[@]}" &&
+  git diff --cached --quiet -- "${qualified_inputs[@]}" || {
+    printf 'Qualified inputs differ from the exact checkout.\n' >&2
+    exit 1
+  }
 # Pull-request artifacts record GitHub's synthetic merge SHA while the run API
 # identifies the PR head. Accept that SHA only for the artifact from this exact
 # run, and still require its qualified tree to equal the head tree checked out
@@ -66,7 +77,7 @@ jq -e \
   --arg tree "$(git rev-parse HEAD^{tree})" \
   --arg pnpm "$(sha256_file pnpm-lock.yaml)" \
   --arg cargo "$(sha256_file deploy/docker/Cargo.lock.hosted-provider)" \
-  --arg revision "$(tr -d '\r\n' <deploy/docker/mdbase-rs-revision)" \
+  --arg revision "$(git cat-file blob HEAD:deploy/docker/mdbase-rs-revision | tr -d '\r\n')" \
   --arg workflow "$(sha256_file .github/workflows/server-ci.yml)" '
     .schema_version == 1 and .qualification == "full"
     and (.commit == $commit or

--- a/scripts/lib/verify-qualified-commit.test.mjs
+++ b/scripts/lib/verify-qualified-commit.test.mjs
@@ -99,6 +99,23 @@ fi
   assert.equal(result.status, 0, result.stderr);
   assert.match(await readFile(output, "utf8"), /artifact_run_id=321/);
 
+  run("git", ["config", "core.autocrlf", "true"], { cwd: fixture });
+  for (const path of [
+    "pnpm-lock.yaml",
+    "deploy/docker/Cargo.lock.hosted-provider",
+    ".github/workflows/server-ci.yml",
+  ]) {
+    const absolutePath = join(fixture, path);
+    const content = await readFile(absolutePath, "utf8");
+    await writeFile(absolutePath, content.replaceAll("\n", "\r\n"));
+  }
+  const crlfCheckout = spawnSync(verifier, [commit], {
+    cwd: fixture,
+    env: environment,
+    encoding: "utf8",
+  });
+  assert.equal(crlfCheckout.status, 0, crlfCheckout.stderr);
+
   await writeFile(join(fixture, "pnpm-lock.yaml"), "changed\n");
   const mismatched = spawnSync(verifier, [commit], {
     cwd: fixture,
@@ -106,5 +123,5 @@ fi
     encoding: "utf8",
   });
   assert.notEqual(mismatched.status, 0);
-  assert.match(mismatched.stderr, /not bound to this exact checkout/);
+  assert.match(mismatched.stderr, /differ from the exact checkout/);
 });

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.82" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.83" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.82",
+  "version": "0.1.0-beta.83",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -122,7 +122,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.82",
+        version: "0.1.0-beta.83",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary

- prepares version 0.1.0-beta.83 for the qualified onboarding and collection-management release
- records the user-facing changes in the changelog
- fixes Windows desktop publication by hashing canonical Git blobs while retaining exact checkout, tree, workflow, lockfile, and qualification-run checks
- adds a CRLF checkout regression test and preserves dirty-input rejection

## Local verification

- pnpm version:check v0.1.0-beta.83
- pnpm check:release-readiness
- pnpm check:architecture
- pnpm build
- pnpm typecheck
- pnpm test
- cargo check --workspace
- cargo fmt --all --check

This release will be staged and accepted before its immutable tag is created.