### PR TITLE
Make hosted entitlement reconciliation resumable

### DIFF
--- a/services/server/src/auth-admin-entitlements.ts
+++ b/services/server/src/auth-admin-entitlements.ts
@@ -169,7 +169,7 @@ async function completeAccount(
     await connection.query(
       `INSERT INTO audit_events
          (id, user_id, event_type, subject_id, metadata)
-       VALUES ($1, $2, 'entitlement.reconciled', $2, $3::jsonb)`,
+       VALUES ($1, $2, 'entitlement.reconciled', $4, $3::jsonb)`,
       [
         randomUUID(),
         userId,
@@ -179,7 +179,8 @@ async function completeAccount(
           operation_id: mutation.operationId,
           entitlement_revision: entitlementRevision,
           reconciled_collections: reconciledCollections
-        })
+        }),
+        userId
       ]
     );
     await connection.query(

--- a/services/server/src/auth-admin-entitlements.ts
+++ b/services/server/src/auth-admin-entitlements.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseConnection, DatabasePool } from "./db.js";
+import { reconcileHostedAccountCollections } from "./entitlements.js";
+import type { HostedProviderClient } from "./hosted-provider.js";
+import {
+  InstanceAdminConflictError,
+  type OperatorMutation
+} from "./instance-admin.js";
+
+interface ActiveHostedReconciliationOutput {
+  operation_id: string;
+  scope: "active_hosted";
+  reconciled_accounts: number;
+  hosted_collections: number;
+  reconciled_collections: number;
+  users_inspected: number;
+}
+
+interface ActiveHostedReconciliationState {
+  state: "running";
+  selected_user_ids: string[];
+  completed_user_ids: string[];
+  hosted_collections: number;
+  reconciled_collections: number;
+  users_inspected: number;
+}
+
+interface StoredOperatorOperation {
+  action: string;
+  target_type: string;
+  target_id: string;
+  actor: string;
+  reason: string;
+  result: unknown;
+}
+
+const ACTIVE_HOSTED_RECONCILIATION_LOCK = [1835295329, 1936028278] as const;
+
+export async function reconcileActiveHostedEntitlements(
+  db: DatabasePool,
+  provider: HostedProviderClient,
+  mutation: OperatorMutation
+): Promise<ActiveHostedReconciliationOutput> {
+  const connection = await db.connect();
+  let locked = false;
+  try {
+    const lock = await connection.query<{ acquired: boolean }>(
+      "SELECT pg_try_advisory_lock($1, $2) AS acquired",
+      [...ACTIVE_HOSTED_RECONCILIATION_LOCK]
+    );
+    locked = lock.rows[0]?.acquired === true;
+    if (!locked) {
+      throw new InstanceAdminConflictError(
+        "Another active-hosted entitlement reconciliation is already running."
+      );
+    }
+
+    const stored = await connection.query<StoredOperatorOperation>(
+      `SELECT action, target_type, target_id, actor, reason, result
+       FROM operator_operations WHERE operation_id = $1`,
+      [mutation.operationId]
+    );
+    const existing = stored.rows[0];
+    if (existing) {
+      assertOperation(existing, mutation);
+      if (isOutput(existing.result, mutation.operationId)) return existing.result;
+    }
+
+    let state = existing
+      ? runningState(existing.result)
+      : await createOperation(connection, mutation);
+
+    for (const userId of state.selected_user_ids) {
+      if (state.completed_user_ids.includes(userId)) continue;
+      const reconciled = await reconcileHostedAccountCollections(
+        connection,
+        provider,
+        userId
+      );
+      state = await completeAccount(
+        connection,
+        mutation,
+        state,
+        userId,
+        reconciled.entitlementRevision,
+        reconciled.reconciledCollections
+      );
+    }
+
+    const output: ActiveHostedReconciliationOutput = {
+      operation_id: mutation.operationId,
+      scope: "active_hosted",
+      reconciled_accounts: state.completed_user_ids.length,
+      hosted_collections: state.hosted_collections,
+      reconciled_collections: state.reconciled_collections,
+      users_inspected: state.users_inspected
+    };
+    await connection.query(
+      `UPDATE operator_operations SET result = $2::jsonb
+       WHERE operation_id = $1`,
+      [mutation.operationId, JSON.stringify(output)]
+    );
+    return output;
+  } finally {
+    if (locked) {
+      await connection.query(
+        "SELECT pg_advisory_unlock($1, $2)",
+        [...ACTIVE_HOSTED_RECONCILIATION_LOCK]
+      ).catch(() => undefined);
+    }
+    connection.release();
+  }
+}
+
+async function createOperation(
+  connection: DatabaseConnection,
+  mutation: OperatorMutation
+): Promise<ActiveHostedReconciliationState> {
+  const users = await connection.query<{
+    id: string;
+    hosted_collections: string | number;
+  }>(
+    `SELECT u.id, count(c.id) AS hosted_collections
+     FROM users u
+     JOIN hosted_collections c ON c.user_id = u.id
+     WHERE u.suspended_at IS NULL
+     GROUP BY u.id
+     ORDER BY u.id`
+  );
+  const inspected = await connection.query<{ count: string | number }>(
+    "SELECT count(*) AS count FROM users"
+  );
+  const state: ActiveHostedReconciliationState = {
+    state: "running",
+    selected_user_ids: users.rows.map((row) => row.id),
+    completed_user_ids: [],
+    hosted_collections: users.rows.reduce(
+      (sum, row) => sum + Number(row.hosted_collections),
+      0
+    ),
+    reconciled_collections: 0,
+    users_inspected: Number(inspected.rows[0]?.count ?? 0)
+  };
+  await connection.query(
+    `INSERT INTO operator_operations
+       (operation_id, action, target_type, target_id, actor, reason, result)
+     VALUES ($1, 'entitlements.reconcile.active-hosted',
+       'entitlement_scope', 'active-hosted', $2, $3, $4::jsonb)`,
+    [mutation.operationId, mutation.actor, mutation.reason, JSON.stringify(state)]
+  );
+  return state;
+}
+
+async function completeAccount(
+  connection: DatabaseConnection,
+  mutation: OperatorMutation,
+  state: ActiveHostedReconciliationState,
+  userId: string,
+  entitlementRevision: number,
+  reconciledCollections: number
+): Promise<ActiveHostedReconciliationState> {
+  const next: ActiveHostedReconciliationState = {
+    ...state,
+    completed_user_ids: [...state.completed_user_ids, userId],
+    reconciled_collections: state.reconciled_collections + reconciledCollections
+  };
+  await connection.query("BEGIN");
+  try {
+    await connection.query(
+      `INSERT INTO audit_events
+         (id, user_id, event_type, subject_id, metadata)
+       VALUES ($1, $2, 'entitlement.reconciled', $2, $3::jsonb)`,
+      [
+        randomUUID(),
+        userId,
+        JSON.stringify({
+          actor: mutation.actor,
+          reason: mutation.reason,
+          operation_id: mutation.operationId,
+          entitlement_revision: entitlementRevision,
+          reconciled_collections: reconciledCollections
+        })
+      ]
+    );
+    await connection.query(
+      `UPDATE operator_operations SET result = $2::jsonb
+       WHERE operation_id = $1`,
+      [mutation.operationId, JSON.stringify(next)]
+    );
+    await connection.query("COMMIT");
+    return next;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  }
+}
+
+function assertOperation(
+  stored: StoredOperatorOperation,
+  mutation: OperatorMutation
+): void {
+  if (
+    stored.action !== "entitlements.reconcile.active-hosted"
+    || stored.target_type !== "entitlement_scope"
+    || stored.target_id !== "active-hosted"
+    || stored.actor !== mutation.actor
+    || stored.reason !== mutation.reason
+  ) {
+    throw new InstanceAdminConflictError(
+      "Operation ID was already used for a different request."
+    );
+  }
+}
+
+function runningState(value: unknown): ActiveHostedReconciliationState {
+  const candidate = value as Partial<ActiveHostedReconciliationState> | null;
+  if (
+    !candidate
+    || typeof candidate !== "object"
+    || candidate.state !== "running"
+    || !stringArray(candidate.selected_user_ids)
+    || !stringArray(candidate.completed_user_ids)
+    || new Set(candidate.selected_user_ids).size !== candidate.selected_user_ids.length
+    || new Set(candidate.completed_user_ids).size !== candidate.completed_user_ids.length
+    || candidate.completed_user_ids.some(
+      (userId) => !candidate.selected_user_ids!.includes(userId)
+    )
+    || !nonNegativeInteger(candidate.hosted_collections)
+    || !nonNegativeInteger(candidate.reconciled_collections)
+    || !nonNegativeInteger(candidate.users_inspected)
+  ) {
+    throw new Error("Stored active-hosted reconciliation state is invalid.");
+  }
+  return candidate as ActiveHostedReconciliationState;
+}
+
+function isOutput(
+  value: unknown,
+  operationId: string
+): value is ActiveHostedReconciliationOutput {
+  const candidate = value as Partial<ActiveHostedReconciliationOutput> | null;
+  return Boolean(
+    candidate
+    && typeof candidate === "object"
+    && candidate.operation_id === operationId
+    && candidate.scope === "active_hosted"
+    && nonNegativeInteger(candidate.reconciled_accounts)
+    && nonNegativeInteger(candidate.hosted_collections)
+    && nonNegativeInteger(candidate.reconciled_collections)
+    && nonNegativeInteger(candidate.users_inspected)
+  );
+}
+
+function stringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -465,6 +465,158 @@ describe("authentication operator command", () => {
     ]);
   });
 
+  it("reconciles active hosted accounts as one resumable private batch", async () => {
+    const context = await fixture();
+    const activeA = "10000000-0000-4000-8000-000000000091";
+    const activeB = "10000000-0000-4000-8000-000000000092";
+    const suspended = "10000000-0000-4000-8000-000000000093";
+    const empty = "10000000-0000-4000-8000-000000000094";
+    for (const [id, status] of [
+      [activeA, "active"],
+      [activeB, "active"],
+      [suspended, "suspended"],
+      [empty, "active"]
+    ]) {
+      await context.db.query(
+        `INSERT INTO users (id, email, name, suspended_at)
+         VALUES ($1, $2, 'Batch account', $3)`,
+        [id, `${id}@example.com`, status === "suspended" ? new Date() : null]
+      );
+    }
+    let grantSequence = 100;
+    for (const userId of [activeA, activeB, suspended]) {
+      grantSequence += 1;
+      await runAuthAdminCommand([
+        "entitlements", "grant",
+        "--user", userId,
+        "--profile", "beta_v1",
+        "--operation-id", `20000000-0000-4000-8000-000000000${grantSequence}`,
+        "--actor", "operator:test",
+        "--reason", "Prepare batch fixture"
+      ], context);
+    }
+    for (const [id, userId] of [
+      ["40000000-0000-4000-8000-000000000091", activeA],
+      ["40000000-0000-4000-8000-000000000092", activeA],
+      ["40000000-0000-4000-8000-000000000093", activeB],
+      ["40000000-0000-4000-8000-000000000094", suspended]
+    ]) {
+      await context.db.query(
+        `INSERT INTO hosted_collections (id, user_id, display_name, template)
+         VALUES ($1, $2, 'Batch collection', 'blank')`,
+        [id, userId]
+      );
+    }
+    const accounts = await context.db.query<{
+      user_id: string;
+      provider_account_id: string;
+    }>(
+      `SELECT user_id, provider_account_id FROM account_storage_accounts
+       WHERE user_id IN ($1, $2)`,
+      [activeA, activeB]
+    );
+    const accountByUser = new Map(
+      accounts.rows.map((row) => [row.user_id, row.provider_account_id])
+    );
+    const calls: string[] = [];
+    const usage = new Map<string, HostedAccountUsage>();
+    let failOnce = true;
+    const provider = {
+      async upsertAccount(
+        accountId: string,
+        entitlementRevision: number,
+        limits: HostedAccountLimits
+      ) {
+        calls.push(accountId);
+        if (accountId === accountByUser.get(activeB) && failOnce) {
+          failOnce = false;
+          throw new Error("provider interruption");
+        }
+        const next = {
+          account_id: accountId,
+          entitlement_revision: entitlementRevision,
+          collection_count: 0,
+          live_content_bytes: 0,
+          live_file_bytes: 0,
+          retained_file_bytes: 0,
+          ...limits
+        };
+        usage.set(accountId, next);
+        return next;
+      },
+      async reconcileCollectionAccount(accountId: string) {
+        const current = usage.get(accountId);
+        if (!current) throw new Error("Account was not reconciled.");
+        usage.set(accountId, {
+          ...current,
+          collection_count: current.collection_count + 1
+        });
+      },
+      async accountUsage(accountId: string) {
+        const current = usage.get(accountId);
+        if (!current) throw new Error("Account was not reconciled.");
+        return current;
+      }
+    } as unknown as HostedProviderClient;
+    const command = [
+      "entitlements", "reconcile",
+      "--active-hosted", "enabled",
+      "--operation-id", "20000000-0000-4000-8000-000000000199",
+      "--actor", "operator:test",
+      "--reason", "Release reconciliation"
+    ];
+
+    await expect(runAuthAdminCommand(command, {
+      ...context,
+      hostedProvider: provider
+    })).rejects.toThrow("provider interruption");
+    expect(calls).toEqual([
+      accountByUser.get(activeA),
+      accountByUser.get(activeB)
+    ]);
+
+    const result = await runAuthAdminCommand(command, {
+      ...context,
+      hostedProvider: provider
+    });
+    expect(result).toEqual({
+      operation_id: "20000000-0000-4000-8000-000000000199",
+      scope: "active_hosted",
+      reconciled_accounts: 2,
+      hosted_collections: 3,
+      reconciled_collections: 3,
+      users_inspected: 4
+    });
+    expect(JSON.stringify(result)).not.toContain(activeA);
+    expect(JSON.stringify(result)).not.toContain(activeB);
+    expect(calls).toEqual([
+      accountByUser.get(activeA),
+      accountByUser.get(activeB),
+      accountByUser.get(activeB)
+    ]);
+
+    expect(await runAuthAdminCommand(command, {
+      ...context,
+      hostedProvider: provider
+    })).toEqual(result);
+    expect(calls).toHaveLength(3);
+    const audits = await context.db.query<{ user_id: string }>(
+      `SELECT user_id FROM audit_events
+       WHERE event_type = 'entitlement.reconciled' ORDER BY user_id`
+    );
+    expect(audits.rows).toEqual([
+      { user_id: activeA },
+      { user_id: activeB }
+    ]);
+    await expect(runAuthAdminCommand([
+      ...command.slice(0, -1),
+      "Different request"
+    ], {
+      ...context,
+      hostedProvider: provider
+    })).rejects.toThrow(/different request/);
+  });
+
   it("reports privacy-minimal compatibility usage and fail-closed sunset gates", async () => {
     const context = await fixture();
     const userId = "10000000-0000-4000-8000-000000000079";

--- a/services/server/src/auth-admin.ts
+++ b/services/server/src/auth-admin.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { DatabasePool } from "./db.js";
 import { compatibilityReport } from "./auth-admin-compatibility.js";
+import { reconcileActiveHostedEntitlements } from "./auth-admin-entitlements.js";
 import {
   AuthenticationPolicyStore,
   type AuthenticationSettings
@@ -193,16 +194,30 @@ async function reconcileEntitlements(
     );
   }
   const flags = parseFlags(argv, new Set([
-    "user", "all", "operation-id", "actor", "reason"
+    "user", "all", "active-hosted", "operation-id", "actor", "reason"
   ]));
   const operationId = requiredFlag(flags, "operation-id");
   const actor = requiredFlag(flags, "actor");
   const reason = requiredFlag(flags, "reason");
   const all = flags.has("all")
     && enabledFlag(requiredFlag(flags, "all"), "all");
-  if (all === flags.has("user")) {
+  const activeHosted = flags.has("active-hosted")
+    && enabledFlag(requiredFlag(flags, "active-hosted"), "active-hosted");
+  const selectors = Number(all) + Number(activeHosted) + Number(flags.has("user"));
+  if (selectors !== 1) {
     throw new AuthAdminUsageError(
-      "Entitlement reconciliation requires exactly one of --user or --all enabled."
+      "Entitlement reconciliation requires exactly one of --user, --all enabled, or --active-hosted enabled."
+    );
+  }
+  if (activeHosted) {
+    return reconcileActiveHostedEntitlements(
+      context.db,
+      context.hostedProvider,
+      {
+        operationId,
+        actor,
+        reason
+      }
     );
   }
   const userIds = all
@@ -952,7 +967,7 @@ export function usage(): string {
     "  auth-admin beta list [--status pending|invited] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin entitlements show --user <uuid|email>",
     "  auth-admin entitlements grant --user <uuid|email> --profile <code> --operation-id <uuid> --actor <id> --reason <text>",
-    "  auth-admin entitlements reconcile (--user <uuid|email> | --all enabled) --operation-id <uuid> --actor <id> --reason <text>",
+    "  auth-admin entitlements reconcile (--user <uuid|email> | --all enabled | --active-hosted enabled) --operation-id <uuid> --actor <id> --reason <text>",
     "  auth-admin users list [--status active|suspended] [--limit <n>] [--cursor <cursor>]",
     "  auth-admin users show --user <uuid|email>",
     "  auth-admin users suspend --user <uuid|email> --operation-id <uuid> --actor <id> --reason <text>",

--- a/services/server/src/db.ts
+++ b/services/server/src/db.ts
@@ -22,6 +22,18 @@ export async function openDatabase(
       implementation: () => true
     });
     memory.public.registerFunction({
+      name: "pg_try_advisory_lock",
+      args: [DataType.integer, DataType.integer],
+      returns: DataType.bool,
+      implementation: () => true
+    });
+    memory.public.registerFunction({
+      name: "pg_advisory_unlock",
+      args: [DataType.integer, DataType.integer],
+      returns: DataType.bool,
+      implementation: () => true
+    });
+    memory.public.registerFunction({
       name: "replace",
       args: [DataType.text, DataType.text, DataType.text],
       returns: DataType.text,


### PR DESCRIPTION
## Summary
- add a server-side active-hosted reconciliation selector
- snapshot and checkpoint one idempotent batch operation
- prevent overlapping batches and keep operator output privacy-minimal

## Validation
- pnpm --filter @mdbase/connect-server test
- pnpm --filter @mdbase/connect-server typecheck
- pnpm check:architecture

Lab qualification will be added before merge.