### PR TITLE
Acknowledge reviewed plans completed by background sync

### DIFF
--- a/crates/connect-mirror/src/directory_plan.rs
+++ b/crates/connect-mirror/src/directory_plan.rs
@@ -25,6 +25,12 @@ impl DirectoryMirror {
                 }
                 return self.apply_prepared(&mut state).await;
             }
+            if state.last_completed_plan.as_deref() == Some(reviewed.fingerprint.as_str()) {
+                return Ok(completed_result(
+                    reviewed.fingerprint.clone(),
+                    self.status_from_state(Some(state)),
+                ));
+            }
         }
         let inspection = self.inspect_plan().await?;
         if inspection.plan.fingerprint != reviewed.fingerprint {
@@ -47,14 +53,26 @@ impl DirectoryMirror {
         &self,
         fingerprint: &str,
     ) -> Result<MirrorApplyResult, MirrorError> {
-        let plan = self.inspect().await?;
-        if plan.fingerprint != fingerprint {
-            return Err(MirrorError::new(
-                "sync_plan_stale",
-                "Reviewed plan fingerprint is stale.",
-            ));
+        let _lease = MirrorLease::acquire(&self.lock_file)?;
+        if let Some(mut state) = self.read_state()? {
+            if let Some(batch) = &state.batch {
+                if batch.plan.fingerprint != fingerprint {
+                    return Err(stale_fingerprint());
+                }
+                return self.apply_prepared(&mut state).await;
+            }
+            if state.last_completed_plan.as_deref() == Some(fingerprint) {
+                return Ok(completed_result(
+                    fingerprint.to_string(),
+                    self.status_from_state(Some(state)),
+                ));
+            }
         }
-        self.apply(&plan).await
+        let inspection = self.inspect_plan().await?;
+        if inspection.plan.fingerprint != fingerprint {
+            return Err(stale_fingerprint());
+        }
+        self.apply_inspection(inspection).await
     }
 
     pub(super) async fn apply_inspection(
@@ -131,6 +149,27 @@ impl DirectoryMirror {
         };
         Ok(result(outcome, &plan, status, execution.completed, None))
     }
+}
+
+fn completed_result(fingerprint: String, checkpoint: MirrorStatus) -> MirrorApplyResult {
+    MirrorApplyResult {
+        status: if checkpoint.state == MirrorStatusState::Attention {
+            "attention".into()
+        } else {
+            "applied".into()
+        },
+        plan_fingerprint: fingerprint,
+        applied: 0,
+        pending: checkpoint.pending,
+        checkpoint_cursor: checkpoint.cursor,
+        conflicts: checkpoint.conflicts.len(),
+        issues: Vec::new(),
+        failure: None,
+    }
+}
+
+fn stale_fingerprint() -> MirrorError {
+    MirrorError::new("sync_plan_stale", "Reviewed plan fingerprint is stale.")
 }
 
 fn result(

--- a/crates/connect-mirror/src/tests.rs
+++ b/crates/connect-mirror/src/tests.rs
@@ -1760,6 +1760,91 @@ async fn writable_initial_file_collision_preserves_identity_and_resolves_exact_b
 }
 
 #[tokio::test]
+async fn reviewed_plan_completed_by_background_sync_is_idempotently_acknowledged() {
+    let source = record("one.md", "One");
+    let (_temporary, mirror, _authority) = harness(SyncReplicaMode::ReadOnly, vec![source]);
+
+    let reviewed = mirror.inspect().await.unwrap();
+    mirror.sync().await.unwrap();
+    assert_eq!(
+        mirror
+            .read_state()
+            .unwrap()
+            .unwrap()
+            .last_completed_plan
+            .as_deref(),
+        Some(reviewed.fingerprint.as_str())
+    );
+
+    let result = mirror
+        .apply_fingerprint(&reviewed.fingerprint)
+        .await
+        .unwrap();
+    assert_eq!(result.status, "applied");
+    assert_eq!(result.plan_fingerprint, reviewed.fingerprint);
+    assert_eq!(result.applied, 0);
+    assert!(result.failure.is_none());
+}
+
+#[tokio::test]
+async fn completed_plan_acknowledgement_does_not_echo_caller_issues() {
+    let source = record("one.md", "One");
+    let (_temporary, mirror, _authority) = harness(SyncReplicaMode::ReadOnly, vec![source]);
+
+    let mut reviewed = mirror.inspect().await.unwrap();
+    mirror.sync().await.unwrap();
+    reviewed.issues.push(MirrorPlanIssue {
+        code: "caller_supplied".into(),
+        message: "This issue was not produced by the mirror.".into(),
+        path: Some("untrusted.md".into()),
+        blocking: true,
+    });
+
+    let result = mirror.apply(&reviewed).await.unwrap();
+    assert_eq!(result.status, "applied");
+    assert!(result.issues.is_empty());
+}
+
+#[tokio::test]
+async fn newer_prepared_batch_takes_precedence_over_completed_plan_acknowledgement() {
+    let source = record("one.md", "One");
+    let (_temporary, mirror, authority) = harness(SyncReplicaMode::ReadOnly, vec![source]);
+
+    let reviewed = mirror.inspect().await.unwrap();
+    mirror.sync().await.unwrap();
+    authority.emit_put(record("two.md", "Two"));
+    let inspection = mirror.inspect_plan().await.unwrap();
+    assert_ne!(inspection.plan.fingerprint, reviewed.fingerprint);
+    mirror.prepare_batch(inspection).unwrap();
+
+    let error = mirror.apply(&reviewed).await.unwrap_err();
+    assert_eq!(error.code, "mirror_recovery_required");
+    let error = mirror
+        .apply_fingerprint(&reviewed.fingerprint)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, "sync_plan_stale");
+}
+
+#[tokio::test]
+async fn apply_fingerprint_still_rejects_a_truly_stale_reviewed_plan() {
+    let (_temporary, mirror, _authority) = harness(SyncReplicaMode::ReadWrite, Vec::new());
+
+    let reviewed = mirror.inspect().await.unwrap();
+    fs::write(
+        mirror.root().join("arrived-after-review.md"),
+        "new local file",
+    )
+    .unwrap();
+
+    let error = mirror
+        .apply_fingerprint(&reviewed.fingerprint)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, "sync_plan_stale");
+}
+
+#[tokio::test]
 async fn inspection_is_deterministic_read_only_and_apply_rejects_a_stale_plan() {
     let (_temporary, mirror, authority) = harness(SyncReplicaMode::ReadWrite, Vec::new());
 

--- a/packages/sync/src/directory-mirror.ts
+++ b/packages/sync/src/directory-mirror.ts
@@ -114,6 +114,15 @@ export class DirectoryMirror<Frontmatter extends JsonObject = JsonObject> {
         }
         return this.executePrepared(state, options.signal);
       }
+      if (state?.last_completed_plan === plan.fingerprint) {
+        const checkpoint = checkpointMirrorStatus(state, this.mode);
+        return mirrorApplyResult(
+          checkpoint.state === "attention" ? "attention" : "applied",
+          { ...plan, issues: [] },
+          checkpoint,
+          0
+        );
+      }
       const inspection = await this.inspectDetailed(state);
       if (inspection.plan.fingerprint !== plan.fingerprint) {
         return mirrorApplyResult(

--- a/packages/sync/src/mirror.test.ts
+++ b/packages/sync/src/mirror.test.ts
@@ -185,6 +185,88 @@ describe("platform-neutral directory mirror", () => {
     expect(fileSystem.files.get("notes/00000.md")).toBe("changed outside the plan");
   });
 
+  it("acknowledges a reviewed plan already completed by background sync", async () => {
+    const hosted = new MemoryAuthority();
+    hosted.seed(records(1));
+    const replicaId = hosted.registerReplica({ name: "Reviewed mirror", mode: "read_only" });
+    const mirror = new DirectoryMirror(replicaId, hosted.transport(replicaId), {
+      fileSystem: new TestFileSystem(),
+      stateStore: new MemoryMirrorStateStore(),
+      runtime: deterministicRuntime()
+    });
+
+    const reviewed = await mirror.inspect();
+    await mirror.sync();
+
+    await expect(mirror.apply(reviewed)).resolves.toMatchObject({
+      status: "applied",
+      plan_fingerprint: reviewed.fingerprint,
+      applied: 0
+    });
+  });
+
+  it("does not echo caller-mutated issues when acknowledging a completed plan", async () => {
+    const hosted = new MemoryAuthority();
+    hosted.seed(records(1));
+    const replicaId = hosted.registerReplica({ name: "Reviewed mirror", mode: "read_only" });
+    const mirror = new DirectoryMirror(replicaId, hosted.transport(replicaId), {
+      fileSystem: new TestFileSystem(),
+      stateStore: new MemoryMirrorStateStore(),
+      runtime: deterministicRuntime()
+    });
+
+    const reviewed = await mirror.inspect();
+    await mirror.sync();
+    reviewed.issues.push({
+      code: "caller_supplied",
+      message: "This issue was not produced by the mirror.",
+      path: "untrusted.md",
+      blocking: true
+    });
+
+    await expect(mirror.apply(reviewed)).resolves.toMatchObject({
+      status: "applied",
+      issues: []
+    });
+  });
+
+  it("gives a newer prepared batch precedence over completed plan acknowledgement", async () => {
+    const hosted = new MemoryAuthority();
+    hosted.seed(records(1));
+    const replicaId = hosted.registerReplica({ name: "Reviewed mirror", mode: "read_only" });
+    const stateStore = new MemoryMirrorStateStore();
+    const mirror = new DirectoryMirror(replicaId, hosted.transport(replicaId), {
+      fileSystem: new TestFileSystem(),
+      stateStore,
+      runtime: deterministicRuntime()
+    });
+
+    const reviewed = await mirror.inspect();
+    await mirror.sync();
+    const state = (await stateStore.read())!;
+    state.batch = {
+      phase: "prepared",
+      plan: { ...reviewed, fingerprint: "sha256:newer-pending-plan" },
+      next_action: 0,
+      receipts: [],
+      payloads: {
+        documents: {},
+        records: {},
+        resources: {},
+        files: {},
+        local_files: {},
+        mutations: {}
+      },
+      checkpoint_before: { generation: state.generation ?? 0, cursor: state.cursor },
+      checkpoint_after: { generation: (state.generation ?? 0) + 1, cursor: state.cursor }
+    };
+    await stateStore.write(state);
+
+    await expect(mirror.apply(reviewed)).rejects.toMatchObject({
+      code: "mirror_recovery_required"
+    });
+  });
+
   it("plans a byte-preserving local move as one identity-preserving move", async () => {
     const hosted = new MemoryAuthority();
     hosted.seed(records(1));


### PR DESCRIPTION
## Summary
- treat a reviewed fingerprint already completed by background sync as an idempotent acknowledgement
- keep pending recovery batches ahead of completed-plan acknowledgement
- preserve true stale-plan rejection in Rust and TypeScript engines

## Verification
- focused Rust completed-plan, pending-batch, and stale-plan tests
- `cargo fmt --all -- --check`

Reproduces and fixes the watched two-way mirror `sync_plan_stale` race.