### PR TITLE
Report control-plane availability accurately

### DIFF
--- a/crates/connect-agent/src/cloud.rs
+++ b/crates/connect-agent/src/cloud.rs
@@ -24,6 +24,29 @@ pub struct CloudControlClient {
     connector_token: String,
 }
 
+pub(crate) enum CloudSnapshotError {
+    Unavailable(ConnectError),
+    Failed(ConnectError),
+}
+
+impl CloudSnapshotError {
+    fn request(error: reqwest::Error) -> Self {
+        let unavailable = error.is_connect() || error.is_timeout() || error.is_body();
+        let error = ConnectError::Cloud(error.to_string());
+        if unavailable {
+            Self::Unavailable(error)
+        } else {
+            Self::Failed(error)
+        }
+    }
+
+    pub(crate) fn into_connect_error(self) -> ConnectError {
+        match self {
+            Self::Unavailable(error) | Self::Failed(error) => error,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RemoteAuthorityTransfer {
     pub id: uuid::Uuid,
@@ -75,8 +98,26 @@ impl CloudControlClient {
         }
     }
 
-    pub async fn snapshot(&self) -> Result<AccessSnapshot, ConnectError> {
-        self.json(Method::GET, "/v1/connectors/control", None).await
+    pub(crate) async fn snapshot(&self) -> Result<AccessSnapshot, CloudSnapshotError> {
+        let response = self
+            .client
+            .get(format!("{}/v1/connectors/control", self.server_url))
+            .timeout(Duration::from_secs(15))
+            .bearer_auth(&self.connector_token)
+            .send()
+            .await
+            .map_err(CloudSnapshotError::request)?;
+        let status = response.status();
+        if transient_snapshot_status(status) {
+            return Err(CloudSnapshotError::Unavailable(ConnectError::Cloud(
+                format!("Cloud request failed with transient HTTP {status}"),
+            )));
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(CloudSnapshotError::request)?;
+        decode_bytes(status, &bytes).map_err(CloudSnapshotError::Failed)
     }
 
     pub fn server_url(&self) -> &str {
@@ -658,6 +699,13 @@ impl CloudControlClient {
     }
 }
 
+fn transient_snapshot_status(status: reqwest::StatusCode) -> bool {
+    matches!(
+        status,
+        reqwest::StatusCode::REQUEST_TIMEOUT | reqwest::StatusCode::TOO_MANY_REQUESTS
+    ) || status.is_server_error()
+}
+
 fn safe_import_source(root: &Path, relative: &str) -> Result<PathBuf, ConnectError> {
     if relative.starts_with('/')
         || relative.contains('\\')
@@ -760,8 +808,15 @@ fn validate_import_prepared_part(
 async fn decode<T: DeserializeOwned>(response: Response) -> Result<T, ConnectError> {
     let status = response.status();
     let bytes = response.bytes().await.map_err(cloud_error)?;
+    decode_bytes(status, &bytes)
+}
+
+fn decode_bytes<T: DeserializeOwned>(
+    status: reqwest::StatusCode,
+    bytes: &[u8],
+) -> Result<T, ConnectError> {
     if !status.is_success() {
-        if let Ok(body) = serde_json::from_slice::<Value>(&bytes) {
+        if let Ok(body) = serde_json::from_slice::<Value>(bytes) {
             if let (Some(code), Some(message)) = (
                 body.pointer("/error/code").and_then(Value::as_str),
                 body.pointer("/error/message").and_then(Value::as_str),
@@ -776,7 +831,7 @@ async fn decode<T: DeserializeOwned>(response: Response) -> Result<T, ConnectErr
             "Cloud request failed with HTTP {status}"
         )));
     }
-    serde_json::from_slice(&bytes).map_err(ConnectError::from)
+    serde_json::from_slice(bytes).map_err(ConnectError::from)
 }
 
 fn cloud_error(error: reqwest::Error) -> ConnectError {

--- a/crates/connect-agent/src/server/account.rs
+++ b/crates/connect-agent/src/server/account.rs
@@ -254,7 +254,10 @@ impl AgentState {
         params: &mdbase_connect_protocol::AuthorizationApproveParams,
     ) -> Result<serde_json::Value, ConnectError> {
         let cloud = self.cloud()?;
-        let snapshot = cloud.snapshot().await?;
+        let snapshot = cloud
+            .snapshot()
+            .await
+            .map_err(crate::cloud::CloudSnapshotError::into_connect_error)?;
         let pending = snapshot
             .pending_authorizations
             .iter()
@@ -348,7 +351,7 @@ impl AgentState {
         };
         let mut snapshot = match cloud.snapshot().await {
             Ok(snapshot) => snapshot,
-            Err(error) => {
+            Err(crate::cloud::CloudSnapshotError::Unavailable(error)) => {
                 tracing::debug!(%error, "cloud control snapshot unavailable; using local cache");
                 mdbase_connect_protocol::AccessSnapshot {
                     configured: true,
@@ -359,6 +362,7 @@ impl AgentState {
                     authority_conflicts: Vec::new(),
                 }
             }
+            Err(error) => return Err(error.into_connect_error()),
         };
         let collections = self.registry.list()?;
         for pending in &mut snapshot.pending_authorizations {

--- a/crates/connect-agent/src/server/tests.rs
+++ b/crates/connect-agent/src/server/tests.rs
@@ -11,6 +11,149 @@ use tokio::net::UnixStream;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
+async fn access_snapshot_response(
+    cloud: CloudControlClient,
+) -> mdbase_connect_protocol::ControlResponse {
+    let test_root = tempfile::tempdir().unwrap();
+    let registry = CollectionRegistry::open(test_root.path().join("state")).unwrap();
+    let watcher = CollectionWatchService::start(registry.clone());
+    let state = Arc::new(AgentState::new(registry, watcher, Some(cloud)));
+    state
+        .execute(ControlRequest::new(ControlCommand::AccessSnapshot))
+        .await
+}
+
+#[tokio::test]
+async fn access_snapshot_falls_back_only_when_the_control_plane_is_unavailable() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+    let response = access_snapshot_response(CloudControlClient::new(
+        format!("http://{address}"),
+        "connector-token".to_string(),
+    ))
+    .await;
+
+    assert!(response.ok, "{:?}", response.error);
+    let snapshot = response.result.unwrap();
+    assert_eq!(snapshot["configured"], true);
+    assert_eq!(snapshot["online"], false);
+}
+
+#[tokio::test]
+async fn access_snapshot_falls_back_for_transient_http_statuses() {
+    for status in [
+        axum::http::StatusCode::REQUEST_TIMEOUT,
+        axum::http::StatusCode::TOO_MANY_REQUESTS,
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+    ] {
+        let app = axum::Router::new().route(
+            "/v1/connectors/control",
+            axum::routing::get(move || async move {
+                (
+                    status,
+                    axum::Json(serde_json::json!({
+                        "error": {
+                            "code": "temporary_control_failure",
+                            "message": "Try again."
+                        }
+                    })),
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let response = access_snapshot_response(CloudControlClient::new(
+            format!("http://{address}"),
+            "connector-token".to_string(),
+        ))
+        .await;
+
+        assert!(response.ok, "HTTP {status}: {:?}", response.error);
+        assert_eq!(response.result.unwrap()["online"], false);
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn access_snapshot_propagates_malformed_control_plane_json() {
+    let app = axum::Router::new().route(
+        "/v1/connectors/control",
+        axum::routing::get(|| async { "not json" }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let response = access_snapshot_response(CloudControlClient::new(
+        format!("http://{address}"),
+        "connector-token".to_string(),
+    ))
+    .await;
+
+    assert!(!response.ok);
+    assert_eq!(response.error.unwrap().code, "serialization_failed");
+    server.abort();
+}
+
+#[tokio::test]
+async fn access_snapshot_propagates_control_plane_protocol_failures() {
+    let app = axum::Router::new().route(
+        "/v1/connectors/control",
+        axum::routing::get(|| async { axum::Json(serde_json::json!({ "online": true })) }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let response = access_snapshot_response(CloudControlClient::new(
+        format!("http://{address}"),
+        "connector-token".to_string(),
+    ))
+    .await;
+
+    assert!(!response.ok);
+    assert_eq!(response.error.unwrap().code, "serialization_failed");
+    server.abort();
+}
+
+#[tokio::test]
+async fn access_snapshot_propagates_structured_cloud_errors() {
+    let app = axum::Router::new().route(
+        "/v1/connectors/control",
+        axum::routing::get(|| async {
+            (
+                axum::http::StatusCode::UNAUTHORIZED,
+                axum::Json(serde_json::json!({
+                    "error": {
+                        "code": "connector_authentication_failed",
+                        "message": "Connector authentication failed."
+                    }
+                })),
+            )
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let response = access_snapshot_response(CloudControlClient::new(
+        format!("http://{address}"),
+        "connector-token".to_string(),
+    ))
+    .await;
+
+    assert!(!response.ok);
+    assert_eq!(
+        response.error.unwrap().code,
+        "connector_authentication_failed"
+    );
+    server.abort();
+}
+
 #[tokio::test]
 async fn listening_callback_runs_after_the_control_socket_is_reachable() {
     // Darwin's sockaddr_un path is substantially shorter than Linux's. Use

--- a/crates/connect-cli/src/output.rs
+++ b/crates/connect-cli/src/output.rs
@@ -168,7 +168,12 @@ pub(super) fn render_human(kind: OutputKind, value: &Value) -> String {
                 .unwrap_or(&[]);
             let grants = value["grants"].as_array().map(Vec::as_slice).unwrap_or(&[]);
             format!(
-                "Pending requests: {}\nActive grants: {}",
+                "Control plane: {}\nPending requests: {}\nActive grants: {}",
+                if value["online"].as_bool().unwrap_or(false) {
+                    "reachable"
+                } else {
+                    "unreachable"
+                },
                 requests.len(),
                 grants.len()
             )
@@ -189,15 +194,27 @@ pub(super) fn render_human(kind: OutputKind, value: &Value) -> String {
             if value["configured"] == Value::Bool(false) {
                 return "This computer is not connected to an account.".to_string();
             }
-            let account = value.get("account").unwrap_or(value);
-            let user = account["user_name"].as_str().unwrap_or("Connected");
+            let account = value
+                .get("account")
+                .filter(|account| !account.is_null())
+                .unwrap_or(value);
+            let user = account["user_name"]
+                .as_str()
+                .unwrap_or("Account configured on this computer");
             let email = account["user_email"].as_str().unwrap_or("");
             let computer = account["connector_name"].as_str().unwrap_or("");
-            [user, email, computer]
+            let mut lines = [user, email, computer]
                 .into_iter()
                 .filter(|value| !value.is_empty())
-                .collect::<Vec<_>>()
-                .join("\n")
+                .collect::<Vec<_>>();
+            if let Some(online) = value.get("online").and_then(Value::as_bool) {
+                lines.push(if online {
+                    "Control plane: reachable"
+                } else {
+                    "Control plane: unreachable"
+                });
+            }
+            lines.join("\n")
         }
         OutputKind::Mirrors => render_rows(
             value.as_array().map(Vec::as_slice).unwrap_or(&[]),

--- a/crates/connect-cli/src/tests.rs
+++ b/crates/connect-cli/src/tests.rs
@@ -70,6 +70,45 @@ fn human_status_is_quiet_and_explicit() {
 }
 
 #[test]
+fn human_access_output_names_control_plane_reachability() {
+    let value = serde_json::json!({
+        "online": false,
+        "pending_authorizations": [],
+        "grants": []
+    });
+    assert_eq!(
+        render_human(OutputKind::Access, &value),
+        "Control plane: unreachable\nPending requests: 0\nActive grants: 0"
+    );
+}
+
+#[test]
+fn human_whoami_output_distinguishes_account_configuration_from_reachability() {
+    let value = serde_json::json!({
+        "configured": true,
+        "online": false,
+        "account": null
+    });
+    assert_eq!(
+        render_human(OutputKind::Account, &value),
+        "Account configured on this computer\nControl plane: unreachable"
+    );
+}
+
+#[test]
+fn human_login_account_output_does_not_invent_control_plane_status() {
+    let value = serde_json::json!({
+        "user_name": "Callum",
+        "user_email": "callum@example.com",
+        "connector_name": "Workstation"
+    });
+    assert_eq!(
+        render_human(OutputKind::Account, &value),
+        "Callum\ncallum@example.com\nWorkstation"
+    );
+}
+
+#[test]
 fn collection_table_has_stable_columns() {
     let value = serde_json::json!([{
         "display_name": "Notes",

--- a/docs/cli-daemon.md
+++ b/docs/cli-daemon.md
@@ -84,6 +84,11 @@ Diagnostics go to stderr. Stable error codes determine non-zero exit status.
 Commands that identify an existing collection, mirror, request, or grant use
 its stable ID.
 
+For `whoami` and `access list`, `online` means the connector could reach the
+Connect control plane. It does not describe independently authorized direct
+access to hosted collections, which can remain available when the control plane
+is unreachable or this computer is not connected to an account.
+
 `daemon run` is the foreground primitive used by service managers, containers,
 tests, and debugging. `daemon install` registers a per-user launch agent,
 systemd user unit, or Windows per-user background task. It must not require an


### PR DESCRIPTION
## Summary
- use cached `online:false` only for transport and transient HTTP unavailability
- propagate malformed protocol responses and structured auth failures
- clarify that the field describes connector control-plane reachability
- avoid inventing an unreachable status in successful login output

## Verification
- five focused daemon snapshot tests
- focused CLI access and login output tests
- `cargo fmt --all -- --check`

Live beta.78 reproduced `online:false` while hosted management remained operational.