### PR TITLE
Preserve authoritative hosted operation outcomes

### DIFF
--- a/crates/connect-agent/src/hosted_connections/support.rs
+++ b/crates/connect-agent/src/hosted_connections/support.rs
@@ -157,9 +157,18 @@ pub(super) async fn response_value(
         }
         bytes.extend_from_slice(&chunk);
     }
-    let value: Value = serde_json::from_slice(&bytes).map_err(|_| ConnectError::CloudProblem {
-        code: "invalid_hosted_response".to_string(),
-        message: "Connect returned a malformed hosted response.".to_string(),
+    let value: Value = serde_json::from_slice(&bytes).map_err(|_| {
+        if status.is_success() {
+            ConnectError::CloudProblem {
+                code: "invalid_hosted_response".to_string(),
+                message: "Connect returned a malformed hosted response.".to_string(),
+            }
+        } else {
+            ConnectError::CloudProblem {
+                code: "hosted_http_error".to_string(),
+                message: format!("Hosted request failed with HTTP {status}."),
+            }
+        }
     })?;
     Ok((status, value))
 }

--- a/crates/connect-agent/src/hosted_connections/tests.rs
+++ b/crates/connect-agent/src/hosted_connections/tests.rs
@@ -2,13 +2,58 @@ use super::*;
 use axum::body::Bytes;
 use axum::extract::{OriginalUri, Path as AxumPath, State};
 use axum::http::HeaderMap;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use p256::ecdsa::signature::Verifier;
 use p256::ecdsa::VerifyingKey;
 use std::sync::Arc;
 
 static TEST_ENV: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[tokio::test]
+async fn non_json_hosted_http_errors_preserve_status_without_leaking_the_body() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let app = Router::new().route(
+        "/error",
+        get(|| async {
+            (
+                StatusCode::FORBIDDEN,
+                "<html>Render WAF secret-body-marker</html>",
+            )
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let response = reqwest::get(format!("http://{address}/error"))
+        .await
+        .unwrap();
+    let error = decode_response::<Value>(response).await.unwrap_err();
+    assert_eq!(error.code(), "hosted_http_error");
+    assert_eq!(
+        error.to_string(),
+        "Hosted request failed with HTTP 403 Forbidden."
+    );
+    assert!(!error.to_string().contains("secret-body-marker"));
+    server.abort();
+}
+
+#[tokio::test]
+async fn non_json_successful_hosted_responses_remain_invalid() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let app = Router::new().route("/success", get(|| async { "not json" }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let response = reqwest::get(format!("http://{address}/success"))
+        .await
+        .unwrap();
+    let error = decode_response::<Value>(response).await.unwrap_err();
+    assert_eq!(error.code(), "invalid_hosted_response");
+    server.abort();
+}
 
 #[derive(Clone)]
 struct ProviderState {

--- a/crates/connect-agent/src/server/operation_responses.rs
+++ b/crates/connect-agent/src/server/operation_responses.rs
@@ -230,7 +230,7 @@ pub(super) fn operation_problem(error: &ConnectError) -> ConnectProblem {
         return collection_setup_problem("collection_configuration_invalid", error);
     }
     let code = match error.code() {
-        "invalid_input" | "invalid_timer_request" => "invalid_request",
+        "invalid_input" => "invalid_request",
         "collection_provider_failed"
         | "io_failed"
         | "registry_failed"
@@ -331,6 +331,37 @@ mod tests {
         assert_eq!(
             problem.operation_outcome,
             Some(ConnectOperationOutcome::NotSent)
+        );
+    }
+
+    #[test]
+    fn timer_operation_codes_cross_the_connector_boundary() {
+        for code in ["invalid_timer_request", "timer_criterion_not_authorized"] {
+            let problem = operation_problem(&ConnectError::Timer {
+                code: code.to_string(),
+                message: "The timer request was rejected.".to_string(),
+            });
+
+            assert_eq!(problem.code, "unknown");
+            assert_eq!(problem.server_code.as_deref(), Some(code));
+            assert_eq!(
+                problem.operation_outcome,
+                Some(ConnectOperationOutcome::Rejected)
+            );
+        }
+    }
+
+    #[test]
+    fn internal_timer_errors_keep_the_established_operation_failure_contract() {
+        let problem = operation_problem(&ConnectError::TimerRuntime(
+            "The timer store failed.".to_string(),
+        ));
+
+        assert_eq!(problem.code, "operation_failed");
+        assert_eq!(problem.server_code, None);
+        assert_eq!(
+            problem.operation_outcome,
+            Some(ConnectOperationOutcome::Rejected)
         );
     }
 }

--- a/crates/connect-agent/src/server/scoped_operations.rs
+++ b/crates/connect-agent/src/server/scoped_operations.rs
@@ -74,13 +74,7 @@ impl AgentState {
                 .and_then(|timers| {
                     timers
                         .operation(collection_id, grant.clone(), operation, input.clone())
-                        .map_err(|error| {
-                            if error.internal {
-                                ConnectError::TimerRuntime(error.message)
-                            } else {
-                                ConnectError::InvalidTimer(error.message)
-                            }
-                        })
+                        .map_err(timer_connect_error)
                 });
             profile_operation(transport, operation, started, 0, &result);
             return result;
@@ -132,5 +126,46 @@ impl AgentState {
         );
         profile_operation(transport, operation, started, synchronize_us.get(), &result);
         result
+    }
+}
+
+fn timer_connect_error(error: mdbase_connect_runtime::TimerOperationError) -> ConnectError {
+    if error.internal {
+        ConnectError::TimerRuntime(error.message)
+    } else {
+        ConnectError::Timer {
+            code: error.code,
+            message: error.message,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::timer_connect_error;
+    use mdbase_connect_core::ConnectError;
+    use mdbase_connect_runtime::TimerOperationError;
+
+    #[test]
+    fn public_timer_errors_preserve_their_codes() {
+        let error = timer_connect_error(TimerOperationError {
+            code: "timer_criterion_not_authorized".to_string(),
+            message: "The criterion is not authorized.".to_string(),
+            internal: false,
+        });
+
+        assert_eq!(error.code(), "timer_criterion_not_authorized");
+    }
+
+    #[test]
+    fn internal_timer_errors_use_the_runtime_failure_contract() {
+        let error = timer_connect_error(TimerOperationError {
+            code: "store_failed".to_string(),
+            message: "The timer store failed.".to_string(),
+            internal: true,
+        });
+
+        assert!(matches!(&error, ConnectError::TimerRuntime(_)));
+        assert_eq!(error.code(), "timer_runtime_failed");
     }
 }

--- a/crates/connect-core/src/registry.rs
+++ b/crates/connect-core/src/registry.rs
@@ -211,6 +211,8 @@ pub enum ConnectError {
     InvalidTimer(String),
     #[error("Timer authority error: {0}")]
     TimerRuntime(String),
+    #[error("{message}")]
+    Timer { code: String, message: String },
     #[error(transparent)]
     Provider(#[from] mdbase::runtime::ProviderError),
 }
@@ -269,6 +271,7 @@ impl ConnectError {
             Self::File { code, .. } => code.as_str(),
             Self::InvalidTimer(_) => "invalid_timer_request",
             Self::TimerRuntime(_) => "timer_runtime_failed",
+            Self::Timer { code, .. } => code.as_str(),
             Self::Provider(error) => error.code(),
         }
     }

--- a/crates/connect-hosted-provider/src/provider/operation_records.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_records.rs
@@ -343,9 +343,7 @@ impl HostedProvider {
                         ApiError::internal("mdbase-rs returned a non-object record document.")
                     })?;
                     if let Some(semantic) = semantic_result {
-                        if let Some(fields) = semantic.result.as_object() {
-                            value.extend(fields.clone());
-                        }
+                        merge_semantic_receipt_extras(context.operation, value, &semantic.result);
                         document.diagnostics.extend(semantic.diagnostics);
                     }
                     if context.operation == "rename" {
@@ -375,5 +373,52 @@ impl HostedProvider {
             ApiError::internal(format!("Hosted operation could not serialize: {error}"))
         })?;
         Ok(result)
+    }
+}
+
+fn merge_semantic_receipt_extras(
+    operation: &str,
+    persisted: &mut serde_json::Map<String, Value>,
+    semantic: &Value,
+) {
+    if operation == "rename" {
+        if let Some(references) = semantic.get("references_updated") {
+            persisted.insert("references_updated".to_string(), references.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_semantic_receipt_extras;
+    use serde_json::{json, Map, Value};
+
+    #[test]
+    fn semantic_receipt_extras_cannot_replace_persisted_record_fields() {
+        let mut persisted = Map::from_iter([
+            ("revision".to_string(), json!("persisted-revision")),
+            (
+                "file".to_string(),
+                json!({"mtime": "persisted-mtime", "size": 42}),
+            ),
+        ]);
+        let staged = json!({
+            "revision": "staged-revision",
+            "file": {"mtime": null, "size": 0},
+            "references_updated": [{"path": "notes/reference.md"}],
+        });
+
+        merge_semantic_receipt_extras("create", &mut persisted, &staged);
+        assert_eq!(persisted["revision"], "persisted-revision");
+        assert_eq!(persisted["file"]["mtime"], "persisted-mtime");
+        assert!(!persisted.contains_key("references_updated"));
+
+        merge_semantic_receipt_extras("rename", &mut persisted, &staged);
+        assert_eq!(persisted["revision"], "persisted-revision");
+        assert_eq!(persisted["file"]["size"], 42);
+        assert_eq!(
+            persisted["references_updated"],
+            Value::Array(vec![json!({"path": "notes/reference.md"})])
+        );
     }
 }

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -5154,7 +5154,64 @@ async fn exercise_candidate_b_projection_lifecycle() {
         .await
         .unwrap();
     assert_eq!(target_created["valid"], true);
-    let target_revision = target_created["result"]["revision"]
+    let target_read = fixture
+        .provider
+        .operation(
+            fixture.collection_id,
+            &writer_token,
+            "read",
+            Uuid::new_v4(),
+            json!({"path": "notes/app-target.md"}),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(target_created["result"], target_read["result"]);
+    DateTime::parse_from_rfc3339(
+        target_created["result"]["file"]["mtime"]
+            .as_str()
+            .expect("hosted create receipts expose persisted file mtime"),
+    )
+    .expect("hosted create receipt file mtime is RFC 3339");
+
+    let target_updated = fixture
+        .provider
+        .operation(
+            fixture.collection_id,
+            &writer_token,
+            "update",
+            Uuid::new_v4(),
+            json!({
+                "path": "notes/app-target.md",
+                "patch": {"title": "Updated application target"},
+                "if_revision": target_created["result"]["revision"],
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let target_read_after_update = fixture
+        .provider
+        .operation(
+            fixture.collection_id,
+            &writer_token,
+            "read",
+            Uuid::new_v4(),
+            json!({"path": "notes/app-target.md"}),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(target_updated["result"], target_read_after_update["result"]);
+    assert_eq!(
+        target_updated["result"]["file"],
+        target_read_after_update["result"]["file"]
+    );
+    assert_eq!(
+        target_updated["result"]["revision"],
+        target_read_after_update["result"]["revision"]
+    );
+    let target_revision = target_updated["result"]["revision"]
         .as_str()
         .unwrap()
         .to_string();

--- a/packages/client/src/connection-transport.ts
+++ b/packages/client/src/connection-transport.ts
@@ -74,6 +74,7 @@ import {
   retryExplicitConnectorBusy
 } from "./transient-retry.js";
 import { probeLoopbackAccess, tokenSupportsDirectAccess } from "./direct-access.js";
+import { decodeHostedOperationResponse } from "./hosted-operation-response.js";
 
 export type {
   ConnectionTransportInternals,
@@ -324,33 +325,17 @@ export class ConnectionTransport {
         knownRejected
       )
     });
-    let body: any;
-    let malformedHostedHttpFailure = false;
+    let decoded;
     try {
-      body = await decodeJsonResponse(
-        response,
-        "invalid_operation_response",
-        "The collection authority returned a response that is not valid JSON."
-      );
+      decoded = await decodeHostedOperationResponse(response, token.authority !== undefined);
     } catch (cause) {
-      if (!response.ok && token.authority && isDefinitiveHostedHttpRejection(response.status)) {
-        malformedHostedHttpFailure = true;
-      } else {
-        if (attempt.pendingMutation) throw unknownMutationOutcome(attempt.requestId, cause);
-        throw connectError(
-          "invalid_operation_response",
-          "The collection authority returned a response that is not valid JSON.",
-          { cause }
-        );
-      }
+      if (attempt.pendingMutation) throw unknownMutationOutcome(attempt.requestId, cause);
+      throw cause;
     }
+    const body = decoded.body;
     if (!response.ok) {
-      const error = malformedHostedHttpFailure
-        ? serverConnectError("operation_failed", "Collection operation failed.", {
-            status: response.status,
-            operationOutcome: "rejected"
-          })
-        : apiError(body, "operation_failed", "Collection operation failed.", response.status);
+      const error = decoded.httpError
+        ?? apiError(body, "operation_failed", "Collection operation failed.", response.status);
       const recovery = await retryBusy(error);
       if (recovery.retried) return recovery.result;
       if (error.code === "fresh_request_required"
@@ -1006,10 +991,4 @@ export class ConnectionTransport {
       void this.keyStore.delete(pending.keyHandle).catch(() => undefined);
     }
   }
-}
-
-function isDefinitiveHostedHttpRejection(status: number): boolean {
-  return status >= 400
-    && status < 500
-    && ![408, 425, 429].includes(status);
 }

--- a/packages/client/src/connection-transport.ts
+++ b/packages/client/src/connection-transport.ts
@@ -325,6 +325,7 @@ export class ConnectionTransport {
       )
     });
     let body: any;
+    let malformedHostedHttpFailure = false;
     try {
       body = await decodeJsonResponse(
         response,
@@ -332,15 +333,24 @@ export class ConnectionTransport {
         "The collection authority returned a response that is not valid JSON."
       );
     } catch (cause) {
-      if (attempt.pendingMutation) throw unknownMutationOutcome(attempt.requestId, cause);
-      throw connectError(
-        "invalid_operation_response",
-        "The collection authority returned a response that is not valid JSON.",
-        { cause }
-      );
+      if (!response.ok && token.authority && isDefinitiveHostedHttpRejection(response.status)) {
+        malformedHostedHttpFailure = true;
+      } else {
+        if (attempt.pendingMutation) throw unknownMutationOutcome(attempt.requestId, cause);
+        throw connectError(
+          "invalid_operation_response",
+          "The collection authority returned a response that is not valid JSON.",
+          { cause }
+        );
+      }
     }
     if (!response.ok) {
-      const error = apiError(body, "operation_failed", "Collection operation failed.", response.status);
+      const error = malformedHostedHttpFailure
+        ? serverConnectError("operation_failed", "Collection operation failed.", {
+            status: response.status,
+            operationOutcome: "rejected"
+          })
+        : apiError(body, "operation_failed", "Collection operation failed.", response.status);
       const recovery = await retryBusy(error);
       if (recovery.retried) return recovery.result;
       if (error.code === "fresh_request_required"
@@ -996,4 +1006,10 @@ export class ConnectionTransport {
       void this.keyStore.delete(pending.keyHandle).catch(() => undefined);
     }
   }
+}
+
+function isDefinitiveHostedHttpRejection(status: number): boolean {
+  return status >= 400
+    && status < 500
+    && ![408, 425, 429].includes(status);
 }

--- a/packages/client/src/hosted-operation-response.ts
+++ b/packages/client/src/hosted-operation-response.ts
@@ -1,0 +1,38 @@
+import { connectError, serverConnectError, type MdbaseConnectError } from "./errors.js";
+import { decodeJsonResponse } from "./runtime-utils.js";
+
+export async function decodeHostedOperationResponse(
+  response: Response,
+  hosted: boolean
+): Promise<{ body: any; httpError?: MdbaseConnectError }> {
+  try {
+    return {
+      body: await decodeJsonResponse(
+        response,
+        "invalid_operation_response",
+        "The collection authority returned a response that is not valid JSON."
+      )
+    };
+  } catch (cause) {
+    if (!response.ok && hosted && isDefinitiveHostedHttpRejection(response.status)) {
+      return {
+        body: undefined,
+        httpError: serverConnectError("operation_failed", "Collection operation failed.", {
+          status: response.status,
+          operationOutcome: "rejected"
+        })
+      };
+    }
+    throw connectError(
+      "invalid_operation_response",
+      "The collection authority returned a response that is not valid JSON.",
+      { cause }
+    );
+  }
+}
+
+function isDefinitiveHostedHttpRejection(status: number): boolean {
+  return status >= 400
+    && status < 500
+    && ![408, 425, 429].includes(status);
+}

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -3079,6 +3079,87 @@ describe("authorization renewal", () => {
       .toBe("Bearer hsa_direct");
   });
 
+  it("preserves a typed hosted HTTP failure when an error body is not JSON", async () => {
+    const { connect } = hostedConnection(["query"]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      "<html>Render WAF reference secret-body-marker</html>",
+      { status: 403, headers: { "content-type": "text/html" } }
+    ));
+
+    const outcome = await connect.query();
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      problem: {
+        code: "operation_failed",
+        message: "Collection operation failed."
+      }
+    });
+    expect(JSON.stringify(outcome)).not.toContain("secret-body-marker");
+  });
+
+  it("keeps malformed successful hosted responses classified as invalid", async () => {
+    const { connect } = hostedConnection(["query"]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      "<html>unexpected success</html>",
+      { status: 200, headers: { "content-type": "text/html" } }
+    ));
+
+    await expect(connect.query()).resolves.toMatchObject({
+      ok: false,
+      problem: { code: "invalid_operation_response" }
+    });
+  });
+
+  it("keeps a malformed successful hosted mutation response ambiguous", async () => {
+    const { connect } = hostedConnection(["create"]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      "<html>unexpected success</html>",
+      { status: 200, headers: { "content-type": "text/html" } }
+    ));
+
+    await expect(connect.create({ path: "ambiguous.md", frontmatter: {} }))
+      .resolves.toMatchObject({
+        ok: false,
+        problem: { code: "operation_outcome_unknown", operation_outcome: "unknown" }
+      });
+    expect(connect.pendingMutations()).toHaveLength(1);
+  });
+
+  it("treats a non-JSON hosted mutation rejection as rejected, not ambiguous", async () => {
+    const { connect } = hostedConnection(["create"]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      "<html>request denied</html>",
+      { status: 403, headers: { "content-type": "text/html" } }
+    ));
+
+    await expect(connect.create({ path: "denied.md", frontmatter: {} })).resolves.toMatchObject({
+      ok: false,
+      problem: { code: "operation_failed", operation_outcome: "rejected" }
+    });
+    expect(connect.pendingMutations()).toEqual([]);
+  });
+
+  it.each([408, 425, 429, 500, 503])(
+    "keeps a non-JSON hosted mutation response at status %i ambiguous",
+    async (status) => {
+      const { connect } = hostedConnection(["create"]);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+        "<html>transient secret-body-marker</html>",
+        { status, headers: { "content-type": "text/html" } }
+      ));
+
+      const outcome = await connect.create({ path: `ambiguous-${status}.md`, frontmatter: {} });
+
+      expect(outcome).toMatchObject({
+        ok: false,
+        problem: { code: "operation_outcome_unknown", operation_outcome: "unknown" }
+      });
+      expect(JSON.stringify(outcome)).not.toContain("secret-body-marker");
+      expect(connect.pendingMutations()).toHaveLength(1);
+    }
+  );
+
   it("keeps hosted sync credentials private and refreshes them for the offline transport", async () => {
     const storage = new MemoryStorage();
     const serverUrl = "https://connect.example";
@@ -4285,6 +4366,41 @@ async function encryptedConnection() {
     applicationId: "01922222-2222-7222-8222-222222222222",
     connect: manager.connection(collectionId)!
   };
+}
+
+function hostedConnection(operations: Array<"query" | "create">) {
+  const storage = new MemoryStorage();
+  const serverUrl = "https://connect.example";
+  const providerUrl = "https://provider.example";
+  const manifestUrl = "https://tasks.example/.well-known/mdbase-app.json";
+  storage.setItem(storedTokenKey(serverUrl, manifestUrl, TEST_COLLECTION_ID), JSON.stringify({
+    version: 1,
+    accessToken: "mdb_control",
+    refreshToken: "ref_current",
+    clientId: TEST_APPLICATION_ID,
+    collectionId: TEST_COLLECTION_ID,
+    collectionName: "Worklog",
+    operations,
+    scope: { contracts: [WORK_ITEM_CONTRACT], access: "contract" },
+    expiresAt: Date.now() + 60_000,
+    refreshExpiresAt: Date.now() + 120_000,
+    authority: {
+      operationsUrl: `${providerUrl}/v1/authorities/${TEST_COLLECTION_ID}/operations`,
+      syncUrl: `${providerUrl}/v1/authorities/${TEST_COLLECTION_ID}/sync`,
+      filesUrl: `${providerUrl}/v1/authorities/${TEST_COLLECTION_ID}/files`,
+      replicaId: "00000000-0000-0000-0000-000000000003",
+      version: 1,
+      accessToken: "hsa_direct"
+    }
+  }));
+  const manager = new MdbaseConnect({
+    serverUrl,
+    manifest: manifestUrl,
+    redirectUri: "https://tasks.example/callback",
+    storage,
+    relayEncryption: "disabled"
+  });
+  return { connect: manager.connection(TEST_COLLECTION_ID)! };
 }
 
 async function encryptedFixtureResponse(


### PR DESCRIPTION
## Summary
- stop staging metadata from replacing authoritative persisted mutation results
- preserve safe rejection versus uncertain mutation semantics for non-JSON hosted responses
- retain HTTP status for direct-connector HTML errors without leaking response bodies
- preserve public timer codes while normalizing internal failures

## Verification
- 212 client tests and client typecheck
- focused daemon timer and non-JSON response tests
- `cargo fmt --all -- --check`

The live lab still returns Render HTML 403 for `../../etc/passwd`; this change makes that diagnosable while the ops PR detects the edge rule.