### PR TITLE
Add hosted read canary

### DIFF
--- a/crates/connect-agent/src/hosted_connections.rs
+++ b/crates/connect-agent/src/hosted_connections.rs
@@ -54,7 +54,6 @@ const CLI_APPLICATION_CAPABILITIES: &[&str] = &[
     "definitions.update",
     "definitions.type-pack.inspect",
     "definitions.type-pack.apply",
-    "collection.setup.apply",
     "sync.offline-replica",
 ];
 const MAX_HOSTED_RESPONSE_BYTES: usize = 32 * 1024 * 1024;

--- a/crates/connect-agent/src/hosted_connections/tests.rs
+++ b/crates/connect-agent/src/hosted_connections/tests.rs
@@ -433,6 +433,7 @@ async fn test_register_application(
         body["manifest"]["requirements"]["capabilities"]["required"],
         json!(CLI_APPLICATION_CAPABILITIES)
     );
+    assert!(!CLI_APPLICATION_CAPABILITIES.contains(&"collection.setup.apply"));
     assert!(body["manifest"]["notifications"].is_null());
     Json(json!({
         "application": {

--- a/crates/connect-cli/src/lib.rs
+++ b/crates/connect-cli/src/lib.rs
@@ -568,6 +568,14 @@ fn hosted_cli_authorization_operations(
     operations: Vec<String>,
     read_only: bool,
 ) -> Result<Vec<String>, CliError> {
+    if operations
+        .iter()
+        .any(|operation| operation == "collection.setup.apply")
+    {
+        return Err(CliError::unsupported_cli_operation(
+            "The mdbase CLI cannot request collection.setup.apply because it declares no setup provisions.",
+        ));
+    }
     if let Some(operation) = operations
         .iter()
         .find(|operation| mdbase_connect_protocol::operation_requires_timer_criterion(operation))
@@ -583,6 +591,7 @@ fn hosted_cli_authorization_operations(
         .iter()
         .filter(|operation| {
             !mdbase_connect_protocol::operation_requires_timer_criterion(operation)
+                && **operation != "collection.setup.apply"
                 && (!read_only
                     || (**operation != "sync"
                         && !mdbase_connect_protocol::MUTATING_OPERATION_IDENTIFIERS

--- a/crates/connect-cli/src/tests.rs
+++ b/crates/connect-cli/src/tests.rs
@@ -244,6 +244,9 @@ fn hosted_cli_timer_operations_are_not_authorizable() {
     assert!(defaults.iter().any(|operation| operation == "create"));
     assert!(!defaults
         .iter()
+        .any(|operation| operation == "collection.setup.apply"));
+    assert!(!defaults
+        .iter()
         .any(|operation| mdbase_connect_protocol::operation_requires_timer_criterion(operation)));
 
     for operation in COLLECTION_OPERATIONS
@@ -255,6 +258,11 @@ fn hosted_cli_timer_operations_are_not_authorizable() {
         assert_eq!(error.code, "unsupported_cli_operation");
         assert!(error.message.contains(operation));
     }
+
+    let setup =
+        hosted_cli_authorization_operations(vec!["collection.setup.apply".to_string()], false)
+            .unwrap_err();
+    assert_eq!(setup.code, "unsupported_cli_operation");
 }
 
 #[test]

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -54,3 +54,46 @@ This behavior is identical in desktop and fully headless sessions.
 Do not expose the local control socket or named pipe over a network. Back up the
 state directory and OS credential store according to the recovery guidance for
 your platform.
+
+## Hosted read canary
+
+`scripts/hosted-read-canary.mjs` checks one immutable Markdown marker through
+the native hosted CLI path. Enrollment is deliberately interactive and separate
+from scheduled execution:
+
+```bash
+mdbase --state-dir /secure/persistent/canary-state connect login
+mdbase --state-dir /secure/persistent/canary-state connect hosted authorize \
+  <collection-id> --operations describe,read
+```
+
+Approve only the final `describe,read` grant. The canary rejects broader or
+different grants. Keep the state directory persistent across runs and use the
+platform's normal keyring or credential store; the state directory alone does
+not contain the grant credentials. Do not select the insecure test secret
+backend and do not pass credentials to the canary.
+Run it without `MDBASE_CONNECT_SOCKET`; inherited endpoint overrides are
+rejected so the selected state directory cannot probe another environment's
+daemon.
+
+Compute the expected digest from the marker's exact UTF-8 Markdown bytes, with
+the `sha256:` prefix. Then schedule the probe with explicit non-secret inputs:
+
+```bash
+node scripts/hosted-read-canary.mjs \
+  --environment production \
+  --cli /opt/mdbase/bin/mdbase \
+  --state-dir /secure/persistent/canary-state \
+  --expected-origin https://connect.mdbase.dev \
+  --collection <collection-id> \
+  --expected-collection-name "Status marker" \
+  --marker-path status/canary.md \
+  --expected-marker-sha256 sha256:<64-lowercase-hex-digits> \
+  --timeout-ms 30000
+```
+
+Every option also has an `MDBASE_HOSTED_CANARY_*` environment-variable form;
+use either the argument or its environment variable, never both. A scheduler
+should retain only the one-line JSON result. Exit `0` is operational, `1` is a
+probe failure, and `2` is invalid or unsafe configuration. Re-enrollment is a
+manual keyring-backed action, not part of the scheduled probe.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check:npm-bootstrap": "node scripts/check-npm-package-bootstrap.mjs",
     "check:release-readiness": "node scripts/check-release-readiness.mjs",
     "check:workspace-pins": "node scripts/check-workspace-pins.mjs",
+    "canary:hosted-read": "node scripts/hosted-read-canary.mjs",
     "generate:problems": "node scripts/generate-connect-problems.mjs",
     "check:problems": "node scripts/generate-connect-problems.mjs --check",
     "generate:operations": "node scripts/generate-operation-catalog.mjs",

--- a/scripts/hosted-read-canary.mjs
+++ b/scripts/hosted-read-canary.mjs
@@ -223,7 +223,7 @@ export async function runCanary(argv = process.argv.slice(2), environmentVariabl
     });
 
     await runStage("describe", async () => {
-      const described = operationResult(await operation("describe", "describe", {}), "describe");
+      const described = await operation("describe", "describe", {});
       if (described?.collection_id !== options.collectionId
           || described?.display_name !== options.expectedCollectionName) {
         throw new CanaryError("describe", "collection_mismatch");

--- a/scripts/hosted-read-canary.mjs
+++ b/scripts/hosted-read-canary.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, readFile, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+import { isAbsolute, posix, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const REQUIRED_OPERATIONS = ["describe", "read"];
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const ENVIRONMENT = /^[a-z0-9][a-z0-9_-]{0,63}$/u;
+
+const INPUTS = {
+  environment: "MDBASE_HOSTED_CANARY_ENVIRONMENT",
+  cli: "MDBASE_HOSTED_CANARY_CLI",
+  "state-dir": "MDBASE_HOSTED_CANARY_STATE_DIR",
+  "expected-origin": "MDBASE_HOSTED_CANARY_EXPECTED_ORIGIN",
+  collection: "MDBASE_HOSTED_CANARY_COLLECTION",
+  "expected-collection-name": "MDBASE_HOSTED_CANARY_EXPECTED_COLLECTION_NAME",
+  "marker-path": "MDBASE_HOSTED_CANARY_MARKER_PATH",
+  "expected-marker-sha256": "MDBASE_HOSTED_CANARY_EXPECTED_MARKER_SHA256",
+  "timeout-ms": "MDBASE_HOSTED_CANARY_TIMEOUT_MS"
+};
+
+class CanaryError extends Error {
+  constructor(stage, code, exitCode = 1) {
+    super(code);
+    this.stage = stage;
+    this.code = code;
+    this.exitCode = exitCode;
+  }
+}
+
+function configError(code = "invalid_config") {
+  return new CanaryError("config", code, 2);
+}
+
+function parseArguments(argv, environmentVariables) {
+  const supplied = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw configError();
+    }
+    const name = flag.slice(2);
+    if (!Object.hasOwn(INPUTS, name) || supplied.has(name)) throw configError();
+    supplied.set(name, value);
+  }
+
+  const value = (name) => {
+    const argument = supplied.get(name);
+    const environmentValue = environmentVariables[INPUTS[name]];
+    if (argument !== undefined && environmentValue !== undefined) throw configError();
+    const result = argument ?? environmentValue;
+    if (result === undefined || result === "") throw configError();
+    return result;
+  };
+
+  const environment = value("environment");
+  const cli = value("cli");
+  const stateDir = value("state-dir");
+  const expectedOrigin = value("expected-origin");
+  const collectionId = value("collection");
+  const expectedCollectionName = value("expected-collection-name");
+  const markerPath = value("marker-path");
+  const expectedMarkerSha256 = value("expected-marker-sha256");
+  const timeoutText = value("timeout-ms");
+  const timeoutMs = Number(timeoutText);
+
+  let parsedOrigin;
+  try {
+    parsedOrigin = new URL(expectedOrigin);
+  } catch {
+    throw configError();
+  }
+  if (!ENVIRONMENT.test(environment)
+      || !isAbsolute(cli)
+      || !isAbsolute(stateDir)
+      || !["https:", "http:"].includes(parsedOrigin.protocol)
+      || parsedOrigin.origin !== expectedOrigin
+      || parsedOrigin.username
+      || parsedOrigin.password
+      || !UUID.test(collectionId)
+      || expectedCollectionName.length > 200
+      || markerPath.length > 1024
+      || posix.isAbsolute(markerPath)
+      || markerPath.split("/").some((part) => part === "" || part === "." || part === "..")
+      || !DIGEST.test(expectedMarkerSha256)
+      || !/^[1-9][0-9]*$/u.test(timeoutText)
+      || !Number.isSafeInteger(timeoutMs)
+      || timeoutMs > 300_000) {
+    throw configError();
+  }
+
+  return {
+    environment,
+    cli,
+    stateDir,
+    expectedOrigin,
+    collectionId,
+    expectedCollectionName,
+    markerPath,
+    expectedMarkerSha256,
+    timeoutMs
+  };
+}
+
+function elapsed(started) {
+  return Math.max(0, Math.round(performance.now() - started));
+}
+
+function parseJson(stdout, stage) {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    throw new CanaryError(stage, "malformed_json");
+  }
+}
+
+function operationResult(value, stage) {
+  if (value?.valid !== true || value.result === undefined) {
+    throw new CanaryError(stage, "invalid_response");
+  }
+  return value.result;
+}
+
+export function markerDocumentSha256(document) {
+  return `sha256:${createHash("sha256").update(document, "utf8").digest("hex")}`;
+}
+
+export async function runCanary(argv = process.argv.slice(2), environmentVariables = process.env) {
+  const started = performance.now();
+  const checkedAt = new Date().toISOString();
+  const stages = [];
+  const environmentArgument = argv.indexOf("--environment");
+  const suppliedEnvironment = environmentArgument === -1
+    ? environmentVariables[INPUTS.environment]
+    : argv[environmentArgument + 1];
+  let environment = ENVIRONMENT.test(suppliedEnvironment ?? "") ? suppliedEnvironment : "unknown";
+  let currentStage = "config";
+
+  const runStage = async (name, action) => {
+    currentStage = name;
+    const stageStarted = performance.now();
+    try {
+      const result = await action();
+      stages.push({ name, status: "operational", duration_ms: elapsed(stageStarted) });
+      return result;
+    } catch (error) {
+      stages.push({ name, status: "failed", duration_ms: elapsed(stageStarted) });
+      throw error;
+    }
+  };
+
+  try {
+    const options = await runStage("config", async () => {
+      const parsed = parseArguments(argv, environmentVariables);
+      environment = parsed.environment;
+      if (environmentVariables.MDBASE_CONNECT_SOCKET) throw configError("endpoint_override");
+      await access(parsed.cli, constants.X_OK).catch(() => { throw configError("cli_unavailable"); });
+      const state = await stat(parsed.stateDir).catch(() => { throw configError("state_unavailable"); });
+      if (!state.isDirectory()) throw configError("state_unavailable");
+      let cloud;
+      try {
+        cloud = JSON.parse(await readFile(resolve(parsed.stateDir, "cloud.json"), "utf8"));
+      } catch {
+        throw configError("invalid_state_config");
+      }
+      if (cloud?.server_url !== parsed.expectedOrigin) throw configError("origin_mismatch");
+      return parsed;
+    });
+
+    const deadline = performance.now() + options.timeoutMs;
+    const runCli = async (stage, argumentsList) => {
+      const remaining = Math.floor(deadline - performance.now());
+      if (remaining <= 0) throw new CanaryError(stage, "timeout");
+      try {
+        const { stdout } = await execFileAsync(options.cli, argumentsList, {
+          env: environmentVariables,
+          timeout: remaining,
+          maxBuffer: MAX_OUTPUT_BYTES,
+          windowsHide: true
+        });
+        return parseJson(stdout, stage);
+      } catch (error) {
+        if (error instanceof CanaryError) throw error;
+        if (error?.killed || error?.code === "ETIMEDOUT") throw new CanaryError(stage, "timeout");
+        if (error?.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+          throw new CanaryError(stage, "output_limit");
+        }
+        throw new CanaryError(stage, "cli_failed");
+      }
+    };
+    const common = ["--state-dir", options.stateDir, "--json"];
+    const operation = (stage, name, input) => runCli(stage, [
+      ...common,
+      "connect", "operation", options.collectionId, name,
+      "--input", JSON.stringify(input)
+    ]);
+
+    await runStage("connections", async () => {
+      const connections = await runCli("connections", [
+        ...common, "connect", "hosted", "connections"
+      ]);
+      if (!Array.isArray(connections)) throw new CanaryError("connections", "invalid_response");
+      const matching = connections.filter((item) => item?.collection_id === options.collectionId);
+      if (matching.length !== 1) throw new CanaryError("connections", "missing_grant");
+      const connection = matching[0];
+      const operations = Array.isArray(connection.operations)
+        ? [...new Set(connection.operations)].sort()
+        : [];
+      if (connection.collection_name !== options.expectedCollectionName
+          || operations.length !== REQUIRED_OPERATIONS.length
+          || operations.some((item, index) => item !== REQUIRED_OPERATIONS[index])) {
+        throw new CanaryError("connections", "grant_mismatch");
+      }
+    });
+
+    await runStage("describe", async () => {
+      const described = operationResult(await operation("describe", "describe", {}), "describe");
+      if (described?.collection_id !== options.collectionId
+          || described?.display_name !== options.expectedCollectionName) {
+        throw new CanaryError("describe", "collection_mismatch");
+      }
+    });
+
+    let document;
+    await runStage("read", async () => {
+      const record = operationResult(await operation("read", "read", {
+        path: options.markerPath,
+        include_document: true
+      }), "read");
+      if (record?.path !== options.markerPath || typeof record.document !== "string") {
+        throw new CanaryError("read", "marker_mismatch");
+      }
+      document = record.document;
+    });
+
+    await runStage("digest", async () => {
+      if (markerDocumentSha256(document) !== options.expectedMarkerSha256) {
+        throw new CanaryError("digest", "digest_mismatch");
+      }
+    });
+
+    return {
+      exitCode: 0,
+      result: {
+        schema_version: 1,
+        environment,
+        component: "hosted_canary",
+        status: "operational",
+        checked_at: checkedAt,
+        duration_ms: elapsed(started),
+        stages
+      }
+    };
+  } catch (error) {
+    const failure = error instanceof CanaryError
+      ? error
+      : new CanaryError(currentStage, "internal_error");
+    if (!stages.some((stage) => stage.name === failure.stage && stage.status === "failed")) {
+      stages.push({ name: failure.stage, status: "failed", duration_ms: 0 });
+    }
+    return {
+      exitCode: failure.exitCode,
+      result: {
+        schema_version: 1,
+        environment,
+        component: "hosted_canary",
+        status: "failed",
+        checked_at: checkedAt,
+        duration_ms: elapsed(started),
+        stages,
+        error: { stage: failure.stage, code: failure.code }
+      }
+    };
+  }
+}
+
+async function main() {
+  const { exitCode, result } = await runCanary();
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exitCode = exitCode;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/lib/hosted-read-canary.test.mjs
+++ b/scripts/lib/hosted-read-canary.test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { markerDocumentSha256 } from "../hosted-read-canary.mjs";
+
+const execFileAsync = promisify(execFile);
+const SCRIPT = resolve(import.meta.dirname, "../hosted-read-canary.mjs");
+const COLLECTION = "01900000-0000-7000-8000-000000000000";
+const ORIGIN = "https://connect.example";
+const NAME = "Status marker";
+const MARKER_PATH = "status/canary.md";
+const DOCUMENT = "---\ntype: status\n---\noperational\n";
+const SECRET = "super-secret-response-value";
+
+async function fixture(t) {
+  const root = await mkdtemp(resolve(tmpdir(), "mdbase-hosted-canary-"));
+  const stateDir = resolve(root, "state");
+  const cli = resolve(root, "mdbase-fake");
+  await mkdir(stateDir);
+  await writeFile(resolve(stateDir, "cloud.json"), `${JSON.stringify({ server_url: ORIGIN })}\n`);
+  await writeFile(cli, `#!/usr/bin/env node
+const mode = process.env.FAKE_CLI_MODE ?? "success";
+const args = process.argv.slice(2);
+const operationIndex = args.indexOf("operation");
+const operation = operationIndex === -1 ? null : args[operationIndex + 2];
+if (mode === "timeout") await new Promise((resolve) => setTimeout(resolve, 10000));
+if (mode === "cli-failure") { process.stderr.write("${SECRET}\\n"); process.exit(1); }
+if (mode === "malformed" && operation === "describe") { process.stdout.write("${SECRET} not-json"); process.exit(0); }
+if (args.includes("connections")) {
+  const operations = mode === "broad-grant" ? ["describe", "read", "query"] : ["describe", "read"];
+  const connections = mode === "missing-grant" ? [] : [{collection_id:"${COLLECTION}",collection_name:"${NAME}",operations,credential:"${SECRET}"}];
+  process.stdout.write(JSON.stringify(connections));
+} else if (operation === "describe") {
+  process.stdout.write(JSON.stringify({valid:true,result:{collection_id:"${COLLECTION}",display_name:"${NAME}",secret:"${SECRET}"},diagnostics:[]}));
+} else if (operation === "read") {
+  process.stdout.write(JSON.stringify({valid:true,result:{path:"${MARKER_PATH}",document:${JSON.stringify(DOCUMENT)},body:"${SECRET}"},diagnostics:[]}));
+} else { process.exit(3); }
+`);
+  await chmod(cli, 0o700);
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return { root, stateDir, cli };
+}
+
+function argumentsFor({ stateDir, cli }, overrides = {}) {
+  const values = {
+    environment: "production",
+    cli,
+    "state-dir": stateDir,
+    "expected-origin": ORIGIN,
+    collection: COLLECTION,
+    "expected-collection-name": NAME,
+    "marker-path": MARKER_PATH,
+    "expected-marker-sha256": markerDocumentSha256(DOCUMENT),
+    "timeout-ms": "2000",
+    ...overrides
+  };
+  return Object.entries(values).flatMap(([name, value]) => [`--${name}`, value]);
+}
+
+async function invoke(options, overrides = {}, environment = {}) {
+  try {
+    const result = await execFileAsync(process.execPath, [SCRIPT, ...argumentsFor(options, overrides)], {
+      env: { ...process.env, ...environment }
+    });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr, json: JSON.parse(result.stdout) };
+  } catch (error) {
+    return {
+      code: error.code,
+      stdout: error.stdout,
+      stderr: error.stderr,
+      json: JSON.parse(error.stdout)
+    };
+  }
+}
+
+test("reports a successful least-privilege hosted read", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options);
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(result.json.stages.map(({ name, status }) => ({ name, status })), [
+    { name: "config", status: "operational" },
+    { name: "connections", status: "operational" },
+    { name: "describe", status: "operational" },
+    { name: "read", status: "operational" },
+    { name: "digest", status: "operational" }
+  ]);
+  assert.equal(result.json.schema_version, 1);
+  assert.equal(result.json.environment, "production");
+  assert.equal(result.json.component, "hosted_canary");
+  assert.equal(result.json.status, "operational");
+  assert.match(result.json.checked_at, /^\d{4}-\d{2}-\d{2}T/u);
+  assert.ok(Number.isInteger(result.json.duration_ms));
+});
+
+test("rejects a state directory bound to the wrong origin", async (t) => {
+  const options = await fixture(t);
+  await writeFile(resolve(options.stateDir, "cloud.json"), JSON.stringify({ server_url: "https://other.example" }));
+  const result = await invoke(options);
+  assert.equal(result.code, 2);
+  assert.deepEqual(result.json.error, { stage: "config", code: "origin_mismatch" });
+});
+
+test("rejects an inherited daemon endpoint override", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {}, { MDBASE_CONNECT_SOCKET: "tcp://127.0.0.1:9999" });
+  assert.equal(result.code, 2);
+  assert.deepEqual(result.json.error, { stage: "config", code: "endpoint_override" });
+});
+
+test("rejects a missing hosted grant", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {}, { FAKE_CLI_MODE: "missing-grant" });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "connections", code: "missing_grant" });
+});
+
+test("rejects a broader than necessary hosted grant", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {}, { FAKE_CLI_MODE: "broad-grant" });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "connections", code: "grant_mismatch" });
+});
+
+test("reports a marker digest mismatch without exposing the document", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {
+    "expected-marker-sha256": `sha256:${"0".repeat(64)}`
+  });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "digest", code: "digest_mismatch" });
+  assert.doesNotMatch(result.stdout, /operational\n|type: status/u);
+});
+
+test("reports malformed CLI JSON with a fixed privacy-safe error", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {}, { FAKE_CLI_MODE: "malformed" });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "describe", code: "malformed_json" });
+  assert.doesNotMatch(result.stdout + result.stderr, new RegExp(SECRET, "u"));
+});
+
+test("bounds the complete probe with a timeout", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, { "timeout-ms": "50" }, { FAKE_CLI_MODE: "timeout" });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "connections", code: "timeout" });
+  assert.ok(result.json.duration_ms < 2000);
+});
+
+test("returns exit 2 for invalid explicit configuration", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, { collection: "not-a-uuid" });
+  assert.equal(result.code, 2);
+  assert.deepEqual(result.json.error, { stage: "config", code: "invalid_config" });
+  assert.equal(result.json.environment, "production");
+});
+
+test("accepts all non-secret inputs from the documented environment variables", async (t) => {
+  const options = await fixture(t);
+  const environment = {
+    ...process.env,
+    MDBASE_HOSTED_CANARY_ENVIRONMENT: "staging",
+    MDBASE_HOSTED_CANARY_CLI: options.cli,
+    MDBASE_HOSTED_CANARY_STATE_DIR: options.stateDir,
+    MDBASE_HOSTED_CANARY_EXPECTED_ORIGIN: ORIGIN,
+    MDBASE_HOSTED_CANARY_COLLECTION: COLLECTION,
+    MDBASE_HOSTED_CANARY_EXPECTED_COLLECTION_NAME: NAME,
+    MDBASE_HOSTED_CANARY_MARKER_PATH: MARKER_PATH,
+    MDBASE_HOSTED_CANARY_EXPECTED_MARKER_SHA256: markerDocumentSha256(DOCUMENT),
+    MDBASE_HOSTED_CANARY_TIMEOUT_MS: "2000"
+  };
+  const { stdout } = await execFileAsync(process.execPath, [SCRIPT], { env: environment });
+  assert.equal(JSON.parse(stdout).environment, "staging");
+});
+
+test("never reflects CLI response bodies, diagnostics, or stderr", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {}, { FAKE_CLI_MODE: "cli-failure" });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "connections", code: "cli_failed" });
+  assert.equal(result.stderr, "");
+  assert.doesNotMatch(result.stdout, new RegExp(SECRET, "u"));
+});

--- a/scripts/lib/hosted-read-canary.test.mjs
+++ b/scripts/lib/hosted-read-canary.test.mjs
@@ -36,7 +36,7 @@ if (args.includes("connections")) {
   const connections = mode === "missing-grant" ? [] : [{collection_id:"${COLLECTION}",collection_name:"${NAME}",operations,credential:"${SECRET}"}];
   process.stdout.write(JSON.stringify(connections));
 } else if (operation === "describe") {
-  process.stdout.write(JSON.stringify({valid:true,result:{collection_id:"${COLLECTION}",display_name:"${NAME}",secret:"${SECRET}"},diagnostics:[]}));
+  process.stdout.write(JSON.stringify({collection_id:"${COLLECTION}",display_name:"${NAME}",secret:"${SECRET}"}));
 } else if (operation === "read") {
   process.stdout.write(JSON.stringify({valid:true,result:{path:"${MARKER_PATH}",document:${JSON.stringify(DOCUMENT)},body:"${SECRET}"},diagnostics:[]}));
 } else { process.exit(3); }


### PR DESCRIPTION
## Summary
- add a privacy-safe native hosted-read canary around the existing mdbase CLI
- require exact production origin, collection identity, and least-privilege `describe,read` grant
- verify an immutable marker digest without logging record content or credentials
- reject inherited daemon endpoint overrides and document interactive enrollment

## Verification
- 11 focused hermetic tests covering success, origin and endpoint isolation, grant scope, malformed output, timeout, digest mismatch, configuration, and redaction
- Node syntax and diff checks