### PR TITLE
Add canonical signed release bundles

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       publish: ${{ steps.diff.outputs.publish }}
+      component_matrix: ${{ steps.release.outputs.component_matrix }}
+      qualification_run_id: ${{ steps.release.outputs.qualification_run_id }}
+      qualification_run_attempt: ${{ steps.release.outputs.qualification_run_attempt }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -50,20 +53,32 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Verify exact Server CI qualification
-        if: github.event_name == 'workflow_run'
+      - id: qualification
+        name: Verify exact Server CI qualification
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          scripts/ci/verify-qualified-commit
-          "$SOURCE_COMMIT"
-          "${{ github.event.workflow_run.id }}"
+          UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == workflow_run ]]; then
+            scripts/ci/verify-qualified-commit "$SOURCE_COMMIT" "$UPSTREAM_RUN_ID"
+          else
+            scripts/ci/verify-qualified-commit "$SOURCE_COMMIT"
+          fi
 
-      - name: Verify manually republished source qualification
-        if: github.event_name == 'workflow_dispatch'
+      - id: release
+        name: Load the canonical release contract
         env:
           GH_TOKEN: ${{ github.token }}
-        run: scripts/ci/verify-qualified-commit "$SOURCE_COMMIT"
+          QUALIFICATION_RUN_ID: ${{ steps.qualification.outputs.run_id }}
+        run: |
+          matrix=$(node scripts/release-components.mjs --github-matrix)
+          run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$QUALIFICATION_RUN_ID")
+          attempt=$(jq -er '.run_attempt | select(. >= 1)' <<<"$run")
+          {
+            echo "component_matrix=$matrix"
+            echo "qualification_run_id=$QUALIFICATION_RUN_ID"
+            echo "qualification_run_attempt=$attempt"
+          } >>"$GITHUB_OUTPUT"
 
       - id: diff
         name: Detect managed runtime changes
@@ -118,20 +133,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - component: connect
-            package: mdbase-connect-server
-            dockerfile: deploy/docker/Dockerfile.server
-          - component: hosted-provider
-            package: mdbase-connect-hosted-provider
-            dockerfile: deploy/docker/Dockerfile.hosted-provider
-          - component: mcp
-            package: mdbase-connect-mcp
-            dockerfile: deploy/docker/Dockerfile.mcp
-          - component: client
-            package: mdbase-connect-client
-            dockerfile: deploy/docker/Dockerfile.client
+      matrix: ${{ fromJSON(needs.changes.outputs.component_matrix) }}
     env:
       IMAGE: ghcr.io/mdbase-dev/${{ matrix.package }}
 
@@ -192,9 +194,9 @@ jobs:
         name: Build and push immutable image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.IMAGE }}:sha-${{ env.SOURCE_COMMIT }}
           build-args: MDBASE_CONNECT_REVISION=${{ env.SOURCE_COMMIT }}
@@ -258,5 +260,55 @@ jobs:
         with:
           name: server-image-${{ matrix.component }}
           path: ${{ runner.temp }}/${{ matrix.component }}.json
+          if-no-files-found: error
+          retention-days: 90
+
+  release-bundle:
+    needs: [changes, publish]
+    if: needs.changes.outputs.publish == 'true'
+    name: Sign immutable release bundle
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.SOURCE_COMMIT }}
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: server-image-*
+          path: ${{ runner.temp }}/release-components
+          merge-multiple: true
+
+      - name: Build the exact-commit release bundle
+        run: >-
+          node scripts/release-components.mjs
+          --build-bundle "$RUNNER_TEMP/release-bundle.json"
+          --components-dir "$RUNNER_TEMP/release-components"
+          --commit "$SOURCE_COMMIT"
+          --qualification-run-id "${{ needs.changes.outputs.qualification_run_id }}"
+          --qualification-run-attempt "${{ needs.changes.outputs.qualification_run_attempt }}"
+          --publication-run-id "$GITHUB_RUN_ID"
+          --publication-run-attempt "$GITHUB_RUN_ATTEMPT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the release bundle with the publishing workflow identity
+        run: >-
+          cosign sign-blob --yes
+          --bundle "$RUNNER_TEMP/release-bundle.sigstore.json"
+          "$RUNNER_TEMP/release-bundle.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-bundle
+          path: |
+            ${{ runner.temp }}/release-bundle.json
+            ${{ runner.temp }}/release-bundle.sigstore.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - id: qualification
         name: Require exact full Server CI qualification
@@ -28,9 +28,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: scripts/ci/verify-qualified-commit "$GITHUB_SHA"
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-staging-images.yml
+++ b/.github/workflows/publish-staging-images.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: candidate-b-staging-images
     outputs:
+      component_matrix: ${{ steps.source.outputs.component_matrix }}
       mdbase_rs_revision: ${{ steps.source.outputs.mdbase_rs_revision }}
     steps:
       - id: qualification
@@ -94,6 +95,8 @@ jobs:
           test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
           revision=$(tr -d '\r\n' <deploy/docker/mdbase-rs-revision)
           [[ $revision =~ ^[0-9a-f]{40}$ ]]
+          matrix=$(node scripts/release-components.mjs --github-matrix)
+          echo "component_matrix=$matrix" >>"$GITHUB_OUTPUT"
           echo "mdbase_rs_revision=$revision" >>"$GITHUB_OUTPUT"
 
       - name: Verify the full qualification artifact
@@ -116,20 +119,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - component: connect
-            package: mdbase-connect-server
-            dockerfile: deploy/docker/Dockerfile.server
-          - component: hosted-provider
-            package: mdbase-connect-hosted-provider
-            dockerfile: deploy/docker/Dockerfile.hosted-provider
-          - component: mcp
-            package: mdbase-connect-mcp
-            dockerfile: deploy/docker/Dockerfile.mcp
-          - component: client
-            package: mdbase-connect-client
-            dockerfile: deploy/docker/Dockerfile.client
+      matrix: ${{ fromJSON(needs.authorize.outputs.component_matrix) }}
     env:
       IMAGE: ghcr.io/mdbase-dev/${{ matrix.package }}
 
@@ -193,9 +183,9 @@ jobs:
         name: Build immutable staging image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.IMAGE }}:candidate-b-staging-sha-${{ env.SOURCE_COMMIT }}
           build-args: MDBASE_CONNECT_REVISION=${{ env.SOURCE_COMMIT }}

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -171,6 +171,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm version:check
       - run: pnpm check:release-readiness
+      - run: pnpm check:release-components
       - run: pnpm audit:dependencies
       - run: pnpm check:architecture
       # Workspace packages publish their declarations from dist, so build the
@@ -185,7 +186,7 @@ jobs:
       # Cache the browser so most runs never contact a mirror at all, and keep
       # the timeout so a cache miss on a slow day fails fast instead of
       # silently consuming an hour.
-      - uses: actions/cache@v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: needs.classify.outputs.run_full == 'true'
         id: playwright-cache
         with:
@@ -373,7 +374,7 @@ jobs:
       # Cache the browser so most runs never contact a mirror at all, and keep
       # the timeout so a cache miss on a slow day fails fast instead of
       # silently consuming an hour.
-      - uses: actions/cache@v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/config/release-bundle.schema.json
+++ b/config/release-bundle.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/release-bundle/v1",
+  "title": "mdbase immutable product release bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "repository", "commit", "version", "sourceDependencies", "qualification", "publication", "components"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "repository": { "const": "mdbase-dev/mdbase-connect" },
+    "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9A-Za-z.-]+$" },
+    "sourceDependencies": { "type": "object" },
+    "qualification": {
+      "type": "object",
+      "required": ["workflow", "runId", "runAttempt"],
+      "properties": {
+        "workflow": { "const": "server-ci.yml" },
+        "runId": { "type": "integer", "minimum": 1 },
+        "runAttempt": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "required": ["workflow", "runId", "runAttempt"],
+      "properties": {
+        "workflow": { "const": "publish-images.yml" },
+        "runId": { "type": "integer", "minimum": 1 },
+        "runAttempt": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "components": { "type": "array", "minItems": 1 }
+  }
+}

--- a/config/release-components.json
+++ b/config/release-components.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "./release-components.schema.json",
+  "schemaVersion": 1,
+  "repository": "mdbase-dev/mdbase-connect",
+  "publication": {
+    "workflow": "publish-images.yml",
+    "artifactName": "release-bundle",
+    "certificateIdentity": "https://github.com/mdbase-dev/mdbase-connect/.github/workflows/publish-images.yml@refs/heads/main",
+    "certificateIssuer": "https://token.actions.githubusercontent.com"
+  },
+  "sourceDependencies": [
+    {
+      "id": "mdbase-rs",
+      "revisionFile": "deploy/docker/mdbase-rs-revision"
+    }
+  ],
+  "components": [
+    {
+      "id": "connect",
+      "required": true,
+      "kind": "oci-image",
+      "image": "ghcr.io/mdbase-dev/mdbase-connect-server",
+      "dockerfile": "deploy/docker/Dockerfile.server",
+      "context": ".",
+      "platform": "linux/amd64",
+      "attestationType": "https://mdbase.dev/attestations/release-image/v1"
+    },
+    {
+      "id": "hosted-provider",
+      "required": true,
+      "kind": "oci-image",
+      "image": "ghcr.io/mdbase-dev/mdbase-connect-hosted-provider",
+      "dockerfile": "deploy/docker/Dockerfile.hosted-provider",
+      "context": ".",
+      "platform": "linux/amd64",
+      "attestationType": "https://mdbase.dev/attestations/release-image/v1"
+    },
+    {
+      "id": "mcp",
+      "required": true,
+      "kind": "oci-image",
+      "image": "ghcr.io/mdbase-dev/mdbase-connect-mcp",
+      "dockerfile": "deploy/docker/Dockerfile.mcp",
+      "context": ".",
+      "platform": "linux/amd64",
+      "attestationType": "https://mdbase.dev/attestations/release-image/v1"
+    },
+    {
+      "id": "client",
+      "required": true,
+      "kind": "oci-image",
+      "image": "ghcr.io/mdbase-dev/mdbase-connect-client",
+      "dockerfile": "deploy/docker/Dockerfile.client",
+      "context": ".",
+      "platform": "linux/amd64",
+      "attestationType": "https://mdbase.dev/attestations/release-image/v1"
+    }
+  ]
+}

--- a/config/release-components.schema.json
+++ b/config/release-components.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mdbase.dev/schemas/release-components/v1",
+  "title": "mdbase product release component contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "repository", "publication", "sourceDependencies", "components"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": 1 },
+    "repository": { "const": "mdbase-dev/mdbase-connect" },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workflow", "artifactName", "certificateIdentity", "certificateIssuer"],
+      "properties": {
+        "workflow": { "const": "publish-images.yml" },
+        "artifactName": { "const": "release-bundle" },
+        "certificateIdentity": { "type": "string", "pattern": "^https://github\\.com/" },
+        "certificateIssuer": { "const": "https://token.actions.githubusercontent.com" }
+      }
+    },
+    "sourceDependencies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "revisionFile"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "revisionFile": { "type": "string" }
+        }
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "required", "kind", "image", "dockerfile", "context", "platform", "attestationType"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "required": { "type": "boolean" },
+          "kind": { "const": "oci-image" },
+          "image": { "type": "string", "pattern": "^ghcr\\.io/mdbase-dev/[a-z0-9-]+$" },
+          "dockerfile": { "type": "string", "pattern": "^deploy/docker/Dockerfile\\.[A-Za-z0-9-]+$" },
+          "context": { "const": "." },
+          "platform": { "const": "linux/amd64" },
+          "attestationType": { "const": "https://mdbase.dev/attestations/release-image/v1" }
+        }
+      }
+    }
+  }
+}

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -1,0 +1,51 @@
+# Product release contract
+
+`config/release-components.json` is the public, non-secret inventory of every
+product artifact promoted together as an mdbase Connect server release. It owns
+component IDs, GHCR repositories, Dockerfiles, build contexts, runtime
+platforms, and release-attestation types. It intentionally contains no Render
+resource IDs, deployment order, capacity, credentials, or private topology.
+
+`node scripts/release-components.mjs --check` validates the contract and its
+repository inputs. Server CI runs this check. Both normal and isolated-staging
+image publishers obtain their GitHub matrix from
+`node scripts/release-components.mjs --github-matrix`; adding an image only to a
+workflow or only to the contract therefore cannot silently produce a partial
+release. The required release set is currently `connect`, `hosted-provider`,
+`mcp`, and `client`.
+
+After every successful normal publication, `publish-images.yml` downloads the
+four exact component records and creates `release-bundle.json`. The bundle is
+bound to:
+
+- the full product commit and workspace version;
+- the pinned `mdbase-rs` revision;
+- the exact successful Server CI run and attempt;
+- the exact publication run and attempt; and
+- each component's digest-only image, platform, and attestation type.
+
+The workflow signs the JSON blob keylessly and publishes it with its Sigstore
+bundle as the `release-bundle` workflow artifact. The signature is an index of
+release evidence, not a replacement for it. Private release preparation must
+verify the workflow identity and GitHub run identities, then independently
+verify every image signature, release-image attestation, source commit, and
+registry digest.
+
+## Changing the contract
+
+1. Update `config/release-components.json` and, if the format changes, both
+   checked-in schemas.
+2. Add or update the Dockerfile and narrow validator tests.
+3. Run:
+
+   ```sh
+   node scripts/release-components.mjs --check
+   node --test scripts/lib/release-components.test.mjs
+   ```
+
+4. Review the private mapping in `mdbase-cloud-ops` separately. Public contract
+   changes never authorize or identify a private deployment target.
+
+Schema versions are monotonic. Readers fail closed on unknown versions and
+unknown, missing, duplicated, mutable, wrong-platform, or wrong-repository
+components.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:architecture": "node scripts/check-architecture.mjs",
     "check:npm-bootstrap": "node scripts/check-npm-package-bootstrap.mjs",
     "check:release-readiness": "node scripts/check-release-readiness.mjs",
+    "check:release-components": "node scripts/release-components.mjs --check",
     "check:workspace-pins": "node scripts/check-workspace-pins.mjs",
     "generate:problems": "node scripts/generate-connect-problems.mjs",
     "check:problems": "node scripts/generate-connect-problems.mjs --check",

--- a/scripts/lib/release-components.mjs
+++ b/scripts/lib/release-components.mjs
@@ -1,0 +1,284 @@
+import { access, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const SHA = /^[0-9a-f]{40}$/;
+const DIGEST_IMAGE = /^(ghcr\.io\/mdbase-dev\/[a-z0-9-]+)@(sha256:[0-9a-f]{64})$/;
+const ID = /^[a-z0-9-]+$/;
+const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+$/;
+const COMPONENT_FIELDS = new Set([
+  "id", "required", "kind", "image", "dockerfile", "context", "platform",
+  "attestationType",
+]);
+
+function requireObject(value, name, failures) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    failures.push(`${name} must be an object`);
+    return false;
+  }
+  return true;
+}
+
+function requireExactFields(value, allowed, name, failures) {
+  for (const field of Object.keys(value)) {
+    if (!allowed.has(field)) failures.push(`${name} has unknown field ${field}`);
+  }
+}
+
+export async function validateReleaseComponents(contract, { root = process.cwd() } = {}) {
+  const failures = [];
+  if (!requireObject(contract, "release contract", failures)) return failures;
+  requireExactFields(contract, new Set([
+    "$schema", "schemaVersion", "repository", "publication",
+    "sourceDependencies", "components",
+  ]), "release contract", failures);
+
+  if (contract.schemaVersion !== 1) failures.push("schemaVersion must be 1");
+  if (contract.repository !== "mdbase-dev/mdbase-connect") {
+    failures.push("repository must be mdbase-dev/mdbase-connect");
+  }
+
+  if (requireObject(contract.publication, "publication", failures)) {
+    requireExactFields(contract.publication, new Set([
+      "workflow", "artifactName", "certificateIdentity", "certificateIssuer",
+    ]), "publication", failures);
+    if (contract.publication.workflow !== "publish-images.yml") {
+      failures.push("publication.workflow must be publish-images.yml");
+    }
+    if (contract.publication.artifactName !== "release-bundle") {
+      failures.push("publication.artifactName must be release-bundle");
+    }
+    const expectedIdentity =
+      "https://github.com/mdbase-dev/mdbase-connect/.github/workflows/" +
+      "publish-images.yml@refs/heads/main";
+    if (contract.publication.certificateIdentity !== expectedIdentity) {
+      failures.push("publication.certificateIdentity is not the trusted main workflow");
+    }
+    if (contract.publication.certificateIssuer !==
+      "https://token.actions.githubusercontent.com") {
+      failures.push("publication.certificateIssuer is not GitHub Actions OIDC");
+    }
+  }
+
+  const dependencyIds = new Set();
+  if (!Array.isArray(contract.sourceDependencies) ||
+      contract.sourceDependencies.length === 0) {
+    failures.push("sourceDependencies must be a non-empty array");
+  } else {
+    for (const [index, dependency] of contract.sourceDependencies.entries()) {
+      const name = `sourceDependencies[${index}]`;
+      if (!requireObject(dependency, name, failures)) continue;
+      requireExactFields(dependency, new Set(["id", "revisionFile"]), name, failures);
+      if (!ID.test(dependency.id ?? "")) failures.push(`${name}.id is invalid`);
+      if (dependencyIds.has(dependency.id)) failures.push(`duplicate dependency ${dependency.id}`);
+      dependencyIds.add(dependency.id);
+      if (typeof dependency.revisionFile !== "string" ||
+          path.isAbsolute(dependency.revisionFile) ||
+          dependency.revisionFile.includes("..")) {
+        failures.push(`${name}.revisionFile must be a repository-relative path`);
+        continue;
+      }
+      try {
+        const revision = (await readFile(path.join(root, dependency.revisionFile), "utf8")).trim();
+        if (!SHA.test(revision)) failures.push(`${name}.revisionFile must contain a full commit`);
+      } catch {
+        failures.push(`${name}.revisionFile does not exist`);
+      }
+    }
+  }
+  if (!dependencyIds.has("mdbase-rs")) failures.push("mdbase-rs source dependency is required");
+
+  const componentIds = new Set();
+  const images = new Set();
+  if (!Array.isArray(contract.components) || contract.components.length === 0) {
+    failures.push("components must be a non-empty array");
+  } else {
+    for (const [index, component] of contract.components.entries()) {
+      const name = `components[${index}]`;
+      if (!requireObject(component, name, failures)) continue;
+      requireExactFields(component, COMPONENT_FIELDS, name, failures);
+      if (!ID.test(component.id ?? "")) failures.push(`${name}.id is invalid`);
+      if (componentIds.has(component.id)) failures.push(`duplicate component ${component.id}`);
+      componentIds.add(component.id);
+      if (component.required !== true) failures.push(`${name}.required must be true`);
+      if (component.kind !== "oci-image") failures.push(`${name}.kind must be oci-image`);
+      if (!/^ghcr\.io\/mdbase-dev\/[a-z0-9-]+$/.test(component.image ?? "")) {
+        failures.push(`${name}.image must be an immutable-release GHCR repository`);
+      }
+      if (images.has(component.image)) failures.push(`duplicate image ${component.image}`);
+      images.add(component.image);
+      if (typeof component.dockerfile !== "string" ||
+          !/^deploy\/docker\/Dockerfile\.[A-Za-z0-9-]+$/.test(component.dockerfile)) {
+        failures.push(`${name}.dockerfile is invalid`);
+      } else {
+        try {
+          await access(path.join(root, component.dockerfile));
+        } catch {
+          failures.push(`${name}.dockerfile does not exist`);
+        }
+      }
+      if (component.context !== ".") failures.push(`${name}.context must be .`);
+      if (component.platform !== "linux/amd64") {
+        failures.push(`${name}.platform must be linux/amd64`);
+      }
+      if (component.attestationType !==
+          "https://mdbase.dev/attestations/release-image/v1") {
+        failures.push(`${name}.attestationType is unsupported`);
+      }
+    }
+  }
+
+  for (const id of ["connect", "hosted-provider", "mcp", "client"]) {
+    if (!componentIds.has(id)) failures.push(`required component ${id} is missing`);
+  }
+  return failures;
+}
+
+export function githubMatrix(contract) {
+  return {
+    include: contract.components.map((component) => ({
+      component: component.id,
+      package: component.image.split("/").at(-1),
+      dockerfile: component.dockerfile,
+      context: component.context,
+      platform: component.platform,
+    })),
+  };
+}
+
+export async function readComponentRecords(directory) {
+  const records = [];
+  for (const entry of await readdir(directory, { withFileTypes: true, recursive: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const file = path.join(entry.parentPath, entry.name);
+    records.push(JSON.parse(await readFile(file, "utf8")));
+  }
+  return records;
+}
+
+export function buildReleaseBundle(contract, records, metadata) {
+  const failures = [];
+  const byId = new Map();
+  for (const record of records) {
+    if (!requireObject(record, "component record", failures)) continue;
+    requireExactFields(record, new Set(["component", "commit", "image"]),
+      "component record", failures);
+    if (byId.has(record.component)) failures.push(`duplicate component record ${record.component}`);
+    byId.set(record.component, record);
+  }
+
+  const components = [];
+  for (const expected of contract.components) {
+    const record = byId.get(expected.id);
+    if (!record) {
+      failures.push(`required component record ${expected.id} is missing`);
+      continue;
+    }
+    if (record.commit !== metadata.commit) {
+      failures.push(`${expected.id} record has a different source commit`);
+    }
+    const match = DIGEST_IMAGE.exec(record.image ?? "");
+    if (!match || match[1] !== expected.image) {
+      failures.push(`${expected.id} record has an invalid image identity`);
+      continue;
+    }
+    components.push({
+      id: expected.id,
+      image: record.image,
+      platform: expected.platform,
+      attestationType: expected.attestationType,
+    });
+  }
+  for (const id of byId.keys()) {
+    if (!contract.components.some((component) => component.id === id)) {
+      failures.push(`unknown component record ${id}`);
+    }
+  }
+  if (!SHA.test(metadata.commit ?? "")) failures.push("bundle commit is invalid");
+  if (!VERSION.test(metadata.version ?? "")) failures.push("bundle version is invalid");
+  if (!SHA.test(metadata.mdbaseRsRevision ?? "")) {
+    failures.push("bundle mdbase-rs revision is invalid");
+  }
+  for (const field of ["qualificationRunId", "qualificationRunAttempt",
+    "publicationRunId", "publicationRunAttempt"]) {
+    if (!Number.isSafeInteger(metadata[field]) || metadata[field] < 1) {
+      failures.push(`${field} must be a positive integer`);
+    }
+  }
+  if (failures.length > 0) throw new Error(failures.join("\n"));
+
+  return {
+    schemaVersion: 1,
+    repository: contract.repository,
+    commit: metadata.commit,
+    version: metadata.version,
+    sourceDependencies: { "mdbase-rs": metadata.mdbaseRsRevision },
+    qualification: {
+      workflow: "server-ci.yml",
+      runId: metadata.qualificationRunId,
+      runAttempt: metadata.qualificationRunAttempt,
+    },
+    publication: {
+      workflow: contract.publication.workflow,
+      runId: metadata.publicationRunId,
+      runAttempt: metadata.publicationRunAttempt,
+    },
+    components,
+  };
+}
+
+export function validateReleaseBundle(contract, bundle) {
+  const failures = [];
+  if (!requireObject(bundle, "release bundle", failures)) return failures;
+  requireExactFields(bundle, new Set([
+    "schemaVersion", "repository", "commit", "version", "sourceDependencies",
+    "qualification", "publication", "components",
+  ]), "release bundle", failures);
+  if (bundle.schemaVersion !== 1) failures.push("bundle schemaVersion must be 1");
+  if (bundle.repository !== contract.repository) failures.push("bundle repository is invalid");
+  if (!SHA.test(bundle.commit ?? "")) failures.push("bundle commit is invalid");
+  if (!VERSION.test(bundle.version ?? "")) failures.push("bundle version is invalid");
+  if (!SHA.test(bundle.sourceDependencies?.["mdbase-rs"] ?? "")) {
+    failures.push("bundle mdbase-rs revision is invalid");
+  }
+  for (const [name, identity] of [["qualification", bundle.qualification],
+    ["publication", bundle.publication]]) {
+    if (!requireObject(identity, name, failures)) continue;
+    if (!Number.isSafeInteger(identity.runId) || identity.runId < 1) {
+      failures.push(`${name}.runId is invalid`);
+    }
+    if (!Number.isSafeInteger(identity.runAttempt) || identity.runAttempt < 1) {
+      failures.push(`${name}.runAttempt is invalid`);
+    }
+  }
+  if (bundle.qualification?.workflow !== "server-ci.yml") {
+    failures.push("qualification workflow is invalid");
+  }
+  if (bundle.publication?.workflow !== contract.publication.workflow) {
+    failures.push("publication workflow is invalid");
+  }
+  try {
+    buildReleaseBundle(contract, (bundle.components ?? []).map((component) => ({
+      component: component.id,
+      commit: bundle.commit,
+      image: component.image,
+    })), {
+      commit: bundle.commit,
+      version: bundle.version,
+      mdbaseRsRevision: bundle.sourceDependencies?.["mdbase-rs"],
+      qualificationRunId: bundle.qualification?.runId,
+      qualificationRunAttempt: bundle.qualification?.runAttempt,
+      publicationRunId: bundle.publication?.runId,
+      publicationRunAttempt: bundle.publication?.runAttempt,
+    });
+  } catch (error) {
+    failures.push(...error.message.split("\n"));
+  }
+  for (const component of bundle.components ?? []) {
+    const expected = contract.components.find(({ id }) => id === component.id);
+    if (expected && (component.platform !== expected.platform ||
+        component.attestationType !== expected.attestationType)) {
+      failures.push(`${component.id} metadata does not match the release contract`);
+    }
+  }
+  return [...new Set(failures)];
+}

--- a/scripts/lib/release-components.test.mjs
+++ b/scripts/lib/release-components.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import {
+  buildReleaseBundle,
+  githubMatrix,
+  validateReleaseBundle,
+  validateReleaseComponents,
+} from "./release-components.mjs";
+
+const root = path.resolve(new URL("../..", import.meta.url).pathname);
+const contract = JSON.parse(await readFile(
+  path.join(root, "config/release-components.json"), "utf8"));
+const commit = "a".repeat(40);
+const digest = (character) => `sha256:${character.repeat(64)}`;
+const records = contract.components.map((component, index) => ({
+  component: component.id,
+  commit,
+  image: `${component.image}@${digest(String(index + 1))}`,
+}));
+const metadata = {
+  commit,
+  version: "0.1.0-beta.99",
+  mdbaseRsRevision: "b".repeat(40),
+  qualificationRunId: 10,
+  qualificationRunAttempt: 1,
+  publicationRunId: 11,
+  publicationRunAttempt: 2,
+};
+
+const clone = (value) => structuredClone(value);
+
+test("the checked-in release component contract is valid", async () => {
+  assert.deepEqual(await validateReleaseComponents(contract, { root }), []);
+  assert.deepEqual(githubMatrix(contract).include.map(({ component }) => component),
+    ["connect", "hosted-provider", "mcp", "client"]);
+});
+
+test("contract validation rejects duplicates, unknown fields, and missing client", async () => {
+  const invalid = clone(contract);
+  invalid.components[0].unexpected = true;
+  invalid.components[1].id = invalid.components[0].id;
+  invalid.components = invalid.components.filter(({ id }) => id !== "client");
+  const failures = await validateReleaseComponents(invalid, { root });
+  assert(failures.some((failure) => failure.includes("unknown field unexpected")));
+  assert(failures.some((failure) => failure.includes("duplicate component connect")));
+  assert(failures.some((failure) => failure.includes("required component client is missing")));
+});
+
+test("bundle generation requires exactly every contract component", () => {
+  assert.throws(() => buildReleaseBundle(contract, records.slice(0, -1), metadata),
+    /required component record client is missing/);
+  assert.throws(() => buildReleaseBundle(contract,
+    [...records, { component: "unknown", commit, image: `ghcr.io/mdbase-dev/unknown@${digest("f")}` }],
+    metadata), /unknown component record unknown/);
+});
+
+test("bundle generation rejects mutable, wrong-repository, and wrong-commit records", () => {
+  for (const image of [
+    "ghcr.io/mdbase-dev/mdbase-connect-server:latest",
+    `ghcr.io/mdbase-dev/wrong@${digest("f")}`,
+  ]) {
+    const invalid = clone(records);
+    invalid[0].image = image;
+    assert.throws(() => buildReleaseBundle(contract, invalid, metadata),
+      /invalid image identity/);
+  }
+  const invalid = clone(records);
+  invalid[0].commit = "c".repeat(40);
+  assert.throws(() => buildReleaseBundle(contract, invalid, metadata),
+    /different source commit/);
+});
+
+test("a generated bundle validates and identity drift is rejected", () => {
+  const bundle = buildReleaseBundle(contract, records, metadata);
+  assert.deepEqual(validateReleaseBundle(contract, bundle), []);
+
+  bundle.publication.workflow = "other.yml";
+  bundle.components[0].platform = "linux/arm64";
+  const failures = validateReleaseBundle(contract, bundle);
+  assert(failures.includes("publication workflow is invalid"));
+  assert(failures.some((failure) => failure.includes("metadata does not match")));
+});

--- a/scripts/release-components.mjs
+++ b/scripts/release-components.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  buildReleaseBundle,
+  githubMatrix,
+  readComponentRecords,
+  validateReleaseBundle,
+  validateReleaseComponents,
+} from "./lib/release-components.mjs";
+
+const root = path.resolve(new URL("..", import.meta.url).pathname);
+const contract = JSON.parse(await readFile(
+  path.join(root, "config/release-components.json"), "utf8"));
+const failures = await validateReleaseComponents(contract, { root });
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index];
+  if (!arg.startsWith("--")) throw new Error(`Unexpected argument: ${arg}`);
+  if (["--github-matrix", "--check"].includes(arg)) args.set(arg, true);
+  else args.set(arg, process.argv[++index]);
+}
+
+if (args.has("--github-matrix")) {
+  process.stdout.write(`${JSON.stringify(githubMatrix(contract))}\n`);
+} else if (args.has("--build-bundle")) {
+  const packageManifest = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+  const records = await readComponentRecords(path.resolve(args.get("--components-dir")));
+  const bundle = buildReleaseBundle(contract, records, {
+    commit: args.get("--commit"),
+    version: packageManifest.version,
+    mdbaseRsRevision: (await readFile(
+      path.join(root, "deploy/docker/mdbase-rs-revision"), "utf8")).trim(),
+    qualificationRunId: Number(args.get("--qualification-run-id")),
+    qualificationRunAttempt: Number(args.get("--qualification-run-attempt")),
+    publicationRunId: Number(args.get("--publication-run-id")),
+    publicationRunAttempt: Number(args.get("--publication-run-attempt")),
+  });
+  const bundleFailures = validateReleaseBundle(contract, bundle);
+  if (bundleFailures.length > 0) throw new Error(bundleFailures.join("\n"));
+  await writeFile(path.resolve(args.get("--build-bundle")),
+    `${JSON.stringify(bundle, null, 2)}\n`);
+} else {
+  console.log(`Release component contract is valid (${contract.components.length} components).`);
+}


### PR DESCRIPTION
## Summary

- define one validated public inventory for connect, hosted-provider, MCP, and client release artifacts
- drive normal and isolated-staging image matrices from that inventory
- generate and keylessly sign an exact-commit release bundle containing component digests, mdbase-rs revision, and CI/publication run identities
- register validation in Server CI and pin release-sensitive actions immutably

## Safety

The bundle is an evidence index, not an authority: private ops independently verifies GitHub run identities, image signatures, attestations, source commits, and registry digests. No deployment topology or secrets are public.

## Validation

- `node --test scripts/lib/*.test.mjs` (63 tests)
- `node scripts/release-components.mjs --check`
- actionlint on changed publication workflows
- `git diff --check`