### PR TITLE
release: prepare beta86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 0.1.0-beta.86
+
+Beta.86 opens verified public password signup and makes non-production Connect
+environments explicit and isolated.
+
+- Public signup verifies email ownership before accepting a password, preserves
+  same-origin authorization return targets, rate-limits requests and token
+  redemption, and avoids revealing whether an account already exists.
+- New public accounts receive the standard beta entitlement, starter collection,
+  legal agreement records, and a signed-in browser session atomically.
+- Invitation signup remains available while registration is open, and the retired
+  beta-access request endpoint no longer stores submissions.
+- Server health identifies the deployment environment, while editor and desktop
+  tooling reject mismatched lab, staging, and production endpoint combinations.
+
 ## 0.1.0-beta.85
 
 Beta.85 makes SDK startup explicit and turns application declaration drift into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ environments explicit and isolated.
 - Public signup verifies email ownership before accepting a password, preserves
   same-origin authorization return targets, rate-limits requests and token
   redemption, and avoids revealing whether an account already exists.
-- New public accounts receive the standard beta entitlement, starter collection,
+- New public accounts receive the permanent open-beta entitlement, including
+  1 GiB hosted storage and three hosted collections, plus a starter collection,
   legal agreement records, and a signed-in browser session atomically.
-- Invitation signup remains available while registration is open, and the retired
-  beta-access request endpoint no longer stores submissions.
+- Account creation claims canonical verified emails across password, invitation,
+  and external-provider flows so concurrent signups cannot create duplicate
+  owners without authenticated account linking.
+- Invitation signup retains its original ten-collection beta allowance while
+  registration is open, and the retired beta-access request endpoint no longer
+  stores submissions.
 - Server health identifies the deployment environment, while editor and desktop
   tooling reject mismatched lab, staging, and production endpoint combinations.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.85"
+version = "0.1.0-beta.86"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.85" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.86" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.85",
+  "version": "0.1.0-beta.86",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -144,7 +144,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.85",
+        version: "0.1.0-beta.86",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary
- promote verified public signup and environment isolation to `0.1.0-beta.86`
- update all npm, Rust workspace, MCP, desktop, portal, and server version surfaces
- refresh canonical and hosted-provider Cargo locks

## Verification
- `pnpm version:check`
- `pnpm check:release-readiness`
- architecture and generated protocol checks
- `cargo check --locked --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`

## Release gates
Two stable-only gates remain intentionally open for this beta: encrypted backup restore drill and platform signing/notarization.