### PR TITLE
Harden public signup isolation, identity, and entitlements

### DIFF
--- a/apps/desktop/src/renderer/runtime-config.ts
+++ b/apps/desktop/src/renderer/runtime-config.ts
@@ -1,0 +1,26 @@
+export const PRODUCTION_CONNECT_ORIGIN = "https://connect.mdbase.dev";
+
+export function defaultConnectServerUrl(value: string | undefined): string {
+  const configured = value?.trim() || PRODUCTION_CONNECT_ORIGIN;
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw new TypeError("The default Connect server must be a valid origin.");
+  }
+  const loopback = ["localhost", "127.0.0.1", "[::1]", "::1"]
+    .includes(url.hostname);
+  if (
+    (url.protocol !== "https:" && !(url.protocol === "http:" && loopback))
+    || url.username
+    || url.password
+    || url.pathname !== "/"
+    || url.search
+    || url.hash
+  ) {
+    throw new TypeError(
+      "The default Connect server must be a credential-free HTTPS origin."
+    );
+  }
+  return url.origin;
+}

--- a/apps/desktop/src/renderer/ui-components.tsx
+++ b/apps/desktop/src/renderer/ui-components.tsx
@@ -12,10 +12,13 @@ import {
 import React, { useEffect, useRef, useState } from "react";
 import type { ConnectionDotState } from "./connection-state.mjs";
 import { markPairingCompleted } from "./onboarding-state.mjs";
+import { defaultConnectServerUrl } from "./runtime-config";
 import { message, type Route } from "./view-model";
 
 export function PairingPanel({ resumeAuthorization = false }: { resumeAuthorization?: boolean }) {
-  const [serverUrl, setServerUrl] = useState("https://connect.mdbase.dev");
+  const [serverUrl, setServerUrl] = useState(() => defaultConnectServerUrl(
+    import.meta.env.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL
+  ));
   const [connectorName, setConnectorName] = useState("This computer");
   const [pairing, setPairing] = useState<{ pairingId: string; verificationUri: string } | null>(null);
   const [pairError, setPairError] = useState("");

--- a/apps/desktop/test/renderer-runtime-config.test.mjs
+++ b/apps/desktop/test/renderer-runtime-config.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  defaultConnectServerUrl,
+  PRODUCTION_CONNECT_ORIGIN
+} from "../src/renderer/runtime-config.ts";
+
+test("uses an isolated desktop Connect origin instead of the production fallback", () => {
+  assert.equal(
+    defaultConnectServerUrl(" https://mdbase-connect-lab.onrender.com/ "),
+    "https://mdbase-connect-lab.onrender.com"
+  );
+  assert.equal(defaultConnectServerUrl(undefined), PRODUCTION_CONNECT_ORIGIN);
+});
+
+test("rejects unsafe or non-origin Connect defaults", () => {
+  for (const value of [
+    "https://user:secret@connect.example",
+    "https://connect.example/path",
+    "http://connect.example"
+  ]) {
+    assert.throws(
+      () => defaultConnectServerUrl(value),
+      /credential-free HTTPS origin|valid origin/u
+    );
+  }
+  assert.equal(
+    defaultConnectServerUrl("http://127.0.0.1:8787"),
+    "http://127.0.0.1:8787"
+  );
+});

--- a/apps/portal/portal-model.test.mjs
+++ b/apps/portal/portal-model.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { capturePortalBootstrapSecrets, message } from "./src/portal-model.ts";
+import {
+  capturePortalBootstrapSecrets,
+  message,
+  returnTarget,
+  signInUrl
+} from "./src/portal-model.ts";
 
 test("captures one-time auth fragments before rendering and removes them from history", () => {
   const replacements = [];
@@ -44,6 +49,38 @@ test("does not rewrite unrelated fragments", () => {
     resetToken: ""
   });
   assert.equal(replaced, false);
+});
+
+test("preserves a same-origin signup return through sign in", () => {
+  const currentLocation = {
+    origin: "https://connect.example",
+    search: "?return_to=%2Fauthorize%2Frequest%3Fsource%3Dsignup%23resume"
+  };
+
+  assert.equal(
+    returnTarget(currentLocation),
+    "https://connect.example/authorize/request?source=signup#resume"
+  );
+  const login = new URL(signInUrl(currentLocation), currentLocation.origin);
+  assert.equal(login.pathname, "/login");
+  assert.equal(
+    login.searchParams.get("return_to"),
+    "https://connect.example/authorize/request?source=signup#resume"
+  );
+});
+
+test("does not preserve an invalid or cross-origin signup return", () => {
+  for (const requested of [
+    "https://evil.example/authorize/request",
+    "http://[invalid"
+  ]) {
+    const currentLocation = {
+      origin: "https://connect.example",
+      search: `?return_to=${encodeURIComponent(requested)}`
+    };
+    assert.equal(returnTarget(currentLocation), "/");
+    assert.equal(signInUrl(currentLocation), "/login");
+  }
 });
 
 test("renders the first collection setup diagnostic with its path", () => {

--- a/apps/portal/src/auth-view.tsx
+++ b/apps/portal/src/auth-view.tsx
@@ -4,7 +4,8 @@ import { api, ApiError } from "./api";
 import {
   isAuthorizationReturnTarget,
   message,
-  returnTarget
+  returnTarget,
+  signInUrl
 } from "./portal-model";
 import { Loading, PageBrand } from "./portal-ui";
 
@@ -517,7 +518,7 @@ export function Signup({
             </button>
           </form>
         )}
-        <a className="quiet-auth-link" href="/login">Return to sign in</a>
+        <a className="quiet-auth-link" href={signInUrl()}>Return to sign in</a>
       </section>
     </main>
   );
@@ -609,7 +610,7 @@ export function Signup({
             </button>
           </form>
         )}
-        <a className="quiet-auth-link" href="/login">Return to sign in</a>
+        <a className="quiet-auth-link" href={signInUrl()}>Return to sign in</a>
       </section>
     </main>
   );

--- a/apps/portal/src/portal-model.ts
+++ b/apps/portal/src/portal-model.ts
@@ -64,11 +64,29 @@ export function scopeDescription(contracts: ContractRequirement[]) {
   const names = contracts.map((contract) => `${contract.id} v${contract.version}`);
   return `Access is limited to records matching ${names.join(" and ")}.`;
 }
-export function returnTarget() {
-  const requested = new URLSearchParams(location.search).get("return_to");
-  if (!requested) return "/";
-  const target = new URL(requested, location.origin);
-  return target.origin === location.origin ? target.href : "/";
+type ReturnLocation = Pick<Location, "origin" | "search">;
+
+function validatedReturnTarget(currentLocation: ReturnLocation): URL | null {
+  const requested = new URLSearchParams(currentLocation.search).get("return_to");
+  if (!requested) return null;
+  try {
+    const target = new URL(requested, currentLocation.origin);
+    return target.origin === currentLocation.origin ? target : null;
+  } catch {
+    return null;
+  }
+}
+
+export function returnTarget(currentLocation: ReturnLocation = location) {
+  return validatedReturnTarget(currentLocation)?.href ?? "/";
+}
+
+export function signInUrl(currentLocation: ReturnLocation = location): string {
+  const target = validatedReturnTarget(currentLocation);
+  if (!target) return "/login";
+  const login = new URL("/login", currentLocation.origin);
+  login.searchParams.set("return_to", target.href);
+  return `${login.pathname}${login.search}`;
 }
 export type PortalBootstrapSecrets = Readonly<{
   invitationToken: string;

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -106,6 +106,12 @@ the link. Challenges are one-hour and single-use;
 requesting another invalidates the previous challenge. Account creation,
 verified email ownership, password credential, agreement acceptance, session,
 entitlement, and starter-collection scheduling commit in one transaction.
+Public signup assigns the permanent `open_beta_v1` profile: 1 GiB live hosted
+storage, 2 GiB retained file storage, three hosted collections in total
+(including the starter collection), 2 MiB per Markdown document, 250 MiB per
+file, 10,000 files per collection, 10 mirror replicas per collection, and 50
+application replicas per collection. Invitation-based `beta_v1` grants retain
+their existing ten-collection allowance.
 
 Password reset links use the same boundary:
 `/reset-password#reset=<token>`. The challenge expires after one hour.

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -18,7 +18,11 @@ the following tables:
 Matching email text never links accounts. Linking requires an authenticated
 session for the existing account plus fresh proof of the identity being added.
 An OAuth callback may update presentation data for its existing provider
-subject, but it cannot claim an email identity owned by another account.
+subject, but it cannot create another account with a verified email already
+claimed for account creation. The user must sign in to that account and link the
+provider from account settings instead. Account-creation claims are reserved in
+the same transaction as the new account; authenticated provider linking does
+not transfer them or infer ownership from matching email text.
 
 Email normalization is deliberately conservative and versioned. Version 1
 trims outer whitespace, applies Unicode NFC, lower-cases the local and domain
@@ -143,10 +147,12 @@ Separate scopes cover normalized email, source network, account, and global
 send volume.
 
 Recovery and public-signup requests allow three attempts per normalized
-address and ten per source network per hour. Reset and signup-verification
-redemption are separately limited by token and source network. All scopes also
-consume the shared global authentication limit. The unauthenticated request
-response remains generic until a limit is crossed.
+address and ten per source network per hour. Signup-verification preview and
+account redemption use separate token, source-network, and global scopes so
+reloading a valid link cannot consume the budget needed to create the account.
+Reset and signup redemption remain independently limited by token and source
+network. The unauthenticated request response remains generic until a limit is
+crossed.
 
 The application will own limit duration, escalation, and cleanup policy. The
 database table owns only the shared counter state. This lets the beta use

--- a/scripts/deploy-editor-dev.mjs
+++ b/scripts/deploy-editor-dev.mjs
@@ -2,18 +2,20 @@ import { spawn } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  managedEnvironments,
+  normalizedEndpointOrigin
+} from "./lib/managed-environments.mjs";
 
 export const developmentDeployments = Object.freeze({
   lab: Object.freeze({
-    editorOrigin: "https://candidate-b.mdbase-editor.pages.dev",
-    connectOrigin: "https://mdbase-connect-lab.onrender.com",
+    ...managedEnvironments.lab,
     project: "mdbase-editor",
     branch: "candidate-b",
     wranglerVersion: "4.114.0"
   }),
   staging: Object.freeze({
-    editorOrigin: "https://editor-staging.mdbase.dev",
-    connectOrigin: "https://connect-staging.mdbase.dev",
+    ...managedEnvironments.staging,
     project: "mdbase-editor",
     branch: "staging",
     wranglerVersion: "4.114.0"
@@ -34,7 +36,12 @@ export async function deployDevelopmentEditor(environment, run = runCommand) {
     throw new Error("Development editor deployments are restricted to lab and staging.");
   }
   const deployment = developmentDeployments[target];
-  const requestedOrigin = environment.MDBASE_CONNECT_URL?.trim();
+  const requestedOrigin = environment.MDBASE_CONNECT_URL?.trim()
+    ? normalizedEndpointOrigin(
+        environment.MDBASE_CONNECT_URL,
+        "MDBASE_CONNECT_URL"
+      )
+    : undefined;
   if (requestedOrigin && requestedOrigin !== deployment.connectOrigin) {
     throw new Error(`MDBASE_CONNECT_URL does not match the ${target} environment.`);
   }

--- a/scripts/deploy-editor-dev.test.mjs
+++ b/scripts/deploy-editor-dev.test.mjs
@@ -4,7 +4,9 @@ import { deployDevelopmentEditor, developmentDeployments } from "./deploy-editor
 
 test("builds and deploys the editor against lab by default", async () => {
   const calls = [];
-  await deployDevelopmentEditor({}, async (command, args, environment) => {
+  await deployDevelopmentEditor({
+    MDBASE_CONNECT_URL: `${developmentDeployments.lab.connectOrigin}/`
+  }, async (command, args, environment) => {
     calls.push({ command, args, environment });
   });
 

--- a/scripts/isolated-desktop.mjs
+++ b/scripts/isolated-desktop.mjs
@@ -5,6 +5,10 @@ import { mkdir, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { availablePort } from "./lib/connect-test-environment.mjs";
+import {
+  managedEnvironments,
+  normalizedEndpointOrigin
+} from "./lib/managed-environments.mjs";
 import { stagingEnvironment } from "./lib/staging-environment.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "..");
@@ -25,8 +29,16 @@ export async function isolatedDesktopConfiguration(
   allocatePort = availablePort
 ) {
   const staging = arguments_.includes("--staging");
-  const namedEnvironment = environment.MDBASE_ENV?.trim()
-    || (staging ? "staging" : "development");
+  const requestedEnvironment = environment.MDBASE_ENV?.trim();
+  if (staging && requestedEnvironment && requestedEnvironment !== "staging") {
+    throw new Error("The staging flag cannot be combined with another MDBASE_ENV.");
+  }
+  const namedEnvironment = staging
+    ? "staging"
+    : requestedEnvironment || "development";
+  if (!/^[a-z][a-z0-9-]{0,31}$/u.test(namedEnvironment)) {
+    throw new Error("MDBASE_ENV must be a lowercase environment identifier.");
+  }
   const profileDirectory = staging
     ? stagingDesktop.profileDirectory
     : `desktop-${namedEnvironment}-profile`;
@@ -39,12 +51,19 @@ export async function isolatedDesktopConfiguration(
   );
   const loopbackPort = environment.MDBASE_CONNECT_LOOPBACK_PORT
     ?? (staging ? stagingDesktop.loopbackPort : String(await allocatePort()));
+  if (!/^[1-9][0-9]{0,4}$/u.test(String(loopbackPort))) {
+    throw new Error("MDBASE_CONNECT_LOOPBACK_PORT must be a valid TCP port.");
+  }
+  const numericLoopbackPort = Number(loopbackPort);
+  if (numericLoopbackPort > 65_535) {
+    throw new Error("MDBASE_CONNECT_LOOPBACK_PORT must be a valid TCP port.");
+  }
   const childEnvironment = {
     ...environment,
-    VITE_MDBASE_ENV: environment.VITE_MDBASE_ENV ?? namedEnvironment,
+    VITE_MDBASE_ENV: namedEnvironment,
     MDBASE_CONNECT_HOME: connectHome,
     MDBASE_CONNECT_USER_DATA_DIR: userData,
-    MDBASE_CONNECT_LOOPBACK_PORT: loopbackPort,
+    MDBASE_CONNECT_LOOPBACK_PORT: String(numericLoopbackPort),
     MDBASE_CONNECT_REGISTER_DEEP_LINKS:
       environment.MDBASE_CONNECT_REGISTER_DEEP_LINKS ?? "0"
   };
@@ -53,40 +72,59 @@ export async function isolatedDesktopConfiguration(
     environment.MDBASE_CONNECT_SERVER_URL,
     environment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL
   ].map((value) => value?.trim()).filter(Boolean);
-  const distinctServerTargets = [...new Set(serverTargets)];
+  const normalizedServerTargets = serverTargets.map((value) =>
+    normalizedEndpointOrigin(value, "The isolated desktop Connect server")
+  );
+  const distinctServerTargets = [...new Set(normalizedServerTargets)];
   if (distinctServerTargets.length > 1) {
     throw new Error("Isolated desktop Connect server targets must match.");
   }
   const configuredServer = distinctServerTargets[0];
-  const configuredEditor = environment.MDBASE_EDITOR_URL?.trim();
+  const configuredEditor = environment.MDBASE_EDITOR_URL?.trim()
+    ? normalizedEndpointOrigin(
+        environment.MDBASE_EDITOR_URL,
+        "The isolated desktop editor"
+      )
+    : undefined;
+  if (Boolean(configuredServer) !== Boolean(configuredEditor)) {
+    throw new Error(
+      "Named isolated desktop environments require both Connect and editor URLs."
+    );
+  }
+
+  const managed = managedEnvironments[namedEnvironment];
   if (staging) {
-    if (configuredServer && configuredServer !== stagingDesktop.serverUrl) {
+    if (configuredServer && configuredServer !== managed.connectOrigin) {
       throw new Error("The staging desktop requires the staging Connect service.");
     }
-    if (configuredEditor && configuredEditor !== stagingDesktop.editorUrl) {
+    if (configuredEditor && configuredEditor !== managed.editorOrigin) {
       throw new Error("The staging desktop requires the staging editor.");
     }
-    childEnvironment.MDBASE_EDITOR_URL = stagingDesktop.editorUrl;
+    childEnvironment.MDBASE_EDITOR_URL = `${managed.editorOrigin}/`;
     childEnvironment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL =
-      stagingDesktop.serverUrl;
-  } else {
-    if (Boolean(configuredServer) !== Boolean(configuredEditor)) {
-      throw new Error(
-        "Named isolated desktop environments require both Connect and editor URLs."
-      );
-    }
-    if (
-      ["lab", "staging", "production"].includes(namedEnvironment)
-      && !configuredServer
-    ) {
+      managed.connectOrigin;
+  } else if (managed) {
+    if (!configuredServer || !configuredEditor) {
       throw new Error(
         `${namedEnvironment} isolated desktops require explicit Connect and editor URLs.`
       );
     }
-    if (configuredServer && configuredEditor) {
-      childEnvironment.MDBASE_EDITOR_URL = configuredEditor;
-      childEnvironment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL = configuredServer;
+    if (configuredServer !== managed.connectOrigin) {
+      throw new Error(
+        `The ${namedEnvironment} desktop requires the ${namedEnvironment} Connect service.`
+      );
     }
+    if (configuredEditor !== managed.editorOrigin) {
+      throw new Error(
+        `The ${namedEnvironment} desktop requires the ${namedEnvironment} editor.`
+      );
+    }
+    childEnvironment.MDBASE_EDITOR_URL = `${managed.editorOrigin}/`;
+    childEnvironment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL =
+      managed.connectOrigin;
+  } else if (configuredServer && configuredEditor) {
+    childEnvironment.MDBASE_EDITOR_URL = `${configuredEditor}/`;
+    childEnvironment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL = configuredServer;
   }
   return {
     staging,
@@ -94,7 +132,7 @@ export async function isolatedDesktopConfiguration(
     fresh: arguments_.includes("--fresh"),
     userData,
     connectHome,
-    loopbackPort,
+    loopbackPort: String(numericLoopbackPort),
     childEnvironment
   };
 }

--- a/scripts/lib/isolated-desktop.test.mjs
+++ b/scripts/lib/isolated-desktop.test.mjs
@@ -5,6 +5,7 @@ import {
   isolatedDesktopConfiguration,
   stagingDesktop
 } from "../isolated-desktop.mjs";
+import { managedEnvironments } from "./managed-environments.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 
@@ -66,23 +67,43 @@ test("explicit development overrides remain available without reading production
   assert.equal(configuration.childEnvironment.MDBASE_CONNECT_REGISTER_DEEP_LINKS, "1");
 });
 
-test("registry-provided environments configure Electron without staging-only flags", async () => {
+test("managed environments configure exact Connect and editor origins", async () => {
+  for (const [name, target] of Object.entries(managedEnvironments)) {
+    const configuration = await isolatedDesktopConfiguration({
+      MDBASE_ENV: name,
+      MDBASE_CONNECT_URL: `${target.connectOrigin}/`,
+      MDBASE_EDITOR_URL: `${target.editorOrigin}/`,
+      MDBASE_CONNECT_LOOPBACK_PORT: "28487"
+    }, [], async () => 1);
+
+    assert.equal(configuration.namedEnvironment, name);
+    assert.equal(configuration.loopbackPort, "28487");
+    assert.equal(
+      configuration.childEnvironment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL,
+      target.connectOrigin
+    );
+    assert.equal(
+      configuration.childEnvironment.MDBASE_EDITOR_URL,
+      `${target.editorOrigin}/`
+    );
+  }
+});
+
+test("registry preview environments retain explicit paired origins", async () => {
   const configuration = await isolatedDesktopConfiguration({
-    MDBASE_ENV: "lab",
-    MDBASE_CONNECT_URL: "https://mdbase-connect-lab.onrender.com",
-    MDBASE_EDITOR_URL: "https://candidate-b.mdbase-editor.pages.dev",
-    MDBASE_CONNECT_LOOPBACK_PORT: "28487"
+    MDBASE_ENV: "candidate-x",
+    MDBASE_CONNECT_URL: "https://connect-candidate-x.example/",
+    MDBASE_EDITOR_URL: "https://editor-candidate-x.example/"
   }, [], async () => 1);
 
-  assert.equal(configuration.namedEnvironment, "lab");
-  assert.equal(configuration.loopbackPort, "28487");
+  assert.equal(configuration.namedEnvironment, "candidate-x");
   assert.equal(
     configuration.childEnvironment.VITE_MDBASE_CONNECT_DEFAULT_SERVER_URL,
-    "https://mdbase-connect-lab.onrender.com"
+    "https://connect-candidate-x.example"
   );
   assert.equal(
     configuration.childEnvironment.MDBASE_EDITOR_URL,
-    "https://candidate-b.mdbase-editor.pages.dev"
+    "https://editor-candidate-x.example/"
   );
 });
 
@@ -108,12 +129,67 @@ test("named environments reject incomplete or conflicting endpoint pairs", async
   );
 });
 
-test("staging flags reject endpoint overrides from another environment", async () => {
+test("managed names reject endpoints from another environment", async () => {
+  await assert.rejects(
+    isolatedDesktopConfiguration({
+      MDBASE_ENV: "lab",
+      MDBASE_CONNECT_URL: managedEnvironments.production.connectOrigin,
+      MDBASE_EDITOR_URL: managedEnvironments.production.editorOrigin
+    }, [], async () => 1),
+    /lab desktop requires the lab Connect service/
+  );
+  await assert.rejects(
+    isolatedDesktopConfiguration({
+      MDBASE_ENV: "production",
+      MDBASE_CONNECT_URL: managedEnvironments.production.connectOrigin,
+      MDBASE_EDITOR_URL: managedEnvironments.staging.editorOrigin
+    }, [], async () => 1),
+    /production desktop requires the production editor/
+  );
+});
+
+test("staging flags reject endpoint and environment overrides", async () => {
   await assert.rejects(
     isolatedDesktopConfiguration({
       MDBASE_CONNECT_URL: "https://connect.mdbase.dev",
       MDBASE_EDITOR_URL: "https://editor.mdbase.dev"
     }, ["--staging"], async () => 1),
     /requires the staging Connect service/
+  );
+  await assert.rejects(
+    isolatedDesktopConfiguration({ MDBASE_ENV: "production" }, ["--staging"], async () => 1),
+    /cannot be combined with another MDBASE_ENV/
+  );
+});
+
+test("managed environments override inherited renderer labels", async () => {
+  const configuration = await isolatedDesktopConfiguration({
+    VITE_MDBASE_ENV: "production"
+  }, ["--staging"], async () => 1);
+  assert.equal(configuration.childEnvironment.VITE_MDBASE_ENV, "staging");
+});
+
+test("environment endpoint configuration rejects unsafe values", async () => {
+  await assert.rejects(
+    isolatedDesktopConfiguration({
+      MDBASE_ENV: "candidate-x",
+      MDBASE_CONNECT_URL: "https://user:secret@connect.example",
+      MDBASE_EDITOR_URL: "https://editor.example"
+    }, [], async () => 1),
+    /credential-free HTTP or HTTPS origin/
+  );
+  await assert.rejects(
+    isolatedDesktopConfiguration({
+      MDBASE_ENV: "../../outside",
+      MDBASE_CONNECT_URL: "https://connect.example",
+      MDBASE_EDITOR_URL: "https://editor.example"
+    }, [], async () => 1),
+    /lowercase environment identifier/
+  );
+  await assert.rejects(
+    isolatedDesktopConfiguration({
+      MDBASE_CONNECT_LOOPBACK_PORT: "70000"
+    }, [], async () => 1),
+    /valid TCP port/
   );
 });

--- a/scripts/lib/managed-environments.mjs
+++ b/scripts/lib/managed-environments.mjs
@@ -1,0 +1,34 @@
+export const managedEnvironments = Object.freeze({
+  lab: Object.freeze({
+    connectOrigin: "https://mdbase-connect-lab.onrender.com",
+    editorOrigin: "https://candidate-b.mdbase-editor.pages.dev"
+  }),
+  staging: Object.freeze({
+    connectOrigin: "https://connect-staging.mdbase.dev",
+    editorOrigin: "https://editor-staging.mdbase.dev"
+  }),
+  production: Object.freeze({
+    connectOrigin: "https://connect.mdbase.dev",
+    editorOrigin: "https://editor.mdbase.dev"
+  })
+});
+
+export function normalizedEndpointOrigin(value, name) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${name} must be a valid HTTP or HTTPS origin.`);
+  }
+  if (
+    !["http:", "https:"].includes(url.protocol)
+    || url.username
+    || url.password
+    || url.pathname !== "/"
+    || url.search
+    || url.hash
+  ) {
+    throw new Error(`${name} must be a credential-free HTTP or HTTPS origin.`);
+  }
+  return url.origin;
+}

--- a/scripts/lib/staging-environment.mjs
+++ b/scripts/lib/staging-environment.mjs
@@ -1,6 +1,7 @@
+import { managedEnvironments } from "./managed-environments.mjs";
+
 export const stagingEnvironment = Object.freeze({
-  connectOrigin: "https://connect-staging.mdbase.dev",
-  editorOrigin: "https://editor-staging.mdbase.dev",
+  ...managedEnvironments.staging,
   loopbackPort: 28_486,
   loopbackOrigin: "http://127.0.0.1:28486"
 });

--- a/services/server/migrations/0022_account_creation_email_claims.sql
+++ b/services/server/migrations/0022_account_creation_email_claims.sql
@@ -1,0 +1,20 @@
+CREATE TABLE account_creation_email_claims (
+  normalized_email text PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source text NOT NULL CHECK (source IN ('email_identity', 'external_identity', 'legacy_user')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO account_creation_email_claims (normalized_email, user_id, source)
+SELECT normalized_email, (min(user_id::text))::uuid, 'email_identity'
+FROM email_identities
+WHERE retired_at IS NULL
+GROUP BY normalized_email
+ON CONFLICT(normalized_email) DO NOTHING;
+
+INSERT INTO account_creation_email_claims (normalized_email, user_id, source)
+SELECT normalized_email, (min(user_id::text))::uuid, 'external_identity'
+FROM external_identities
+WHERE email_verified = true AND normalized_email IS NOT NULL
+GROUP BY normalized_email
+ON CONFLICT(normalized_email) DO NOTHING;

--- a/services/server/migrations/0023_open_beta_entitlement.sql
+++ b/services/server/migrations/0023_open_beta_entitlement.sql
@@ -1,0 +1,10 @@
+-- Preserve the original beta_v1 allowance for invited participants while
+-- giving new public-signup accounts a smaller hosted-collection ceiling.
+INSERT INTO entitlement_profiles
+  (code, hosted_storage_bytes, retained_file_bytes, max_document_bytes,
+   max_single_file_bytes, max_mirror_replicas_per_collection,
+   max_application_replicas_per_collection, max_hosted_collections,
+   max_files_per_collection)
+VALUES
+  ('open_beta_v1', 1073741824, 2147483648, 2097152, 262144000,
+   10, 50, 3, 10000);

--- a/services/server/src/account-creation-email-claims.ts
+++ b/services/server/src/account-creation-email-claims.ts
@@ -1,0 +1,79 @@
+import type { DatabaseQueryable } from "./database-types.js";
+import { normalizeEmailAddress } from "./email-identity.js";
+
+export type AccountCreationEmailClaimSource =
+  | "email_identity"
+  | "external_identity"
+  | "legacy_user";
+
+export async function accountCreationEmailClaimed(
+  db: DatabaseQueryable,
+  normalizedEmail: string
+): Promise<boolean> {
+  const result = await db.query(
+    `SELECT user_id FROM account_creation_email_claims
+     WHERE normalized_email = $1
+     UNION ALL
+     SELECT user_id FROM email_identities
+     WHERE normalized_email = $1 AND retired_at IS NULL
+     UNION ALL
+     SELECT user_id FROM external_identities
+     WHERE normalized_email = $1 AND email_verified = true
+     LIMIT 1`,
+    [normalizedEmail]
+  );
+  if (result.rows[0]) return true;
+
+  const legacyUsers = await db.query<{ email: string }>(
+    "SELECT email FROM users WHERE email IS NOT NULL"
+  );
+  return legacyUsers.rows.some(({ email }) => {
+    try {
+      return normalizeEmailAddress(email) === normalizedEmail;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export async function backfillLegacyAccountCreationEmailClaims(
+  db: DatabaseQueryable
+): Promise<void> {
+  const legacyUsers = await db.query<{ id: string; email: string }>(
+    "SELECT id, email FROM users WHERE email IS NOT NULL ORDER BY id"
+  );
+  for (const user of legacyUsers.rows) {
+    let normalizedEmail: string;
+    try {
+      normalizedEmail = normalizeEmailAddress(user.email);
+    } catch {
+      continue;
+    }
+    await reserveAccountCreationEmail(db, {
+      normalizedEmail,
+      userId: user.id,
+      source: "legacy_user"
+    });
+  }
+}
+
+export async function reserveAccountCreationEmail(
+  db: DatabaseQueryable,
+  input: {
+    normalizedEmail: string;
+    userId: string;
+    source: AccountCreationEmailClaimSource;
+  }
+): Promise<boolean> {
+  const claimed = await db.query<{ user_id: string }>(
+    `INSERT INTO account_creation_email_claims
+       (normalized_email, user_id, source)
+     VALUES ($1, $2, $3)
+     ON CONFLICT(normalized_email) DO UPDATE SET
+       normalized_email = excluded.normalized_email
+     WHERE account_creation_email_claims.user_id = excluded.user_id
+     RETURNING user_id`,
+    [input.normalizedEmail, input.userId, input.source]
+  );
+  return claimed.rows[0]?.user_id === input.userId;
+}

--- a/services/server/src/beta-welcome-email.test.ts
+++ b/services/server/src/beta-welcome-email.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  OPEN_BETA_WELCOME_MESSAGE_KIND,
   renderBetaWelcomeEmail,
+  renderOpenBetaWelcomeEmail,
   renderScheduledEmail
 } from "./beta-welcome-email.js";
 
@@ -37,6 +39,25 @@ describe("Beta welcome email", () => {
       text: APPROVED_TEXT
     });
     expect(message.text).toMatch(/^[\x00-\x7f]*$/u);
+  });
+
+  it("renders the open Beta collection and replica limits", () => {
+    const message = renderOpenBetaWelcomeEmail({
+      name: "Person Example",
+      email: "person@example.com"
+    });
+    expect(message.text).toContain("2 GB retained-file allowance");
+    expect(message.text).toContain("up to 10,000 files");
+    expect(message.text).toContain("up to 3 hosted collections in total");
+    expect(message.text).toContain("including the starter collection");
+    expect(message.text).toContain("10 synced folders and 50 application installations");
+    expect(renderScheduledEmail({
+      userId: "user-1",
+      name: "Person Example",
+      email: "person@example.com",
+      messageKind: OPEN_BETA_WELCOME_MESSAGE_KIND,
+      templateVersion: 1
+    })).toEqual(message);
   });
 
   it("escapes recipient names in the matching HTML version", () => {

--- a/services/server/src/beta-welcome-email.ts
+++ b/services/server/src/beta-welcome-email.ts
@@ -7,6 +7,8 @@ import {
 
 export const BETA_WELCOME_MESSAGE_KIND = "beta_welcome";
 export const BETA_WELCOME_TEMPLATE_VERSION = 1;
+export const OPEN_BETA_WELCOME_MESSAGE_KIND = "open_beta_welcome";
+export const OPEN_BETA_WELCOME_TEMPLATE_VERSION = 1;
 const BETA_WELCOME_DELAY_MS = 24 * 60 * 60 * 1_000;
 
 const SUBJECT = "A note about mdbase Connect";
@@ -33,20 +35,61 @@ export async function scheduleBetaWelcomeEmail(
   });
 }
 
+export async function scheduleOpenBetaWelcomeEmail(
+  db: DatabaseQueryable,
+  input: {
+    userId: string;
+    emailIdentityId: string;
+    signedUpAt?: Date;
+  }
+): Promise<{ id: string; duplicate: boolean }> {
+  return scheduleEmail(db, {
+    userId: input.userId,
+    emailIdentityId: input.emailIdentityId,
+    messageKind: OPEN_BETA_WELCOME_MESSAGE_KIND,
+    templateVersion: OPEN_BETA_WELCOME_TEMPLATE_VERSION,
+    category: "onboarding",
+    deduplicationKey:
+      `${OPEN_BETA_WELCOME_MESSAGE_KIND}:${input.userId}:v${OPEN_BETA_WELCOME_TEMPLATE_VERSION}`,
+    scheduledFor: new Date(
+      (input.signedUpAt ?? new Date()).getTime() + BETA_WELCOME_DELAY_MS
+    )
+  });
+}
+
 export function renderScheduledEmail(
   context: EmailRenderContext
 ): TransactionalEmail {
   if (
-    context.messageKind !== BETA_WELCOME_MESSAGE_KIND
-    || context.templateVersion !== BETA_WELCOME_TEMPLATE_VERSION
-  ) {
-    throw new TypeError("Scheduled email template is unavailable.");
-  }
-  return renderBetaWelcomeEmail(context);
+    context.messageKind === BETA_WELCOME_MESSAGE_KIND
+    && context.templateVersion === BETA_WELCOME_TEMPLATE_VERSION
+  ) return renderBetaWelcomeEmail(context);
+  if (
+    context.messageKind === OPEN_BETA_WELCOME_MESSAGE_KIND
+    && context.templateVersion === OPEN_BETA_WELCOME_TEMPLATE_VERSION
+  ) return renderOpenBetaWelcomeEmail(context);
+  throw new TypeError("Scheduled email template is unavailable.");
 }
 
 export function renderBetaWelcomeEmail(
   input: Pick<EmailRenderContext, "name" | "email">
+): TransactionalEmail {
+  return renderWelcomeEmail(input,
+    "Because you joined during the beta, your account has a 1 GB hosted-storage allowance that does not expire when the beta ends. It is shared across your Markdown files and other files. You can create up to 10 hosted collections, connect up to 10 replicas to each collection, store Markdown documents up to 2 MB, and store individual files up to 250 MB. I hope to offer paid plans with more storage later, and you'll be able to add one without losing your beta allowance."
+  );
+}
+
+export function renderOpenBetaWelcomeEmail(
+  input: Pick<EmailRenderContext, "name" | "email">
+): TransactionalEmail {
+  return renderWelcomeEmail(input,
+    "Because you joined during the open beta, your account has a 1 GB hosted-storage allowance that does not expire when the beta ends. It is shared across your Markdown files and other files. Your account also includes a 2 GB retained-file allowance, and each collection can contain up to 10,000 files. You can have up to 3 hosted collections in total, including the starter collection created with your account. Each collection can connect up to 10 synced folders and 50 application installations. Markdown documents can be up to 2 MB and individual files up to 250 MB. I hope to offer paid plans with more storage later, and you'll be able to add one without losing your beta allowance."
+  );
+}
+
+function renderWelcomeEmail(
+  input: Pick<EmailRenderContext, "name" | "email">,
+  entitlement: string
 ): TransactionalEmail {
   const paragraphs = [
     `Hi ${input.name},`,
@@ -56,7 +99,7 @@ export function renderBetaWelcomeEmail(
     "A lot of the software that we use, especially SaaS software, puts your data in its own database. This can make it difficult to use elsewhere or leave with the data when the software becomes unsuitable to your needs. The goal of mdbase is to enable users to enjoy good software while maintaining control of their data, with or without mdbase.",
     "There is one important thing to keep in mind, though. By design, an application you connect may be able to read data from a collection. If you give it write access, it may also be able to create, change, move, or delete files in that collection, and, again by design, those changes can be synchronized back to your computer. mdbase checks that each application stays within the permissions you've granted, but you should still only connect applications you trust, especially when they ask for write access.",
     "You can also build applications using the mdbase SDK. This is a way to make your own tools that work with your data online or offline, without giving a third-party application access to it.",
-    "Because you joined during the beta, your account has a 1 GB hosted-storage allowance that does not expire when the beta ends. It is shared across your Markdown files and other files. You can create up to 10 hosted collections, connect up to 10 replicas to each collection, store Markdown documents up to 2 MB, and store individual files up to 250 MB. I hope to offer paid plans with more storage later, and you'll be able to add one without losing your beta allowance.",
+    entitlement,
     "There will probably be some rough edges, so please let me know when something breaks, behaves unexpectedly, or is confusing. You can send an email to support@mdbase.dev or open an issue on GitHub. mdbase is early in its development and so feedback is super-helpful!",
     "Best,\nCallum."
   ];

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -57,7 +57,8 @@ describe("database migrations", () => {
       "0019_authorization_binding_v5_compatibility",
       "0020_protocol_usage_telemetry",
       "0021_device_authorization_origin",
-      "0022_account_creation_email_claims"
+      "0022_account_creation_email_claims",
+      "0023_open_beta_entitlement"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -575,7 +576,8 @@ describe("database migrations", () => {
       "0019_authorization_binding_v5_compatibility",
       "0020_protocol_usage_telemetry",
       "0021_device_authorization_origin",
-      "0022_account_creation_email_claims"
+      "0022_account_creation_email_claims",
+      "0023_open_beta_entitlement"
     ]);
   });
 

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -56,7 +56,8 @@ describe("database migrations", () => {
       "0018_account_onboarding",
       "0019_authorization_binding_v5_compatibility",
       "0020_protocol_usage_telemetry",
-      "0021_device_authorization_origin"
+      "0021_device_authorization_origin",
+      "0022_account_creation_email_claims"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -70,6 +71,12 @@ describe("database migrations", () => {
          AND column_name = 'file_capability'`
     );
     expect(fileCapability.rows).toHaveLength(1);
+    const emailClaims = await db.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'account_creation_email_claims'
+         AND column_name = 'normalized_email'`
+    );
+    expect(emailClaims.rows).toHaveLength(1);
 
     await expect(assertControlPlaneMigrationsCurrent(db)).resolves.toBeUndefined();
     await runControlPlaneMigrations(db);
@@ -77,6 +84,33 @@ describe("database migrations", () => {
       "SELECT id FROM schema_migrations ORDER BY id"
     );
     expect(repeated.rows).toEqual(applied.rows);
+  });
+
+  it("backfills legacy user emails with canonical normalization", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const userId = randomUUID();
+    await db.query(
+      `INSERT INTO users (id, email, name)
+       VALUES ($1, ' User@bücher.de ', 'Legacy user')`,
+      [userId]
+    );
+
+    await runControlPlaneMigrations(db);
+    const claim = await db.query<{
+      normalized_email: string;
+      user_id: string;
+      source: string;
+    }>(
+      `SELECT normalized_email, user_id, source
+       FROM account_creation_email_claims WHERE user_id = $1`,
+      [userId]
+    );
+    expect(claim.rows).toEqual([{
+      normalized_email: "user@xn--bcher-kva.de",
+      user_id: userId,
+      source: "legacy_user"
+    }]);
   });
 
   it("preserves v2 local grants as revoked reauthorization records during the v3 break", async () => {
@@ -540,7 +574,8 @@ describe("database migrations", () => {
       "0018_account_onboarding",
       "0019_authorization_binding_v5_compatibility",
       "0020_protocol_usage_telemetry",
-      "0021_device_authorization_origin"
+      "0021_device_authorization_origin",
+      "0022_account_creation_email_claims"
     ]);
   });
 

--- a/services/server/src/entitlements.test.ts
+++ b/services/server/src/entitlements.test.ts
@@ -6,7 +6,9 @@ import {
   attachInvitationEntitlement,
   BETA_ENTITLEMENT_PROFILE,
   effectiveEntitlement,
-  materializeInvitationEntitlement
+  materializeInvitationEntitlement,
+  materializePublicSignupEntitlement,
+  OPEN_BETA_ENTITLEMENT_PROFILE
 } from "./entitlements.js";
 
 const resources: Array<() => Promise<void>> = [];
@@ -52,6 +54,26 @@ describe("account entitlements", () => {
       maxMirrorReplicasPerCollection: 10,
       maxApplicationReplicasPerCollection: 50,
       maxHostedCollections: 10,
+      maxFilesPerCollection: 10_000
+    });
+  });
+
+  it("materializes the permanent three-collection open Beta grant", async () => {
+    const { db, userId } = await fixture();
+
+    const first = await materializePublicSignupEntitlement(db, userId);
+    const replay = await materializePublicSignupEntitlement(db, userId);
+
+    expect(replay).toEqual(first);
+    expect(await effectiveEntitlement(db, userId)).toEqual({
+      profileCodes: [OPEN_BETA_ENTITLEMENT_PROFILE],
+      hostedStorageBytes: 1_073_741_824,
+      retainedFileBytes: 2_147_483_648,
+      maxDocumentBytes: 2_097_152,
+      maxSingleFileBytes: 262_144_000,
+      maxMirrorReplicasPerCollection: 10,
+      maxApplicationReplicasPerCollection: 50,
+      maxHostedCollections: 3,
       maxFilesPerCollection: 10_000
     });
   });

--- a/services/server/src/entitlements.ts
+++ b/services/server/src/entitlements.ts
@@ -7,6 +7,7 @@ import type {
 } from "./hosted-provider.js";
 
 export const BETA_ENTITLEMENT_PROFILE = "beta_v1";
+export const OPEN_BETA_ENTITLEMENT_PROFILE = "open_beta_v1";
 
 export interface EffectiveEntitlement {
   profileCodes: string[];
@@ -117,7 +118,7 @@ export async function materializePublicSignupEntitlement(
        (id, user_id, profile_code, source, source_reference)
      VALUES ($1, $2, $3, 'subscription', 'public_signup_v1')
      ON CONFLICT DO NOTHING`,
-    [randomUUID(), userId, BETA_ENTITLEMENT_PROFILE]
+    [randomUUID(), userId, OPEN_BETA_ENTITLEMENT_PROFILE]
   );
   const account = await db.query<{
     provider_account_id: string;

--- a/services/server/src/external-auth.test.ts
+++ b/services/server/src/external-auth.test.ts
@@ -35,6 +35,14 @@ describe("external account sessions", () => {
       allowAccountCreation: false
     })).resolves.toMatchObject({ userId: created.userId });
     expect((await db.query("SELECT id FROM users")).rows).toHaveLength(1);
+    expect((await db.query(
+      `SELECT normalized_email, user_id, source
+       FROM account_creation_email_claims`
+    )).rows).toEqual([{
+      normalized_email: "invited@example.com",
+      user_id: created.userId,
+      source: "external_identity"
+    }]);
   });
 
   it("captures the account epoch and refuses sessions for suspended accounts", async () => {

--- a/services/server/src/external-auth.ts
+++ b/services/server/src/external-auth.ts
@@ -1,4 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
+import {
+  accountCreationEmailClaimed,
+  reserveAccountCreationEmail
+} from "./account-creation-email-claims.js";
 import type { DatabasePool } from "./db.js";
 import {
   EMAIL_NORMALIZATION_VERSION,
@@ -55,11 +59,27 @@ export async function createExternalSession(
     }
     const userId = existing.rows[0]?.user_id ?? externalUserId(identity.provider, identity.subject);
     if (!existing.rows[0]) {
+      if (
+        normalizedEmail
+        && await accountCreationEmailClaimed(connection, normalizedEmail)
+      ) {
+        throw new AccountUnavailableError();
+      }
       await connection.query(
         `INSERT INTO users (id, email, name) VALUES ($1, NULL, $2)
          ON CONFLICT(id) DO NOTHING`,
         [userId, identity.name]
       );
+      if (
+        normalizedEmail
+        && !await reserveAccountCreationEmail(connection, {
+          normalizedEmail,
+          userId,
+          source: "external_identity"
+        })
+      ) {
+        throw new AccountUnavailableError();
+      }
     }
     await connection.query(
       `INSERT INTO external_identities

--- a/services/server/src/features/auth/password-routes.ts
+++ b/services/server/src/features/auth/password-routes.ts
@@ -52,6 +52,12 @@ const PASSWORD_LOGIN_IP_LIMIT: AuthRateLimitRule = {
   baseBlockSeconds: 5 * 60,
   maxBlockSeconds: 60 * 60
 };
+const PASSWORD_SIGNUP_PREVIEW_TOKEN_LIMIT: AuthRateLimitRule = {
+  maxAttempts: 5,
+  windowSeconds: 60 * 60,
+  baseBlockSeconds: 15 * 60,
+  maxBlockSeconds: 6 * 60 * 60
+};
 const PASSWORD_SIGNUP_TOKEN_LIMIT: AuthRateLimitRule = {
   maxAttempts: 5,
   windowSeconds: 60 * 60,
@@ -339,17 +345,17 @@ export function registerPasswordAuthRoutes(
       authenticationRateLimiter,
       [
         {
-          scope: "password.signup_verification.token",
+          scope: "password.signup_verification_preview.token",
           key: input.verification_token,
-          rule: PASSWORD_SIGNUP_TOKEN_LIMIT
+          rule: PASSWORD_SIGNUP_PREVIEW_TOKEN_LIMIT
         },
         {
-          scope: "password.signup_verification.ip",
+          scope: "password.signup_verification_preview.ip",
           key: request.ip,
           rule: PASSWORD_SIGNUP_IP_LIMIT
         },
         {
-          scope: "password.signup_verification.global",
+          scope: "password.signup_verification_preview.global",
           key: "global",
           rule: PASSWORD_AUTH_GLOBAL_LIMIT
         }
@@ -387,17 +393,17 @@ export function registerPasswordAuthRoutes(
       authenticationRateLimiter,
       [
         {
-          scope: "password.signup_verification.token",
+          scope: "password.signup_redemption.token",
           key: input.verification_token,
           rule: PASSWORD_SIGNUP_TOKEN_LIMIT
         },
         {
-          scope: "password.signup_verification.ip",
+          scope: "password.signup_redemption.ip",
           key: request.ip,
           rule: PASSWORD_SIGNUP_IP_LIMIT
         },
         {
-          scope: "password.signup_verification.global",
+          scope: "password.signup_redemption.global",
           key: "global",
           rule: PASSWORD_AUTH_GLOBAL_LIMIT
         }

--- a/services/server/src/migrations.ts
+++ b/services/server/src/migrations.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import {
+  backfillLegacyAccountCreationEmailClaims
+} from "./account-creation-email-claims.js";
 import type {
   DatabaseConnection,
   DatabasePool,
@@ -42,6 +45,9 @@ export async function runControlPlaneMigrations(
       connection,
       options.directory ?? resolve(import.meta.dirname, "../migrations")
     );
+    if (await tableExists(connection, "account_creation_email_claims")) {
+      await backfillLegacyAccountCreationEmailClaims(connection);
+    }
   } finally {
     if (options.lock) {
       await connection

--- a/services/server/src/password-auth-routes.test.ts
+++ b/services/server/src/password-auth-routes.test.ts
@@ -390,14 +390,23 @@ describe("password authentication HTTP boundary", () => {
       "SELECT token_hash FROM authentication_challenges"
     )).rows)).not.toContain(verificationToken);
 
-    const preview = await app.inject({
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const preview = await app.inject({
+        method: "POST",
+        url: "/v1/auth/password/signup/verification",
+        headers: { origin },
+        payload: { verification_token: verificationToken }
+      });
+      expect(preview.statusCode).toBe(200);
+      expect(preview.json().verification.email).toBe("person@example.com");
+    }
+    const exhaustedPreview = await app.inject({
       method: "POST",
       url: "/v1/auth/password/signup/verification",
       headers: { origin },
       payload: { verification_token: verificationToken }
     });
-    expect(preview.statusCode).toBe(200);
-    expect(preview.json().verification.email).toBe("person@example.com");
+    expect(exhaustedPreview.statusCode).toBe(429);
     const completed = await app.inject({
       method: "POST",
       url: "/v1/auth/password/signup/public",
@@ -412,6 +421,20 @@ describe("password authentication HTTP boundary", () => {
       }
     });
     expect(completed.statusCode).toBe(201);
+    const signupScopes = await db.query<{ scope: string }>(
+      `SELECT scope FROM auth_rate_limit_buckets
+       WHERE scope LIKE 'password.signup_%' ORDER BY scope`
+    );
+    expect(signupScopes.rows.map(({ scope }) => scope)).toEqual(
+      expect.arrayContaining([
+        "password.signup_redemption.global",
+        "password.signup_redemption.ip",
+        "password.signup_redemption.token",
+        "password.signup_verification_preview.global",
+        "password.signup_verification_preview.ip",
+        "password.signup_verification_preview.token"
+      ])
+    );
     expect(completed.cookies.find(
       ({ name }) => name === "__Host-mdbase_session"
     )).toMatchObject({ httpOnly: true, secure: true, sameSite: "Lax" });

--- a/services/server/src/password-auth.ts
+++ b/services/server/src/password-auth.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  accountCreationEmailClaimed,
+  reserveAccountCreationEmail
+} from "./account-creation-email-claims.js";
 import type {
   DatabasePool,
   DatabaseQueryable
@@ -191,7 +195,7 @@ export class PasswordAccountService {
     const connection = await this.db.connect();
     try {
       await connection.query("BEGIN");
-      if (await identityExists(connection, normalizedEmail)) {
+      if (await accountCreationEmailClaimed(connection, normalizedEmail)) {
         throw new InvitationTargetConflictError();
       }
       await connection.query(
@@ -311,13 +315,20 @@ export class PasswordAccountService {
       ) {
         throw new InvalidInvitationError();
       }
-      if (await identityExists(connection, row.normalized_email)) {
+      if (await accountCreationEmailClaimed(connection, row.normalized_email)) {
         throw new InvitationTargetConflictError();
       }
       await connection.query(
         "INSERT INTO users (id, email, name) VALUES ($1, NULL, $2)",
         [userId, name]
       );
+      if (!await reserveAccountCreationEmail(connection, {
+        normalizedEmail: row.normalized_email,
+        userId,
+        source: "email_identity"
+      })) {
+        throw new InvitationTargetConflictError();
+      }
       const emailIdentityId = randomUUID();
       await connection.query(
         `INSERT INTO email_identities
@@ -665,25 +676,6 @@ function agreementsMatch(
   ) {
     throw new InvalidInvitationError();
   }
-}
-
-async function identityExists(
-  db: DatabaseQueryable,
-  normalizedEmail: string
-): Promise<boolean> {
-  const result = await db.query(
-    `SELECT user_id FROM email_identities
-     WHERE normalized_email = $1 AND retired_at IS NULL
-     UNION ALL
-     SELECT user_id FROM external_identities
-     WHERE normalized_email = $1 AND email_verified = true
-     UNION ALL
-     SELECT id AS user_id FROM users
-     WHERE email IS NOT NULL AND lower(email) = lower($1)
-     LIMIT 1`,
-    [normalizedEmail]
-  );
-  return Boolean(result.rows[0]);
 }
 
 function requiredText(value: string, maxLength: number, name: string): string {

--- a/services/server/src/public-signup.test.ts
+++ b/services/server/src/public-signup.test.ts
@@ -57,22 +57,28 @@ describe("public password signup", () => {
       profile_code: string;
       source_reference: string;
       timezone: string;
+      message_kind: string;
+      template_version: number;
     }>(
       `SELECT identity.verified_at, session.provider, entitlement.profile_code,
-              entitlement.source_reference, onboarding.timezone
+              entitlement.source_reference, onboarding.timezone,
+              email_job.message_kind, email_job.template_version
        FROM email_identities identity
        JOIN sessions session ON session.user_id = identity.user_id
        JOIN account_entitlement_grants entitlement
          ON entitlement.user_id = identity.user_id
        JOIN account_onboarding onboarding ON onboarding.user_id = identity.user_id
+       JOIN email_jobs email_job ON email_job.user_id = identity.user_id
        WHERE identity.user_id = $1`,
       [account.user.id]
     );
     expect(materialized.rows[0]).toMatchObject({
       provider: "password",
-      profile_code: "beta_v1",
+      profile_code: "open_beta_v1",
       source_reference: "public_signup_v1",
-      timezone: "Australia/Melbourne"
+      timezone: "Australia/Melbourne",
+      message_kind: "open_beta_welcome",
+      template_version: 1
     });
     expect(materialized.rows[0]?.verified_at).toBeInstanceOf(Date);
     const agreements = await db.query<{

--- a/services/server/src/public-signup.test.ts
+++ b/services/server/src/public-signup.test.ts
@@ -154,6 +154,74 @@ describe("public password signup", () => {
     expect(await service.create("google@example.com")).toBeNull();
   });
 
+  it("rejects a new external account after password signup claims the email", async () => {
+    const { db, service } = await fixture();
+    const verification = await service.create("shared@example.com");
+    await service.complete({
+      verificationToken: verification!.token,
+      name: "Password Account",
+      password: "a durable public account password",
+      termsVersion: "terms-2026-08",
+      privacyVersion: "privacy-2026-08"
+    });
+
+    await expect(createExternalSession(db, {
+      provider: "google",
+      subject: "same-email-google-subject",
+      name: "Google Account",
+      login: null,
+      email: "SHARED@example.com",
+      emailVerified: true,
+      avatarUrl: null
+    }, { allowAccountCreation: true })).rejects.toMatchObject({
+      name: "AccountUnavailableError"
+    });
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(1);
+    expect((await db.query(
+      "SELECT provider, subject FROM external_identities"
+    )).rows).toHaveLength(0);
+    expect((await db.query(
+      `SELECT normalized_email, user_id
+       FROM account_creation_email_claims`
+    )).rows).toEqual([{
+      normalized_email: "shared@example.com",
+      user_id: (await db.query<{ id: string }>("SELECT id FROM users")).rows[0]!.id
+    }]);
+  });
+
+  it("allows only one account to win concurrent verified-email creation", async () => {
+    const { db, service } = await fixture();
+    const verification = await service.create("race@example.com");
+    const passwordCompletion = service.complete({
+      verificationToken: verification!.token,
+      name: "Password Account",
+      password: "a durable public account password",
+      termsVersion: "terms-2026-08",
+      privacyVersion: "privacy-2026-08"
+    });
+    const externalCompletion = createExternalSession(db, {
+      provider: "google",
+      subject: "race-google-subject",
+      name: "Google Account",
+      login: null,
+      email: "race@example.com",
+      emailVerified: true,
+      avatarUrl: null
+    }, { allowAccountCreation: true });
+
+    const results = await Promise.allSettled([
+      passwordCompletion,
+      externalCompletion
+    ]);
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    expect(results.filter(({ status }) => status === "rejected")).toHaveLength(1);
+    expect((await db.query("SELECT id FROM users")).rows).toHaveLength(1);
+    expect((await db.query(
+      `SELECT normalized_email FROM account_creation_email_claims
+       WHERE normalized_email = 'race@example.com'`
+    )).rows).toHaveLength(1);
+  });
+
   it("rejects expired links and an identity claimed after verification was requested", async () => {
     const { db, service } = await fixture();
     const expired = await service.create("expired@example.com");

--- a/services/server/src/public-signup.ts
+++ b/services/server/src/public-signup.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type {
-  DatabasePool,
-  DatabaseQueryable
-} from "./database-types.js";
+import {
+  accountCreationEmailClaimed,
+  reserveAccountCreationEmail
+} from "./account-creation-email-claims.js";
+import type { DatabasePool, DatabaseQueryable } from "./database-types.js";
 import {
   EMAIL_NORMALIZATION_VERSION,
   normalizeEmailAddress
@@ -95,7 +96,7 @@ export class PublicSignupService {
       requirePublicSignupEnabled(
         await this.policy.currentForAccountChange(connection)
       );
-      const existingIdentity = await identityExists(connection, email);
+      const existingIdentity = await accountCreationEmailClaimed(connection, email);
       await connection.query(
         `UPDATE authentication_challenges SET invalidated_at = now()
          WHERE purpose = 'public_signup'
@@ -189,13 +190,26 @@ export class PublicSignupService {
         [challengeHash]
       );
       const challenge = consumed.rows[0];
-      if (!challenge || await identityExists(connection, challenge.normalized_email)) {
+      if (
+        !challenge
+        || await accountCreationEmailClaimed(
+          connection,
+          challenge.normalized_email
+        )
+      ) {
         throw new InvalidPublicSignupVerificationError();
       }
       await connection.query(
         "INSERT INTO users (id, email, name) VALUES ($1, NULL, $2)",
         [userId, name]
       );
+      if (!await reserveAccountCreationEmail(connection, {
+        normalizedEmail: challenge.normalized_email,
+        userId,
+        source: "email_identity"
+      })) {
+        throw new InvalidPublicSignupVerificationError();
+      }
       await connection.query(
         `INSERT INTO email_identities
            (id, user_id, email, normalized_email, normalization_version,
@@ -298,25 +312,6 @@ function agreementsMatch(
   ) {
     throw new InvalidPublicSignupVerificationError();
   }
-}
-
-async function identityExists(
-  db: DatabaseQueryable,
-  normalizedEmail: string
-): Promise<boolean> {
-  const result = await db.query(
-    `SELECT user_id FROM email_identities
-     WHERE normalized_email = $1 AND retired_at IS NULL
-     UNION ALL
-     SELECT user_id FROM external_identities
-     WHERE normalized_email = $1 AND email_verified = true
-     UNION ALL
-     SELECT id AS user_id FROM users
-     WHERE email IS NOT NULL AND lower(email) = lower($1)
-     LIMIT 1`,
-    [normalizedEmail]
-  );
-  return Boolean(result.rows[0]);
 }
 
 function requiredText(value: string, maxLength: number, name: string): string {

--- a/services/server/src/public-signup.ts
+++ b/services/server/src/public-signup.ts
@@ -13,7 +13,7 @@ import {
   type AuthenticationSettings
 } from "./authentication-policy.js";
 import { scheduleStarterCollection } from "./account-onboarding.js";
-import { scheduleBetaWelcomeEmail } from "./beta-welcome-email.js";
+import { scheduleOpenBetaWelcomeEmail } from "./beta-welcome-email.js";
 import { materializePublicSignupEntitlement } from "./entitlements.js";
 import { hashPassword } from "./password.js";
 import { randomToken, tokenHash } from "./security.js";
@@ -236,7 +236,7 @@ export class PublicSignupService {
         [userId, input.termsVersion, input.privacyVersion]
       );
       await materializePublicSignupEntitlement(connection, userId);
-      await scheduleBetaWelcomeEmail(connection, { userId, emailIdentityId });
+      await scheduleOpenBetaWelcomeEmail(connection, { userId, emailIdentityId });
       await scheduleStarterCollection(connection, userId, input.timezone ?? "UTC");
       await connection.query(
         `INSERT INTO sessions


### PR DESCRIPTION
## Summary

Follow-up to #293 addressing the merged-change review findings and completing the open-beta entitlement split:

- pin managed desktop environments to canonical Connect/editor origin pairs and make the configured Connect origin the actual pairing default;
- reject conflicting verified-email account creation across public password signup, invitations, and new external-provider accounts without auto-linking identities;
- add an additive account-creation email-claim migration with canonical legacy-email backfill and transactional race protection;
- separate public-signup verification-preview and redemption rate-limit scopes;
- preserve same-origin `return_to` when leaving signup for sign-in;
- assign future public password signups the permanent `open_beta_v1` profile while preserving invited participants' `beta_v1` allowance;
- schedule and render distinct open-beta welcome email copy covering the three-collection, storage, file, and replica limits.

The desktop environment helpers also reject unsafe endpoint, environment, and loopback-port configuration. Arbitrary named preview environments remain supported when both origins are explicit.

## Verification

- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- focused server/portal/desktop/environment regression tests
- focused entitlement, migration, public-signup, and welcome-email tests
- `pnpm check:architecture`
- `pnpm test:accessibility`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `pnpm test:system --suite container` (packaged Node 24 server, PostgreSQL migration, pairing, restart; completed on the review-fix commit before the open-beta follow-up)
- renderer build assertion with the LAB Connect origin embedded as the pairing default

## Deployment note

Migrations `0022_account_creation_email_claims.sql` and `0023_open_beta_entitlement.sql` are additive. Keep public/external account creation closed during a rolling deployment. Do not reopen registration until all older server and email-worker instances have drained: older instances neither participate in the email-claim boundary nor understand the new `open_beta_welcome` template.
