### PR TITLE
Fix editor collection authorization redirects

### DIFF
--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -673,11 +673,9 @@ function editorSurfaceUrls(collectionId?: string): { notes: string; types: strin
 }
 
 function editorCollectionUrl(collectionId: string): string {
-  const url = applyConnectServerOverride(
-    new URL("/", location.origin),
-    management.baseUrl
-  );
+  const url = new URL("/", location.origin);
   url.searchParams.set("collection", collectionId);
+  applyConnectServerOverride(url, management.baseUrl);
   return url.href;
 }
 

--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -14,6 +14,10 @@ import { useCallback, useEffect, useRef, useState, type FormEvent, type MouseEve
 import { AccountManagement, DeletedAccount } from "./AccountManagement";
 import { MdbaseMark } from "./Brand";
 import {
+  applyConnectServerOverride,
+  connectServerUrl
+} from "./connect-endpoint";
+import {
   ConfirmAction,
   ConnectEmpty as Empty,
   ConnectPage as Page,
@@ -40,9 +44,7 @@ type PerformOperation = (
   action: (options: ManagementRequestOptions) => Promise<void>
 ) => Promise<boolean>;
 
-const serverUrl = new URLSearchParams(location.search).get("server")
-  ?? import.meta.env.VITE_MDBASE_CONNECT_URL
-  ?? "https://connect.mdbase.dev";
+const serverUrl = connectServerUrl();
 const management = new ConnectManagementClient(serverUrl);
 const desktopReleaseUrl = "https://mdbase.dev/downloads/";
 const allOperations = [
@@ -649,16 +651,20 @@ function joinWords(words: string[]): string {
 }
 
 function connectViewUrl(view: ConnectView, collectionId?: string): string {
-  const url = new URL(view === "overview" ? "/connect" : `/connect/${view}`, location.origin);
-  url.searchParams.set("server", new URL(management.baseUrl).origin);
+  const url = applyConnectServerOverride(
+    new URL(view === "overview" ? "/connect" : `/connect/${view}`, location.origin),
+    management.baseUrl
+  );
   if (collectionId) url.searchParams.set("collection", collectionId);
   return `${url.pathname}${url.search}`;
 }
 
 function editorSurfaceUrls(collectionId?: string): { notes: string; types: string; settings: string } {
   const surface = (name?: "types" | "settings") => {
-    const url = new URL("/", location.origin);
-    url.searchParams.set("server", new URL(management.baseUrl).origin);
+    const url = applyConnectServerOverride(
+      new URL("/", location.origin),
+      management.baseUrl
+    );
     if (collectionId) url.searchParams.set("collection", collectionId);
     if (name) url.searchParams.set("surface", name);
     return url.href;
@@ -667,9 +673,11 @@ function editorSurfaceUrls(collectionId?: string): { notes: string; types: strin
 }
 
 function editorCollectionUrl(collectionId: string): string {
-  const url = new URL("/", location.origin);
+  const url = applyConnectServerOverride(
+    new URL("/", location.origin),
+    management.baseUrl
+  );
   url.searchParams.set("collection", collectionId);
-  url.searchParams.set("server", new URL(management.baseUrl).origin);
   return url.href;
 }
 

--- a/apps/editor/src/connect-endpoint.test.ts
+++ b/apps/editor/src/connect-endpoint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyConnectServerOverride,
+  connectServerUrl
+} from "./connect-endpoint";
+
+describe("Connect endpoint URLs", () => {
+  it("uses the configured environment without a redundant server override", () => {
+    const configured = "https://connect.mdbase.dev";
+    expect(connectServerUrl("?server=https%3A%2F%2Fconnect.mdbase.dev", configured))
+      .toBe(configured);
+
+    const target = applyConnectServerOverride(
+      new URL("https://editor.mdbase.dev/"),
+      configured,
+      configured
+    );
+    expect(target.href).toBe("https://editor.mdbase.dev/");
+  });
+
+  it("preserves a deliberate cross-environment override", () => {
+    const target = applyConnectServerOverride(
+      new URL("https://editor.mdbase.dev/"),
+      "https://connect-staging.mdbase.dev",
+      "https://connect.mdbase.dev"
+    );
+    expect(target.searchParams.get("server"))
+      .toBe("https://connect-staging.mdbase.dev");
+  });
+
+  it("removes a stale redundant override from callback URLs", () => {
+    const target = applyConnectServerOverride(
+      new URL("https://editor.mdbase.dev/?server=https%3A%2F%2Fold.example"),
+      "https://connect.mdbase.dev",
+      "https://connect.mdbase.dev"
+    );
+    expect(target.href).toBe("https://editor.mdbase.dev/");
+  });
+});

--- a/apps/editor/src/connect-endpoint.ts
+++ b/apps/editor/src/connect-endpoint.ts
@@ -1,0 +1,23 @@
+const productionConnectOrigin = "https://connect.mdbase.dev";
+
+export const configuredConnectServerUrl =
+  import.meta.env.VITE_MDBASE_CONNECT_URL ?? productionConnectOrigin;
+
+export function connectServerUrl(
+  search = location.search,
+  configuredServerUrl = configuredConnectServerUrl
+): string {
+  return new URLSearchParams(search).get("server") ?? configuredServerUrl;
+}
+
+export function applyConnectServerOverride(
+  url: URL,
+  serverUrl: string,
+  configuredServerUrl = configuredConnectServerUrl
+): URL {
+  const activeOrigin = new URL(serverUrl).origin;
+  const configuredOrigin = new URL(configuredServerUrl).origin;
+  if (activeOrigin === configuredOrigin) url.searchParams.delete("server");
+  else url.searchParams.set("server", activeOrigin);
+  return url;
+}

--- a/apps/editor/src/gateway.ts
+++ b/apps/editor/src/gateway.ts
@@ -17,6 +17,10 @@ import {
   type TypePackAssessment,
   type TypePackProvision
 } from "@mdbase-dev/connect";
+import {
+  applyConnectServerOverride,
+  connectServerUrl
+} from "./connect-endpoint";
 import { persistedBody, titlePatch } from "./note";
 import type {
   CollectionGateway,
@@ -82,14 +86,9 @@ export class ConnectCollectionGateway implements CollectionGateway {
   private readonly renamePreflights = new Map<string, import("@mdbase-dev/connect").RenamePreflightResult>();
   private readonly deletePreflights = new Map<string, import("@mdbase-dev/connect").DeletePreflightResult>();
 
-  constructor(serverUrl = new URLSearchParams(location.search).get("server")
-      ?? import.meta.env.VITE_MDBASE_CONNECT_URL
-      ?? "https://connect.mdbase.dev") {
+  constructor(serverUrl = connectServerUrl()) {
     const appRoot = new URL(import.meta.env.BASE_URL, location.href);
-    const redirectUri = new URL(appRoot);
-    if (new URLSearchParams(location.search).has("server")) {
-      redirectUri.searchParams.set("server", new URL(serverUrl).origin);
-    }
+    const redirectUri = applyConnectServerOverride(new URL(appRoot), serverUrl);
     const connect = new MdbaseConnect<NoteFrontmatter>({
       serverUrl,
       manifest: new URL(".well-known/mdbase-app.json", appRoot).href,


### PR DESCRIPTION
## Summary
- omit redundant managed Connect server parameters from editor links and OAuth redirects
- keep deliberate cross-environment overrides explicit
- restore exact redirect URI matching for the production editor manifest

## Incident
Production editor requests opened from the Connect workspace included `?server=https://connect.mdbase.dev` in the OAuth redirect URI. The registered production manifest permits `https://editor.mdbase.dev/`, so Connect correctly rejected authorization with `invalid_client`.

The blocked Cloudflare Insights beacon is unrelated; the editor CSP is correctly refusing an injected analytics script.

## Validation
- editor unit tests: 289 passed
- editor typecheck
- editor production build
- CSP check
- bundle budgets
- reproduced the pre-fix `invalid_client` response against isolated LAB