### PR TITLE
Add bounded Connect feedback intake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ MDBASE_CONNECT_MANAGEMENT_ORIGINS=http://127.0.0.1:5173
 # Optional when more than one management origin is allowlisted. This is the
 # primary editor destination used after portal transactions.
 MDBASE_EDITOR_ORIGIN=http://127.0.0.1:5173
+# Optional build-time editor feedback configuration. Production builds hide
+# the feedback entry when the endpoint is absent.
+# VITE_MDBASE_FEEDBACK_URL=https://feedback-api.example.com/v1/feedback
+# VITE_MDBASE_TURNSTILE_SITE_KEY=
+# VITE_MDBASE_BUILD_REVISION=development
 
 # Public deployments set MDBASE_CONNECT_DEV_AUTH=0 and configure one or more
 # external identity providers. Registration remains closed unless explicitly

--- a/.github/workflows/editor-pages.yml
+++ b/.github/workflows/editor-pages.yml
@@ -10,6 +10,7 @@ on:
       - "packages/management/**"
       - "packages/protocol/**"
       - "packages/ui/**"
+      - "services/feedback/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".github/workflows/editor-pages.yml"
@@ -47,6 +48,8 @@ jobs:
       - run: pnpm build:packages
       - run: pnpm --filter mdbase-editor typecheck
       - run: pnpm --filter mdbase-editor test
+      - run: pnpm --filter @mdbase/feedback-worker typecheck
+      - run: pnpm --filter @mdbase/feedback-worker test
       - run: pnpm --filter mdbase-editor test:deployment
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm --filter mdbase-editor test:e2e
@@ -84,6 +87,10 @@ jobs:
         env:
           MDBASE_EDITOR_ORIGIN: https://editor.mdbase.dev
           MDBASE_EDITOR_BASE_PATH: /
+          VITE_MDBASE_BUILD_REVISION: ${{ github.sha }}
+          VITE_MDBASE_ENV: production
+          VITE_MDBASE_FEEDBACK_URL: ${{ vars.MDBASE_FEEDBACK_URL }}
+          VITE_MDBASE_TURNSTILE_SITE_KEY: ${{ vars.MDBASE_FEEDBACK_TURNSTILE_SITE_KEY }}
       - name: Verify editor manifest
         run: node apps/editor/scripts/verify-deployment-manifest.mjs apps/editor/dist/.well-known/mdbase-app.json https://editor.mdbase.dev/
       - name: Deploy editor
@@ -131,6 +138,10 @@ jobs:
           MDBASE_EDITOR_BASE_PATH: /
           MDBASE_CONNECT_URL: https://connect-staging.mdbase.dev
           VITE_MDBASE_CONNECT_URL: https://connect-staging.mdbase.dev
+          VITE_MDBASE_BUILD_REVISION: ${{ github.sha }}
+          VITE_MDBASE_ENV: staging
+          VITE_MDBASE_FEEDBACK_URL: ${{ vars.MDBASE_FEEDBACK_URL }}
+          VITE_MDBASE_TURNSTILE_SITE_KEY: ${{ vars.MDBASE_FEEDBACK_TURNSTILE_SITE_KEY }}
       - name: Verify staging editor manifest
         run: node apps/editor/scripts/verify-deployment-manifest.mjs apps/editor/dist/.well-known/mdbase-app.json https://editor-staging.mdbase.dev/ https://connect-staging.mdbase.dev
       - name: Deploy staging editor

--- a/apps/editor/public/_headers
+++ b/apps/editor/public/_headers
@@ -4,7 +4,7 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-U+U8JsfpXvlTIxNjisfbc6WRGcza8Y4PQwu4wCNFX5Q=' https://accounts.google.com/gsi/client; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style; frame-src https://accounts.google.com/gsi/ blob:; font-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob: https: http:
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-U+U8JsfpXvlTIxNjisfbc6WRGcza8Y4PQwu4wCNFX5Q=' https://accounts.google.com/gsi/client https://challenges.cloudflare.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style; frame-src https://accounts.google.com/gsi/ https://challenges.cloudflare.com blob:; font-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob: https: http:
 
 /.well-known/mdbase-app.json
   Cache-Control: no-store

--- a/apps/editor/scripts/check-csp.mjs
+++ b/apps/editor/scripts/check-csp.mjs
@@ -36,7 +36,10 @@ for (const name of ["img-src", "media-src", "frame-src", "worker-src", "connect-
 for (const required of [
   "https://accounts.google.com/gsi/client",
   "frame-src https://accounts.google.com/gsi/",
-  "https://accounts.google.com/gsi/style"
+  "https://accounts.google.com/gsi/style",
+  "script-src 'self' 'wasm-unsafe-eval'",
+  "https://challenges.cloudflare.com",
+  "frame-src https://accounts.google.com/gsi/ https://challenges.cloudflare.com"
 ]) {
   if (!policy.includes(required)) {
     throw new Error(`The Content-Security-Policy does not allow the account provider source: ${required}`);

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -52,6 +52,21 @@ describe("ConnectApp", () => {
     expect(screen.getByRole("heading", { name: "Applications" })).toBeInTheDocument();
   });
 
+  it("opens feedback from the quiet Connect footer with current context available", async () => {
+    overview.grants = applicationGrants();
+    const user = userEvent.setup();
+    render(<ConnectApp />);
+
+    await screen.findByRole("heading", { name: "Garden notes" });
+    await user.click(screen.getAllByRole("link", { name: "Send feedback" })[0]);
+
+    await waitFor(() => expect(location.pathname).toBe("/connect/feedback"));
+    expect(screen.getByRole("heading", { name: "Send feedback" })).toHaveFocus();
+    expect(screen.getByRole("checkbox", { name: /Include collection name: Garden notes/ })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /Include application origin/ })).not.toBeChecked();
+    expect(screen.getByText(/Nothing here is included unless you choose it/)).toBeInTheDocument();
+  });
+
   it("keeps Connect inside the editor collection shell", async () => {
     const user = userEvent.setup();
     render(<ConnectApp />);

--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -25,6 +25,8 @@ import {
   InlineRename
 } from "./ConnectPrimitives";
 import { EditorRail } from "./EditorRail";
+import { FeedbackPage } from "./FeedbackPage";
+import { feedbackEndpoint as configuredFeedbackEndpoint, recordFeedbackFailure, turnstileSiteKey, type FeedbackSourceView } from "./feedback";
 import {
   BracketsCurlyIcon as Braces,
   GearSixIcon as Settings,
@@ -36,7 +38,7 @@ import {
 } from "./icons";
 import "./connect.css";
 
-type ConnectView = "overview" | "storage" | "access" | "collections" | "applications" | "computers" | "account";
+type ConnectView = FeedbackSourceView;
 type Grant = ManagementOverview["grants"][number];
 type BusyOperations = ReadonlySet<string>;
 type PerformOperation = (
@@ -57,6 +59,7 @@ const allOperations = [
 export function ConnectApp() {
   const [accountDeleted, setAccountDeleted] = useState(location.pathname === "/connect/account-deleted");
   const [view, setView] = useState<ConnectView>(viewFromPath);
+  const [feedbackSourceView, setFeedbackSourceView] = useState<FeedbackSourceView>("overview");
   const [data, setData] = useState<ManagementOverview>();
   const [sessions, setSessions] = useState<Awaited<ReturnType<typeof management.sessions>>["sessions"]>();
   const [refreshError, setRefreshError] = useState("");
@@ -89,6 +92,7 @@ export function ConnectApp() {
         }
       } catch (reason) {
         if (signal?.aborted) return;
+        recordFeedbackFailure("management_refresh_failed", reason);
         if (reason instanceof ManagementApiError && reason.status === 401) {
           location.href = new URL("/login", management.baseUrl).href;
           return;
@@ -141,7 +145,10 @@ export function ConnectApp() {
       await action({ signal: controller.signal });
       succeeded = true;
     } catch (reason) {
-      if (!lifecycle.aborted) setMutationError(errorMessage(reason));
+      if (!lifecycle.aborted) {
+        recordFeedbackFailure("management_request_failed", reason);
+        setMutationError(errorMessage(reason));
+      }
     } finally {
       lifecycle.removeEventListener("abort", abort);
       if (!lifecycle.aborted) await refresh(lifecycle);
@@ -152,6 +159,7 @@ export function ConnectApp() {
   }
 
   function navigate(next: ConnectView, collectionId?: string) {
+    if (next === "feedback" && view !== "feedback") setFeedbackSourceView(view);
     const path = next === "overview" ? "/connect" : `/connect/${next}`;
     const url = new URL(location.href);
     url.pathname = path;
@@ -199,6 +207,10 @@ export function ConnectApp() {
   const activeView = selectedCollection || !isCollectionView(view) ? view : "collections";
   const activeGrants = data.grants.filter((grant) => grant.revocation_status !== "revoked");
   const applications = groupApplicationAccess(activeGrants);
+  const feedbackEndpoint = configuredFeedbackEndpoint();
+  const feedbackApplicationOrigins = [...new Set((selectedCollection
+    ? activeGrants.filter((grant) => grant.collection_id === selectedCollection.id)
+    : activeGrants).map((grant) => normalizedOrigin(grant.application_origin)).filter(Boolean))].sort();
   const selectedGrants = selectedCollection
     ? activeGrants.filter((grant) => grant.collection_id === selectedCollection.id)
     : [];
@@ -221,6 +233,7 @@ export function ConnectApp() {
       onSwitch={() => navigate("collections", selectedCollection?.id)}
       footer={<>
         {selectedCollection && <p role="status"><span className={`status-dot ${selectedCollection.available ? "connected" : "reconnecting"}`} aria-hidden="true" /><span>{selectedCollection.status}</span></p>}
+        {feedbackEndpoint && <RouteLink className="connect-rail-feedback" view="feedback" collectionId={selectedCollection?.id} navigate={navigate}>Send feedback</RouteLink>}
         <RouteLink className="connect-rail-account" view="account" collectionId={selectedCollection?.id} navigate={navigate} ariaLabel="Open account and sessions"><span className="connect-avatar" aria-hidden="true">{initials(data.user.name)}</span><span><strong>{data.user.name}</strong><small>{identityLabel(data.user)}</small></span></RouteLink>
       </>}
     />
@@ -239,6 +252,7 @@ export function ConnectApp() {
           <NavLink label="Applications" icon={<Package />} selected={activeView === "applications"} view="applications" collectionId={selectedCollection?.id} navigate={navigate} />
           <NavLink label="Computers" icon={<Braces />} selected={activeView === "computers"} view="computers" collectionId={selectedCollection?.id} navigate={navigate} />
           <NavLink label="Account & sessions" icon={<Settings />} selected={activeView === "account"} view="account" collectionId={selectedCollection?.id} navigate={navigate} />
+          {feedbackEndpoint && <RouteLink className="connect-feedback-mobile-link" view="feedback" collectionId={selectedCollection?.id} navigate={navigate}>Send feedback</RouteLink>}
         </section>
       </nav>
     </aside>
@@ -254,6 +268,15 @@ export function ConnectApp() {
       {activeView === "applications" && <Applications groups={applications} busy={busy} perform={perform} />}
       {activeView === "computers" && <Computers data={data} busy={busy} perform={perform} />}
       {activeView === "account" && <AccountManagement client={management} overview={data} sessions={sessions} onOverviewRefresh={refresh} onDeleted={() => setAccountDeleted(true)} />}
+      {activeView === "feedback" && feedbackEndpoint && <FeedbackPage
+        endpoint={feedbackEndpoint}
+        turnstileSiteKey={turnstileSiteKey()}
+        sourceView={feedbackSourceView}
+        collectionName={selectedCollection?.name}
+        applicationOrigins={feedbackApplicationOrigins}
+        onDone={() => navigate(feedbackSourceView === "feedback" ? "overview" : feedbackSourceView, selectedCollection?.id)}
+      />}
+      {activeView === "feedback" && !feedbackEndpoint && <Page title="Feedback unavailable" intro="This deployment has not configured a feedback destination."><section><Empty title="Feedback is unavailable" body="Contact the person who operates this mdbase connect deployment." /></section></Page>}
     </main>
   </div>;
 }
@@ -591,7 +614,7 @@ function DesktopRecoveryHelp({ action }: { action: string }) {
 
 function viewFromPath(): ConnectView {
   const segment = location.pathname.split("/")[2];
-  return segment === "storage" || segment === "access" || segment === "collections" || segment === "applications" || segment === "computers" || segment === "account" ? segment : "overview";
+  return segment === "storage" || segment === "access" || segment === "collections" || segment === "applications" || segment === "computers" || segment === "account" || segment === "feedback" ? segment : "overview";
 }
 
 function isCollectionView(view: ConnectView): boolean {
@@ -605,6 +628,7 @@ function viewLabel(view: ConnectView): string {
   if (view === "collections") return "All collections";
   if (view === "applications") return "Applications";
   if (view === "computers") return "Computers";
+  if (view === "feedback") return "Send feedback";
   return "Account & sessions";
 }
 
@@ -696,6 +720,10 @@ function identityLabel(user: ManagementOverview["user"]): string {
 
 function host(value: string): string {
   try { return new URL(value).host; } catch { return value; }
+}
+
+function normalizedOrigin(value: string): string {
+  try { return new URL(value).origin; } catch { return ""; }
 }
 
 function relativeTime(value: string): string {

--- a/apps/editor/src/FeedbackPage.test.tsx
+++ b/apps/editor/src/FeedbackPage.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedbackPage } from "./FeedbackPage";
+import { FEEDBACK_MAX_SCREENSHOT_BYTES, readFeedbackScreenshot } from "./feedback";
+
+const ONE_PIXEL_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => Response.json({ ok: true }, { status: 202 })));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("FeedbackPage", () => {
+  it("shows optional context and sends only consented fields", async () => {
+    const user = userEvent.setup();
+    render(<FeedbackPage
+      endpoint="https://feedback-api.mdbase.dev/v1/feedback"
+      turnstileSiteKey={null}
+      sourceView="applications"
+      collectionName="Garden notes"
+      applicationOrigins={["https://example.app"]}
+      onDone={() => undefined}
+    />);
+
+    await user.click(screen.getByRole("radio", { name: /Share an idea/ }));
+    await user.type(screen.getByLabelText("What would you like to be able to do?"), "Make application access easier to compare.");
+    await user.type(screen.getByLabelText(/Reply email/), "person@example.com");
+    await user.click(screen.getByRole("checkbox", { name: /Include collection name/ }));
+    await user.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    expect(await screen.findByRole("heading", { name: "Feedback sent" })).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://feedback-api.mdbase.dev/v1/feedback");
+    expect(init).toMatchObject({ method: "POST", credentials: "omit", referrerPolicy: "no-referrer" });
+    const submission = JSON.parse(String(init?.body));
+    expect(submission).toMatchObject({
+      schema_version: 1,
+      topic: "idea",
+      message: "Make application access easier to compare.",
+      reply_email: "person@example.com",
+      context: { collection_name: "Garden notes" },
+      diagnostics: { schema_version: 1, surface: "connect", source_view: "applications" }
+    });
+    expect(submission.context.application_origin).toBeUndefined();
+    expect(JSON.stringify(submission.diagnostics)).not.toContain("Garden notes");
+    expect(JSON.stringify(submission.diagnostics)).not.toContain("example.app");
+  });
+
+  it("preserves the draft when delivery fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json({ error: { message: "Feedback could not be delivered. Please try again." } }, { status: 503 }));
+    const user = userEvent.setup();
+    render(<FeedbackPage
+      endpoint="https://feedback-api.mdbase.dev/v1/feedback"
+      turnstileSiteKey={null}
+      sourceView="overview"
+      applicationOrigins={[]}
+      onDone={() => undefined}
+    />);
+
+    const message = screen.getByLabelText("What were you trying to do, and what happened?");
+    await user.type(message, "The collection stayed offline.");
+    await user.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Feedback could not be delivered");
+    expect(message).toHaveValue("The collection stayed offline.");
+    expect(screen.getByRole("button", { name: "Send feedback" })).toBeEnabled();
+  });
+
+  it("validates screenshot size, type, and magic bytes before submission", async () => {
+    const oversized = fakeFile("image/png", new Uint8Array(FEEDBACK_MAX_SCREENSHOT_BYTES + 1));
+    await expect(readFeedbackScreenshot(oversized)).rejects.toThrow("smaller than 3 MB");
+
+    const disguised = fakeFile("image/png", new TextEncoder().encode("not a png"));
+    await expect(readFeedbackScreenshot(disguised)).rejects.toThrow("does not contain a valid PNG");
+
+    const canonicalPng = bytesFromBase64(ONE_PIXEL_PNG_BASE64);
+    vi.stubGlobal("createImageBitmap", vi.fn(async () => ({ width: 1, height: 1, close: vi.fn() })));
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({ drawImage: vi.fn() } as unknown as CanvasRenderingContext2D);
+    const canonicalBuffer = new ArrayBuffer(canonicalPng.byteLength);
+    new Uint8Array(canonicalBuffer).set(canonicalPng);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) => callback(new Blob([canonicalBuffer], { type: "image/png" })));
+    const png = fakeFile("image/png", canonicalPng);
+    await expect(readFeedbackScreenshot(png)).resolves.toMatchObject({ media_type: "image/png", filename: "screenshot.png", content_base64: ONE_PIXEL_PNG_BASE64 });
+  });
+
+  it("requires a configured Turnstile token before enabling submission", async () => {
+    render(<FeedbackPage
+      endpoint="https://feedback-api.mdbase.dev/v1/feedback"
+      turnstileSiteKey="site-key"
+      sourceView="overview"
+      applicationOrigins={[]}
+      onDone={() => undefined}
+    />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("What were you trying to do, and what happened?"), "A clear problem description.");
+    expect(screen.getByRole("button", { name: "Send feedback" })).toBeDisabled();
+  });
+});
+
+function bytesFromBase64(value: string): Uint8Array {
+  return Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+}
+
+function fakeFile(type: string, bytes: Uint8Array): File {
+  const data = Uint8Array.from(bytes).buffer;
+  const file = new File([data], "capture", { type });
+  Object.defineProperty(file, "size", { value: data.byteLength });
+  Object.defineProperty(file, "arrayBuffer", { value: async () => data });
+  return file;
+}

--- a/apps/editor/src/FeedbackPage.tsx
+++ b/apps/editor/src/FeedbackPage.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from "react";
+import { ConnectPage as Page, ConnectSectionTitle as SectionTitle } from "./ConnectPrimitives";
+import { Turnstile } from "./Turnstile";
+import {
+  FEEDBACK_MAX_MESSAGE_LENGTH,
+  buildFeedbackDiagnostics,
+  readFeedbackScreenshot,
+  sendFeedback,
+  type FeedbackScreenshot,
+  type FeedbackSourceView,
+  type FeedbackTopic
+} from "./feedback";
+
+export function FeedbackPage({ endpoint, turnstileSiteKey, sourceView, collectionName, applicationOrigins, onDone }: {
+  endpoint: string;
+  turnstileSiteKey: string | null;
+  sourceView: FeedbackSourceView;
+  collectionName?: string;
+  applicationOrigins: string[];
+  onDone(): void;
+}) {
+  const [topic, setTopic] = useState<FeedbackTopic>("problem");
+  const [message, setMessage] = useState("");
+  const [replyEmail, setReplyEmail] = useState("");
+  const [includeCollection, setIncludeCollection] = useState(false);
+  const [includeApplication, setIncludeApplication] = useState(false);
+  const [applicationOrigin, setApplicationOrigin] = useState(applicationOrigins[0] ?? "");
+  const [includeDiagnostics, setIncludeDiagnostics] = useState(true);
+  const [screenshot, setScreenshot] = useState<FeedbackScreenshot>();
+  const [screenshotPreview, setScreenshotPreview] = useState("");
+  const [screenshotError, setScreenshotError] = useState("");
+  const [readingScreenshot, setReadingScreenshot] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const [turnstileAttempt, setTurnstileAttempt] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const requestId = useRef(createRequestId());
+  const diagnostics = useMemo(() => buildFeedbackDiagnostics(sourceView), [sourceView]);
+
+  useEffect(() => () => {
+    if (screenshotPreview) URL.revokeObjectURL(screenshotPreview);
+  }, [screenshotPreview]);
+
+  async function chooseScreenshot(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    setScreenshot(undefined);
+    setScreenshotError("");
+    if (!file) return;
+    setReadingScreenshot(true);
+    try {
+      const next = await readFeedbackScreenshot(file);
+      setScreenshot(next);
+      setScreenshotPreview(URL.createObjectURL(file));
+    } catch (reason) {
+      event.target.value = "";
+      setScreenshotPreview("");
+      setScreenshotError(reason instanceof Error ? reason.message : "The screenshot could not be read.");
+    } finally {
+      setReadingScreenshot(false);
+    }
+  }
+
+  function removeScreenshot() {
+    setScreenshot(undefined);
+    setScreenshotPreview("");
+    setScreenshotError("");
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const cleanMessage = message.trim();
+    if (!cleanMessage || readingScreenshot || (turnstileSiteKey && !turnstileToken)) return;
+    setSubmitting(true);
+    setSubmitError("");
+    try {
+      await sendFeedback(endpoint, {
+        schema_version: 1,
+        request_id: requestId.current,
+        topic,
+        message: cleanMessage,
+        ...(replyEmail.trim() ? { reply_email: replyEmail.trim() } : {}),
+        ...(includeCollection || includeApplication ? { context: {
+          ...(includeCollection && collectionName ? { collection_name: collectionName } : {}),
+          ...(includeApplication && applicationOrigin ? { application_origin: applicationOrigin } : {})
+        } } : {}),
+        ...(includeDiagnostics ? { diagnostics } : {}),
+        ...(screenshot ? { screenshot } : {}),
+        ...(turnstileToken ? { turnstile_token: turnstileToken } : {})
+      });
+      setSubmitted(true);
+    } catch (reason) {
+      if (turnstileSiteKey) {
+        setTurnstileToken("");
+        setTurnstileAttempt((attempt) => attempt + 1);
+      }
+      setSubmitError(reason instanceof Error ? reason.message : "Feedback could not be sent. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return <Page title="Feedback sent" intro="Thank you. Your feedback has been delivered for review.">
+      <section className="connect-feedback-complete">
+        <SectionTitle title="What happens next" />
+        <p>Feedback is reviewed, but it may not receive an individual response. Security reports should use the private reporting instructions instead.</p>
+        <button className="connect-primary-action" onClick={onDone}>Back to mdbase connect</button>
+      </section>
+    </Page>;
+  }
+
+  return <Page title="Send feedback" intro="Report a problem or share an idea about mdbase connect. Feedback is reviewed by the mdbase team.">
+    <form className="connect-feedback-form" onSubmit={(event) => void submit(event)}>
+      <section>
+        <SectionTitle title="Your feedback" />
+        <fieldset className="connect-feedback-topic">
+          <legend>What would you like to share?</legend>
+          <label><input type="radio" name="feedback-topic" value="problem" checked={topic === "problem"} onChange={() => setTopic("problem")} /><span><strong>Report a problem</strong><small>Something failed or was difficult to understand.</small></span></label>
+          <label><input type="radio" name="feedback-topic" value="idea" checked={topic === "idea"} onChange={() => setTopic("idea")} /><span><strong>Share an idea</strong><small>Describe what you would like to accomplish.</small></span></label>
+        </fieldset>
+        <label className="connect-feedback-field"><span>{topic === "problem" ? "What were you trying to do, and what happened?" : "What would you like to be able to do?"}</span><textarea required maxLength={FEEDBACK_MAX_MESSAGE_LENGTH} rows={8} value={message} onChange={(event) => setMessage(event.target.value)} /></label>
+        <span className="connect-feedback-count">{message.length.toLocaleString()} / {FEEDBACK_MAX_MESSAGE_LENGTH.toLocaleString()}</span>
+        <label className="connect-feedback-field"><span>Reply email <small>Optional</small></span><input type="email" maxLength={320} autoComplete="email" value={replyEmail} onChange={(event) => setReplyEmail(event.target.value)} placeholder="you@example.com" /></label>
+      </section>
+
+      <section>
+        <SectionTitle title="Screenshot" note="Optional · one PNG or JPEG · up to 3 MB" />
+        <label className="connect-feedback-upload"><input type="file" accept="image/png,image/jpeg" onChange={(event) => void chooseScreenshot(event)} /><span>{readingScreenshot ? "Reading screenshot…" : screenshot ? "Replace screenshot" : "Choose screenshot"}</span></label>
+        {screenshotPreview && <div className="connect-feedback-preview"><img src={screenshotPreview} alt="Screenshot preview" /><button type="button" onClick={removeScreenshot}>Remove screenshot</button></div>}
+        {screenshotError && <p className="connect-feedback-error" role="alert">{screenshotError}</p>}
+        <p className="connect-feedback-help">Review screenshots for information you do not want to share, such as record contents, local paths, or credentials. The image is decoded and re-created before sending to remove embedded metadata.</p>
+      </section>
+
+      {(collectionName || applicationOrigins.length > 0) && <section>
+        <SectionTitle title="Product context" note="Nothing here is included unless you choose it" />
+        <div className="connect-feedback-options">
+          {collectionName && <label><input type="checkbox" checked={includeCollection} onChange={(event) => setIncludeCollection(event.target.checked)} /><span>Include collection name: <strong>{collectionName}</strong></span></label>}
+          {applicationOrigins.length > 0 && <label><input type="checkbox" checked={includeApplication} onChange={(event) => setIncludeApplication(event.target.checked)} /><span>Include application origin</span></label>}
+          {includeApplication && <label className="connect-feedback-origin"><span>Application origin</span><select value={applicationOrigin} onChange={(event) => setApplicationOrigin(event.target.value)}>{applicationOrigins.map((origin) => <option key={origin}>{origin}</option>)}</select></label>}
+        </div>
+      </section>}
+
+      <section>
+        <SectionTitle title="Technical diagnostics" note="Safe, structured information from this browser tab" />
+        <label className="connect-feedback-diagnostics-toggle"><input type="checkbox" checked={includeDiagnostics} onChange={(event) => setIncludeDiagnostics(event.target.checked)} /><span>Include technical diagnostics</span></label>
+        {includeDiagnostics && <details className="connect-feedback-diagnostics"><summary>Preview diagnostics</summary><pre>{JSON.stringify(diagnostics, null, 2)}</pre></details>}
+        <p className="connect-feedback-help">Diagnostics contain product version, browser and operating-system family, viewport class, and recent bounded Connect error codes. They do not include collection contents, request bodies, cookies, tokens, or local paths.</p>
+      </section>
+
+      {turnstileSiteKey && <Turnstile key={turnstileAttempt} siteKey={turnstileSiteKey} onToken={setTurnstileToken} />}
+      {submitError && <p className="connect-feedback-error" role="alert">{submitError}</p>}
+      <div className="connect-feedback-actions"><button type="button" onClick={onDone}>Cancel</button><button className="connect-primary-action" disabled={submitting || readingScreenshot || !message.trim() || Boolean(turnstileSiteKey && !turnstileToken)}>{submitting ? "Sending…" : "Send feedback"}</button></div>
+      <p className="connect-feedback-help">Do not use this form for security reports or urgent support.</p>
+    </form>
+  </Page>;
+}
+
+function createRequestId(): string {
+  return typeof crypto.randomUUID === "function" ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/apps/editor/src/Turnstile.tsx
+++ b/apps/editor/src/Turnstile.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+
+interface TurnstileApi {
+  render(container: HTMLElement, options: {
+    sitekey: string;
+    callback(token: string): void;
+    "expired-callback"(): void;
+    "error-callback"(): void;
+    action: "feedback";
+    theme: "auto";
+  }): string;
+  remove(widgetId: string): void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+let turnstileScript: Promise<void> | undefined;
+
+export function Turnstile({ siteKey, onToken }: { siteKey: string; onToken(token: string): void }) {
+  const container = useRef<HTMLDivElement>(null);
+  const callback = useRef(onToken);
+  const [error, setError] = useState("");
+  callback.current = onToken;
+
+  useEffect(() => {
+    let active = true;
+    let widgetId: string | undefined;
+    void loadTurnstile().then(() => {
+      if (!active || !container.current || !window.turnstile) return;
+      widgetId = window.turnstile.render(container.current, {
+        sitekey: siteKey,
+        callback: (token) => { setError(""); callback.current(token); },
+        "expired-callback": () => callback.current(""),
+        "error-callback": () => { callback.current(""); setError("Verification could not be completed. Try again."); },
+        action: "feedback",
+        theme: "auto"
+      });
+    }).catch(() => {
+      if (active) setError("Verification could not be loaded. Check your connection and try again.");
+    });
+    return () => {
+      active = false;
+      if (widgetId && window.turnstile) window.turnstile.remove(widgetId);
+    };
+  }, [siteKey]);
+
+  return <div className="connect-feedback-turnstile">
+    <div ref={container} />
+    {error && <p role="alert">{error}</p>}
+  </div>;
+}
+
+function loadTurnstile(): Promise<void> {
+  if (window.turnstile) return Promise.resolve();
+  if (turnstileScript) return turnstileScript;
+  turnstileScript = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>('script[data-mdbase-turnstile="true"]');
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener("error", () => reject(new Error("Turnstile failed to load")), { once: true });
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+    script.async = true;
+    script.defer = true;
+    script.dataset.mdbaseTurnstile = "true";
+    script.addEventListener("load", () => resolve(), { once: true });
+    script.addEventListener("error", () => reject(new Error("Turnstile failed to load")), { once: true });
+    document.head.append(script);
+  });
+  return turnstileScript;
+}

--- a/apps/editor/src/connect.css
+++ b/apps/editor/src/connect.css
@@ -163,6 +163,16 @@
 .connect-rail-account strong { font-size: 0.8rem; }
 .connect-rail-account small { color: var(--faint); font-size: 0.75rem; }
 
+.connect-rail-feedback {
+  padding: 3px;
+  color: var(--muted);
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+
+.connect-rail-feedback:hover { color: var(--accent-strong); }
+.connect-feedback-mobile-link { display: none !important; }
+
 .connect-pending-banner {
   width: min(734px, calc(100% - 116px));
   display: grid;
@@ -702,6 +712,154 @@ button.danger:disabled {
 
 .connect-account-action:hover { background: var(--hover); }
 .connect-account-danger { margin-top: 18px; color: var(--danger); }
+
+.connect-feedback-form {
+  display: grid;
+  gap: 48px;
+}
+
+.connect-feedback-form > section {
+  display: grid;
+  gap: 16px;
+}
+
+.connect-feedback-topic {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.connect-feedback-topic legend {
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.connect-feedback-topic label {
+  min-height: 72px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 13px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.connect-feedback-topic label:has(input:checked) {
+  border-color: var(--accent);
+  background: var(--selected);
+}
+
+.connect-feedback-topic input,
+.connect-feedback-options input,
+.connect-feedback-diagnostics-toggle input {
+  width: 16px;
+  height: 16px;
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+}
+
+.connect-feedback-topic label > span {
+  display: grid;
+  gap: 3px;
+}
+
+.connect-feedback-topic strong { font-size: 0.82rem; }
+.connect-feedback-topic small { color: var(--muted); font-size: 0.75rem; line-height: 1.4; }
+
+.connect-feedback-field {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.connect-feedback-field > span small { margin-left: 5px; color: var(--faint); font-weight: 400; }
+
+.connect-feedback-field input,
+.connect-feedback-field textarea,
+.connect-feedback-origin select {
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--ink);
+  background: var(--white);
+  font: inherit;
+  font-weight: 400;
+}
+
+.connect-feedback-field textarea { min-height: 150px; resize: vertical; line-height: 1.5; }
+.connect-feedback-count { justify-self: end; margin-top: -10px; color: var(--faint); font-family: var(--mono); font-size: 0.68rem; }
+
+.connect-feedback-upload {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-self: start;
+  padding: 7px 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.connect-feedback-upload input { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); }
+.connect-feedback-upload:focus-within { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.connect-feedback-preview {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+}
+
+.connect-feedback-preview img {
+  max-width: min(100%, 620px);
+  max-height: 360px;
+  border: 1px solid var(--line);
+  object-fit: contain;
+}
+
+.connect-feedback-preview button,
+.connect-feedback-actions > button:first-child { color: var(--accent-strong); font-size: 0.78rem; }
+
+.connect-feedback-options { display: grid; gap: 12px; }
+.connect-feedback-options > label,
+.connect-feedback-diagnostics-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+.connect-feedback-options strong { color: var(--ink); }
+.connect-feedback-origin { width: min(100%, 520px); display: grid !important; gap: 6px !important; margin-left: 25px; font-weight: 700; }
+
+.connect-feedback-diagnostics {
+  border: 1px solid var(--line);
+  border-radius: 5px;
+}
+
+.connect-feedback-diagnostics summary { padding: 10px 12px; color: var(--accent-strong); font-size: 0.78rem; cursor: pointer; }
+.connect-feedback-diagnostics pre { max-height: 280px; overflow: auto; margin: 0; padding: 12px; border-top: 1px solid var(--line); background: var(--soft); color: var(--muted); font: 0.68rem/1.55 var(--mono); white-space: pre-wrap; }
+.connect-feedback-help { max-width: 72ch; margin: 0; color: var(--muted); font-size: 0.75rem; line-height: 1.5; }
+.connect-feedback-error { margin: 0; color: var(--danger); font-size: 0.78rem; line-height: 1.5; }
+.connect-feedback-actions { display: flex; align-items: center; justify-content: flex-end; gap: 16px; }
+.connect-feedback-actions .connect-primary-action:disabled { opacity: 0.5; }
+.connect-feedback-turnstile { min-height: 65px; }
+.connect-feedback-turnstile > p { margin: 8px 0 0; color: var(--danger); font-size: 0.75rem; }
+.connect-feedback-complete p { max-width: 68ch; color: var(--muted); font-size: 0.84rem; line-height: 1.5; }
+.connect-feedback-complete .connect-primary-action { justify-self: start; }
+
 .connect-account-danger:disabled,
 .connect-account-action:disabled { opacity: 0.45; }
 
@@ -1028,6 +1186,7 @@ button.danger:disabled {
   }
 
   .connect-shell > .collection-rail .connection-footer > p,
+  .connect-rail-feedback,
   .connect-rail-account > span:last-child {
     display: none;
   }
@@ -1096,6 +1255,15 @@ button.danger:disabled {
     min-height: 44px;
   }
 
+  .connect-nav > nav > .connect-nav-group > .connect-feedback-mobile-link {
+    display: flex !important;
+    align-items: center;
+    padding: 8px 12px;
+    color: var(--muted);
+    font-size: 0.78rem;
+    text-decoration: none;
+  }
+
   .connect-main {
     overflow: visible;
   }
@@ -1134,6 +1302,11 @@ button.danger:disabled {
   .connect-inline-form label {
     width: 100%;
   }
+
+  .connect-feedback-topic { grid-template-columns: 1fr; }
+  .connect-feedback-actions { justify-content: flex-start; }
+  .connect-feedback-upload { min-height: 44px; }
+
 
   .connect-account-details > div {
     grid-template-columns: 1fr;

--- a/apps/editor/src/feedback.ts
+++ b/apps/editor/src/feedback.ts
@@ -1,0 +1,241 @@
+import { ManagementApiError } from "@mdbase/connect-management";
+
+export const FEEDBACK_MAX_MESSAGE_LENGTH = 5_000;
+export const FEEDBACK_MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024;
+const MAX_DIAGNOSTIC_EVENTS = 30;
+const DIAGNOSTIC_WINDOW_MS = 5 * 60_000;
+
+export type FeedbackTopic = "problem" | "idea";
+export type FeedbackSourceView = "overview" | "storage" | "access" | "collections" | "applications" | "computers" | "account" | "feedback";
+
+export interface FeedbackDiagnosticEvent {
+  at: string;
+  event: "management_request_failed" | "management_refresh_failed";
+  code: "cancelled" | "http_error" | "invalid_response" | "outcome_unknown" | "partial_failure" | "timeout" | "network_error" | "unknown_error";
+  status?: number;
+}
+
+export interface FeedbackDiagnostics {
+  schema_version: 1;
+  product: "mdbase editor";
+  surface: "connect";
+  source_view: FeedbackSourceView;
+  build_revision: string | null;
+  environment: string;
+  browser: string;
+  operating_system: string;
+  viewport: "compact" | "medium" | "wide";
+  events: FeedbackDiagnosticEvent[];
+}
+
+export interface FeedbackScreenshot {
+  media_type: "image/png" | "image/jpeg";
+  filename: "screenshot.png" | "screenshot.jpg";
+  content_base64: string;
+}
+
+export interface FeedbackSubmission {
+  schema_version: 1;
+  request_id: string;
+  topic: FeedbackTopic;
+  message: string;
+  reply_email?: string;
+  context?: {
+    collection_name?: string;
+    application_origin?: string;
+  };
+  diagnostics?: FeedbackDiagnostics;
+  screenshot?: FeedbackScreenshot;
+  turnstile_token?: string;
+}
+
+const diagnosticEvents: FeedbackDiagnosticEvent[] = [];
+
+export function recordFeedbackFailure(event: FeedbackDiagnosticEvent["event"], reason: unknown): void {
+  const failure = reason instanceof ManagementApiError
+    ? { code: reason.code, status: reason.status }
+    : { code: isNetworkFailure(reason) ? "network_error" as const : "unknown_error" as const };
+  diagnosticEvents.push({ at: new Date().toISOString(), event, ...failure });
+  pruneDiagnosticEvents();
+}
+
+export function buildFeedbackDiagnostics(sourceView: FeedbackSourceView): FeedbackDiagnostics {
+  pruneDiagnosticEvents();
+  return {
+    schema_version: 1,
+    product: "mdbase editor",
+    surface: "connect",
+    source_view: sourceView,
+    build_revision: normalizedBuildRevision(import.meta.env.VITE_MDBASE_BUILD_REVISION),
+    environment: normalizedEnvironment(import.meta.env.VITE_MDBASE_ENV),
+    browser: browserFamily(),
+    operating_system: operatingSystem(),
+    viewport: window.innerWidth < 760 ? "compact" : window.innerWidth < 1200 ? "medium" : "wide",
+    events: diagnosticEvents.map((event) => ({ ...event }))
+  };
+}
+
+export async function readFeedbackScreenshot(file: File): Promise<FeedbackScreenshot> {
+  if (file.size > FEEDBACK_MAX_SCREENSHOT_BYTES) {
+    throw new Error("Choose a screenshot smaller than 3 MB.");
+  }
+  if (file.type !== "image/png" && file.type !== "image/jpeg") {
+    throw new Error("Choose a PNG or JPEG screenshot.");
+  }
+  const sourceBytes = new Uint8Array(await file.arrayBuffer());
+  if (!matchesImageSignature(sourceBytes, file.type)) {
+    throw new Error("The screenshot does not contain a valid PNG or JPEG image.");
+  }
+  const canonical = await canonicalizeScreenshot(file);
+  const bytes = new Uint8Array(await canonical.arrayBuffer());
+  if (bytes.byteLength > FEEDBACK_MAX_SCREENSHOT_BYTES) {
+    throw new Error("The cleaned screenshot is larger than 3 MB. Crop it and try again.");
+  }
+  return {
+    media_type: file.type,
+    filename: file.type === "image/png" ? "screenshot.png" : "screenshot.jpg",
+    content_base64: bytesToBase64(bytes)
+  };
+}
+
+export async function sendFeedback(endpoint: string, submission: FeedbackSubmission, signal?: AbortSignal): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(submission),
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+      signal
+    });
+  } catch {
+    throw new Error("Feedback could not be sent. Check your connection and try again.");
+  }
+  if (response.ok) return;
+  let message = "Feedback could not be sent. Please try again.";
+  try {
+    const result = await response.json() as { error?: { message?: string } };
+    if (typeof result.error?.message === "string" && result.error.message.length <= 200) message = result.error.message;
+  } catch {
+    // Provider and infrastructure response bodies are intentionally ignored.
+  }
+  throw new Error(message);
+}
+
+export function feedbackEndpoint(): string | null {
+  const configured = import.meta.env.VITE_MDBASE_FEEDBACK_URL?.trim();
+  const value = configured || (import.meta.env.DEV ? "http://127.0.0.1:8790/v1/feedback" : "");
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.hostname !== "127.0.0.1" && url.hostname !== "localhost") return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function turnstileSiteKey(): string | null {
+  return import.meta.env.VITE_MDBASE_TURNSTILE_SITE_KEY?.trim() || null;
+}
+
+function pruneDiagnosticEvents(now = Date.now()): void {
+  const cutoff = now - DIAGNOSTIC_WINDOW_MS;
+  while (diagnosticEvents.length > 0 && new Date(diagnosticEvents[0].at).getTime() < cutoff) diagnosticEvents.shift();
+  if (diagnosticEvents.length > MAX_DIAGNOSTIC_EVENTS) diagnosticEvents.splice(0, diagnosticEvents.length - MAX_DIAGNOSTIC_EVENTS);
+}
+
+function matchesImageSignature(bytes: Uint8Array, type: File["type"]): boolean {
+  if (type === "image/png") {
+    return bytes.length >= 8 && [137, 80, 78, 71, 13, 10, 26, 10].every((value, index) => bytes[index] === value);
+  }
+  return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+}
+
+async function canonicalizeScreenshot(file: File): Promise<Blob> {
+  const source = await decodeImage(file);
+  try {
+    if (source.width < 1 || source.height < 1 || source.width > 8_192 || source.height > 8_192 || source.width * source.height > 16_000_000) {
+      throw new Error("Choose a screenshot smaller than 16 megapixels.");
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = source.width;
+    canvas.height = source.height;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("The screenshot could not be cleaned in this browser.");
+    context.drawImage(source.image, 0, 0);
+    const blob = await new Promise<Blob>((resolve, reject) => canvas.toBlob(
+      (result) => result ? resolve(result) : reject(new Error("The screenshot could not be cleaned in this browser.")),
+      file.type,
+      file.type === "image/jpeg" ? 0.9 : undefined
+    ));
+    return blob;
+  } finally {
+    source.close();
+  }
+}
+
+async function decodeImage(file: File): Promise<{ width: number; height: number; image: CanvasImageSource; close(): void }> {
+  if (typeof createImageBitmap === "function") {
+    try {
+      const bitmap = await createImageBitmap(file);
+      return { width: bitmap.width, height: bitmap.height, image: bitmap, close: () => bitmap.close() };
+    } catch {
+      throw new Error("The screenshot could not be decoded as a PNG or JPEG image.");
+    }
+  }
+  const objectUrl = URL.createObjectURL(file);
+  const image = new Image();
+  try {
+    image.src = objectUrl;
+    await image.decode();
+    return { width: image.naturalWidth, height: image.naturalHeight, image, close: () => URL.revokeObjectURL(objectUrl) };
+  } catch {
+    URL.revokeObjectURL(objectUrl);
+    throw new Error("The screenshot could not be decoded as a PNG or JPEG image.");
+  }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+  return btoa(binary);
+}
+
+function normalizedBuildRevision(value: string | undefined): string | null {
+  const revision = value?.trim();
+  return revision && /^[a-zA-Z0-9._-]{1,64}$/u.test(revision) ? revision : null;
+}
+
+function normalizedEnvironment(value: string | undefined): string {
+  const environment = value?.trim().toLowerCase();
+  return environment === "production" || environment === "staging" || environment === "development" ? environment : import.meta.env.DEV ? "development" : "production";
+}
+
+function browserFamily(): string {
+  const userAgent = navigator.userAgent;
+  const match = userAgent.match(/(?:Edg|Chrome|Firefox|Version)\/(\d+)/u);
+  const version = match?.[1] ?? "unknown";
+  if (/Edg\//u.test(userAgent)) return `Edge ${version}`;
+  if (/Firefox\//u.test(userAgent)) return `Firefox ${version}`;
+  if (/Chrome\//u.test(userAgent)) return `Chrome ${version}`;
+  if (/Safari\//u.test(userAgent)) return `Safari ${version}`;
+  return "Other";
+}
+
+function operatingSystem(): string {
+  const userAgent = navigator.userAgent;
+  if (/Windows/u.test(userAgent)) return "Windows";
+  if (/Macintosh|Mac OS/u.test(userAgent)) return "macOS";
+  if (/Android/u.test(userAgent)) return "Android";
+  if (/iPhone|iPad|iPod/u.test(userAgent)) return "iOS";
+  if (/Linux/u.test(userAgent)) return "Linux";
+  return "Other";
+}
+
+function isNetworkFailure(value: unknown): boolean {
+  return value instanceof TypeError && /fetch|network|load/i.test(value.message);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,15 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  services/feedback:
+    devDependencies:
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   services/mcp:
     dependencies:
       '@fastify/cors':

--- a/services/feedback/README.md
+++ b/services/feedback/README.md
@@ -1,0 +1,33 @@
+# mdbase feedback Worker
+
+This stateless Cloudflare Worker accepts bounded feedback from configured mdbase editor origins and forwards it to a private support inbox through Resend. It does not store feedback or screenshots.
+
+Product code and request validation live here. Managed Worker names, routes, recipients, secrets, deployment, and verification belong in the private `mdbase-cloud-ops` repository.
+
+## Runtime contract
+
+Route: `POST /v1/feedback` with `Content-Type: application/json`.
+
+Required variables:
+
+- `ALLOWED_ORIGINS`: comma-separated exact editor origins;
+- `FEEDBACK_FROM`: verified sender mailbox or `Name <mailbox>`;
+- `FEEDBACK_TO`: one support mailbox;
+- `RESEND_API_KEY`: secret Resend credential.
+
+Optional variables:
+
+- `TURNSTILE_REQUIRED`: set to `1` to fail readiness unless the secret is present;
+- `TURNSTILE_SECRET`: when present, every submission must carry a valid `turnstile_token`;
+- `MDBASE_REVISION`: exact 40-character product source commit exposed by `GET /health`.
+
+The browser schema is defined in `apps/editor/src/feedback.ts`. The Worker independently rejects unknown fields, oversized bodies, unapproved origins, arbitrary diagnostics, invalid reply addresses, and screenshots that are not bounded PNG/JPEG data. It sends plain text only and never reflects provider response bodies.
+
+## Local checks
+
+```sh
+pnpm --filter @mdbase/feedback-worker typecheck
+pnpm --filter @mdbase/feedback-worker test
+```
+
+Deploy through `mdbase-cloud-ops`; do not add production credentials or deployment topology here.

--- a/services/feedback/package.json
+++ b/services/feedback/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@mdbase/feedback-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/services/feedback/src/index.test.ts
+++ b/services/feedback/src/index.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFeedbackWorker, type FeedbackWorkerEnv } from "./index";
+
+const ONE_PIXEL_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+const ONE_PIXEL_JPEG_BASE64 = "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q==";
+
+const env: FeedbackWorkerEnv = {
+  ALLOWED_ORIGINS: "https://editor.mdbase.dev,https://editor-staging.mdbase.dev",
+  FEEDBACK_FROM: "mdbase feedback <feedback@notifications.mdbase.dev>",
+  FEEDBACK_TO: "support@mdbase.dev",
+  RESEND_API_KEY: "re_test_secret",
+  MDBASE_REVISION: "a".repeat(40)
+};
+
+function submission(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: 1,
+    request_id: "123e4567-e89b-42d3-a456-426614174000",
+    topic: "problem",
+    message: "Application access did not finish.",
+    diagnostics: {
+      schema_version: 1,
+      product: "mdbase editor",
+      surface: "connect",
+      source_view: "applications",
+      build_revision: "abc123",
+      environment: "production",
+      browser: "Chrome 140",
+      operating_system: "Linux",
+      viewport: "wide",
+      events: [{ at: "2026-08-24T10:00:00.000Z", event: "management_request_failed", code: "http_error", status: 503 }]
+    },
+    ...overrides
+  };
+}
+
+function request(body: unknown = submission(), origin = "https://editor.mdbase.dev") {
+  return new Request("https://feedback-api.mdbase.dev/v1/feedback", {
+    method: "POST",
+    headers: { origin, "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+describe("feedback Worker", () => {
+  it("delivers a bounded plain-text email with idempotency", async () => {
+    const provider = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => Response.json({ id: "email" }, { status: 200 }));
+    const response = await createFeedbackWorker(provider).fetch(request(submission({
+      reply_email: "person@example.com",
+      context: { collection_name: "Garden notes", application_origin: "https://example.app" },
+      screenshot: {
+        media_type: "image/png",
+        filename: "screenshot.png",
+        content_base64: ONE_PIXEL_PNG_BASE64
+      }
+    })), env);
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://editor.mdbase.dev");
+    expect(provider).toHaveBeenCalledOnce();
+    const [url, init] = provider.mock.calls[0];
+    expect(url).toBe("https://api.resend.com/emails");
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer re_test_secret");
+    expect(new Headers(init?.headers).get("idempotency-key")).toBe("mdbase-feedback/123e4567-e89b-42d3-a456-426614174000");
+    const email = JSON.parse(String(init?.body));
+    expect(email).toMatchObject({
+      from: env.FEEDBACK_FROM,
+      to: [env.FEEDBACK_TO],
+      reply_to: "person@example.com",
+      subject: "[Problem] mdbase connect feedback"
+    });
+    expect(email.html).toBeUndefined();
+    expect(email.text).toContain("Collection: Garden notes");
+    expect(email.attachments.map((attachment: { filename: string }) => attachment.filename)).toEqual(["screenshot.png", "diagnostics.json"]);
+  });
+
+  it("accepts a structurally valid stripped JPEG", async () => {
+    const provider = vi.fn(async () => Response.json({ id: "email" }));
+    const response = await createFeedbackWorker(provider).fetch(request(submission({
+      screenshot: { media_type: "image/jpeg", filename: "screenshot.jpg", content_base64: ONE_PIXEL_JPEG_BASE64 }
+    })), env);
+    expect(response.status).toBe(202);
+    expect(provider).toHaveBeenCalledOnce();
+  });
+
+  it("rejects origins before reading or forwarding the body", async () => {
+    const provider = vi.fn();
+    const response = await createFeedbackWorker(provider).fetch(request(undefined, "https://attacker.example"), env);
+    expect(response.status).toBe(403);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("answers preflight only for an allowed origin and POST", async () => {
+    const response = await createFeedbackWorker(vi.fn()).fetch(new Request("https://feedback-api.mdbase.dev/v1/feedback", {
+      method: "OPTIONS",
+      headers: { origin: "https://editor.mdbase.dev", "access-control-request-method": "POST" }
+    }), env);
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-methods")).toBe("POST, OPTIONS");
+  });
+
+  it("stops reading an oversized stream without relying on Content-Length", async () => {
+    const chunk = new Uint8Array(2_300_000);
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(chunk);
+        if (pulls === 3) controller.close();
+      }
+    });
+    const streamed = new Request("https://feedback-api.mdbase.dev/v1/feedback", {
+      method: "POST",
+      headers: { origin: "https://editor.mdbase.dev", "content-type": "application/json" },
+      body,
+      duplex: "half"
+    } as RequestInit & { duplex: "half" });
+    const provider = vi.fn();
+    const response = await createFeedbackWorker(provider).fetch(streamed, env);
+    expect(response.status).toBe(413);
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("strictly rejects unknown fields and invalid image bytes", async () => {
+    const worker = createFeedbackWorker(vi.fn());
+    const unknown = await worker.fetch(request(submission({ account_id: "private" })), env);
+    expect(unknown.status).toBe(400);
+    expect(await unknown.json()).toMatchObject({ error: { code: "unknown_field" } });
+
+    const image = await worker.fetch(request(submission({
+      screenshot: { media_type: "image/png", filename: "screenshot.png", content_base64: btoa("not a png") }
+    })), env);
+    expect(image.status).toBe(400);
+    expect(await image.json()).toMatchObject({ error: { code: "invalid_screenshot" } });
+
+    const appended = btoa(`${atob(ONE_PIXEL_PNG_BASE64)}hidden`);
+    const polyglot = await worker.fetch(request(submission({
+      screenshot: { media_type: "image/png", filename: "screenshot.png", content_base64: appended }
+    })), env);
+    expect(polyglot.status).toBe(400);
+  });
+
+  it("does not expose provider response details", async () => {
+    const provider = vi.fn(async () => new Response("mailbox and provider details", { status: 500 }));
+    const response = await createFeedbackWorker(provider).fetch(request(), env);
+    expect(response.status).toBe(503);
+    const body = await response.text();
+    expect(body).not.toContain("mailbox and provider details");
+    expect(body).not.toContain(env.FEEDBACK_TO);
+  });
+
+  it("requires and verifies Turnstile when configured", async () => {
+    const provider = vi.fn(async (input: RequestInfo | URL) => String(input).includes("siteverify")
+      ? Response.json({ success: true, hostname: "editor.mdbase.dev", action: "feedback" })
+      : Response.json({ id: "email" }));
+    const protectedEnv = { ...env, TURNSTILE_REQUIRED: "1", TURNSTILE_SECRET: "turnstile-secret" };
+    const missing = await createFeedbackWorker(provider).fetch(request(), protectedEnv);
+    expect(missing.status).toBe(400);
+    expect(await missing.json()).toMatchObject({ error: { code: "verification_required" } });
+
+    provider.mockClear();
+    const accepted = await createFeedbackWorker(provider).fetch(request(submission({ turnstile_token: "browser-token" })), protectedEnv);
+    expect(accepted.status).toBe(202);
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(String(provider.mock.calls[0][0])).toContain("siteverify");
+    expect(String(provider.mock.calls[1][0])).toBe("https://api.resend.com/emails");
+
+    const wrongHost = vi.fn(async () => Response.json({ success: true, hostname: "attacker.example", action: "feedback" }));
+    const rejected = await createFeedbackWorker(wrongHost).fetch(request(submission({ turnstile_token: "other-token" })), protectedEnv);
+    expect(rejected.status).toBe(400);
+    expect(await rejected.json()).toMatchObject({ error: { code: "verification_failed" } });
+  });
+
+  it("fails readiness when managed Turnstile protection is missing", async () => {
+    const response = await createFeedbackWorker(vi.fn()).fetch(new Request("https://feedback-api.mdbase.dev/health"), { ...env, TURNSTILE_REQUIRED: "1" });
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ ok: false, service: "mdbase-feedback", revision: "a".repeat(40) });
+  });
+
+  it("exposes only service identity and revision on health", async () => {
+    const response = await createFeedbackWorker(vi.fn()).fetch(new Request("https://feedback-api.mdbase.dev/health"), env);
+    expect(await response.json()).toEqual({ ok: true, service: "mdbase-feedback", revision: "a".repeat(40) });
+  });
+});

--- a/services/feedback/src/index.ts
+++ b/services/feedback/src/index.ts
@@ -1,0 +1,423 @@
+const MAX_BODY_BYTES = 4_400_000;
+const MAX_MESSAGE_LENGTH = 5_000;
+const MAX_SCREENSHOT_BYTES = 3 * 1024 * 1024;
+const MAX_DIAGNOSTIC_EVENTS = 30;
+const EMAIL_TIMEOUT_MS = 10_000;
+
+export interface FeedbackWorkerEnv {
+  ALLOWED_ORIGINS: string;
+  FEEDBACK_FROM: string;
+  FEEDBACK_TO: string;
+  RESEND_API_KEY: string;
+  TURNSTILE_REQUIRED?: string;
+  TURNSTILE_SECRET?: string;
+  MDBASE_REVISION?: string;
+}
+
+interface FeedbackScreenshot {
+  media_type: "image/png" | "image/jpeg";
+  filename: "screenshot.png" | "screenshot.jpg";
+  content_base64: string;
+  bytes: Uint8Array;
+}
+
+interface FeedbackSubmission {
+  schema_version: 1;
+  request_id: string;
+  topic: "problem" | "idea";
+  message: string;
+  reply_email?: string;
+  context?: { collection_name?: string; application_origin?: string };
+  diagnostics?: Record<string, unknown>;
+  screenshot?: FeedbackScreenshot;
+  turnstile_token?: string;
+}
+
+class RequestError extends Error {
+  constructor(public readonly status: number, public readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+export function createFeedbackWorker(fetchImpl: typeof fetch = fetch) {
+  return {
+    async fetch(request: Request, env: FeedbackWorkerEnv): Promise<Response> {
+      const healthRequest = request.method === "GET" && new URL(request.url).pathname === "/health";
+      let allowedOrigins: Set<string>;
+      try {
+        allowedOrigins = configuredOrigins(env.ALLOWED_ORIGINS);
+        validateEmailConfiguration(env);
+      } catch {
+        return healthRequest
+          ? json({ ok: false, service: "mdbase-feedback", revision: safeRevision(env.MDBASE_REVISION) }, 503)
+          : jsonError(503, "service_unavailable", "Feedback is temporarily unavailable.");
+      }
+      if (healthRequest) return json({ ok: true, service: "mdbase-feedback", revision: safeRevision(env.MDBASE_REVISION) });
+
+      const origin = request.headers.get("origin") ?? "";
+      if (!allowedOrigins.has(origin)) return jsonError(403, "origin_denied", "This feedback origin is not allowed.");
+      const cors = corsHeaders(origin);
+      if (request.method === "OPTIONS") {
+        const requestedMethod = request.headers.get("access-control-request-method");
+        return requestedMethod === "POST"
+          ? new Response(null, { status: 204, headers: cors })
+          : jsonError(405, "method_not_allowed", "Only POST submissions are accepted.", cors);
+      }
+      if (request.method !== "POST") return jsonError(405, "method_not_allowed", "Only POST submissions are accepted.", cors);
+      if (new URL(request.url).pathname !== "/v1/feedback") return jsonError(404, "not_found", "Feedback endpoint not found.", cors);
+      if (request.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() !== "application/json") {
+        return jsonError(415, "unsupported_media_type", "Feedback must be sent as JSON.", cors);
+      }
+      const contentLengthHeader = request.headers.get("content-length");
+      const contentLength = contentLengthHeader === null ? null : Number(contentLengthHeader);
+      if (contentLength !== null && (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > MAX_BODY_BYTES)) {
+        return jsonError(413, "payload_too_large", "The feedback attachment is too large.", cors);
+      }
+
+      try {
+        const body = await readBoundedBody(request, MAX_BODY_BYTES);
+        let raw: unknown;
+        try { raw = JSON.parse(body); } catch { throw new RequestError(400, "invalid_json", "Feedback must contain valid JSON."); }
+        const submission = validateSubmission(raw);
+        if (env.TURNSTILE_SECRET) await verifyTurnstile(fetchImpl, env.TURNSTILE_SECRET, submission.turnstile_token, origin);
+        await sendEmail(fetchImpl, env, submission);
+        return json({ ok: true, request_id: submission.request_id }, 202, cors);
+      } catch (reason) {
+        if (reason instanceof RequestError) return jsonError(reason.status, reason.code, reason.message, cors);
+        return jsonError(503, "delivery_failed", "Feedback could not be delivered. Please try again.", cors);
+      }
+    }
+  };
+}
+
+const worker = createFeedbackWorker();
+export default worker;
+
+function validateSubmission(value: unknown): FeedbackSubmission {
+  const input = object(value, "Feedback must be an object.");
+  exactKeys(input, ["schema_version", "request_id", "topic", "message", "reply_email", "context", "diagnostics", "screenshot", "turnstile_token"]);
+  if (input.schema_version !== 1) throw new RequestError(400, "unsupported_schema", "This feedback format is not supported.");
+  const requestId = text(input.request_id, "request_id", 64);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(requestId)) {
+    throw new RequestError(400, "invalid_request_id", "The feedback request identifier is invalid.");
+  }
+  if (input.topic !== "problem" && input.topic !== "idea") throw new RequestError(400, "invalid_topic", "Choose problem or idea.");
+  const message = text(input.message, "message", MAX_MESSAGE_LENGTH).trim();
+  if (!message) throw new RequestError(400, "missing_message", "Describe the feedback before sending it.");
+  if (message.includes("\0")) throw new RequestError(400, "invalid_message", "The feedback message contains unsupported characters.");
+  const replyEmail = input.reply_email === undefined ? undefined : email(text(input.reply_email, "reply_email", 320));
+  const context = input.context === undefined ? undefined : validateContext(input.context);
+  const diagnostics = input.diagnostics === undefined ? undefined : validateDiagnostics(input.diagnostics);
+  const screenshot = input.screenshot === undefined ? undefined : validateScreenshot(input.screenshot);
+  const turnstileToken = input.turnstile_token === undefined ? undefined : text(input.turnstile_token, "turnstile_token", 2_048);
+  return {
+    schema_version: 1,
+    request_id: requestId,
+    topic: input.topic,
+    message,
+    ...(replyEmail ? { reply_email: replyEmail } : {}),
+    ...(context ? { context } : {}),
+    ...(diagnostics ? { diagnostics } : {}),
+    ...(screenshot ? { screenshot } : {}),
+    ...(turnstileToken ? { turnstile_token: turnstileToken } : {})
+  };
+}
+
+function validateContext(value: unknown): FeedbackSubmission["context"] {
+  const input = object(value, "Feedback context must be an object.");
+  exactKeys(input, ["collection_name", "application_origin"]);
+  const collectionName = input.collection_name === undefined ? undefined : text(input.collection_name, "collection_name", 200).trim();
+  let applicationOrigin: string | undefined;
+  if (input.application_origin !== undefined) {
+    const candidate = text(input.application_origin, "application_origin", 2_048);
+    try {
+      const parsed = new URL(candidate);
+      if ((parsed.protocol !== "https:" && parsed.protocol !== "http:") || parsed.origin !== candidate) throw new Error("not an origin");
+      applicationOrigin = parsed.origin;
+    } catch {
+      throw new RequestError(400, "invalid_application_origin", "The application origin is invalid.");
+    }
+  }
+  if (!collectionName && !applicationOrigin) return undefined;
+  return { ...(collectionName ? { collection_name: collectionName } : {}), ...(applicationOrigin ? { application_origin: applicationOrigin } : {}) };
+}
+
+function validateDiagnostics(value: unknown): Record<string, unknown> {
+  const input = object(value, "Diagnostics must be an object.");
+  exactKeys(input, ["schema_version", "product", "surface", "source_view", "build_revision", "environment", "browser", "operating_system", "viewport", "events"]);
+  if (input.schema_version !== 1 || input.product !== "mdbase editor" || input.surface !== "connect") {
+    throw new RequestError(400, "invalid_diagnostics", "The diagnostic format is invalid.");
+  }
+  if (!["overview", "storage", "access", "collections", "applications", "computers", "account", "feedback"].includes(String(input.source_view))) {
+    throw new RequestError(400, "invalid_diagnostics", "The diagnostic source is invalid.");
+  }
+  if (input.build_revision !== null && input.build_revision !== undefined && !/^[a-zA-Z0-9._-]{1,64}$/u.test(String(input.build_revision))) {
+    throw new RequestError(400, "invalid_diagnostics", "The diagnostic revision is invalid.");
+  }
+  if (!["production", "staging", "development"].includes(String(input.environment))) throw new RequestError(400, "invalid_diagnostics", "The diagnostic environment is invalid.");
+  const browser = text(input.browser, "browser", 40);
+  const operatingSystem = text(input.operating_system, "operating_system", 20);
+  if (!/^(?:Edge|Firefox|Chrome|Safari) (?:\d+|unknown)$|^Other$/u.test(browser)) throw new RequestError(400, "invalid_diagnostics", "The diagnostic browser is invalid.");
+  if (!["Windows", "macOS", "Android", "iOS", "Linux", "Other"].includes(operatingSystem)) throw new RequestError(400, "invalid_diagnostics", "The diagnostic operating system is invalid.");
+  if (!["compact", "medium", "wide"].includes(String(input.viewport))) throw new RequestError(400, "invalid_diagnostics", "The diagnostic viewport is invalid.");
+  if (!Array.isArray(input.events) || input.events.length > MAX_DIAGNOSTIC_EVENTS) throw new RequestError(400, "invalid_diagnostics", "The diagnostic events are invalid.");
+  const events = input.events.map(validateDiagnosticEvent);
+  return { ...input, browser, operating_system: operatingSystem, events };
+}
+
+function validateDiagnosticEvent(value: unknown): Record<string, unknown> {
+  const event = object(value, "A diagnostic event must be an object.");
+  exactKeys(event, ["at", "event", "code", "status"]);
+  const at = text(event.at, "diagnostic event time", 40);
+  if (!Number.isFinite(Date.parse(at))) throw new RequestError(400, "invalid_diagnostics", "A diagnostic event time is invalid.");
+  if (event.event !== "management_request_failed" && event.event !== "management_refresh_failed") throw new RequestError(400, "invalid_diagnostics", "A diagnostic event name is invalid.");
+  if (!["cancelled", "http_error", "invalid_response", "outcome_unknown", "partial_failure", "timeout", "network_error", "unknown_error"].includes(String(event.code))) {
+    throw new RequestError(400, "invalid_diagnostics", "A diagnostic event code is invalid.");
+  }
+  if (event.status !== undefined && (!Number.isInteger(event.status) || Number(event.status) < 0 || Number(event.status) > 599)) {
+    throw new RequestError(400, "invalid_diagnostics", "A diagnostic status is invalid.");
+  }
+  return { at, event: event.event, code: event.code, ...(event.status === undefined ? {} : { status: event.status }) };
+}
+
+function validateScreenshot(value: unknown): FeedbackScreenshot {
+  const input = object(value, "Screenshot must be an object.");
+  exactKeys(input, ["media_type", "filename", "content_base64"]);
+  if (input.media_type !== "image/png" && input.media_type !== "image/jpeg") throw new RequestError(400, "invalid_screenshot", "Choose a PNG or JPEG screenshot.");
+  const expectedFilename = input.media_type === "image/png" ? "screenshot.png" : "screenshot.jpg";
+  if (input.filename !== expectedFilename) throw new RequestError(400, "invalid_screenshot", "The screenshot filename is invalid.");
+  const content = text(input.content_base64, "screenshot content", 4_200_000);
+  if (!/^[a-zA-Z0-9+/]*={0,2}$/u.test(content)) throw new RequestError(400, "invalid_screenshot", "The screenshot encoding is invalid.");
+  let bytes: Uint8Array;
+  try { bytes = Uint8Array.from(atob(content), (character) => character.charCodeAt(0)); } catch { throw new RequestError(400, "invalid_screenshot", "The screenshot encoding is invalid."); }
+  if (bytes.byteLength > MAX_SCREENSHOT_BYTES || !isValidRaster(bytes, input.media_type)) {
+    throw new RequestError(400, "invalid_screenshot", "The screenshot is invalid or too large.");
+  }
+  return { media_type: input.media_type, filename: expectedFilename, content_base64: content, bytes };
+}
+
+async function verifyTurnstile(fetchImpl: typeof fetch, secret: string, token: string | undefined, origin: string): Promise<void> {
+  if (!token) throw new RequestError(400, "verification_required", "Complete the verification before sending feedback.");
+  let response: Response;
+  try {
+    response = await fetchImpl("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ secret, response: token }),
+      signal: AbortSignal.timeout(EMAIL_TIMEOUT_MS)
+    });
+  } catch {
+    throw new RequestError(503, "verification_unavailable", "Verification is temporarily unavailable. Please try again.");
+  }
+  if (!response.ok) throw new RequestError(503, "verification_unavailable", "Verification is temporarily unavailable. Please try again.");
+  const result = await response.json().catch(() => null) as { success?: unknown; hostname?: unknown; action?: unknown } | null;
+  const expectedHostname = new URL(origin).hostname;
+  if (result?.success !== true || result.hostname !== expectedHostname || result.action !== "feedback") {
+    throw new RequestError(400, "verification_failed", "Verification failed. Please try again.");
+  }
+}
+
+async function sendEmail(fetchImpl: typeof fetch, env: FeedbackWorkerEnv, submission: FeedbackSubmission): Promise<void> {
+  const attachments: Array<{ filename: string; content: string }> = [];
+  if (submission.screenshot) attachments.push({ filename: submission.screenshot.filename, content: submission.screenshot.content_base64 });
+  if (submission.diagnostics) attachments.push({ filename: "diagnostics.json", content: stringToBase64(`${JSON.stringify(submission.diagnostics, null, 2)}\n`) });
+  const response = await fetchImpl("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "content-type": "application/json",
+      "idempotency-key": `mdbase-feedback/${submission.request_id}`
+    },
+    body: JSON.stringify({
+      from: env.FEEDBACK_FROM,
+      to: [env.FEEDBACK_TO],
+      subject: submission.topic === "problem" ? "[Problem] mdbase connect feedback" : "[Idea] mdbase connect feedback",
+      text: emailBody(submission),
+      ...(submission.reply_email ? { reply_to: submission.reply_email } : {}),
+      ...(attachments.length > 0 ? { attachments } : {})
+    }),
+    signal: AbortSignal.timeout(EMAIL_TIMEOUT_MS)
+  });
+  if (!response.ok) throw new Error("Email provider rejected feedback");
+}
+
+function emailBody(submission: FeedbackSubmission): string {
+  const lines = [
+    `Feedback ID: ${submission.request_id}`,
+    `Topic: ${submission.topic}`,
+    "",
+    submission.message,
+    "",
+    "Context"
+  ];
+  lines.push(`Collection: ${submission.context?.collection_name ?? "Not included"}`);
+  lines.push(`Application origin: ${submission.context?.application_origin ?? "Not included"}`);
+  lines.push(`Reply email: ${submission.reply_email ?? "Not provided"}`);
+  lines.push(`Diagnostics: ${submission.diagnostics ? "Attached" : "Not included"}`);
+  lines.push(`Screenshot: ${submission.screenshot ? "Attached" : "Not included"}`);
+  return `${lines.join("\n")}\n`;
+}
+
+async function readBoundedBody(request: Request, maximumBytes: number): Promise<string> {
+  if (!request.body) return "";
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maximumBytes) {
+        await reader.cancel("feedback payload limit exceeded");
+        throw new RequestError(413, "payload_too_large", "The feedback attachment is too large.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    throw new RequestError(400, "invalid_encoding", "Feedback must use UTF-8 encoding.");
+  }
+}
+
+function configuredOrigins(value: string): Set<string> {
+  const origins = value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  if (origins.length === 0) throw new Error("No origins configured");
+  return new Set(origins.map((entry) => {
+    const url = new URL(entry);
+    if (url.origin !== entry || (url.protocol !== "https:" && url.hostname !== "127.0.0.1" && url.hostname !== "localhost")) throw new Error("Invalid origin");
+    return url.origin;
+  }));
+}
+
+function validateEmailConfiguration(env: FeedbackWorkerEnv): void {
+  if (!env.RESEND_API_KEY || env.RESEND_API_KEY.includes("\n") || env.RESEND_API_KEY.includes("\r")) throw new Error("Invalid API key");
+  if (!validMailbox(env.FEEDBACK_TO) || /[\r\n]/u.test(env.FEEDBACK_FROM) || !/^.{1,200}<[^<>]+@[^<>]+>$|^[^<>\s]+@[^<>\s]+$/u.test(env.FEEDBACK_FROM.trim())) throw new Error("Invalid email configuration");
+  if (env.TURNSTILE_REQUIRED !== undefined && env.TURNSTILE_REQUIRED !== "0" && env.TURNSTILE_REQUIRED !== "1") throw new Error("Invalid Turnstile policy");
+  if (env.TURNSTILE_REQUIRED === "1" && !env.TURNSTILE_SECRET) throw new Error("Turnstile secret is required");
+}
+
+function validMailbox(value: string): boolean {
+  return value.length <= 320 && !/[\r\n]/u.test(value) && /^[^<>\s@]+@[^<>\s@]+\.[^<>\s@]+$/u.test(value);
+}
+
+function email(value: string): string {
+  if (!validMailbox(value)) throw new RequestError(400, "invalid_reply_email", "Enter a valid reply email address.");
+  return value;
+}
+
+function object(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new RequestError(400, "invalid_request", message);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: string[]): void {
+  const allowedKeys = new Set(allowed);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) throw new RequestError(400, "unknown_field", "The feedback contains an unsupported field.");
+}
+
+function text(value: unknown, field: string, maxLength: number): string {
+  if (typeof value !== "string" || value.length > maxLength) throw new RequestError(400, "invalid_field", `The ${field} field is invalid.`);
+  return value;
+}
+
+function isValidRaster(bytes: Uint8Array, type: "image/png" | "image/jpeg"): boolean {
+  return type === "image/png" ? isValidPng(bytes) : isValidJpeg(bytes);
+}
+
+function isValidPng(bytes: Uint8Array): boolean {
+  if (bytes.length < 45 || ![137, 80, 78, 71, 13, 10, 26, 10].every((value, index) => bytes[index] === value)) return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 8;
+  let sawHeader = false;
+  while (offset + 12 <= bytes.length) {
+    const length = view.getUint32(offset);
+    const type = String.fromCharCode(...bytes.subarray(offset + 4, offset + 8));
+    const end = offset + 12 + length;
+    if (end > bytes.length) return false;
+    if (!sawHeader) {
+      if (type !== "IHDR" || length !== 13) return false;
+      const width = view.getUint32(offset + 8);
+      const height = view.getUint32(offset + 12);
+      if (!validImageDimensions(width, height)) return false;
+      sawHeader = true;
+    }
+    if (["eXIf", "iTXt", "tEXt", "zTXt"].includes(type)) return false;
+    if (type === "IEND") return sawHeader && length === 0 && end === bytes.length;
+    offset = end;
+  }
+  return false;
+}
+
+function isValidJpeg(bytes: Uint8Array): boolean {
+  if (bytes.length < 20 || bytes[0] !== 0xff || bytes[1] !== 0xd8 || bytes.at(-2) !== 0xff || bytes.at(-1) !== 0xd9) return false;
+  let offset = 2;
+  let sawDimensions = false;
+  while (offset < bytes.length - 2) {
+    while (bytes[offset] === 0xff) offset += 1;
+    const marker = bytes[offset++];
+    if (marker === undefined || marker === 0x00) return false;
+    if (marker === 0xda) return sawDimensions;
+    if (marker === 0xd9) return sawDimensions && offset === bytes.length;
+    if (marker >= 0xd0 && marker <= 0xd7) continue;
+    if (offset + 2 > bytes.length) return false;
+    const length = (bytes[offset] << 8) | bytes[offset + 1];
+    if (length < 2 || offset + length > bytes.length) return false;
+    if ([0xe1, 0xe2, 0xed, 0xfe].includes(marker)) return false;
+    if ([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf].includes(marker)) {
+      if (length < 7) return false;
+      const height = (bytes[offset + 3] << 8) | bytes[offset + 4];
+      const width = (bytes[offset + 5] << 8) | bytes[offset + 6];
+      if (!validImageDimensions(width, height)) return false;
+      sawDimensions = true;
+    }
+    offset += length;
+  }
+  return false;
+}
+
+function validImageDimensions(width: number, height: number): boolean {
+  return width > 0 && height > 0 && width <= 8_192 && height <= 8_192 && width * height <= 16_000_000;
+}
+
+function stringToBase64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 32_768) binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  return btoa(binary);
+}
+
+function corsHeaders(origin: string): Headers {
+  return new Headers({
+    "access-control-allow-origin": origin,
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+    "access-control-max-age": "600",
+    "cache-control": "no-store",
+    vary: "Origin"
+  });
+}
+
+function json(value: unknown, status = 200, headers = new Headers()): Response {
+  headers.set("content-type", "application/json; charset=utf-8");
+  headers.set("cache-control", "no-store");
+  return new Response(JSON.stringify(value), { status, headers });
+}
+
+function jsonError(status: number, code: string, message: string, headers = new Headers()): Response {
+  return json({ error: { code, message } }, status, headers);
+}
+
+function safeRevision(value: string | undefined): string {
+  return value && /^[0-9a-f]{40}$/u.test(value) ? value : "development";
+}

--- a/services/feedback/tsconfig.json
+++ b/services/feedback/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- add a quiet authenticated `/connect/feedback` surface for problems and ideas
- make collection names, application origins, diagnostics, and screenshots explicit and previewable
- add a stateless Cloudflare Worker that validates bounded intake and forwards plain-text email through Resend
- keep the feature disabled until deployment-scoped feedback URL and Turnstile variables are configured

## Safety

- no feedback data enters the Connect control-plane database
- diagnostics use a strict allowlist and exclude content, paths, request bodies, cookies, and tokens
- screenshots are decoded/re-encoded client-side, structurally checked server-side, and limited to one 3 MiB raster
- managed intake fails closed without Turnstile and validates its hostname/action
- request bodies are streamed with a hard byte limit; provider errors and secrets are not reflected

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter mdbase-editor build`
- `pnpm --filter mdbase-editor check:csp`
- `pnpm check:architecture`
- manual authenticated form review on the local Connect workspace

`pnpm check:workspace-pins` cannot resolve `../mdbase-rs` from the isolated worktree path; this is a worktree-layout limitation rather than a changed pin.
