### PR TITLE
release: prepare beta88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 0.1.0-beta.87
+## 0.1.0-beta.88
+
+Beta.88 improves the editor's loading continuity, navigation, and feedback.
+
+- Loading skeletons align with the editor surface on desktop and mobile.
+- Note lists gain grouped headers and accessible arrow-key navigation.
+- The editor adds word counts, document outlines, action-palette commands,
+  unified toasts, and smoother preview transitions.
+
+## 0.1.0-beta.88
 
 Beta.87 makes local multi-collection discovery fast and resilient and corrects
 editor authorization redirects.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.87"
+version = "0.1.0-beta.88"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.87" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.88" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.87",
+  "version": "0.1.0-beta.88",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -144,7 +144,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.87",
+        version: "0.1.0-beta.88",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary
- bump the coordinated workspace/runtime version to `0.1.0-beta.88`
- record the editor UX release notes
- keep all package, Cargo, MCP, and release-test versions consistent

## Validation
- `pnpm version:check`
- `pnpm check:release-components`
- `pnpm check:release-readiness`
