### PR TITLE
Temporarily hold account deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.0-beta.89
+
+Beta.89 temporarily pauses account deletion while the hosted deletion workflow
+is corrected.
+
+- Account deletion fails closed after same-origin and session authentication,
+  without consuming reauthentication tokens or changing account state.
+- The account surface explains that deletion is temporarily unavailable.
+- Hosted provider data and credentials are never mutated by a blocked request.
+
 ## 0.1.0-beta.88
 
 Beta.88 improves the editor's loading continuity, navigation, and feedback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/editor/src/AccountManagement.tsx
+++ b/apps/editor/src/AccountManagement.tsx
@@ -217,7 +217,9 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
 
     <section className="connect-danger-section">
       <SectionTitle title="Delete account" note="Permanent for hosted data. Local files are never removed from your computers." />
-      {!account.deletion.available ? <p>This account is managed by your tailnet and cannot be deleted here.</p> : !deletionOpen ? <button className="connect-account-danger" onClick={() => setDeletionOpen(true)}>Delete account…</button> : <form className="connect-account-form" onSubmit={(event) => void deleteAccount(event)}>
+      {!account.deletion.available ? <p>{account.deletion.unavailable_reason === "temporarily_disabled"
+        ? "Account deletion is temporarily unavailable while we complete a service correction."
+        : "This account is managed by your tailnet and cannot be deleted here."}</p> : !deletionOpen ? <button className="connect-account-danger" onClick={() => setDeletionOpen(true)}>Delete account…</button> : <form className="connect-account-form" onSubmit={(event) => void deleteAccount(event)}>
         <div className="connect-deletion-effects">
           <p><strong>This permanently deletes:</strong></p>
           <ul><li>{pluralLabel(account.deletion.hosted_collections, "hosted collection", "hosted collections")} and their stored data</li><li>Application access and {pluralLabel(account.deletion.computers, "connected computer", "connected computers")}</li><li>Every browser session and sign-in method</li></ul>

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -490,13 +490,11 @@ describe("ConnectApp", () => {
     expect(screen.getByRole("heading", { name: "Sign-in methods" })).toBeInTheDocument();
     expect(screen.getByText("Local collection files stay on your computers and are not measured here.")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Delete account…" }));
-    await user.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
-    await user.click(screen.getByRole("button", { name: "Delete account permanently" }));
-
-    expect(await screen.findByRole("heading", { name: "Your account has been deleted." })).toBeInTheDocument();
-    expect(location.pathname).toBe("/connect/account-deleted");
-    expect(screen.getByText(/local collection and mirror files remain/i)).toBeInTheDocument();
+    expect(screen.getByText(
+      "Account deletion is temporarily unavailable while we complete a service correction."
+    )).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete account…" }))
+      .not.toBeInTheDocument();
   });
 });
 
@@ -628,7 +626,8 @@ function accountFixture(): AccountData {
       }]
     },
     deletion: {
-      available: true,
+      available: false,
+      unavailable_reason: "temporarily_disabled",
       hosted_collections: 1,
       local_collections: 1,
       computers: 1,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.88"
+version = "0.1.0-beta.89"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -193,6 +193,15 @@ store a short browser/platform label for recognition; they do not store the
 source IP or raw user-agent string. `last_seen_at` is touched at most once per
 five minutes.
 
+## Account deletion hold
+
+Account deletion is temporarily unavailable while the hosted deletion workflow
+is corrected. `GET /v1/account` reports deletion as unavailable and authenticated
+`DELETE /v1/account` returns `503 account_deletion_unavailable` after same-origin
+and session checks. The hold does not consume reauthentication tokens, call the
+hosted provider, write `account.deleted`, clear session cookies, or mutate account
+state.
+
 ## Deployment
 
 Authentication schema changes are additive. Render applies them through the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/index.ts
+++ b/packages/management/index.ts
@@ -64,6 +64,7 @@ export interface AccountData {
   };
   deletion: {
     available: boolean;
+    unavailable_reason: "managed_identity" | "temporarily_disabled" | null;
     hosted_collections: number;
     local_collections: number;
     computers: number;

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/system/provider/portal-lifecycle.mjs
+++ b/scripts/system/provider/portal-lifecycle.mjs
@@ -154,17 +154,22 @@ export async function portalLifecycleE2E({
     assert.equal(account.storage.status, "available");
     assert.equal(accountCollection.usage.collection_id, deletionCollectionId);
     assert.equal(accountCollection.usage.max_content_bytes, 1024 * 1024 * 1024);
-    await page.getByRole("button", { name: "Delete account…" }).click();
-    await expect(page.getByText(/Local files are never removed/)).toBeVisible();
     await expect(page.getByText(
-      "Local collection and mirror files remain on your computers.",
+      "Account deletion is temporarily unavailable while we complete a service correction.",
       { exact: true }
     )).toBeVisible();
-    await page.getByLabel("Type DELETE to confirm").fill("DELETE");
-    await page.getByRole("button", { name: "Delete account permanently" }).click();
-    await expect(page).toHaveURL(/\/connect\/account-deleted(?:\?.*)?$/);
-    await expect(page.getByRole("heading", { name: "Your account has been deleted." }))
-      .toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete account…" })).toHaveCount(0);
+    const blockedDeletion = await page.evaluate(async (server) => {
+      const response = await fetch(`${server}/v1/account`, {
+        method: "DELETE",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ confirmation: "DELETE" })
+      });
+      return { status: response.status, body: await response.json() };
+    }, controlUrl);
+    assert.equal(blockedDeletion.status, 503);
+    assert.equal(blockedDeletion.body.error.code, "account_deletion_unavailable");
     assert.equal(
       (
         await rawRequest(
@@ -173,7 +178,7 @@ export async function portalLifecycleE2E({
           { token: internalToken }
         )
       ).status,
-      404
+      200
     );
     assert.match(
       await readFile(join(browserMirrorDirectory, "mdbase.yaml"), "utf8"),

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.88" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.89" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.88",
+  "version": "0.1.0-beta.89",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/account-management.test.ts
+++ b/services/server/src/account-management.test.ts
@@ -309,7 +309,7 @@ describe("account management", () => {
     expect(currentMethod.json().error.code).toBe("current_identity");
   });
 
-  it("requires fresh external reauthentication, deletes hosted data first, and preserves local files semantically", async () => {
+  it("fails account deletion closed without consuming fresh external reauthentication", async () => {
     const deleteCollection = vi.fn(async () => undefined);
     const { app, db } = await fixture({
       githubAuth: githubConfig({ id: "12558714", login: "callumalpass" }),
@@ -330,15 +330,28 @@ describe("account management", () => {
        VALUES ($1, $2, 'Only hosted copy', 'mdbase', '[]'::jsonb)`,
       [hostedId, account.userId]
     );
-
-    const unconfirmed = await app.inject({
+    const details = await app.inject({
+      method: "GET",
+      url: "/v1/account",
+      headers: { cookie: account.cookie }
+    });
+    expect(details.json().deletion).toMatchObject({
+      available: false,
+      unavailable_reason: "temporarily_disabled",
+      development_confirmation: false
+    });
+    expect((await app.inject({
       method: "DELETE",
       url: "/v1/account",
-      headers: { cookie: account.cookie, origin },
+      headers: { origin },
       payload: { confirmation: "DELETE" }
-    });
-    expect(unconfirmed.statusCode).toBe(403);
-    expect(deleteCollection).not.toHaveBeenCalled();
+    })).statusCode).toBe(401);
+    expect((await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin: "https://evil.example" },
+      payload: { confirmation: "DELETE" }
+    })).statusCode).toBe(403);
 
     const started = await app.inject({
       method: "GET",
@@ -350,31 +363,32 @@ describe("account management", () => {
     const token = new URLSearchParams(redirect.hash.slice(1)).get("delete_token")!;
     expect(token).toMatch(/^act_/);
 
-    const deleted = await app.inject({
+    const blocked = await app.inject({
       method: "DELETE",
       url: "/v1/account",
       headers: { cookie: account.cookie, origin },
       payload: { confirmation: "DELETE", reauth_token: token }
     });
-    expect(deleted.statusCode).toBe(200);
-    expect(deleteCollection).toHaveBeenCalledWith(hostedId);
-    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows).toEqual([]);
-    const event = await db.query<{ user_id: string | null; metadata: Record<string, number> }>(
-      "SELECT user_id, metadata FROM audit_events WHERE event_type = 'account.deleted'"
-    );
-    expect(event.rows[0]).toEqual({
-      user_id: null,
-      metadata: { hosted_collections_deleted: 1, local_collections_preserved: 0 }
-    });
-    expect(responseCookies(deleted).join("\n")).toContain("Max-Age=0");
+    expect(blocked.statusCode).toBe(503);
+    expect(blocked.json().error.code).toBe("account_deletion_unavailable");
+    expect(responseCookies(blocked).join("\n")).not.toContain("Max-Age=0");
+    expect(deleteCollection).not.toHaveBeenCalled();
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
+      .toHaveLength(1);
+    expect((await db.query(
+      "SELECT consumed_at FROM account_action_tokens WHERE user_id = $1",
+      [account.userId]
+    )).rows[0].consumed_at).toBeNull();
+    expect((await db.query(
+      "SELECT id FROM audit_events WHERE event_type = 'account.deleted'"
+    )).rows).toEqual([]);
   });
 
-  it("keeps the account intact when hosted-provider deletion fails", async () => {
+  it("fails password-confirmed deletion closed without calling the provider", async () => {
+    const deleteCollection = vi.fn(async () => { throw new Error("provider offline"); });
     const { app, db } = await fixture({
       hostedCollections: true,
-      hostedProvider: fakeProvider({
-        deleteCollection: vi.fn(async () => { throw new Error("provider offline"); })
-      })
+      hostedProvider: fakeProvider({ deleteCollection })
     });
     const account = await seedSession(db);
     await seedPassword(db, account.userId, account.email, oldPassword);
@@ -384,15 +398,21 @@ describe("account management", () => {
        VALUES ($1, $2, 'Important', 'mdbase', '[]'::jsonb)`,
       [randomUUID(), account.userId]
     );
-    const response = await app.inject({
-      method: "DELETE",
-      url: "/v1/account",
-      headers: { cookie: account.cookie, origin },
-      payload: { confirmation: "DELETE", current_password: oldPassword }
-    });
-    expect(response.statusCode).toBe(500);
+    for (const currentPassword of ["not the password", oldPassword]) {
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/v1/account",
+        headers: { cookie: account.cookie, origin },
+        payload: { confirmation: "DELETE", current_password: currentPassword }
+      });
+      expect(response.statusCode).toBe(503);
+    }
+    expect(deleteCollection).not.toHaveBeenCalled();
     expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
       .toHaveLength(1);
+    expect((await db.query(
+      "SELECT id FROM audit_events WHERE event_type = 'account.deleted'"
+    )).rows).toEqual([]);
   });
 });
 

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -144,7 +144,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.88",
+        version: "0.1.0-beta.89",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY

--- a/services/server/src/features/account/management-routes.ts
+++ b/services/server/src/features/account/management-routes.ts
@@ -1,9 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import {
-  AccountDeletionAuthorizationError,
   accountSignInMethodCounts,
-  consumeAccountActionToken,
   removeExternalIdentity
 } from "../../account-management.js";
 import type { AuthenticationPolicyStore } from "../../authentication-policy.js";
@@ -18,14 +16,12 @@ import {
   PasswordAuthenticationUnavailableError
 } from "../../password-auth.js";
 import { PASSWORD_MAX_UTF8_BYTES } from "../../password.js";
-import { audit } from "../../platform/audit-events.js";
 import { apiError } from "../../platform/http-errors.js";
 import {
   requireSessionContext,
   requireUser
 } from "../../platform/request-authentication.js";
 import { requireSameOrigin } from "../../platform/request-security.js";
-import { clearSessionCookies } from "../../platform/session-cookies.js";
 
 interface AccountManagementRoutesOptions {
   db: DatabasePool;
@@ -153,11 +149,12 @@ export function registerAccountManagementRoutes(
       },
       storage,
       deletion: {
-        available: authenticationProvider !== "tailscale",
+        available: false,
+        unavailable_reason: "temporarily_disabled",
         hosted_collections: hostedCollections.rows.length,
         local_collections: Number(counts.rows[0]?.local_collections ?? 0),
         computers: Number(counts.rows[0]?.connectors ?? 0),
-        development_confirmation: options.developmentAuth === true
+        development_confirmation: false
       }
     };
   });
@@ -216,51 +213,10 @@ export function registerAccountManagementRoutes(
     requireSameOrigin(request, options.publicUrl, options.managementOrigins);
     const authenticated = await requireSessionContext(request, reply, options.db);
     if (!authenticated) return;
-    const input = z.object({
-      confirmation: z.literal("DELETE"),
-      current_password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES).optional(),
-      reauth_token: z.string().min(1).max(200).optional()
-    }).strict().parse(request.body);
-    let authorized = options.developmentAuth === true;
-    if (!authorized && input.current_password) {
-      authorized = await passwordAccounts.verifyAccountPassword(
-        authenticated.user.id,
-        input.current_password
-      );
-    }
-    if (!authorized && input.reauth_token) {
-      authorized = await consumeAccountActionToken(
-        options.db,
-        authenticated.user.id,
-        authenticated.sessionId,
-        "delete_account",
-        input.reauth_token
-      );
-    }
-    if (!authorized) throw new AccountDeletionAuthorizationError();
-
-    const hosted = await options.db.query<HostedCollectionRow>(
-      "SELECT id, display_name FROM hosted_collections WHERE user_id = $1",
-      [authenticated.user.id]
-    );
-    await deleteHostedAuthorities(hosted.rows, options);
-    const localCount = await options.db.query<{ count: string | number }>(
-      "SELECT count(*) AS count FROM collections WHERE user_id = $1 AND present = true",
-      [authenticated.user.id]
-    );
-    await audit(
-      options.db,
-      authenticated.user.id,
-      "account.deleted",
-      authenticated.user.id,
-      {
-        hosted_collections_deleted: hosted.rows.length,
-        local_collections_preserved: Number(localCount.rows[0]?.count ?? 0)
-      }
-    );
-    await options.db.query("DELETE FROM users WHERE id = $1", [authenticated.user.id]);
-    clearSessionCookies(reply);
-    return { ok: true };
+    return reply.code(503).send(apiError(
+      "account_deletion_unavailable",
+      "Account deletion is temporarily unavailable."
+    ));
   });
 }
 
@@ -337,17 +293,4 @@ async function storageSnapshot(
       usage: usage[index]
     }))
   };
-}
-
-async function deleteHostedAuthorities(
-  collections: HostedCollectionRow[],
-  options: AccountManagementRoutesOptions
-): Promise<void> {
-  await Promise.all(collections.map(async (collection) => {
-    if (options.hostedProvider) {
-      await options.hostedProvider.deleteCollection(collection.id);
-    } else if (options.hostedReference) {
-      await options.hostedReference.delete(collection.id);
-    }
-  }));
 }


### PR DESCRIPTION
## Summary

- fails `DELETE /v1/account` closed with a typed 503 after same-origin and authenticated-session checks
- advertises the temporary hold in account management and removes the destructive action from the editor
- preserves account state, reauthentication tokens, provider state, audit state, and session cookies
- prepares v0.1.0-beta.89 as the containment release

## Validation

- `pnpm test:fast`
- `pnpm test:integration`
- `pnpm e2e`
- `pnpm typecheck`
- `cargo fmt --all --check`
- `node scripts/release-components.mjs --check`
- `pnpm version:check v0.1.0-beta.89`
- independent adversarial review: no blockers

This is the temporary containment release. The atomic deletion repair and semantic production canary will follow together in the next release.