### PR TITLE
Make account deletion consistent and observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.1.0-beta.90
+
+Beta.90 makes account deletion transactional, isolates stale hosted grants, and
+extends the production canary through application registration.
+
+- Account deletion revokes local capabilities and commits the user teardown in
+  one transaction before durable, retryable provider cleanup begins.
+- Cross-account replicas, failed local transactions, transferred authorities,
+  provider outages, and duplicate cleanup delivery are handled explicitly.
+- Confirmed missing provider collections are quarantined locally; their grants,
+  tokens, replicas, and pairing requests fail closed without conflating
+  ownership conflicts or transient provider failures.
+- One confirmed-missing grant no longer blocks another account from registering
+  the same application, while ownership conflicts remain visible failures.
+- The hosted-read canary now registers the exact portable CLI application before
+  authenticated describe, marker read, and digest verification.
+- `MDBASE_CONNECT_ACCOUNT_DELETION=disabled` retains a fail-closed operational
+  hold for future incident response.
+
 ## 0.1.0-beta.89
 
 Beta.89 temporarily pauses account deletion while the hosted deletion workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/editor/src/AccountManagement.tsx
+++ b/apps/editor/src/AccountManagement.tsx
@@ -244,7 +244,7 @@ export function AccountManagement({ client, overview, sessions, onOverviewRefres
 }
 
 export function DeletedAccount({ client }: { client: ConnectManagementClient }) {
-  return <main className="connect-deleted-account"><div><h1>Your account has been deleted.</h1><span>Hosted data and access credentials were removed. Any local collection and mirror files remain on your computers.</span><a className="connect-account-action" href={new URL("/login", client.baseUrl).href}>Return to sign in</a></div></main>;
+  return <main className="connect-deleted-account"><div><h1>Your account has been deleted.</h1><span>Hosted access was removed immediately. Hosted data deletion continues automatically in the background. Any local collection and mirror files remain on your computers.</span><a className="connect-account-action" href={new URL("/login", client.baseUrl).href}>Return to sign in</a></div></main>;
 }
 
 function StorageRow({ collection }: { collection: AccountData["storage"]["collections"][number] }) {

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -476,6 +476,34 @@ describe("ConnectApp", () => {
     )).toHaveLength(overviewCalls);
   });
 
+  it("explains a temporary account-deletion hold without offering the destructive action", async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const path = new URL(String(input)).pathname;
+      if (path === "/v1/account/sessions") return Response.json({ sessions: [] });
+      if (path === "/v1/account") {
+        const account = accountFixture();
+        return Response.json({
+          ...account,
+          deletion: {
+            ...account.deletion,
+            available: false,
+            unavailable_reason: "temporarily_disabled"
+          }
+        });
+      }
+      return Response.json(overview);
+    });
+    const user = userEvent.setup();
+    render(<ConnectApp />);
+
+    await user.click(await screen.findByRole("link", { name: "Open account and sessions" }));
+    expect(await screen.findByText(
+      "Account deletion is temporarily unavailable while we complete a service correction."
+    )).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete account…" }))
+      .not.toBeInTheDocument();
+  });
+
   it("keeps hosted storage, sign-in methods, and account deletion in the editor", async () => {
     const user = userEvent.setup();
     render(<ConnectApp />);
@@ -490,11 +518,13 @@ describe("ConnectApp", () => {
     expect(screen.getByRole("heading", { name: "Sign-in methods" })).toBeInTheDocument();
     expect(screen.getByText("Local collection files stay on your computers and are not measured here.")).toBeInTheDocument();
 
-    expect(screen.getByText(
-      "Account deletion is temporarily unavailable while we complete a service correction."
-    )).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Delete account…" }))
-      .not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Delete account…" }));
+    await user.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
+    await user.click(screen.getByRole("button", { name: "Delete account permanently" }));
+
+    expect(await screen.findByRole("heading", { name: "Your account has been deleted." })).toBeInTheDocument();
+    expect(location.pathname).toBe("/connect/account-deleted");
+    expect(screen.getByText(/local collection and mirror files remain/i)).toBeInTheDocument();
   });
 });
 
@@ -626,8 +656,8 @@ function accountFixture(): AccountData {
       }]
     },
     deletion: {
-      available: false,
-      unavailable_reason: "temporarily_disabled",
+      available: true,
+      unavailable_reason: null,
       hosted_collections: 1,
       local_collections: 1,
       computers: 1,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "async-trait",
  "axum",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "async-trait",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.89"
+version = "0.1.0-beta.90"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docs/account-authentication.md
+++ b/docs/account-authentication.md
@@ -193,14 +193,21 @@ store a short browser/platform label for recognition; they do not store the
 source IP or raw user-agent string. `last_seen_at` is touched at most once per
 five minutes.
 
-## Account deletion hold
+## Account deletion
 
-Account deletion is temporarily unavailable while the hosted deletion workflow
-is corrected. `GET /v1/account` reports deletion as unavailable and authenticated
-`DELETE /v1/account` returns `503 account_deletion_unavailable` after same-origin
-and session checks. The hold does not consume reauthentication tokens, call the
-hosted provider, write `account.deleted`, clear session cookies, or mutate account
-state.
+`DELETE /v1/account` commits the complete control-plane teardown in one database
+transaction. The transaction revokes cross-account hosted replicas, records
+provider collection and capability cleanup as durable work, writes the
+`account.deleted` audit event, and deletes the user. A failed transaction leaves
+none of those effects committed. Irreversible provider cleanup starts only after
+the transaction commits and is idempotently retried until complete.
+
+`MDBASE_CONNECT_ACCOUNT_DELETION` is the operational hold. Its only accepted
+values are `enabled` and `disabled`; omitted means `enabled`. While disabled,
+`GET /v1/account` reports deletion as unavailable and `DELETE /v1/account`
+returns `503 account_deletion_unavailable` without changing account or provider
+state. The in-process development reference authority also fails account
+deletion closed because it has no durable provider-cleanup worker.
 
 ## Deployment
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -57,8 +57,10 @@ your platform.
 
 ## Hosted read canary
 
-`scripts/hosted-read-canary.mjs` checks one immutable Markdown marker through
-the native hosted CLI path. Enrollment is deliberately interactive and separate
+`scripts/hosted-read-canary.mjs` registers the exact portable CLI manifest,
+then checks one immutable Markdown marker through the native hosted CLI path.
+This exercises application registration and authenticated hosted access in one
+bounded probe. Enrollment is deliberately interactive and separate
 from scheduled execution:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/hosted-read-canary.mjs
+++ b/scripts/hosted-read-canary.mjs
@@ -11,6 +11,42 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const MAX_OUTPUT_BYTES = 256 * 1024;
 const REQUIRED_OPERATIONS = ["describe", "read"];
+const CLI_APPLICATION_MANIFEST = {
+  manifest_version: 1,
+  distribution: "portable",
+  id: "dev.mdbase.cli",
+  name: "mdbase CLI",
+  requirements: {
+    access: "full_collection",
+    contracts: [],
+    capabilities: {
+      contract_version: 1,
+      required: [
+        "collection.inspect",
+        "records.watch",
+        "records.read",
+        "records.query",
+        "records.validate",
+        "records.create",
+        "records.update",
+        "records.delete",
+        "records.rename",
+        "views.list",
+        "views.execute",
+        "views.source.read",
+        "views.source.create",
+        "views.source.update",
+        "views.source.delete",
+        "definitions.read",
+        "definitions.create",
+        "definitions.update",
+        "definitions.type-pack.inspect",
+        "definitions.type-pack.apply",
+        "sync.offline-replica"
+      ]
+    }
+  }
+};
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const DIGEST = /^sha256:[0-9a-f]{64}$/u;
 const ENVIRONMENT = /^[a-z0-9][a-z0-9_-]{0,63}$/u;
@@ -134,7 +170,11 @@ export function markerDocumentSha256(document) {
   return `sha256:${createHash("sha256").update(document, "utf8").digest("hex")}`;
 }
 
-export async function runCanary(argv = process.argv.slice(2), environmentVariables = process.env) {
+export async function runCanary(
+  argv = process.argv.slice(2),
+  environmentVariables = process.env,
+  dependencies = {}
+) {
   const started = performance.now();
   const checkedAt = new Date().toISOString();
   const stages = [];
@@ -177,9 +217,13 @@ export async function runCanary(argv = process.argv.slice(2), environmentVariabl
     });
 
     const deadline = performance.now() + options.timeoutMs;
-    const runCli = async (stage, argumentsList) => {
+    const remainingTime = (stage) => {
       const remaining = Math.floor(deadline - performance.now());
       if (remaining <= 0) throw new CanaryError(stage, "timeout");
+      return remaining;
+    };
+    const runCli = async (stage, argumentsList) => {
+      const remaining = remainingTime(stage);
       try {
         const { stdout } = await execFileAsync(options.cli, argumentsList, {
           env: environmentVariables,
@@ -197,6 +241,47 @@ export async function runCanary(argv = process.argv.slice(2), environmentVariabl
         throw new CanaryError(stage, "cli_failed");
       }
     };
+    await runStage("registration", async () => {
+      let response;
+      try {
+        response = await (dependencies.fetchImpl ?? fetch)(
+          `${options.expectedOrigin}/v1/apps/register`,
+          {
+            method: "POST",
+            headers: {
+              accept: "application/json",
+              "content-type": "application/json"
+            },
+            body: JSON.stringify({ manifest: CLI_APPLICATION_MANIFEST }),
+            signal: AbortSignal.timeout(remainingTime("registration"))
+          }
+        );
+      } catch (error) {
+        if (error?.name === "AbortError" || error?.name === "TimeoutError") {
+          throw new CanaryError("registration", "timeout");
+        }
+        throw new CanaryError("registration", "network_error");
+      }
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new CanaryError("registration", `http_${response.status}`);
+      }
+      let body;
+      try {
+        body = await response.json();
+      } catch {
+        throw new CanaryError("registration", "malformed_json");
+      }
+      if (
+        typeof body?.application?.id !== "string"
+        || !UUID.test(body.application.id)
+        || typeof body.application.manifest_digest !== "string"
+        || !/^[0-9a-f]{64}$/u.test(body.application.manifest_digest)
+      ) {
+        throw new CanaryError("registration", "invalid_response");
+      }
+    });
+
     const common = ["--state-dir", options.stateDir, "--json"];
     const operation = (stage, name, input) => runCli(stage, [
       ...common,

--- a/scripts/lib/hosted-read-canary.test.mjs
+++ b/scripts/lib/hosted-read-canary.test.mjs
@@ -1,15 +1,13 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
 import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import test from "node:test";
-import { promisify } from "node:util";
 
-import { markerDocumentSha256 } from "../hosted-read-canary.mjs";
-
-const execFileAsync = promisify(execFile);
-const SCRIPT = resolve(import.meta.dirname, "../hosted-read-canary.mjs");
+import {
+  markerDocumentSha256,
+  runCanary
+} from "../hosted-read-canary.mjs";
 const COLLECTION = "01900000-0000-7000-8000-000000000000";
 const ORIGIN = "https://connect.example";
 const NAME = "Status marker";
@@ -62,20 +60,24 @@ function argumentsFor({ stateDir, cli }, overrides = {}) {
   return Object.entries(values).flatMap(([name, value]) => [`--${name}`, value]);
 }
 
-async function invoke(options, overrides = {}, environment = {}) {
-  try {
-    const result = await execFileAsync(process.execPath, [SCRIPT, ...argumentsFor(options, overrides)], {
-      env: { ...process.env, ...environment }
-    });
-    return { code: 0, stdout: result.stdout, stderr: result.stderr, json: JSON.parse(result.stdout) };
-  } catch (error) {
-    return {
-      code: error.code,
-      stdout: error.stdout,
-      stderr: error.stderr,
-      json: JSON.parse(error.stdout)
-    };
-  }
+async function invoke(options, overrides = {}, environment = {}, dependencies = {}) {
+  const fetchImpl = dependencies.fetchImpl ?? (async () => Response.json({
+    application: {
+      id: "01900000-0000-7000-8000-000000000001",
+      manifest_digest: "a".repeat(64)
+    }
+  }));
+  const { exitCode, result } = await runCanary(
+    argumentsFor(options, overrides),
+    { ...process.env, ...environment },
+    { fetchImpl }
+  );
+  return {
+    code: exitCode,
+    stdout: `${JSON.stringify(result)}\n`,
+    stderr: "",
+    json: result
+  };
 }
 
 test("reports a successful least-privilege hosted read", async (t) => {
@@ -85,6 +87,7 @@ test("reports a successful least-privilege hosted read", async (t) => {
   assert.equal(result.stderr, "");
   assert.deepEqual(result.json.stages.map(({ name, status }) => ({ name, status })), [
     { name: "config", status: "operational" },
+    { name: "registration", status: "operational" },
     { name: "connections", status: "operational" },
     { name: "describe", status: "operational" },
     { name: "read", status: "operational" },
@@ -96,6 +99,41 @@ test("reports a successful least-privilege hosted read", async (t) => {
   assert.equal(result.json.status, "operational");
   assert.match(result.json.checked_at, /^\d{4}-\d{2}-\d{2}T/u);
   assert.ok(Number.isInteger(result.json.duration_ms));
+});
+
+test("registers the exact portable CLI application without exposing its response", async (t) => {
+  const options = await fixture(t);
+  let request;
+  const result = await invoke(options, {}, {}, {
+    fetchImpl: async (url, init) => {
+      request = { url, init };
+      return Response.json({
+        application: {
+          id: "01900000-0000-7000-8000-000000000001",
+          manifest_digest: "b".repeat(64),
+          private_value: SECRET
+        }
+      });
+    }
+  });
+  assert.equal(result.code, 0);
+  assert.equal(request.url, `${ORIGIN}/v1/apps/register`);
+  assert.equal(request.init.method, "POST");
+  const body = JSON.parse(request.init.body);
+  assert.equal(body.manifest.id, "dev.mdbase.cli");
+  assert.equal(body.manifest.distribution, "portable");
+  assert.deepEqual(body.manifest.requirements.contracts, []);
+  assert.doesNotMatch(result.stdout, new RegExp(SECRET, "u"));
+});
+
+test("reports registration failure with only a fixed status code", async (t) => {
+  const options = await fixture(t);
+  const result = await invoke(options, {}, {}, {
+    fetchImpl: async () => new Response(SECRET, { status: 502 })
+  });
+  assert.equal(result.code, 1);
+  assert.deepEqual(result.json.error, { stage: "registration", code: "http_502" });
+  assert.doesNotMatch(result.stdout + result.stderr, new RegExp(SECRET, "u"));
 });
 
 test("rejects a state directory bound to the wrong origin", async (t) => {
@@ -175,8 +213,16 @@ test("accepts all non-secret inputs from the documented environment variables", 
     MDBASE_HOSTED_CANARY_EXPECTED_MARKER_SHA256: markerDocumentSha256(DOCUMENT),
     MDBASE_HOSTED_CANARY_TIMEOUT_MS: "2000"
   };
-  const { stdout } = await execFileAsync(process.execPath, [SCRIPT], { env: environment });
-  assert.equal(JSON.parse(stdout).environment, "staging");
+  const { exitCode, result } = await runCanary([], environment, {
+    fetchImpl: async () => Response.json({
+      application: {
+        id: "01900000-0000-7000-8000-000000000001",
+        manifest_digest: "c".repeat(64)
+      }
+    })
+  });
+  assert.equal(exitCode, 0);
+  assert.equal(result.environment, "staging");
 });
 
 test("never reflects CLI response bodies, diagnostics, or stderr", async (t) => {

--- a/scripts/system/provider/portal-lifecycle.mjs
+++ b/scripts/system/provider/portal-lifecycle.mjs
@@ -154,32 +154,26 @@ export async function portalLifecycleE2E({
     assert.equal(account.storage.status, "available");
     assert.equal(accountCollection.usage.collection_id, deletionCollectionId);
     assert.equal(accountCollection.usage.max_content_bytes, 1024 * 1024 * 1024);
+    await page.getByRole("button", { name: "Delete account…" }).click();
+    await expect(page.getByText(/Local files are never removed/)).toBeVisible();
     await expect(page.getByText(
-      "Account deletion is temporarily unavailable while we complete a service correction.",
+      "Local collection and mirror files remain on your computers.",
       { exact: true }
     )).toBeVisible();
-    await expect(page.getByRole("button", { name: "Delete account…" })).toHaveCount(0);
-    const blockedDeletion = await page.evaluate(async (server) => {
-      const response = await fetch(`${server}/v1/account`, {
-        method: "DELETE",
-        credentials: "include",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ confirmation: "DELETE" })
-      });
-      return { status: response.status, body: await response.json() };
-    }, controlUrl);
-    assert.equal(blockedDeletion.status, 503);
-    assert.equal(blockedDeletion.body.error.code, "account_deletion_unavailable");
-    assert.equal(
-      (
-        await rawRequest(
-          providerUrl,
-          `/internal/v1/collections/${deletionCollectionId}/usage`,
-          { token: internalToken }
-        )
-      ).status,
-      200
-    );
+    await page.getByLabel("Type DELETE to confirm").fill("DELETE");
+    await page.getByRole("button", { name: "Delete account permanently" }).click();
+    await expect(page).toHaveURL(/\/connect\/account-deleted(?:\?.*)?$/);
+    await expect(page.getByRole("heading", { name: "Your account has been deleted." }))
+      .toBeVisible();
+    await expect(page.getByText(/Hosted data deletion continues automatically/))
+      .toBeVisible();
+    await expect.poll(async () => (
+      await rawRequest(
+        providerUrl,
+        `/internal/v1/collections/${deletionCollectionId}/usage`,
+        { token: internalToken }
+      )
+    ).status, { timeout: 20_000 }).toBe(404);
     assert.match(
       await readFile(join(browserMirrorDirectory, "mdbase.yaml"), "utf8"),
       /spec_version: 0\.3\.0/

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.89" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.90" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/migrations/0024_account_deletion_consistency.sql
+++ b/services/server/migrations/0024_account_deletion_consistency.sql
@@ -1,0 +1,36 @@
+ALTER TABLE hosted_collections
+  ADD COLUMN quarantined_at timestamptz;
+
+ALTER TABLE hosted_collections
+  ADD COLUMN quarantine_reason text;
+
+ALTER TABLE hosted_collections
+  ADD CONSTRAINT hosted_collections_quarantine_check
+  CHECK (
+    (quarantined_at IS NULL AND quarantine_reason IS NULL)
+    OR (
+      quarantined_at IS NOT NULL
+      AND quarantine_reason = 'provider_collection_missing'
+    )
+  );
+
+CREATE TABLE provider_collection_deletion_jobs (
+  id uuid PRIMARY KEY,
+  collection_id uuid NOT NULL,
+  reason text NOT NULL CHECK (reason IN ('account_deletion')),
+  state text NOT NULL DEFAULT 'pending'
+    CHECK (state IN ('pending', 'sending', 'completed')),
+  attempts integer NOT NULL DEFAULT 0,
+  available_at timestamptz NOT NULL DEFAULT now(),
+  last_error text,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX provider_collection_deletion_jobs_active_collection_idx
+  ON provider_collection_deletion_jobs(collection_id)
+  WHERE completed_at IS NULL;
+
+CREATE INDEX provider_collection_deletion_jobs_ready_idx
+  ON provider_collection_deletion_jobs(state, available_at)
+  WHERE completed_at IS NULL;

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.89",
+  "version": "0.1.0-beta.90",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/account-management.test.ts
+++ b/services/server/src/account-management.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { deleteAccountLocally } from "./account-management.js";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
 import { hashPassword } from "./password.js";
@@ -309,7 +310,40 @@ describe("account management", () => {
     expect(currentMethod.json().error.code).toBe("current_identity");
   });
 
-  it("fails account deletion closed without consuming fresh external reauthentication", async () => {
+  it("fails account deletion closed while the operational hold is active", async () => {
+    const deleteCollection = vi.fn(async () => undefined);
+    const { app, db } = await fixture({
+      accountDeletionEnabled: false,
+      hostedCollections: true,
+      hostedProvider: fakeProvider({ deleteCollection })
+    });
+    const account = await seedSession(db);
+    await seedPassword(db, account.userId, account.email, oldPassword);
+
+    const details = await app.inject({
+      method: "GET",
+      url: "/v1/account",
+      headers: { cookie: account.cookie }
+    });
+    expect(details.statusCode).toBe(200);
+    expect(details.json().deletion).toMatchObject({
+      available: false,
+      unavailable_reason: "temporarily_disabled"
+    });
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin },
+      payload: { confirmation: "DELETE", current_password: oldPassword }
+    });
+    expect(response.statusCode).toBe(503);
+    expect(response.json().error.code).toBe("account_deletion_unavailable");
+    expect(deleteCollection).not.toHaveBeenCalled();
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
+      .toHaveLength(1);
+  });
+
+  it("requires fresh external reauthentication, commits local deletion, and then cleans up hosted data", async () => {
     const deleteCollection = vi.fn(async () => undefined);
     const { app, db } = await fixture({
       githubAuth: githubConfig({ id: "12558714", login: "callumalpass" }),
@@ -324,34 +358,24 @@ describe("account management", () => {
       [account.userId]
     );
     const hostedId = randomUUID();
+    const transferredId = randomUUID();
     await db.query(
       `INSERT INTO hosted_collections
-         (id, user_id, display_name, template, contracts)
-       VALUES ($1, $2, 'Only hosted copy', 'mdbase', '[]'::jsonb)`,
-      [hostedId, account.userId]
+         (id, user_id, display_name, template, contracts, authority_state)
+       VALUES
+         ($1, $2, 'Only hosted copy', 'mdbase', '[]'::jsonb, 'active'),
+         ($3, $2, 'Transferred copy', 'mdbase', '[]'::jsonb, 'transferred')`,
+      [hostedId, account.userId, transferredId]
     );
-    const details = await app.inject({
-      method: "GET",
-      url: "/v1/account",
-      headers: { cookie: account.cookie }
-    });
-    expect(details.json().deletion).toMatchObject({
-      available: false,
-      unavailable_reason: "temporarily_disabled",
-      development_confirmation: false
-    });
-    expect((await app.inject({
+
+    const unconfirmed = await app.inject({
       method: "DELETE",
       url: "/v1/account",
-      headers: { origin },
+      headers: { cookie: account.cookie, origin },
       payload: { confirmation: "DELETE" }
-    })).statusCode).toBe(401);
-    expect((await app.inject({
-      method: "DELETE",
-      url: "/v1/account",
-      headers: { cookie: account.cookie, origin: "https://evil.example" },
-      payload: { confirmation: "DELETE" }
-    })).statusCode).toBe(403);
+    });
+    expect(unconfirmed.statusCode).toBe(403);
+    expect(deleteCollection).not.toHaveBeenCalled();
 
     const started = await app.inject({
       method: "GET",
@@ -363,28 +387,125 @@ describe("account management", () => {
     const token = new URLSearchParams(redirect.hash.slice(1)).get("delete_token")!;
     expect(token).toMatch(/^act_/);
 
-    const blocked = await app.inject({
+    const deleted = await app.inject({
       method: "DELETE",
       url: "/v1/account",
       headers: { cookie: account.cookie, origin },
       payload: { confirmation: "DELETE", reauth_token: token }
     });
-    expect(blocked.statusCode).toBe(503);
-    expect(blocked.json().error.code).toBe("account_deletion_unavailable");
-    expect(responseCookies(blocked).join("\n")).not.toContain("Max-Age=0");
-    expect(deleteCollection).not.toHaveBeenCalled();
-    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
-      .toHaveLength(1);
-    expect((await db.query(
-      "SELECT consumed_at FROM account_action_tokens WHERE user_id = $1",
-      [account.userId]
-    )).rows[0].consumed_at).toBeNull();
-    expect((await db.query(
-      "SELECT id FROM audit_events WHERE event_type = 'account.deleted'"
-    )).rows).toEqual([]);
+    expect(deleted.statusCode, deleted.body).toBe(200);
+    await vi.waitFor(() => expect(deleteCollection).toHaveBeenCalledWith(hostedId));
+    expect(deleteCollection).not.toHaveBeenCalledWith(transferredId);
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows).toEqual([]);
+    const event = await db.query<{ user_id: string | null; metadata: Record<string, number> }>(
+      "SELECT user_id, metadata FROM audit_events WHERE event_type = 'account.deleted'"
+    );
+    expect(event.rows[0]).toEqual({
+      user_id: null,
+      metadata: {
+        hosted_collections_scheduled_for_deletion: 1,
+        cross_account_replicas_revoked: 0,
+        local_collections_preserved: 0
+      }
+    });
+    expect(responseCookies(deleted).join("\n")).toContain("Max-Age=0");
   });
 
-  it("fails password-confirmed deletion closed without calling the provider", async () => {
+  it("revokes cross-account hosted replicas before deleting an account", async () => {
+    const deleteCollection = vi.fn(async () => undefined);
+    const revokeReplica = vi.fn(async () => undefined);
+    const revokeNotificationGrant = vi.fn(async () => undefined);
+    const { app, db } = await fixture({
+      hostedCollections: true,
+      hostedProvider: fakeProvider({
+        deleteCollection,
+        revokeReplica,
+        revokeNotificationGrant
+      })
+    });
+    const account = await seedSession(db, { email: "departing@example.com" });
+    await seedPassword(db, account.userId, account.email, oldPassword);
+    const owner = await seedSession(db, { email: "owner@example.com" });
+    const ownedCollectionId = randomUUID();
+    const sharedCollectionId = randomUUID();
+    const sharedReplicaId = randomUUID();
+    const previouslyRevokedReplicaId = randomUUID();
+    const applicationId = randomUUID();
+    const grantId = randomUUID();
+    await db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, contracts)
+       VALUES
+         ($1, $2, 'Departing account notes', 'mdbase', '[]'::jsonb),
+         ($3, $4, 'Shared notes', 'mdbase', '[]'::jsonb)`,
+      [ownedCollectionId, account.userId, sharedCollectionId, owner.userId]
+    );
+    await db.query(
+      `INSERT INTO hosted_replicas
+         (id, collection_id, authorized_user_id, name, purpose, mode,
+          token_hash, revoked_at)
+       VALUES
+         ($1, $2, $3, 'Shared application', 'application', 'read_write', $4, NULL),
+         ($5, $2, $3, 'Old shared mirror', 'mirror', 'read_only', NULL, now())`,
+      [
+        sharedReplicaId,
+        sharedCollectionId,
+        account.userId,
+        tokenHash("shared-replica-token"),
+        previouslyRevokedReplicaId
+      ]
+    );
+    await db.query(
+      `INSERT INTO applications
+         (id, canonical_identity, name, homepage, redirect_uris)
+       VALUES ($1, $2, 'Shared app', 'https://app.example', '[]'::jsonb)`,
+      [applicationId, `test:${applicationId}`]
+    );
+    await db.query(
+      `INSERT INTO grants
+         (id, user_id, application_id, hosted_collection_id,
+          hosted_replica_id, operations)
+       VALUES ($1, $2, $3, $4, $5, '["query"]'::jsonb)`,
+      [grantId, account.userId, applicationId, sharedCollectionId, sharedReplicaId]
+    );
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin },
+      payload: { confirmation: "DELETE", current_password: oldPassword }
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    await vi.waitFor(() => expect(revokeReplica).toHaveBeenCalledWith(sharedReplicaId));
+    await vi.waitFor(() => expect(revokeNotificationGrant).toHaveBeenCalledWith(
+      sharedCollectionId,
+      grantId
+    ));
+    await vi.waitFor(() => expect(deleteCollection).toHaveBeenCalledWith(ownedCollectionId));
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
+      .toEqual([]);
+    expect((await db.query(
+      "SELECT id FROM hosted_collections WHERE id = $1",
+      [sharedCollectionId]
+    )).rows).toEqual([{ id: sharedCollectionId }]);
+    expect((await db.query(
+      `SELECT authorized_user_id, revoked_at, token_hash
+       FROM hosted_replicas WHERE id = $1`,
+      [sharedReplicaId]
+    )).rows[0]).toEqual({
+      authorized_user_id: null,
+      revoked_at: expect.any(Date),
+      token_hash: null
+    });
+    expect((await db.query(
+      "SELECT authorized_user_id FROM hosted_replicas WHERE id = $1",
+      [previouslyRevokedReplicaId]
+    )).rows[0]).toEqual({ authorized_user_id: null });
+    expect(revokeReplica).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps provider cleanup durable when deletion succeeds while the provider is offline", async () => {
     const deleteCollection = vi.fn(async () => { throw new Error("provider offline"); });
     const { app, db } = await fixture({
       hostedCollections: true,
@@ -392,27 +513,75 @@ describe("account management", () => {
     });
     const account = await seedSession(db);
     await seedPassword(db, account.userId, account.email, oldPassword);
+    const collectionId = randomUUID();
+    await db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, contracts)
+       VALUES ($1, $2, 'Important', 'mdbase', '[]'::jsonb)`,
+      [collectionId, account.userId]
+    );
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/account",
+      headers: { cookie: account.cookie, origin },
+      payload: { confirmation: "DELETE", current_password: oldPassword }
+    });
+    expect(response.statusCode, response.body).toBe(200);
+    await vi.waitFor(() => expect(deleteCollection).toHaveBeenCalledWith(collectionId));
+    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
+      .toEqual([]);
+    await vi.waitFor(async () => {
+      expect((await db.query(
+        `SELECT collection_id, state, attempts, last_error
+         FROM provider_collection_deletion_jobs WHERE completed_at IS NULL`
+      )).rows).toEqual([{
+        collection_id: collectionId,
+        state: "pending",
+        attempts: 1,
+        last_error: "provider offline"
+      }]);
+    });
+  });
+
+  it("rolls back the cleanup job and account.deleted audit event when local deletion fails", async () => {
+    const { db } = await fixture();
+    const account = await seedSession(db);
+    const session = await db.query<{ id: string }>(
+      "SELECT id FROM sessions WHERE user_id = $1",
+      [account.userId]
+    );
     await db.query(
       `INSERT INTO hosted_collections
          (id, user_id, display_name, template, contracts)
        VALUES ($1, $2, 'Important', 'mdbase', '[]'::jsonb)`,
       [randomUUID(), account.userId]
     );
-    for (const currentPassword of ["not the password", oldPassword]) {
-      const response = await app.inject({
-        method: "DELETE",
-        url: "/v1/account",
-        headers: { cookie: account.cookie, origin },
-        payload: { confirmation: "DELETE", current_password: currentPassword }
-      });
-      expect(response.statusCode).toBe(503);
-    }
-    expect(deleteCollection).not.toHaveBeenCalled();
-    expect((await db.query("SELECT id FROM users WHERE id = $1", [account.userId])).rows)
-      .toHaveLength(1);
-    expect((await db.query(
-      "SELECT id FROM audit_events WHERE event_type = 'account.deleted'"
-    )).rows).toEqual([]);
+    const statements: string[] = [];
+    const failingPool = {
+      connect: async () => {
+        const connection = await db.connect();
+        return {
+          query: async (text: string, values?: unknown[]) => {
+            statements.push(text);
+            if (text === "DELETE FROM users WHERE id = $1") {
+              throw new Error("simulated local delete failure");
+            }
+            return connection.query(text, values);
+          },
+          release: () => connection.release()
+        };
+      }
+    } as typeof db;
+
+    await expect(deleteAccountLocally(failingPool, {
+      userId: account.userId,
+      sessionId: session.rows[0].id,
+      authorized: true,
+      queueProviderCleanup: true
+    })).rejects.toThrow("simulated local delete failure");
+
+    expect(statements.at(-1)).toBe("ROLLBACK");
+    expect(statements).not.toContain("COMMIT");
   });
 });
 

--- a/services/server/src/account-management.ts
+++ b/services/server/src/account-management.ts
@@ -3,6 +3,7 @@ import type {
   DatabasePool,
   DatabaseQueryable
 } from "./database-types.js";
+import { queueAccountProviderCleanup } from "./hosted-capability-lifecycle.js";
 import type {
   ExternalProvider,
   VerifiedExternalIdentity
@@ -40,6 +41,78 @@ export class AccountDeletionAuthorizationError extends Error {
 export interface AccountSignInMethodCounts {
   external: number;
   password: boolean;
+}
+
+export interface AccountDeletionResult {
+  hostedCollectionsScheduledForDeletion: number;
+  crossAccountReplicasRevoked: number;
+  localCollectionsPreserved: number;
+}
+
+export async function deleteAccountLocally(
+  db: DatabasePool,
+  input: {
+    userId: string;
+    sessionId: string;
+    authorized: boolean;
+    reauthToken?: string;
+    queueProviderCleanup: boolean;
+  }
+): Promise<AccountDeletionResult> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const locked = await connection.query(
+      "SELECT id FROM users WHERE id = $1 FOR UPDATE",
+      [input.userId]
+    );
+    if (!locked.rows[0]) throw new AccountDeletionAuthorizationError();
+
+    let authorized = input.authorized;
+    if (!authorized && input.reauthToken) {
+      authorized = await consumeAccountActionToken(
+        connection,
+        input.userId,
+        input.sessionId,
+        "delete_account",
+        input.reauthToken
+      );
+    }
+    if (!authorized) throw new AccountDeletionAuthorizationError();
+
+    const cleanup = input.queueProviderCleanup
+      ? await queueAccountProviderCleanup(connection, input.userId)
+      : {
+          hostedCollections: Number((await connection.query<{ count: string }>(
+            "SELECT count(*)::text AS count FROM hosted_collections WHERE user_id = $1",
+            [input.userId]
+          )).rows[0]?.count ?? 0),
+          crossAccountReplicas: 0
+        };
+    const localCount = await connection.query<{ count: string | number }>(
+      "SELECT count(*) AS count FROM collections WHERE user_id = $1 AND present = true",
+      [input.userId]
+    );
+    const result: AccountDeletionResult = {
+      hostedCollectionsScheduledForDeletion: cleanup.hostedCollections,
+      crossAccountReplicasRevoked: cleanup.crossAccountReplicas,
+      localCollectionsPreserved: Number(localCount.rows[0]?.count ?? 0)
+    };
+    await audit(connection, input.userId, "account.deleted", input.userId, {
+      hosted_collections_scheduled_for_deletion:
+        result.hostedCollectionsScheduledForDeletion,
+      cross_account_replicas_revoked: result.crossAccountReplicasRevoked,
+      local_collections_preserved: result.localCollectionsPreserved
+    });
+    await connection.query("DELETE FROM users WHERE id = $1", [input.userId]);
+    await connection.query("COMMIT");
+    return result;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
 }
 
 export async function accountSignInMethodCounts(

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -20,7 +20,10 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "./app.js";
 import { createDatabase } from "./db.js";
-import { HostedProviderClient } from "./hosted-provider.js";
+import {
+  HostedProviderClient,
+  HostedProviderResponseError
+} from "./hosted-provider.js";
 import { authorityProofMessage } from "./authority-proof.js";
 import { pkceChallenge, tokenHash } from "./security.js";
 import {
@@ -144,7 +147,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.89",
+        version: "0.1.0-beta.90",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY
@@ -1882,6 +1885,98 @@ describe("mdbase connect server", () => {
     });
     expect(removed.statusCode).toBe(200);
     expect(hostedProvider.deleteCollection).toHaveBeenCalledWith(collectionId);
+  });
+
+  it("keeps shared application registration available when another account has a confirmed missing collection", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const staleCollectionId = randomUUID();
+    const healthyCollectionId = randomUUID();
+    const revokeNotificationGrant = vi.fn(async (collectionId: string) => {
+      if (collectionId === staleCollectionId) {
+        throw new HostedProviderResponseError(
+          404,
+          "hosted_collection_not_found",
+          "Hosted collection not found."
+        );
+      }
+    });
+    const hostedProvider = {
+      url: "https://sync.example",
+      revokeNotificationGrant,
+      revokeReplica: vi.fn(async () => undefined)
+    } as unknown as HostedProviderClient;
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      hostedCollections: true,
+      hostedProvider,
+      publicUrl: "http://connect.test",
+      allowInsecureManifests: true
+    });
+    resources.push(() => app.close());
+    const manifest = applicationManifestFixture({
+      configuration: [],
+      contracts: [],
+      access: "full_collection",
+      collection_kind: "hosted"
+    }, "Shared hosted app").manifest;
+    const initial = await app.inject({
+      method: "POST",
+      url: "/v1/apps/register",
+      payload: { manifest }
+    });
+    expect(initial.statusCode, JSON.stringify(initial.json())).toBe(200);
+    const applicationId = initial.json().application.id as string;
+    const users = [randomUUID(), randomUUID()];
+    const collections = [staleCollectionId, healthyCollectionId];
+    const grants = [randomUUID(), randomUUID()];
+    for (let index = 0; index < users.length; index += 1) {
+      const replicaId = randomUUID();
+      await db.query(
+        "INSERT INTO users (id, email, name) VALUES ($1, $2, 'User')",
+        [users[index], `${users[index]}@example.com`]
+      );
+      await db.query(
+        `INSERT INTO hosted_collections
+           (id, user_id, display_name, template, contracts)
+         VALUES ($1, $2, 'Hosted collection', 'mdbase', '[]'::jsonb)`,
+        [collections[index], users[index]]
+      );
+      await db.query(
+        `INSERT INTO hosted_replicas
+           (id, collection_id, authorized_user_id, name, purpose, mode,
+            allowed_types)
+         VALUES ($1, $2, $3, 'Application', 'application', 'read_only',
+                 '[]'::jsonb)`,
+        [replicaId, collections[index], users[index]]
+      );
+      await db.query(
+        `INSERT INTO grants
+           (id, user_id, application_id, hosted_collection_id,
+            hosted_replica_id, operations, scope, notification_criteria,
+            application_origin)
+         VALUES ($1, $2, $3, $4, $5, '["query"]'::jsonb,
+                 '{"contracts":[],"access":"full_collection"}'::jsonb,
+                 '[]'::jsonb, 'http://localhost:4173')`,
+        [grants[index], users[index], applicationId, collections[index], replicaId]
+      );
+    }
+
+    const registration = await app.inject({
+      method: "POST",
+      url: "/v1/apps/register",
+      payload: { manifest }
+    });
+
+    expect(registration.statusCode, JSON.stringify(registration.json())).toBe(200);
+    expect(revokeNotificationGrant).toHaveBeenCalledWith(staleCollectionId, grants[0]);
+    expect(revokeNotificationGrant).toHaveBeenCalledWith(healthyCollectionId, grants[1]);
+    const state = await db.query<{ id: string; revoked_at: Date | null }>(
+      "SELECT id, revoked_at FROM grants ORDER BY id"
+    );
+    expect(state.rows.find(({ id }) => id === grants[0])?.revoked_at).toBeTruthy();
+    expect(state.rows.find(({ id }) => id === grants[1])?.revoked_at).toBeNull();
   });
 
   it("provisions and reconciles contract-free hosted application access as unrestricted", async () => {

--- a/services/server/src/app.ts
+++ b/services/server/src/app.ts
@@ -76,6 +76,7 @@ interface BuildOptions {
   authenticationLegalDocuments?: AuthenticationLegalDocuments;
   emailTransport?: EmailTransport;
   resendWebhookSecret?: string;
+  accountDeletionEnabled?: boolean;
   hostedCollections?: boolean;
   hostedProvider?: HostedProviderClient;
   hostedReferenceAuthority?: boolean;
@@ -146,7 +147,7 @@ export async function buildApp(options: BuildOptions) {
         options.hostedProvider,
         (error) => app.log.error(
           { err: error },
-          "hosted provider revocation worker failed"
+          "hosted provider cleanup worker failed"
         )
       )
     : undefined;
@@ -309,10 +310,17 @@ export async function buildApp(options: BuildOptions) {
     tailscaleAuth: options.tailscaleAuth,
     developmentAuth: options.devAuth,
     passwordAuthenticationAvailable: Boolean(options.authRateLimitSecret),
+    accountDeletionEnabled: options.accountDeletionEnabled !== false
+      && hostedReference === undefined,
     githubAvailable: options.githubAuth !== undefined,
     googleAvailable: options.googleAuth !== undefined,
     hostedProvider: options.hostedProvider,
-    hostedReference
+    triggerProviderCleanup: () => {
+      void providerRevocations?.drain().catch((error) => app.log.error(
+        { err: error },
+        "hosted account cleanup trigger failed"
+      ));
+    }
   });
   registerMirrorPairingRoutes(app, {
     db: options.db,

--- a/services/server/src/collection-catalog.ts
+++ b/services/server/src/collection-catalog.ts
@@ -46,7 +46,7 @@ export async function resolveHostedCollection(
             authority_state, authority_epoch, transferred_collection_id,
             created_at
      FROM hosted_collections
-     WHERE id = $1`,
+     WHERE id = $1 AND quarantined_at IS NULL`,
     [collectionId]
   );
   return result.rows[0] ? hostedEntry(result.rows[0]) : null;
@@ -72,7 +72,7 @@ export async function listHostedCollectionsVisibleToUser(
             authority_state, authority_epoch, transferred_collection_id,
             created_at
      FROM hosted_collections
-     WHERE user_id = $1
+     WHERE user_id = $1 AND quarantined_at IS NULL
      ORDER BY display_name`,
     [userId]
   );

--- a/services/server/src/db.test.ts
+++ b/services/server/src/db.test.ts
@@ -58,7 +58,8 @@ describe("database migrations", () => {
       "0020_protocol_usage_telemetry",
       "0021_device_authorization_origin",
       "0022_account_creation_email_claims",
-      "0023_open_beta_entitlement"
+      "0023_open_beta_entitlement",
+      "0024_account_deletion_consistency"
     ]);
     const columns = await db.query<{ column_name: string }>(
       `SELECT column_name FROM information_schema.columns
@@ -78,6 +79,47 @@ describe("database migrations", () => {
          AND column_name = 'normalized_email'`
     );
     expect(emailClaims.rows).toHaveLength(1);
+    const quarantineColumns = await db.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'hosted_collections'
+         AND column_name IN ('quarantined_at', 'quarantine_reason')`
+    );
+    expect(new Set(quarantineColumns.rows.map(({ column_name }) => column_name)))
+      .toEqual(new Set(["quarantined_at", "quarantine_reason"]));
+    const collectionDeletionJobs = await db.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'provider_collection_deletion_jobs'`
+    );
+    expect(new Set(collectionDeletionJobs.rows.map(({ column_name }) => column_name)))
+      .toEqual(new Set([
+        "id",
+        "collection_id",
+        "reason",
+        "state",
+        "attempts",
+        "available_at",
+        "last_error",
+        "completed_at",
+        "created_at"
+      ]));
+    const legacyRevocationShape = await db.query<{
+      column_name: string;
+      is_nullable: string;
+    }>(
+      `SELECT column_name, is_nullable FROM information_schema.columns
+       WHERE table_name = 'provider_revocation_jobs'
+         AND column_name IN ('replica_id', 'operation')`
+    );
+    expect(legacyRevocationShape.rows).toEqual([{
+      column_name: "replica_id",
+      is_nullable: "NO"
+    }]);
+    await expect(db.query(
+      `INSERT INTO provider_collection_deletion_jobs
+         (id, collection_id, reason)
+       VALUES ($1, $2, 'unexpected_reason')`,
+      [randomUUID(), randomUUID()]
+    )).rejects.toThrow();
 
     await expect(assertControlPlaneMigrationsCurrent(db)).resolves.toBeUndefined();
     await runControlPlaneMigrations(db);
@@ -577,7 +619,8 @@ describe("database migrations", () => {
       "0020_protocol_usage_telemetry",
       "0021_device_authorization_origin",
       "0022_account_creation_email_claims",
-      "0023_open_beta_entitlement"
+      "0023_open_beta_entitlement",
+      "0024_account_deletion_consistency"
     ]);
   });
 

--- a/services/server/src/entitlements.ts
+++ b/services/server/src/entitlements.ts
@@ -276,6 +276,7 @@ export async function reconcileHostedAccountCollections(
     `SELECT id FROM hosted_collections
      WHERE user_id = $1
        AND authority_state IN ('importing', 'active', 'transferring')
+       AND quarantined_at IS NULL
      ORDER BY id`,
     [userId]
   );

--- a/services/server/src/features/account/management-routes.ts
+++ b/services/server/src/features/account/management-routes.ts
@@ -2,11 +2,11 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import {
   accountSignInMethodCounts,
+  deleteAccountLocally,
   removeExternalIdentity
 } from "../../account-management.js";
 import type { AuthenticationPolicyStore } from "../../authentication-policy.js";
 import type { DatabasePool } from "../../database-types.js";
-import type { HostedAuthorityRegistry } from "../../hosted.js";
 import type {
   HostedCollectionUsage,
   HostedProviderClient
@@ -16,12 +16,14 @@ import {
   PasswordAuthenticationUnavailableError
 } from "../../password-auth.js";
 import { PASSWORD_MAX_UTF8_BYTES } from "../../password.js";
+import { audit } from "../../platform/audit-events.js";
 import { apiError } from "../../platform/http-errors.js";
 import {
   requireSessionContext,
   requireUser
 } from "../../platform/request-authentication.js";
 import { requireSameOrigin } from "../../platform/request-security.js";
+import { clearSessionCookies } from "../../platform/session-cookies.js";
 
 interface AccountManagementRoutesOptions {
   db: DatabasePool;
@@ -31,10 +33,11 @@ interface AccountManagementRoutesOptions {
   tailscaleAuth?: boolean;
   developmentAuth?: boolean;
   passwordAuthenticationAvailable?: boolean;
+  accountDeletionEnabled?: boolean;
   githubAvailable?: boolean;
   googleAvailable?: boolean;
   hostedProvider?: HostedProviderClient;
-  hostedReference?: HostedAuthorityRegistry;
+  triggerProviderCleanup?: () => void;
 }
 
 interface ExternalIdentityRow {
@@ -89,6 +92,7 @@ export function registerAccountManagementRoutes(
         options.db.query<HostedCollectionRow>(
           `SELECT id, display_name FROM hosted_collections
            WHERE user_id = $1 AND authority_state <> 'transferred'
+             AND quarantined_at IS NULL
            ORDER BY display_name`,
           [user.id]
         ),
@@ -149,12 +153,17 @@ export function registerAccountManagementRoutes(
       },
       storage,
       deletion: {
-        available: false,
-        unavailable_reason: "temporarily_disabled",
+        available: authenticationProvider !== "tailscale"
+          && options.accountDeletionEnabled !== false,
+        unavailable_reason: authenticationProvider === "tailscale"
+          ? "managed_identity"
+          : options.accountDeletionEnabled === false
+            ? "temporarily_disabled"
+            : null,
         hosted_collections: hostedCollections.rows.length,
         local_collections: Number(counts.rows[0]?.local_collections ?? 0),
         computers: Number(counts.rows[0]?.connectors ?? 0),
-        development_confirmation: false
+        development_confirmation: options.developmentAuth === true
       }
     };
   });
@@ -213,10 +222,35 @@ export function registerAccountManagementRoutes(
     requireSameOrigin(request, options.publicUrl, options.managementOrigins);
     const authenticated = await requireSessionContext(request, reply, options.db);
     if (!authenticated) return;
-    return reply.code(503).send(apiError(
-      "account_deletion_unavailable",
-      "Account deletion is temporarily unavailable."
-    ));
+    if (options.accountDeletionEnabled === false) {
+      return reply.code(503).send(apiError(
+        "account_deletion_unavailable",
+        "Account deletion is temporarily unavailable."
+      ));
+    }
+    const input = z.object({
+      confirmation: z.literal("DELETE"),
+      current_password: z.string().min(1).max(PASSWORD_MAX_UTF8_BYTES).optional(),
+      reauth_token: z.string().min(1).max(200).optional()
+    }).strict().parse(request.body);
+    let authorized = options.developmentAuth === true;
+    if (!authorized && input.current_password) {
+      authorized = await passwordAccounts.verifyAccountPassword(
+        authenticated.user.id,
+        input.current_password
+      );
+    }
+
+    await deleteAccountLocally(options.db, {
+      userId: authenticated.user.id,
+      sessionId: authenticated.sessionId,
+      authorized,
+      reauthToken: input.reauth_token,
+      queueProviderCleanup: options.hostedProvider !== undefined
+    });
+    options.triggerProviderCleanup?.();
+    clearSessionCookies(reply);
+    return { ok: true };
   });
 }
 

--- a/services/server/src/features/authorizations/approval-service.ts
+++ b/services/server/src/features/authorizations/approval-service.ts
@@ -625,10 +625,17 @@ export async function approveHostedAuthorization(
       pending.requirements,
       pending.notifications
     );
-    await connection.query(
-      "SELECT id FROM hosted_collections WHERE id = $1 FOR UPDATE",
+    const hostedCollection = await connection.query(
+      `SELECT id FROM hosted_collections
+       WHERE id = $1 AND quarantined_at IS NULL
+       FOR UPDATE`,
       [input.collectionId]
     );
+    if (!hostedCollection.rows[0]) {
+      throw new RequestValidationError(
+        "That hosted collection is unavailable."
+      );
+    }
     if (pending.collection_id && pending.collection_id !== input.collectionId) {
       throw new RequestValidationError(
         "This authorization request is restricted to a different collection."

--- a/services/server/src/features/grants/service.test.ts
+++ b/services/server/src/features/grants/service.test.ts
@@ -3,10 +3,22 @@ import type {
   GrantSummary,
   NotificationCriterion
 } from "@mdbase-dev/connect-protocol";
+import { randomUUID } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
-import type { DatabaseQueryable } from "../../db.js";
-import type { HostedProviderClient } from "../../hosted-provider.js";
-import { syncHostedNotificationGrant } from "./service.js";
+import {
+  createDatabase,
+  type DatabasePool,
+  type DatabaseQueryable
+} from "../../db.js";
+import {
+  HostedProviderResponseError,
+  type HostedProviderClient
+} from "../../hosted-provider.js";
+import type { RelayHub } from "../../relay.js";
+import {
+  reconcileApplicationGrants,
+  syncHostedNotificationGrant
+} from "./service.js";
 
 const collectionId = "00000000-0000-4000-8000-000000000001";
 const grantId = "00000000-0000-4000-8000-000000000002";
@@ -96,4 +108,207 @@ describe("hosted notification grant synchronization", () => {
       }) satisfies Partial<GrantSummary>
     );
   });
+
+  it("quarantines a confirmed missing collection without blocking another account", async () => {
+    const fixture = await reconciliationFixture(2);
+    try {
+      const upsertNotificationGrant = vi.fn(async (candidateCollectionId: string) => {
+        if (candidateCollectionId === fixture.collectionIds[0]) {
+          throw new HostedProviderResponseError(
+            404,
+            "hosted_collection_not_found",
+            "Hosted collection not found."
+          );
+        }
+      });
+      const provider = { upsertNotificationGrant } as unknown as HostedProviderClient;
+
+      await expect(reconcileApplicationGrants(
+        fixture.db,
+        { pushPolicy: vi.fn() } as unknown as RelayHub,
+        provider,
+        fixture.application
+      )).resolves.toBeUndefined();
+
+      expect(upsertNotificationGrant).toHaveBeenCalledTimes(2);
+      const grants = await fixture.db.query<{ id: string; revoked_at: Date | null }>(
+        "SELECT id, revoked_at FROM grants ORDER BY id"
+      );
+      expect(grants.rows.find(({ id }) => id === fixture.grantIds[0])?.revoked_at)
+        .toBeTruthy();
+      expect(grants.rows.find(({ id }) => id === fixture.grantIds[1])?.revoked_at)
+        .toBeNull();
+      expect((await fixture.db.query(
+        `SELECT quarantine_reason FROM hosted_collections
+         WHERE id = $1 AND quarantined_at IS NOT NULL`,
+        [fixture.collectionIds[0]]
+      )).rows).toEqual([{
+        quarantine_reason: "provider_collection_missing"
+      }]);
+      expect((await fixture.db.query("SELECT id FROM provider_revocation_jobs")).rows)
+        .toEqual([]);
+    } finally {
+      await fixture.db.end();
+    }
+  });
+
+  it("quarantines a confirmed missing replica without blocking registration", async () => {
+    const fixture = await reconciliationFixture(1);
+    try {
+      await fixture.db.query(
+        `UPDATE hosted_replicas SET allowed_types = '["stale"]'::jsonb
+         WHERE collection_id = $1`,
+        [fixture.collectionIds[0]]
+      );
+      const provider = {
+        upsertNotificationGrant: vi.fn(async () => undefined),
+        updateApplicationReplica: vi.fn(async () => {
+          throw new HostedProviderResponseError(
+            404,
+            "replica_not_found",
+            "Active application capability not found."
+          );
+        })
+      } as unknown as HostedProviderClient;
+
+      await expect(reconcileApplicationGrants(
+        fixture.db,
+        { pushPolicy: vi.fn() } as unknown as RelayHub,
+        provider,
+        fixture.application
+      )).resolves.toBeUndefined();
+      const grant = await fixture.db.query<{ revoked_at: Date | null }>(
+        "SELECT revoked_at FROM grants WHERE id = $1",
+        [fixture.grantIds[0]]
+      );
+      expect(grant.rows[0].revoked_at).toBeTruthy();
+      expect((await fixture.db.query(
+        "SELECT reason FROM provider_revocation_jobs"
+      )).rows).toEqual([{ reason: "hosted_resource_missing" }]);
+    } finally {
+      await fixture.db.end();
+    }
+  });
+
+  it("does not reinterpret an ownership conflict as a missing collection", async () => {
+    const fixture = await reconciliationFixture(1);
+    try {
+      const provider = {
+        upsertNotificationGrant: vi.fn(async () => {
+          throw new HostedProviderResponseError(
+            409,
+            "hosted_collection_account_conflict",
+            "Hosted collection belongs to another account."
+          );
+        })
+      } as unknown as HostedProviderClient;
+
+      await expect(reconcileApplicationGrants(
+        fixture.db,
+        { pushPolicy: vi.fn() } as unknown as RelayHub,
+        provider,
+        fixture.application
+      )).rejects.toMatchObject({ code: "hosted_collection_account_conflict" });
+      const grant = await fixture.db.query<{ revoked_at: Date | null }>(
+        "SELECT revoked_at FROM grants WHERE id = $1",
+        [fixture.grantIds[0]]
+      );
+      expect(grant.rows[0].revoked_at).toBeNull();
+      expect((await fixture.db.query("SELECT id FROM provider_revocation_jobs")).rows)
+        .toEqual([]);
+    } finally {
+      await fixture.db.end();
+    }
+  });
 });
+
+async function reconciliationFixture(accountCount: number): Promise<{
+  db: DatabasePool;
+  collectionIds: string[];
+  grantIds: string[];
+  application: Parameters<typeof reconcileApplicationGrants>[3];
+}> {
+  const db = await createDatabase("memory");
+  const applicationId = randomUUID();
+  await db.query(
+    `INSERT INTO applications
+       (id, canonical_identity, family_identity, name, homepage, redirect_uris,
+        requirements, notifications, manifest_digest)
+     VALUES ($1, 'https://app.example', 'bundle:dev.tasknotes.app', 'Shared app',
+             'https://app.example', '[]'::jsonb, $2::jsonb, $3::jsonb, $4)`,
+    [
+      applicationId,
+      JSON.stringify({
+        configuration: [],
+        contracts: [],
+        access: "full_collection",
+        collection_kind: "hosted"
+      }),
+      JSON.stringify({ criteria: notificationCriteria }),
+      applicationManifestDigest
+    ]
+  );
+  const collectionIds: string[] = [];
+  const grantIds: string[] = [];
+  for (let index = 0; index < accountCount; index += 1) {
+    const userId = randomUUID();
+    const collectionId = randomUUID();
+    const replicaId = randomUUID();
+    const grantId = randomUUID();
+    collectionIds.push(collectionId);
+    grantIds.push(grantId);
+    await db.query(
+      "INSERT INTO users (id, email, name) VALUES ($1, $2, 'User')",
+      [userId, `${userId}@example.com`]
+    );
+    await db.query(
+      `INSERT INTO hosted_collections
+         (id, user_id, display_name, template, contracts)
+       VALUES ($1, $2, 'Hosted collection', 'mdbase', '[]'::jsonb)`,
+      [collectionId, userId]
+    );
+    await db.query(
+      `INSERT INTO hosted_replicas
+         (id, collection_id, authorized_user_id, name, purpose, mode,
+          allowed_types)
+       VALUES ($1, $2, $3, 'Application', 'application', 'read_only',
+               '[]'::jsonb)`,
+      [replicaId, collectionId, userId]
+    );
+    await db.query(
+      `INSERT INTO grants
+         (id, user_id, application_id, hosted_collection_id,
+          hosted_replica_id, operations, scope, notification_criteria,
+          application_origin, proof_public_key, application_authorization)
+       VALUES ($1, $2, $3, $4, $5, '["query"]'::jsonb,
+               '{"contracts":[],"access":"full_collection"}'::jsonb,
+               $6::jsonb, 'https://app.example', 'proof-key', $7::jsonb)`,
+      [
+        grantId,
+        userId,
+        applicationId,
+        collectionId,
+        replicaId,
+        JSON.stringify(notificationCriteria),
+        JSON.stringify(applicationAuthorization)
+      ]
+    );
+  }
+  return {
+    db,
+    collectionIds,
+    grantIds,
+    application: {
+      id: applicationId,
+      family_identity: "bundle:dev.tasknotes.app",
+      manifest_digest: applicationManifestDigest,
+      requirements: {
+        configuration: [],
+        contracts: [],
+        access: "full_collection",
+        collection_kind: "hosted"
+      },
+      notifications: { criteria: notificationCriteria }
+    }
+  };
+}

--- a/services/server/src/features/grants/service.ts
+++ b/services/server/src/features/grants/service.ts
@@ -12,9 +12,15 @@ import type {
   NotificationCriterion
 } from "@mdbase-dev/connect-protocol";
 import type { DatabasePool, DatabaseQueryable } from "../../db.js";
-import { queueHostedGrantRevocation } from "../../hosted-capability-lifecycle.js";
+import {
+  quarantineMissingHostedCollection,
+  queueHostedGrantRevocation
+} from "../../hosted-capability-lifecycle.js";
 import { contractRequirements, effectiveHostedContractDescriptors } from "../../hosted.js";
-import { HostedProviderClient } from "../../hosted-provider.js";
+import {
+  HostedProviderClient,
+  HostedProviderResponseError
+} from "../../hosted-provider.js";
 import { fileCapabilityForRequirements } from "../../grant-planner.js";
 import { hostedReplicaCollectionOperations } from "../../hosted-replica-policy.js";
 import { RelayHub } from "../../relay.js";
@@ -243,7 +249,21 @@ export async function reconcileApplicationGrants(
       if (!hostedProvider) {
         throw new Error("Hosted provider unavailable during notification reconciliation.");
       }
-      await syncHostedNotificationGrant(db, hostedProvider, grant.id);
+      try {
+        await syncHostedNotificationGrant(db, hostedProvider, grant.id);
+      } catch (error) {
+        const missingCode = missingHostedResourceCode(error);
+        if (!missingCode) throw error;
+        await quarantineMissingHostedGrant(db, {
+          userId: grant.user_id,
+          grantId: grant.id,
+          collectionId: grant.hosted_collection_id,
+          applicationId: application.id,
+          providerErrorCode: missingCode
+        });
+        if (grant.connector_id) changedConnectors.add(grant.connector_id);
+        continue;
+      }
     }
     const hostedDescriptors = grant.template
       ? effectiveHostedContractDescriptors(grant.hosted_contracts, grant.template)
@@ -309,26 +329,40 @@ export async function reconcileApplicationGrants(
         ) || desiredFileCapability?.actions.some((action) =>
           ["add", "replace", "move", "delete"].includes(action)
         ) === true;
-        await hostedProvider.updateApplicationReplica(grant.hosted_replica_id, {
-          grantId: grant.id,
-          mode: write ? "read_write" : "read_only",
-          allowedTypes: desiredAllowedTypes,
-          contractScope: desiredScope.access === "contract" ? desiredScope.contracts : [],
-          fullCollection: application.requirements.access === "full_collection",
-          allowedOperations: hostedReplicaCollectionOperations(grant.operations),
-          operationTransportProtocol:
-            grant.application_authorization.binding.contracts.operation_transport,
-          operationTransportRecoveryProtocols:
-            grant.application_authorization.binding.contracts
-              .operation_transport_recovery ?? [],
-          fileCapability: desiredFileCapability,
-          allowedOrigin: grant.application_origin,
-          proofPublicKey: grant.proof_public_key,
-          applicationDeclarationId: declarationIdFromFamilyIdentity(
-            application.family_identity
-          ),
-          applicationDeclarationDigest: `sha256:${application.manifest_digest}`
-        });
+        try {
+          await hostedProvider.updateApplicationReplica(grant.hosted_replica_id, {
+            grantId: grant.id,
+            mode: write ? "read_write" : "read_only",
+            allowedTypes: desiredAllowedTypes,
+            contractScope: desiredScope.access === "contract" ? desiredScope.contracts : [],
+            fullCollection: application.requirements.access === "full_collection",
+            allowedOperations: hostedReplicaCollectionOperations(grant.operations),
+            operationTransportProtocol:
+              grant.application_authorization.binding.contracts.operation_transport,
+            operationTransportRecoveryProtocols:
+              grant.application_authorization.binding.contracts
+                .operation_transport_recovery ?? [],
+            fileCapability: desiredFileCapability,
+            allowedOrigin: grant.application_origin,
+            proofPublicKey: grant.proof_public_key,
+            applicationDeclarationId: declarationIdFromFamilyIdentity(
+              application.family_identity
+            ),
+            applicationDeclarationDigest: `sha256:${application.manifest_digest}`
+          });
+        } catch (error) {
+          const missingCode = missingHostedResourceCode(error);
+          if (!missingCode) throw error;
+          await quarantineMissingHostedGrant(db, {
+            userId: grant.user_id,
+            grantId: grant.id,
+            collectionId: grant.hosted_collection_id,
+            applicationId: application.id,
+            providerErrorCode: missingCode
+          });
+          if (grant.connector_id) changedConnectors.add(grant.connector_id);
+          continue;
+        }
         await db.query(
           "UPDATE hosted_replicas SET allowed_types = $2::jsonb, mode = $3 WHERE id = $1",
           [
@@ -382,6 +416,51 @@ export async function reconcileApplicationGrants(
   for (const connectorId of changedConnectors) {
     await relay.pushPolicy(connectorId);
   }
+}
+
+function missingHostedResourceCode(error: unknown): string | null {
+  if (
+    !(error instanceof HostedProviderResponseError)
+    || error.status !== 404
+    || !["hosted_collection_not_found", "replica_not_found"].includes(error.code)
+  ) return null;
+  return error.code;
+}
+
+async function quarantineMissingHostedGrant(
+  db: DatabasePool,
+  input: {
+    userId: string;
+    grantId: string;
+    collectionId: string | null;
+    applicationId: string;
+    providerErrorCode: string;
+  }
+): Promise<void> {
+  if (
+    input.providerErrorCode === "hosted_collection_not_found"
+    && input.collectionId
+  ) {
+    await quarantineMissingHostedCollection(db, input.collectionId);
+    return;
+  }
+  const queued = await queueHostedGrantRevocation(
+    db,
+    input.userId,
+    input.grantId,
+    "hosted_resource_missing"
+  );
+  if (!queued) return;
+  await audit(
+    db,
+    input.userId,
+    "grant.revoked_after_hosted_resource_missing",
+    input.grantId,
+    {
+      application_id: input.applicationId,
+      provider_error_code: input.providerErrorCode
+    }
+  );
 }
 
 function scopesEqual(left: GrantScope, right: GrantScope): boolean {

--- a/services/server/src/features/hosted/connector-routes.ts
+++ b/services/server/src/features/hosted/connector-routes.ts
@@ -152,7 +152,7 @@ export function registerConnectorHostedRoutes(
            AND EXISTS (
              SELECT 1 FROM hosted_collections
              WHERE id = $3 AND user_id = $2
-               AND authority_state = 'active'
+               AND authority_state = 'active' AND quarantined_at IS NULL
            )
          RETURNING id, mode`,
         [pairingId, connector.user_id, input.collection_id]

--- a/services/server/src/features/mirrors/pairing-routes.ts
+++ b/services/server/src/features/mirrors/pairing-routes.ts
@@ -95,6 +95,7 @@ export function registerMirrorPairingRoutes(
     }>(
       `SELECT id, display_name FROM hosted_collections
        WHERE user_id = $1 AND authority_state = 'active'
+         AND quarantined_at IS NULL
        ORDER BY display_name`,
       [user.id]
     );
@@ -130,6 +131,7 @@ export function registerMirrorPairingRoutes(
            AND EXISTS (
              SELECT 1 FROM hosted_collections
              WHERE id = $3 AND user_id = $2 AND authority_state = 'active'
+               AND quarantined_at IS NULL
            )
          RETURNING id, mirror_name, mode`,
         [pairingId, user.id, input.collection_id]

--- a/services/server/src/hosted-capability-lifecycle.test.ts
+++ b/services/server/src/hosted-capability-lifecycle.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDatabase, type DatabasePool } from "./db.js";
+import { HostedProviderResponseError } from "./hosted-provider.js";
 import {
   hostedGrantRevocationStatus,
   hostedReplicaRevocationStatus,
   ProviderRevocationWorker,
+  quarantineMissingHostedCollection,
   queueHostedGrantRevocation,
   queueHostedReplicaRevocation
 } from "./hosted-capability-lifecycle.js";
@@ -59,6 +61,74 @@ describe("hosted capability lifecycle", () => {
       fixture.userId,
       fixture.grantId
     )).toBe("revoking");
+  });
+
+  it("quarantines a confirmed missing collection and every local capability atomically", async () => {
+    const fixture = await capabilityFixture();
+    const applicationId = randomUUID();
+    const replicaId = randomUUID();
+    const grantId = randomUUID();
+    await fixture.db.query(
+      `INSERT INTO applications
+         (id, canonical_identity, name, homepage, redirect_uris)
+       VALUES ($1, $2, 'Second app', 'https://second.example', '[]'::jsonb)`,
+      [applicationId, `test:${applicationId}`]
+    );
+    await fixture.db.query(
+      `INSERT INTO hosted_replicas
+         (id, collection_id, authorized_user_id, name, purpose, mode)
+       VALUES ($1, $2, $3, 'Second application', 'application', 'read_only')`,
+      [replicaId, fixture.collectionId, fixture.userId]
+    );
+    await fixture.db.query(
+      `INSERT INTO grants
+         (id, user_id, application_id, hosted_collection_id,
+          hosted_replica_id, operations)
+       VALUES ($1, $2, $3, $4, $5, '["read"]'::jsonb)`,
+      [grantId, fixture.userId, applicationId, fixture.collectionId, replicaId]
+    );
+
+    expect(await quarantineMissingHostedCollection(
+      fixture.db,
+      fixture.collectionId
+    )).toEqual({ changed: true, grantsRevoked: 2, replicasRevoked: 2 });
+    const collection = await fixture.db.query(
+      `SELECT quarantine_reason, quarantined_at
+       FROM hosted_collections WHERE id = $1`,
+      [fixture.collectionId]
+    );
+    expect(collection.rows[0]).toEqual({
+      quarantine_reason: "provider_collection_missing",
+      quarantined_at: expect.any(Date)
+    });
+    const grants = await fixture.db.query<{ revoked_at: Date | null }>(
+      "SELECT revoked_at FROM grants WHERE hosted_collection_id = $1",
+      [fixture.collectionId]
+    );
+    expect(grants.rows).toHaveLength(2);
+    expect(grants.rows.every(({ revoked_at }) => revoked_at !== null)).toBe(true);
+    const replicas = await fixture.db.query<{
+      revoked_at: Date | null;
+      token_hash: string | null;
+    }>(
+      "SELECT revoked_at, token_hash FROM hosted_replicas WHERE collection_id = $1",
+      [fixture.collectionId]
+    );
+    expect(replicas.rows.every(({ revoked_at, token_hash }) =>
+      revoked_at !== null && token_hash === null
+    )).toBe(true);
+    expect((await fixture.db.query(
+      `SELECT id FROM access_tokens WHERE revoked_at IS NULL
+       UNION ALL SELECT id FROM refresh_tokens WHERE revoked_at IS NULL`
+    )).rows).toEqual([]);
+    expect((await fixture.db.query(
+      `SELECT id FROM audit_events
+       WHERE event_type = 'hosted_collection.quarantined_missing'`
+    )).rows).toHaveLength(1);
+    expect(await quarantineMissingHostedCollection(
+      fixture.db,
+      fixture.collectionId
+    )).toEqual({ changed: false, grantsRevoked: 0, replicasRevoked: 0 });
   });
 
   it("delivers queued revocation to both provider capability surfaces", async () => {
@@ -232,6 +302,95 @@ describe("hosted capability lifecycle", () => {
     expect(completed.rows[0]).toMatchObject({
       state: "completed",
       attempts: 2,
+      last_error: null
+    });
+  });
+
+  it("continues unrelated cleanup after one provider job fails", async () => {
+    const fixture = await capabilityFixture();
+    await queueHostedGrantRevocation(
+      fixture.db,
+      fixture.userId,
+      fixture.grantId,
+      "provider_outage"
+    );
+    await fixture.db.query(
+      `UPDATE provider_revocation_jobs
+       SET created_at = now() - interval '1 minute'
+       WHERE grant_id = $1`,
+      [fixture.grantId]
+    );
+    const secondReplicaId = randomUUID();
+    await fixture.db.query(
+      `INSERT INTO hosted_replicas
+         (id, collection_id, authorized_user_id, name, purpose, mode)
+       VALUES ($1, $2, $3, 'Second mirror', 'mirror', 'read_only')`,
+      [secondReplicaId, fixture.collectionId, fixture.userId]
+    );
+    await queueHostedReplicaRevocation(
+      fixture.db,
+      secondReplicaId,
+      fixture.collectionId,
+      "user_request"
+    );
+    const provider = {
+      revokeReplica: vi.fn(async (replicaId: string) => {
+        if (replicaId === fixture.replicaId) throw new Error("provider failure");
+      }),
+      revokeNotificationGrant: vi.fn(async () => undefined)
+    };
+    const errors: unknown[] = [];
+
+    expect(await new ProviderRevocationWorker(
+      fixture.db,
+      provider as never,
+      (error) => errors.push(error)
+    ).drain()).toBe(1);
+    expect(provider.revokeReplica).toHaveBeenCalledTimes(2);
+    expect(errors).toHaveLength(1);
+    const jobs = await fixture.db.query<{
+      replica_id: string;
+      state: string;
+    }>(
+      "SELECT replica_id, state FROM provider_revocation_jobs ORDER BY created_at"
+    );
+    expect(jobs.rows.find(({ replica_id }) => replica_id === fixture.replicaId)?.state)
+      .toBe("pending");
+    expect(jobs.rows.find(({ replica_id }) => replica_id === secondReplicaId)?.state)
+      .toBe("completed");
+  });
+
+  it("completes cleanup when the provider confirms the resource is already missing", async () => {
+    const fixture = await capabilityFixture();
+    await queueHostedGrantRevocation(
+      fixture.db,
+      fixture.userId,
+      fixture.grantId,
+      "missing_collection"
+    );
+    const provider = {
+      revokeReplica: vi.fn(async () => undefined),
+      revokeNotificationGrant: vi.fn(async () => {
+        throw new HostedProviderResponseError(
+          404,
+          "hosted_collection_not_found",
+          "Hosted collection not found."
+        );
+      })
+    };
+    const errors: unknown[] = [];
+
+    expect(await new ProviderRevocationWorker(
+      fixture.db,
+      provider as never,
+      (error) => errors.push(error)
+    ).drain()).toBe(1);
+    expect(errors).toEqual([]);
+    expect((await fixture.db.query(
+      "SELECT state, completed_at, last_error FROM provider_revocation_jobs"
+    )).rows[0]).toEqual({
+      state: "completed",
+      completed_at: expect.any(Date),
       last_error: null
     });
   });

--- a/services/server/src/hosted-capability-lifecycle.ts
+++ b/services/server/src/hosted-capability-lifecycle.ts
@@ -1,13 +1,32 @@
 import { randomUUID } from "node:crypto";
 import type { DatabasePool, DatabaseQueryable } from "./db.js";
-import type { HostedProviderClient } from "./hosted-provider.js";
+import { audit } from "./platform/audit-events.js";
+import {
+  HostedProviderResponseError,
+  type HostedProviderClient
+} from "./hosted-provider.js";
 
 interface RevocationJob {
+  kind: "revoke_replica";
   id: string;
   replica_id: string;
   grant_id: string | null;
   collection_id: string;
   attempts: number;
+}
+
+interface CollectionDeletionJob {
+  kind: "delete_collection";
+  id: string;
+  collection_id: string;
+  attempts: number;
+}
+
+type ProviderCleanupJob = RevocationJob | CollectionDeletionJob;
+
+export interface AccountProviderCleanup {
+  hostedCollections: number;
+  crossAccountReplicas: number;
 }
 
 export interface QueuedGrantRevocation {
@@ -206,6 +225,217 @@ export async function queueHostedReplicaRevocation(
   }
 }
 
+export interface HostedCollectionQuarantineResult {
+  changed: boolean;
+  grantsRevoked: number;
+  replicasRevoked: number;
+}
+
+/**
+ * Fails a hosted collection closed only after the provider has returned the
+ * exact typed missing-collection response. The control row remains available
+ * for operator investigation, but every local capability becomes unusable.
+ */
+export async function quarantineMissingHostedCollection(
+  db: DatabasePool,
+  collectionId: string
+): Promise<HostedCollectionQuarantineResult | null> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const collection = await connection.query<{
+      user_id: string;
+      quarantined_at: string | Date | null;
+    }>(
+      `SELECT user_id, quarantined_at FROM hosted_collections
+       WHERE id = $1
+       FOR UPDATE`,
+      [collectionId]
+    );
+    const row = collection.rows[0];
+    if (!row) {
+      await connection.query("ROLLBACK");
+      return null;
+    }
+    if (row.quarantined_at !== null) {
+      await connection.query("COMMIT");
+      return { changed: false, grantsRevoked: 0, replicasRevoked: 0 };
+    }
+    const grants = await connection.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM grants
+       WHERE hosted_collection_id = $1 AND revoked_at IS NULL`,
+      [collectionId]
+    );
+    const replicas = await connection.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM hosted_replicas
+       WHERE collection_id = $1 AND revoked_at IS NULL`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE hosted_collections
+       SET quarantined_at = now(), quarantine_reason = 'provider_collection_missing'
+       WHERE id = $1`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE grants SET revoked_at = COALESCE(revoked_at, now())
+       WHERE hosted_collection_id = $1`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE access_tokens SET revoked_at = COALESCE(revoked_at, now())
+       WHERE grant_id IN (
+         SELECT id FROM grants WHERE hosted_collection_id = $1
+       )`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE refresh_tokens SET revoked_at = COALESCE(revoked_at, now())
+       WHERE grant_id IN (
+         SELECT id FROM grants WHERE hosted_collection_id = $1
+       )`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE hosted_replicas
+       SET revoked_at = COALESCE(revoked_at, now()), token_hash = NULL
+       WHERE collection_id = $1`,
+      [collectionId]
+    );
+    await connection.query(
+      `DELETE FROM mirror_pairing_requests
+       WHERE replica_id IN (
+         SELECT id FROM hosted_replicas WHERE collection_id = $1
+       )`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE provider_revocation_jobs
+       SET state = 'completed', completed_at = COALESCE(completed_at, now()),
+           last_error = NULL
+       WHERE collection_id = $1 AND completed_at IS NULL`,
+      [collectionId]
+    );
+    await connection.query(
+      `UPDATE provider_collection_deletion_jobs
+       SET state = 'completed', completed_at = COALESCE(completed_at, now()),
+           last_error = NULL
+       WHERE collection_id = $1 AND completed_at IS NULL`,
+      [collectionId]
+    );
+    const result = {
+      changed: true,
+      grantsRevoked: Number(grants.rows[0]?.count ?? 0),
+      replicasRevoked: Number(replicas.rows[0]?.count ?? 0)
+    };
+    await audit(
+      connection,
+      row.user_id,
+      "hosted_collection.quarantined_missing",
+      collectionId,
+      {
+        reason: "provider_collection_missing",
+        grants_revoked: result.grantsRevoked,
+        replicas_revoked: result.replicasRevoked
+      }
+    );
+    await connection.query("COMMIT");
+    return result;
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+/**
+ * Makes every provider capability owned by an account unusable in the same
+ * transaction that deletes the account, and records idempotent provider
+ * cleanup for delivery after commit.
+ */
+export async function queueAccountProviderCleanup(
+  db: DatabaseQueryable,
+  userId: string
+): Promise<AccountProviderCleanup> {
+  const ownedCollections = await db.query<{
+    id: string;
+    authority_state: string;
+    quarantined_at: string | Date | null;
+  }>(
+    `SELECT id, authority_state, quarantined_at FROM hosted_collections
+     WHERE user_id = $1 ORDER BY id FOR UPDATE`,
+    [userId]
+  );
+  const collections = ownedCollections.rows.filter(
+    ({ authority_state, quarantined_at }) =>
+      authority_state !== "transferred" && quarantined_at === null
+  );
+  const authorizedReplicas = await db.query<{
+    id: string;
+    collection_id: string;
+    revoked_at: string | Date | null;
+  }>(
+    `SELECT id, collection_id, revoked_at
+     FROM hosted_replicas
+     WHERE authorized_user_id = $1
+     ORDER BY id
+     FOR UPDATE`,
+    [userId]
+  );
+  const ownedCollectionIds = new Set(ownedCollections.rows.map(({ id }) => id));
+  const crossAccountReplicas = authorizedReplicas.rows.filter(
+    (replica) => !ownedCollectionIds.has(replica.collection_id)
+  );
+
+  let activeCrossAccountReplicas = 0;
+  for (const replica of crossAccountReplicas) {
+    const grant = replica.revoked_at === null
+      ? await db.query<{ id: string }>(
+          `SELECT id FROM grants
+           WHERE hosted_replica_id = $1 AND revoked_at IS NULL
+           ORDER BY created_at DESC LIMIT 1`,
+          [replica.id]
+        )
+      : { rows: [] };
+    await db.query(
+      `UPDATE hosted_replicas
+       SET revoked_at = COALESCE(revoked_at, now()), token_hash = NULL,
+           authorized_user_id = NULL
+       WHERE id = $1`,
+      [replica.id]
+    );
+    await db.query(
+      "DELETE FROM mirror_pairing_requests WHERE replica_id = $1",
+      [replica.id]
+    );
+    if (replica.revoked_at !== null) continue;
+    activeCrossAccountReplicas += 1;
+    await db.query(
+      `INSERT INTO provider_revocation_jobs
+         (id, replica_id, grant_id, collection_id, reason)
+       VALUES ($1, $2, $3, $4, 'account_deletion')
+       ON CONFLICT DO NOTHING`,
+      [randomUUID(), replica.id, grant.rows[0]?.id ?? null, replica.collection_id]
+    );
+  }
+
+  for (const collection of collections) {
+    await db.query(
+      `INSERT INTO provider_collection_deletion_jobs
+         (id, collection_id, reason)
+       VALUES ($1, $2, 'account_deletion')
+       ON CONFLICT DO NOTHING`,
+      [randomUUID(), collection.id]
+    );
+  }
+
+  return {
+    hostedCollections: collections.length,
+    crossAccountReplicas: activeCrossAccountReplicas
+  };
+}
+
 export class ProviderRevocationWorker {
   private timer: NodeJS.Timeout | undefined;
   private drainInFlight: Promise<number> | undefined;
@@ -250,33 +480,44 @@ export class ProviderRevocationWorker {
   }
 
   private async drainAvailable(limit: number): Promise<number> {
+    let attempted = 0;
     let completed = 0;
-    while (completed < limit) {
-      const job = await claimRevocationJob(this.db);
+    while (attempted < limit) {
+      const job = await claimProviderCleanupJob(this.db);
       if (!job) break;
+      attempted += 1;
       try {
-        await this.provider.revokeReplica(job.replica_id);
-        if (job.grant_id) {
-          await this.provider.revokeNotificationGrant(
-            job.collection_id,
-            job.grant_id
-          );
+        if (job.kind === "delete_collection") {
+          await this.provider.deleteCollection(job.collection_id);
+        } else {
+          await this.provider.revokeReplica(job.replica_id);
+          if (job.grant_id) {
+            await this.provider.revokeNotificationGrant(
+              job.collection_id,
+              job.grant_id
+            );
+          }
         }
-        await this.db.query(
-          `UPDATE provider_revocation_jobs
-           SET state = 'completed', completed_at = now(), last_error = NULL
-           WHERE id = $1`,
-          [job.id]
-        );
+        await completeProviderCleanupJob(this.db, job);
         completed += 1;
       } catch (error) {
-        await rescheduleRevocationJob(this.db, job, error);
+        if (isAlreadyMissingProviderResource(error)) {
+          await completeProviderCleanupJob(this.db, job);
+          completed += 1;
+          continue;
+        }
+        await rescheduleProviderCleanupJob(this.db, job, error);
         this.onError(error);
-        break;
       }
     }
     return completed;
   }
+}
+
+async function claimProviderCleanupJob(
+  db: DatabasePool
+): Promise<ProviderCleanupJob | null> {
+  return await claimRevocationJob(db) ?? await claimCollectionDeletionJob(db);
 }
 
 async function claimRevocationJob(
@@ -285,7 +526,7 @@ async function claimRevocationJob(
   const connection = await db.connect();
   try {
     await connection.query("BEGIN");
-    const found = await connection.query<RevocationJob>(
+    const found = await connection.query<Omit<RevocationJob, "kind">>(
       `SELECT id, replica_id, grant_id, collection_id, attempts
        FROM provider_revocation_jobs
        WHERE completed_at IS NULL AND state IN ('pending', 'sending')
@@ -302,12 +543,12 @@ async function claimRevocationJob(
     await connection.query(
       `UPDATE provider_revocation_jobs
        SET state = 'sending', attempts = attempts + 1,
-           available_at = now() + interval '30 seconds'
+           available_at = now() + interval '60 seconds'
        WHERE id = $1`,
       [job.id]
     );
     await connection.query("COMMIT");
-    return job;
+    return { kind: "revoke_replica", ...job };
   } catch (error) {
     await connection.query("ROLLBACK");
     throw error;
@@ -316,23 +557,94 @@ async function claimRevocationJob(
   }
 }
 
-async function rescheduleRevocationJob(
+async function claimCollectionDeletionJob(
+  db: DatabasePool
+): Promise<CollectionDeletionJob | null> {
+  const connection = await db.connect();
+  try {
+    await connection.query("BEGIN");
+    const found = await connection.query<Omit<CollectionDeletionJob, "kind">>(
+      `SELECT id, collection_id, attempts
+       FROM provider_collection_deletion_jobs
+       WHERE completed_at IS NULL AND state IN ('pending', 'sending')
+         AND available_at <= now()
+       ORDER BY created_at
+       LIMIT 1
+       FOR UPDATE`
+    );
+    const job = found.rows[0];
+    if (!job) {
+      await connection.query("COMMIT");
+      return null;
+    }
+    await connection.query(
+      `UPDATE provider_collection_deletion_jobs
+       SET state = 'sending', attempts = attempts + 1,
+           available_at = now() + interval '60 seconds'
+       WHERE id = $1`,
+      [job.id]
+    );
+    await connection.query("COMMIT");
+    return { kind: "delete_collection", ...job };
+  } catch (error) {
+    await connection.query("ROLLBACK");
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+async function completeProviderCleanupJob(
   db: DatabaseQueryable,
-  job: RevocationJob,
+  job: ProviderCleanupJob
+): Promise<void> {
+  if (job.kind === "delete_collection") {
+    await db.query(
+      `UPDATE provider_collection_deletion_jobs
+       SET state = 'completed', completed_at = now(), last_error = NULL
+       WHERE id = $1`,
+      [job.id]
+    );
+    return;
+  }
+  await db.query(
+    `UPDATE provider_revocation_jobs
+     SET state = 'completed', completed_at = now(), last_error = NULL
+     WHERE id = $1`,
+    [job.id]
+  );
+}
+
+function isAlreadyMissingProviderResource(error: unknown): boolean {
+  return error instanceof HostedProviderResponseError
+    && error.status === 404
+    && ["hosted_collection_not_found", "replica_not_found"].includes(error.code);
+}
+
+async function rescheduleProviderCleanupJob(
+  db: DatabaseQueryable,
+  job: ProviderCleanupJob,
   error: unknown
 ): Promise<void> {
   const delaySeconds = Math.min(300, 2 ** Math.min(job.attempts + 1, 8));
-  const availableAt = new Date(Date.now() + delaySeconds * 1_000);
+  const values = [
+    job.id,
+    new Date(Date.now() + delaySeconds * 1_000),
+    error instanceof Error ? error.message.slice(0, 2_000) : String(error)
+  ];
+  if (job.kind === "delete_collection") {
+    await db.query(
+      `UPDATE provider_collection_deletion_jobs
+       SET state = 'pending', available_at = $2, last_error = $3
+       WHERE id = $1`,
+      values
+    );
+    return;
+  }
   await db.query(
     `UPDATE provider_revocation_jobs
-     SET state = 'pending',
-         available_at = $2,
-         last_error = $3
+     SET state = 'pending', available_at = $2, last_error = $3
      WHERE id = $1`,
-    [
-      job.id,
-      availableAt,
-      error instanceof Error ? error.message.slice(0, 2_000) : String(error)
-    ]
+    values
   );
 }

--- a/services/server/src/index.ts
+++ b/services/server/src/index.ts
@@ -41,6 +41,7 @@ const { app } = await buildApp({
     ? new ResendEmailTransport(runtime.transactionalEmail)
     : undefined,
   resendWebhookSecret: runtime.resendWebhookSecret ?? undefined,
+  accountDeletionEnabled: runtime.accountDeletionEnabled,
   hostedCollections: runtime.hostedCollections,
   hostedReferenceAuthority: runtime.hostedReferenceAuthority,
   hostedProvider: runtime.hostedProvider

--- a/services/server/src/runtime-config.test.ts
+++ b/services/server/src/runtime-config.test.ts
@@ -22,6 +22,7 @@ function config(overrides: Partial<Parameters<typeof validateRuntimeConfig>[0]> 
     authenticationLegalDocuments: null,
     transactionalEmail: null,
     resendWebhookSecret: null,
+    accountDeletionEnabled: true,
     hostedCollections: false,
     hostedProvider: null,
     hostedReferenceAuthority: false,
@@ -47,6 +48,23 @@ describe("public runtime configuration", () => {
       MDBASE_CONNECT_DEV_AUTH: "1",
       MDBASE_CONNECT_ENVIRONMENT: "local"
     }).environment).toBe("local");
+  });
+
+  it("parses the account-deletion hold fail closed", () => {
+    expect(runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_ACCOUNT_DELETION: "disabled"
+    }).accountDeletionEnabled).toBe(false);
+    expect(runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1"
+    }).accountDeletionEnabled).toBe(true);
+    expect(() => runtimeConfigFromEnv({
+      PUBLIC_URL: "http://localhost:8787",
+      MDBASE_CONNECT_DEV_AUTH: "1",
+      MDBASE_CONNECT_ACCOUNT_DELETION: "maybe"
+    })).toThrow(/MDBASE_CONNECT_ACCOUNT_DELETION/);
   });
 
   it("allows explicit loopback development authentication", () => {

--- a/services/server/src/runtime-config.ts
+++ b/services/server/src/runtime-config.ts
@@ -33,6 +33,7 @@ export interface RuntimeConfig {
   authenticationLegalDocuments: AuthenticationLegalDocuments | null;
   transactionalEmail: TransactionalEmailConfig | null;
   resendWebhookSecret: string | null;
+  accountDeletionEnabled: boolean;
   hostedCollections: boolean;
   hostedProvider: HostedProviderConfig | null;
   hostedReferenceAuthority: boolean;
@@ -267,6 +268,13 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
     : null;
   const resendWebhookSecret =
     env.MDBASE_CONNECT_RESEND_WEBHOOK_SECRET?.trim() || null;
+  const accountDeletion =
+    env.MDBASE_CONNECT_ACCOUNT_DELETION?.trim() || "enabled";
+  if (!["enabled", "disabled"].includes(accountDeletion)) {
+    throw new Error(
+      "MDBASE_CONNECT_ACCOUNT_DELETION must be enabled or disabled."
+    );
+  }
   const port = Number(env.PORT ?? 8787);
   const host = env.HOST ?? "127.0.0.1";
   const hostedProvider = hostedProviderConfigFromEnv(env);
@@ -328,6 +336,7 @@ export function runtimeConfigFromEnv(env: NodeJS.ProcessEnv): RuntimeConfig {
     authenticationLegalDocuments,
     transactionalEmail,
     resendWebhookSecret,
+    accountDeletionEnabled: accountDeletion === "enabled",
     hostedCollections: env.MDBASE_CONNECT_HOSTED_COLLECTIONS === "1",
     hostedReferenceAuthority:
       env.MDBASE_CONNECT_HOSTED_REFERENCE_AUTHORITY === "1",

--- a/test/upgrade/server-from-previous
+++ b/test/upgrade/server-from-previous
@@ -91,4 +91,65 @@ location=$(curl --silent --show-error \
   "$authorization_uri")
 [[ $location == "$UPGRADE_SERVER_URL/authorize/$authorization_id" ]]
 
-printf 'Previous server upgrade and OAuth path passed.\n'
+upgrade_phase 'proving account deletion rollback on PostgreSQL'
+docker run --rm --interactive --network host \
+  --env DATABASE_URL \
+  "$CANDIDATE_IMAGE" \
+  node --input-type=module <<'NODE'
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { deleteAccountLocally } from "/app/services/server/dist/account-management.js";
+import { createDatabase } from "/app/services/server/dist/db.js";
+
+const db = await createDatabase(process.env.DATABASE_URL);
+const userId = randomUUID();
+const collectionId = randomUUID();
+try {
+  await db.query(
+    "INSERT INTO users (id, email, name) VALUES ($1, $2, 'Deletion rollback canary')",
+    [userId, `${userId}@example.invalid`]
+  );
+  await db.query(
+    `INSERT INTO hosted_collections
+       (id, user_id, display_name, template, contracts)
+     VALUES ($1, $2, 'Deletion rollback canary', 'mdbase', '[]'::jsonb)`,
+    [collectionId, userId]
+  );
+  await db.query(
+    "CREATE TABLE account_deletion_upgrade_guard (user_id uuid REFERENCES users(id))"
+  );
+  await db.query(
+    "INSERT INTO account_deletion_upgrade_guard (user_id) VALUES ($1)",
+    [userId]
+  );
+
+  await assert.rejects(
+    deleteAccountLocally(db, {
+      userId,
+      sessionId: randomUUID(),
+      authorized: true,
+      queueProviderCleanup: true
+    })
+  );
+
+  const user = await db.query("SELECT id FROM users WHERE id = $1", [userId]);
+  const jobs = await db.query(
+    "SELECT id FROM provider_collection_deletion_jobs WHERE collection_id = $1",
+    [collectionId]
+  );
+  const events = await db.query(
+    `SELECT id FROM audit_events
+     WHERE event_type = 'account.deleted' AND subject_id = $1`,
+    [userId]
+  );
+  assert.equal(user.rowCount, 1, "the account must survive a failed local delete");
+  assert.equal(jobs.rowCount, 0, "the provider cleanup job must roll back");
+  assert.equal(events.rowCount, 0, "account.deleted must not survive rollback");
+} finally {
+  await db.query("DROP TABLE IF EXISTS account_deletion_upgrade_guard");
+  await db.query("DELETE FROM users WHERE id = $1", [userId]);
+  await db.end();
+}
+NODE
+
+printf 'Previous server upgrade, OAuth, and deletion-atomicity paths passed.\n'


### PR DESCRIPTION
## Summary

- replaces the beta89 deletion hold with one atomic local teardown and a separate rollback-safe provider collection-deletion outbox
- revokes active and previously revoked cross-account replica authorization before deleting the user
- quarantines provider-confirmed missing collections, revokes every local capability, and excludes them from authorization, mirrors, and entitlement reconciliation
- isolates confirmed missing collection/replica grants so one stale account cannot fail shared `/v1/apps/register`, while ownership conflicts and transient failures remain visible
- extends the hosted-read canary through exact CLI application registration before authenticated describe/read/digest checks
- retains `MDBASE_CONNECT_ACCOUNT_DELETION=disabled` as a future fail-closed hold
- prepares v0.1.0-beta.90

## Validation

- server unit suite: 352 passing
- hosted canary tests: 13 passing; live production canary now includes registration and remains operational
- `pnpm test:fast`
- `pnpm test:integration`
- `pnpm e2e:provider` including browser account deletion and asynchronous provider cleanup
- real PostgreSQL 17 previous-release upgrade and deletion rollback proof
- `pnpm typecheck`
- `cargo fmt --all --check`
- release component and version checks
- independent adversarial review: no blockers

The status/GitHub monitoring activation is prepared separately in mdbase-cloud-ops and will be promoted in the same beta90 change window.