### PR TITLE
Isolate missing collections during entitlement reconciliation

### DIFF
--- a/crates/connect-hosted-provider/src/provider/account_quotas.rs
+++ b/crates/connect-hosted-provider/src/provider/account_quotas.rs
@@ -195,9 +195,21 @@ impl HostedProvider {
         .execute(&mut *transaction)
         .await?;
         if result.rows_affected() == 0 {
+            let existing = sqlx::query_scalar::<_, Uuid>(
+                "SELECT id FROM hosted_provider_collections WHERE id = $1 AND state <> 'deleting'",
+            )
+            .bind(collection_id)
+            .fetch_optional(&mut *transaction)
+            .await?;
+            if existing.is_none() {
+                return Err(ApiError::not_found(
+                    "hosted_collection_not_found",
+                    "Hosted collection not found.",
+                ));
+            }
             return Err(ApiError::conflict(
                 "hosted_collection_account_conflict",
-                "The hosted collection is missing or belongs to another account.",
+                "The hosted collection belongs to another account.",
             ));
         }
         sqlx::query(

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -1291,6 +1291,34 @@ schema:
       timezone: "UTC"
     }
   });
+  const missingAccountReconciliation = await rawRequest(
+    quotaProvider.url,
+    `/internal/v1/accounts/${quotaAccountId}/collections/${crypto.randomUUID()}`,
+    { method: "PUT", token: internalToken, body: {} }
+  );
+  assert.equal(missingAccountReconciliation.status, 404);
+  assert.equal(
+    missingAccountReconciliation.body.error.code,
+    "hosted_collection_not_found"
+  );
+  const otherAccountId = await provisionProviderAccount(quotaProvider.url, {
+    hosted_storage_bytes: 500,
+    retained_file_bytes: 1000,
+    max_document_bytes: 512,
+    max_mirror_replicas_per_collection: 1,
+    max_application_replicas_per_collection: 1,
+    max_hosted_collections: 2
+  });
+  const conflictingAccountReconciliation = await rawRequest(
+    quotaProvider.url,
+    `/internal/v1/accounts/${otherAccountId}/collections/${quotaCollectionId}`,
+    { method: "PUT", token: internalToken, body: {} }
+  );
+  assert.equal(conflictingAccountReconciliation.status, 409);
+  assert.equal(
+    conflictingAccountReconciliation.body.error.code,
+    "hosted_collection_account_conflict"
+  );
   await provisionTypes(quotaProvider.url, quotaCollectionId, [WORK_ITEM_PROVISION]);
   await internalRequest(
     quotaProvider.url,

--- a/services/server/src/auth-admin-entitlements.ts
+++ b/services/server/src/auth-admin-entitlements.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { DatabaseConnection, DatabasePool } from "./db.js";
 import { reconcileHostedAccountCollections } from "./entitlements.js";
 import type { HostedProviderClient } from "./hosted-provider.js";
+import { quarantineMissingHostedCollection } from "./hosted-capability-lifecycle.js";
 import {
   InstanceAdminConflictError,
   type OperatorMutation
@@ -75,7 +76,12 @@ export async function reconcileActiveHostedEntitlements(
       const reconciled = await reconcileHostedAccountCollections(
         connection,
         provider,
-        userId
+        userId,
+        {
+          onMissingCollection: async (collectionId) => {
+            await quarantineMissingHostedCollection(db, collectionId);
+          }
+        }
       );
       state = await completeAccount(
         connection,
@@ -123,7 +129,7 @@ async function createOperation(
     `SELECT u.id, count(c.id) AS hosted_collections
      FROM users u
      JOIN hosted_collections c ON c.user_id = u.id
-     WHERE u.suspended_at IS NULL
+     WHERE u.suspended_at IS NULL AND c.quarantined_at IS NULL
      GROUP BY u.id
      ORDER BY u.id`
   );

--- a/services/server/src/auth-admin.test.ts
+++ b/services/server/src/auth-admin.test.ts
@@ -9,10 +9,11 @@ import {
   EmailDeliveryError,
   type EmailTransport
 } from "./email.js";
-import type {
-  HostedAccountLimits,
-  HostedAccountUsage,
-  HostedProviderClient
+import {
+  HostedProviderResponseError,
+  type HostedAccountLimits,
+  type HostedAccountUsage,
+  type HostedProviderClient
 } from "./hosted-provider.js";
 import { tokenHash } from "./security.js";
 
@@ -518,6 +519,7 @@ describe("authentication operator command", () => {
     const accountByUser = new Map(
       accounts.rows.map((row) => [row.user_id, row.provider_account_id])
     );
+    const missingCollectionId = "40000000-0000-4000-8000-000000000091";
     const calls: string[] = [];
     const usage = new Map<string, HostedAccountUsage>();
     let failOnce = true;
@@ -544,7 +546,14 @@ describe("authentication operator command", () => {
         usage.set(accountId, next);
         return next;
       },
-      async reconcileCollectionAccount(accountId: string) {
+      async reconcileCollectionAccount(accountId: string, collectionId: string) {
+        if (collectionId === missingCollectionId) {
+          throw new HostedProviderResponseError(
+            404,
+            "hosted_collection_not_found",
+            "Hosted collection not found."
+          );
+        }
         const current = usage.get(accountId);
         if (!current) throw new Error("Account was not reconciled.");
         usage.set(accountId, {
@@ -584,7 +593,7 @@ describe("authentication operator command", () => {
       scope: "active_hosted",
       reconciled_accounts: 2,
       hosted_collections: 3,
-      reconciled_collections: 3,
+      reconciled_collections: 2,
       users_inspected: 4
     });
     expect(JSON.stringify(result)).not.toContain(activeA);
@@ -608,6 +617,13 @@ describe("authentication operator command", () => {
       { user_id: activeA },
       { user_id: activeB }
     ]);
+    expect((await context.db.query(
+      `SELECT quarantine_reason FROM hosted_collections
+       WHERE id = $1 AND quarantined_at IS NOT NULL`,
+      [missingCollectionId]
+    )).rows).toEqual([{
+      quarantine_reason: "provider_collection_missing"
+    }]);
     await expect(runAuthAdminCommand([
       ...command.slice(0, -1),
       "Different request"

--- a/services/server/src/entitlements.test.ts
+++ b/services/server/src/entitlements.test.ts
@@ -8,8 +8,15 @@ import {
   effectiveEntitlement,
   materializeInvitationEntitlement,
   materializePublicSignupEntitlement,
-  OPEN_BETA_ENTITLEMENT_PROFILE
+  OPEN_BETA_ENTITLEMENT_PROFILE,
+  reconcileHostedAccountCollections
 } from "./entitlements.js";
+import {
+  HostedProviderResponseError,
+  type HostedAccountLimits,
+  type HostedAccountUsage,
+  type HostedProviderClient
+} from "./hosted-provider.js";
 
 const resources: Array<() => Promise<void>> = [];
 
@@ -114,12 +121,101 @@ describe("account entitlements", () => {
       .toBe(1_073_741_824);
   });
 
+  it("isolates only a typed missing collection during batch reconciliation", async () => {
+    const { db, userId, invitationId } = await fixture();
+    await materializeInvitationEntitlement(
+      db,
+      userId,
+      invitationId,
+      BETA_ENTITLEMENT_PROFILE
+    );
+    const collectionId = randomUUID();
+    await db.query(
+      `INSERT INTO hosted_collections (id, user_id, display_name, template)
+       VALUES ($1, $2, 'Missing provider collection', 'blank')`,
+      [collectionId, userId]
+    );
+    const missing: string[] = [];
+    const result = await reconcileHostedAccountCollections(
+      db,
+      reconciliationProvider(() => {
+        throw new HostedProviderResponseError(
+          404,
+          "hosted_collection_not_found",
+          "Hosted collection not found."
+        );
+      }),
+      userId,
+      { onMissingCollection: async (id) => { missing.push(id); } }
+    );
+    expect(result.reconciledCollections).toBe(0);
+    expect(missing).toEqual([collectionId]);
+  });
+
+  it("keeps collection ownership conflicts visible during reconciliation", async () => {
+    const { db, userId, invitationId } = await fixture();
+    await materializeInvitationEntitlement(
+      db,
+      userId,
+      invitationId,
+      BETA_ENTITLEMENT_PROFILE
+    );
+    await db.query(
+      `INSERT INTO hosted_collections (id, user_id, display_name, template)
+       VALUES ($1, $2, 'Conflicting provider collection', 'blank')`,
+      [randomUUID(), userId]
+    );
+    await expect(reconcileHostedAccountCollections(
+      db,
+      reconciliationProvider(() => {
+        throw new HostedProviderResponseError(
+          409,
+          "hosted_collection_account_conflict",
+          "The hosted collection belongs to another account."
+        );
+      }),
+      userId,
+      { onMissingCollection: async () => undefined }
+    )).rejects.toMatchObject({ code: "hosted_collection_account_conflict" });
+  });
+
   it("rejects an unknown invitation profile", async () => {
     const { db, invitationId } = await fixture();
     await expect(attachInvitationEntitlement(db, invitationId, "missing_v1"))
       .rejects.toThrow("Unknown entitlement profile");
   });
 });
+
+function reconciliationProvider(
+  reconcile: () => void | Promise<void>
+): HostedProviderClient {
+  let usage: HostedAccountUsage | undefined;
+  return {
+    async upsertAccount(
+      accountId: string,
+      entitlementRevision: number,
+      limits: HostedAccountLimits
+    ) {
+      usage = {
+        account_id: accountId,
+        entitlement_revision: entitlementRevision,
+        collection_count: 0,
+        live_content_bytes: 0,
+        live_file_bytes: 0,
+        retained_file_bytes: 0,
+        ...limits
+      };
+      return usage;
+    },
+    async reconcileCollectionAccount() {
+      await reconcile();
+    },
+    async accountUsage() {
+      if (!usage) throw new Error("Hosted account was not reconciled.");
+      return usage;
+    }
+  } as unknown as HostedProviderClient;
+}
 
 async function fixture(): Promise<{
   db: DatabasePool;

--- a/services/server/src/entitlements.ts
+++ b/services/server/src/entitlements.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { DatabasePool, DatabaseQueryable } from "./database-types.js";
-import type {
-  HostedAccountLimits,
-  HostedAccountUsage,
-  HostedProviderClient
+import {
+  HostedProviderResponseError,
+  type HostedAccountLimits,
+  type HostedAccountUsage,
+  type HostedProviderClient
 } from "./hosted-provider.js";
 
 export const BETA_ENTITLEMENT_PROFILE = "beta_v1";
@@ -269,7 +270,10 @@ export async function reconcileHostedAccount(
 export async function reconcileHostedAccountCollections(
   db: DatabaseQueryable,
   provider: HostedProviderClient,
-  userId: string
+  userId: string,
+  options: {
+    onMissingCollection?: (collectionId: string) => Promise<void>;
+  } = {}
 ): Promise<ReconciledHostedAccount & { reconciledCollections: number }> {
   const account = await reconcileHostedAccount(db, provider, userId);
   const collections = await db.query<{ id: string }>(
@@ -282,11 +286,24 @@ export async function reconcileHostedAccountCollections(
   );
   let reconciledCollections = 0;
   for (const collection of collections.rows) {
-    await provider.reconcileCollectionAccount(
-      account.providerAccountId,
-      collection.id
-    );
-    reconciledCollections += 1;
+    try {
+      await provider.reconcileCollectionAccount(
+        account.providerAccountId,
+        collection.id
+      );
+      reconciledCollections += 1;
+    } catch (error) {
+      if (
+        options.onMissingCollection
+        && error instanceof HostedProviderResponseError
+        && error.status === 404
+        && error.code === "hosted_collection_not_found"
+      ) {
+        await options.onMissingCollection(collection.id);
+        continue;
+      }
+      throw error;
+    }
   }
   const usage = await provider.accountUsage(account.providerAccountId);
   return { ...account, usage, reconciledCollections };


### PR DESCRIPTION
## Summary

- makes the provider distinguish a confirmed missing collection (404) from an ownership conflict (409) during account reconciliation
- quarantines only confirmed missing collections in the active-hosted release batch and continues unrelated accounts
- keeps ownership conflicts visible and fatal
- adds provider contract, resumable batch, and direct entitlement regressions

## Why

The beta89 containment promotion safely rolled back because entitlement reconciliation still encountered a combined missing-or-conflict response. Beta90 needs this typed distinction so the release gate can quarantine confirmed absence without masking ownership conflicts.

## Validation

- server suite: 354 passing
- server typecheck
- hosted-provider Rust compile/test
- provider E2E contract coverage added
- existing beta90 migration and account-deletion suites remain unchanged.