### PR TITLE
Prepare beta.91 candidate identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.1.0-beta.91
+
+Beta.91 hardens collection ownership, filesystem convergence, and authorization
+revocation across the Editor, local connector, hosted provider, and mirrors.
+
+- Editor collection transitions freeze and drain owned work before changing
+  authority, fence stale publication, isolate transclusions, and keep detached
+  type-definition saves generation-safe.
+- Watcher and mirror paths preserve typed invalid-record outcomes, capability-
+  bound filesystem reads, exact cache acknowledgement, bounded retry state, and
+  feed silence for invalid private observations.
+- Hosted authority imports, mutation recovery, account snapshots, selected-folder
+  scopes, and exact timer reconciliation now retain their execution-time
+  authority and fail closed under contention or stale completion.
+- Connector policy leases use exact-session acknowledgements, bounded renewal,
+  cross-instance coalescing, and transport-bound publication fences so revoked
+  work cannot publish through a successor policy.
+- Release tooling can bind an exact signed candidate, client, and Editor revision
+  to guarded LAB-only deployment and rollback evidence without permitting a
+  staging or production target.
+
 ## 0.1.0-beta.90
 
 Beta.90 makes account deletion transactional, isolates stale hosted grants, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -132,19 +132,39 @@ describe("mdbase editor", () => {
     render(<App gateway={new DemoCollectionGateway(12)} />);
 
     await screen.findByRole("heading", { name: "Writing" });
-    const row = screen.getAllByRole("option")[1] as HTMLButtonElement;
+    const row = screen.getByRole("option", { name: /^Garden notes 2/ }) as HTMLButtonElement;
     const title = row.querySelector(".note-title")?.textContent;
     expect(title).toBeTruthy();
 
-    fireEvent.mouseEnter(row);
-    const preview = await screen.findByRole("tooltip");
-    expect(preview).toHaveAccessibleName(/Preview of/);
-    expect(preview.querySelector("header strong")?.textContent).toBeTruthy();
-    expect(preview.querySelector("header span")?.textContent).toMatch(/\.md$/);
-    expect(row).toHaveAttribute("aria-describedby", "note-preview-popover");
-
     fireEvent.mouseLeave(row);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    let openPreview: TimerHandler | undefined;
+    const nativeSetTimeout = window.setTimeout.bind(window);
+    const timeout = vi.spyOn(window, "setTimeout").mockImplementation((handler, delay, ...args) => {
+      if (delay === 360) {
+        openPreview = handler;
+        return 1;
+      }
+      return nativeSetTimeout(handler, delay, ...args);
+    });
+    try {
+      fireEvent.mouseOver(row);
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      expect(timeout.mock.calls.filter(([, delay]) => delay === 360)).toHaveLength(1);
+      expect(openPreview).toBeTypeOf("function");
+
+      await act(async () => { (openPreview as () => void)(); });
+      const preview = screen.getByRole("tooltip");
+      expect(preview).toHaveAccessibleName(/Preview of/);
+      expect(preview.querySelector("header strong")?.textContent).toBeTruthy();
+      expect(preview.querySelector("header span")?.textContent).toMatch(/\.md$/);
+      expect(row).toHaveAttribute("aria-describedby", "note-preview-popover");
+
+      fireEvent.mouseLeave(row);
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    } finally {
+      timeout.mockRestore();
+    }
   });
 
   it("does not reload the collection index after saving one note", async () => {

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.90"
+version = "0.1.0-beta.91"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.90" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.91" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.90",
+  "version": "0.1.0-beta.91",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -147,7 +147,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.90",
+        version: "0.1.0-beta.91",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary
- advance the exact integrated candidate to `0.1.0-beta.91`
- keep package, Cargo, MCP, server-fixture, and hosted-provider lock identities aligned
- document the already-merged beta.91 hardening scope

## Validation
- `pnpm version:check`
- `pnpm check:release-components`
- `pnpm check:architecture`
- byte-identical root and hosted-provider Cargo locks
- `git diff --check`
- independent release-diff audit: ACCEPT

This changes release identity and changelog only. It does not deploy or modify LAB, staging, or production.

## Merge-group correction
- deterministically select a note row and capture the exact 360ms hover callback
- focused hover regression: 50/50
- Editor suite: 52 files / 375 tests
- Editor typecheck
- independent correction audit: ACCEPT
