### PR TITLE
Recover updater from stale Sigstore trust cache

### DIFF
--- a/apps/desktop/src/main/release-source.ts
+++ b/apps/desktop/src/main/release-source.ts
@@ -1,4 +1,6 @@
 import { verify, type Bundle } from "sigstore";
+import { randomUUID } from "node:crypto";
+import { rename, rm } from "node:fs/promises";
 import {
   channelForVersion,
   compareVersions,
@@ -157,15 +159,76 @@ async function verifyReleaseBundle(
   identity: string,
   trustCacheDirectory: string
 ): Promise<void> {
-  await verify(bundle as Bundle, payload, {
-    certificateIssuer: OIDC_ISSUER,
-    certificateIdentityURI: identity,
-    tlogThreshold: 1,
-    ctLogThreshold: 1,
-    tufCachePath: trustCacheDirectory,
-    timeout: 10_000,
-    retry: { retries: 2 }
-  });
+  const verifyAt = async (cachePath: string): Promise<void> => {
+    await verify(bundle as Bundle, payload, {
+      certificateIssuer: OIDC_ISSUER,
+      certificateIdentityURI: identity,
+      tlogThreshold: 1,
+      ctLogThreshold: 1,
+      tufCachePath: cachePath,
+      timeout: 10_000,
+      retry: { retries: 2 }
+    });
+  };
+  try {
+    await verifyAt(trustCacheDirectory);
+  } catch (error) {
+    if (!isRecoverableTrustCacheError(error)) throw error;
+    await recoverTrustCache(trustCacheDirectory, verifyAt, error);
+  }
+}
+
+export async function recoverTrustCache(
+  trustCacheDirectory: string,
+  verifyAt: (cachePath: string) => Promise<void>,
+  originalError: unknown
+): Promise<void> {
+  const nonce = randomUUID();
+  const recovery = `${trustCacheDirectory}.recovery-${nonce}`;
+  const stale = `${trustCacheDirectory}.stale-${nonce}`;
+  try {
+    // A new Sigstore cache still bootstraps from the library's pinned TUF root
+    // and performs the complete certificate, transparency-log and CT checks.
+    // It is not a verification fallback or an alternate trust source.
+    await verifyAt(recovery);
+  } catch (recoveryError) {
+    await rm(recovery, { recursive: true, force: true });
+    throw new AggregateError(
+      [originalError, recoveryError],
+      "The cached and freshly bootstrapped Sigstore trust metadata both failed verification."
+    );
+  }
+
+  let movedStale = false;
+  try {
+    await rename(trustCacheDirectory, stale);
+    movedStale = true;
+  } catch (error) {
+    if (!isMissingPath(error)) {
+      await rm(recovery, { recursive: true, force: true });
+      throw error;
+    }
+  }
+  try {
+    await rename(recovery, trustCacheDirectory);
+  } catch (error) {
+    if (movedStale) await rename(stale, trustCacheDirectory).catch(() => undefined);
+    throw error;
+  }
+  if (movedStale) await rm(stale, { recursive: true, force: true }).catch(() => undefined);
+}
+
+export function isRecoverableTrustCacheError(error: unknown): boolean {
+  for (let current: unknown = error; current instanceof Error; current = current.cause) {
+    if (/root was signed by \d+\/\d+ keys|expired (?:root|TUF) metadata/i.test(current.message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMissingPath(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
 async function request(fetchImpl: typeof fetch, url: string): Promise<Response> {

--- a/apps/desktop/test/release-source.test.mjs
+++ b/apps/desktop/test/release-source.test.mjs
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import test from "node:test";
 
 const require = createRequire(import.meta.url);
-const { findLatestRelease } = require("../dist/main/release-source.js");
+const {
+  findLatestRelease,
+  isRecoverableTrustCacheError,
+  recoverTrustCache
+} = require("../dist/main/release-source.js");
 
 const indexUrl =
   "https://api.github.com/repos/mdbase-dev/mdbase-connect/releases?per_page=100";
@@ -193,4 +200,45 @@ test("oversized release metadata is rejected before parsing", async () => {
     }),
     /size limit/
   );
+});
+
+test("a threshold failure is classified as a recoverable trust-cache error", () => {
+  const error = new Error("outer", {
+    cause: new Error("root was signed by 0/3 keys")
+  });
+  assert.equal(isRecoverableTrustCacheError(error), true);
+  assert.equal(isRecoverableTrustCacheError(new Error("untrusted release signer")), false);
+});
+
+test("successful fresh verification atomically replaces a stale trust cache", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-trust-"));
+  const cache = join(directory, "sigstore");
+  await mkdir(cache);
+  await writeFile(join(cache, "root.json"), "stale");
+  const calls = [];
+
+  await recoverTrustCache(cache, async (candidate) => {
+    calls.push(candidate);
+    await mkdir(candidate);
+    await writeFile(join(candidate, "root.json"), "fresh");
+  }, new Error("root was signed by 0/3 keys"));
+
+  assert.equal(calls.length, 1);
+  assert.equal(await readFile(join(cache, "root.json"), "utf8"), "fresh");
+});
+
+test("failed fresh verification preserves the existing trust cache", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "mdbase-update-trust-"));
+  const cache = join(directory, "sigstore");
+  await mkdir(cache);
+  await writeFile(join(cache, "root.json"), "stale");
+
+  await assert.rejects(
+    recoverTrustCache(cache, async (candidate) => {
+      await mkdir(candidate);
+      throw new Error("fresh verification failed");
+    }, new Error("root was signed by 0/3 keys")),
+    /cached and freshly bootstrapped/
+  );
+  assert.equal(await readFile(join(cache, "root.json"), "utf8"), "stale");
 });


### PR DESCRIPTION
## Summary
- retry recognized stale/expired Sigstore TUF root failures against a freshly bootstrapped pinned cache
- atomically replace the stale cache only after full verification succeeds
- preserve the existing cache and fail closed when fresh verification fails

## Validation
- `pnpm --filter @mdbase/connect-desktop typecheck`
- `pnpm --filter @mdbase/connect-desktop test` (71 tests)