### PR TITLE
Prepare beta.92 candidate identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.1.0-beta.92
+
+Beta.92 restores relay compatibility with signed beta.90 connectors while
+preserving the stronger policy-freshness lease as an optional beta capability.
+
+- Relay policy negotiation now selects explicit `lease_v1` or frozen
+  `legacy_ack_v0` behavior; beta.90 receives its original policy wire shape and
+  acknowledgement revision without claiming bounded offline revocation.
+- Lease negotiation and acknowledged adoption are durable and monotonic, so a
+  concurrent, failed, or incomplete attach cannot reopen legacy admission after
+  a connector has crossed either boundary.
+- Initial and changed-policy acknowledgements fence routing and publication;
+  stale mutation responses surface an unknown outcome instead of publishing
+  through superseded authority.
+- Connector-side lease adoption remains sticky, partial lease metadata fails
+  closed, and websocket shutdown aborts the policy coordinator before it can
+  restore a disconnected session to `Connected`.
+- Account surfaces truthfully recommend updates for legacy acknowledgements and
+  retain beta.91 as the lease capability floor while the baseline connector
+  floor remains independent.
+- `policy-freshness-lease-v1` stays optional for every beta. Stable `v0.1.0` is
+  only the earliest possible enforcement boundary and remains subject to the
+  documented production-observation and rollback gates.
+
 ## 0.1.0-beta.91
 
 Beta.91 hardens collection ownership, filesystem convergence, and authorization

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.91"
+version = "0.1.0-beta.92"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.91" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.92" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.91",
+  "version": "0.1.0-beta.92",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -147,7 +147,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.91",
+        version: "0.1.0-beta.92",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary

Prepare `v0.1.0-beta.92` from the merged capability-compatibility bridge.

- bump the Rust workspace, TypeScript packages, MCP/server identities, and release lockfile to beta.92
- document explicit `legacy_ack_v0` compatibility and optional `lease_v1` adoption
- retain beta.91 as the truthful lease capability floor without making it mandatory during beta
- document durable negotiation/adoption, policy fencing, stale mutation outcomes, and policy-worker shutdown safety

The underlying compatibility bridge was merged in #355 and received a focused adversarial `ACCEPT` plus full merge-group qualification.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install --frozen-lockfile`
- `pnpm version:check`
- `pnpm check:release-readiness`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e`
- release Cargo lockfiles are byte-identical

The existing browser SDK review warnings remain unchanged at 230089 raw / 58608 gzip bytes, below the 65536-byte hard ceiling.
