### PR TITLE
Fix editor sidebar overflow for long titles

### DIFF
--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -30,6 +30,37 @@ vi.mock("@tanstack/react-virtual", () => ({
 }));
 
 describe("mdbase editor", () => {
+  it("clamps a widened notes sidebar when an inspector reduces the available space", async () => {
+    vi.stubGlobal("innerWidth", 1_150);
+    localStorage.setItem("mdbase-editor:layout", JSON.stringify({
+      collectionWidth: 176,
+      listWidth: 520,
+      inspectorWidth: 340,
+      collectionCollapsed: false,
+      listCollapsed: false
+    }));
+    const gateway = new DemoCollectionGateway(12);
+    const describe = gateway.describe.bind(gateway);
+    gateway.describe = async () => ({
+      ...await describe(),
+      displayName: "A collection title that is far too long to fit in the notes sidebar"
+    });
+    const user = userEvent.setup();
+    const { container } = render(<App gateway={gateway} />);
+
+    await screen.findByRole("heading", { name: "A collection title that is far too long to fit in the notes sidebar" });
+    await screen.findByRole("textbox", { name: "Note body" });
+    expect(container.querySelector<HTMLElement>(".app-shell")?.style.getPropertyValue("--list-track")).toBe("520px");
+
+    await user.click(screen.getByRole("button", { name: "Note properties" }));
+    await waitFor(() => expect(container.querySelector<HTMLElement>(".app-shell")?.style.getPropertyValue("--list-track")).toBe("314px"));
+    const resizeHandle = screen.getByRole("separator", { name: "Resize notes sidebar" });
+    expect(resizeHandle).toHaveAttribute("aria-valuenow", "314");
+    resizeHandle.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(container.querySelector<HTMLElement>(".app-shell")?.style.getPropertyValue("--list-track")).toBe("306px");
+  });
+
   it("collapses, restores, and resizes both navigation sidebars", async () => {
     const user = userEvent.setup();
     render(<App gateway={new DemoCollectionGateway(12)} />);

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -1790,26 +1790,28 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
 
   const selectedType = description.types.find((type) => type.name === selectedTypeName);
   const hasListPane = surface !== "settings";
-  const collectionTrack = layout.collectionCollapsed ? 0 : layout.collectionWidth;
-  const listTrack = hasListPane && !layout.listCollapsed ? layout.listWidth : 0;
+  const preferredCollectionTrack = layout.collectionCollapsed ? 0 : layout.collectionWidth;
+  const preferredListTrack = hasListPane && !layout.listCollapsed ? layout.listWidth : 0;
   const editorMinimum = viewportWidth <= 1120 ? 320 : 380;
   const inspectorVisible = propertiesOpen || backlinksOpen;
   const inspectorResizeMax = Math.max(INSPECTOR_WIDTH.min, Math.min(
     INSPECTOR_WIDTH.max,
     viewportWidth > 1120
-      ? viewportWidth - collectionTrack - listTrack - editorMinimum
+      ? viewportWidth - preferredCollectionTrack - preferredListTrack - editorMinimum
       : viewportWidth - editorMinimum
   ));
   const inspectorTrack = Math.min(layout.inspectorWidth, inspectorResizeMax);
   const reservedInspectorWidth = inspectorVisible && viewportWidth > 1120 ? inspectorTrack : 0;
   const collectionResizeMax = Math.max(COLLECTION_WIDTH.min, Math.min(
     COLLECTION_WIDTH.max,
-    viewportWidth - listTrack - editorMinimum - reservedInspectorWidth
+    viewportWidth - preferredListTrack - editorMinimum - reservedInspectorWidth
   ));
   const listResizeMax = Math.max(LIST_WIDTH.min, Math.min(
     LIST_WIDTH.max,
-    viewportWidth - collectionTrack - editorMinimum - reservedInspectorWidth
+    viewportWidth - preferredCollectionTrack - editorMinimum - reservedInspectorWidth
   ));
+  const collectionTrack = Math.min(preferredCollectionTrack, collectionResizeMax);
+  const listTrack = Math.min(preferredListTrack, listResizeMax);
   const listName = surface === "types" ? "types" : "notes";
   const historyBackPath = noteHistoryState.paths[noteHistoryState.index - 1];
   const historyForwardPath = noteHistoryState.paths[noteHistoryState.index + 1];
@@ -2122,7 +2124,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
       {!layout.collectionCollapsed && <PaneResizeHandle
         className="collection-resizer"
         label="Resize collections sidebar"
-        value={layout.collectionWidth}
+        value={collectionTrack}
         min={COLLECTION_WIDTH.min}
         max={collectionResizeMax}
         onChange={(collectionWidth) => setLayout((current) => ({ ...current, collectionWidth }))}
@@ -2132,7 +2134,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
       {hasListPane && !layout.listCollapsed && <PaneResizeHandle
         className="list-resizer"
         label={`Resize ${listName} sidebar`}
-        value={layout.listWidth}
+        value={listTrack}
         min={LIST_WIDTH.min}
         max={listResizeMax}
         onChange={(listWidth) => setLayout((current) => ({ ...current, listWidth }))}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1379,7 +1379,9 @@ select:focus-visible {
 .type-list-pane {
   grid-column: 2;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto auto minmax(0, 1fr);
+  overflow: hidden;
   border-right: 1px solid var(--line);
 }
 
@@ -1626,7 +1628,6 @@ select:focus-visible {
 
 .note-list-controls .search-field {
   min-width: 0;
-  width: 100%;
   margin: 0;
 }
 

--- a/apps/editor/tests/editor.spec.ts
+++ b/apps/editor/tests/editor.spec.ts
@@ -1153,6 +1153,39 @@ test("resizes, collapses, and restores the desktop sidebars", async ({ page }) =
   expect(restored).toBeCloseTo(after, 0);
 });
 
+test("contains a long collection heading when a saved notes sidebar is clamped", async ({ page }) => {
+  await page.setViewportSize({ width: 1_150, height: 760 });
+  await page.addInitScript(() => localStorage.setItem("mdbase-editor:layout", JSON.stringify({
+    collectionWidth: 176,
+    listWidth: 520,
+    inspectorWidth: 340,
+    collectionCollapsed: false,
+    listCollapsed: false
+  })));
+  await page.goto("?demo=12");
+  await expect(page.getByRole("textbox", { name: "Note body" })).toBeVisible();
+  await page.locator(".list-header h1").evaluate((heading) => {
+    heading.textContent = "A-collection-title-that-is-much-too-long-to-fit-in-the-notes-sidebar-without-being-contained";
+  });
+
+  await page.getByRole("button", { name: "Note properties" }).click();
+  const pane = page.locator(".note-list-pane");
+  const search = page.locator(".note-list-controls .search-field");
+  await expect.poll(async () => pane.evaluate((element) => element.getBoundingClientRect().width)).toBeCloseTo(314, 0);
+  const bounds = await Promise.all([pane, search].map((locator) => locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { left: rect.left, right: rect.right };
+  })));
+  expect(bounds[1].left).toBeGreaterThanOrEqual(bounds[0].left);
+  expect(bounds[1].right).toBeLessThanOrEqual(bounds[0].right);
+
+  const resize = page.getByRole("separator", { name: "Resize notes sidebar" });
+  await expect(resize).toHaveAttribute("aria-valuenow", "314");
+  await resize.focus();
+  await page.keyboard.press("ArrowLeft");
+  await expect.poll(async () => pane.evaluate((element) => element.getBoundingClientRect().width)).toBeCloseTo(306, 0);
+});
+
 test("keeps the current note inspector open and resizable between note switches", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 760 });
   await page.goto("?demo=12");


### PR DESCRIPTION
## Summary

- constrain the note-list grid column so long collection headings cannot expand controls beyond the pane
- clamp rendered sidebar tracks and keep resize handles aligned with the visible widths
- add unit and browser regressions for search-field containment and immediate resizing

## Verification

- `pnpm build:packages`
- `pnpm --filter mdbase-editor typecheck`
- `pnpm --filter mdbase-editor test` (52 files, 377 tests)
- `pnpm --filter mdbase-editor exec playwright test tests/editor.spec.ts --grep "contains a long collection heading"`