### PR TITLE
Bound relay replacement broker flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ preserving the stronger policy-freshness lease as an optional beta capability.
 - Initial and changed-policy acknowledgements fence routing and publication;
   stale mutation responses surface an unknown outcome instead of publishing
   through superseded authority.
+- Advisory replacement broadcasts now use a bounded broker flush, so a stalled
+  broker acknowledgement cannot prevent the initial policy from reaching an
+  otherwise authenticated connector session.
 - Connector-side lease adoption remains sticky, partial lease metadata fails
   closed, and websocket shutdown aborts the policy coordinator before it can
   restore a disconnected session to `Connected`.

--- a/services/server/src/relay-broker.test.ts
+++ b/services/server/src/relay-broker.test.ts
@@ -1,6 +1,8 @@
+import type { NatsConnection } from "nats";
 import { describe, expect, it, vi } from "vitest";
 import {
   LocalRelayBroker,
+  NatsRelayBroker,
   RelayBrokerUnavailableError,
   type RelayBrokerCommand
 } from "./relay-broker.js";
@@ -12,6 +14,22 @@ const policy: RelayBrokerCommand = {
   kind: "policy",
   message: POLICY_PUSH_SIGNAL
 };
+
+describe("NATS relay broker", () => {
+  it("bounds replacement publication flush before policy startup", async () => {
+    const connection = {
+      publish: vi.fn(),
+      flush: vi.fn(() => new Promise<void>(() => undefined)),
+      isClosed: vi.fn(() => false),
+      status: async function* () {}
+    } as unknown as NatsConnection;
+    const broker = new NatsRelayBroker(connection, 5);
+
+    await expect(broker.publishReplacement(connectorId, "1"))
+      .rejects.toBeInstanceOf(RelayBrokerUnavailableError);
+    expect(connection.publish).toHaveBeenCalledOnce();
+  });
+});
 
 describe("local relay broker", () => {
   it("routes only to the exact connector session generation", async () => {

--- a/services/server/src/relay-broker.ts
+++ b/services/server/src/relay-broker.ts
@@ -185,7 +185,10 @@ export class NatsRelayBroker implements RelayBroker {
   private available = true;
   private readonly framed: NatsFramedTransport;
 
-  private constructor(private readonly connection: NatsConnection) {
+  constructor(
+    private readonly connection: NatsConnection,
+    private readonly flushTimeoutMs = 1_000
+  ) {
     this.framed = new NatsFramedTransport(connection);
     void this.monitorConnection();
   }
@@ -301,7 +304,7 @@ export class NatsRelayBroker implements RelayBroker {
     this.assertAvailable();
     assertSubjectParts(connectorId, generation);
     this.connection.publish(replacementSubject(connectorId), encodeJson({ version: 1, generation }));
-    await this.connection.flush();
+    await withTimeout(this.connection.flush(), this.flushTimeoutMs);
   }
 
   async ready(): Promise<void> {


### PR DESCRIPTION
## Summary
- bound the advisory NATS replacement flush using the existing one-second broker timeout
- preserve the PostgreSQL generation as the hard replacement fence
- prevent a stalled broker acknowledgement from blocking initial connector policy publication
- add a deterministic stalled-flush regression

## Reproduction
During genuine signed beta.92/beta.90 staging qualification, clients received `relay_welcome` and remained at `awaiting initial policy` until bounded scenario cleanup. `RelayHub.attach` awaited an unbounded `publishReplacement` flush immediately before `session.policy.start()`.

## Verification
- `pnpm --filter @mdbase/connect-server test -- relay-broker.test.ts` (399 passed, 7 skipped)
- `pnpm --filter @mdbase/connect-server typecheck`
- `git diff --check`
- adversarial review: ACCEPT