### PR TITLE
Trace delayed connector policy stages

### DIFF
--- a/services/server/src/relay-policy-session.ts
+++ b/services/server/src/relay-policy-session.ts
@@ -11,6 +11,7 @@ import {
 } from "./relay-errors.js";
 import {
   buildPolicySnapshot,
+  observeConnectorPolicyStage,
   type PolicyMode,
   type PolicySnapshot
 } from "./relay-policy.js";
@@ -221,20 +222,28 @@ export class ExactPolicyPublisher {
     authority: ExactPolicyAuthority,
     send: (message: PolicySnapshot) => Promise<unknown>
   ): Promise<ExactPolicyAcknowledgement> {
-    if (!await this.isCurrent(authority)) throw new StalePolicyAuthorityError();
-    const message = await buildPolicySnapshot(
+    if (!await observeConnectorPolicyStage("generation_before", () => this.isCurrent(authority))) {
+      throw new StalePolicyAuthorityError();
+    }
+    const message = await observeConnectorPolicyStage("snapshot_build", () => buildPolicySnapshot(
       this.db,
       authority.connectorId,
       this.leaseMs,
       authority.generation,
       () => this.isOpen() && authority.isStillCurrent(),
       this.mode
-    );
-    if (!message || !await this.isCurrent(authority)) {
+    ));
+    if (!message || !await observeConnectorPolicyStage(
+      "generation_after_build", () => this.isCurrent(authority)
+    )) {
       throw new StalePolicyAuthorityError();
     }
-    const settled = await send(message);
-    if (!await this.isCurrent(authority)) throw new StalePolicyAuthorityError();
+    const settled = await observeConnectorPolicyStage("policy_delivery_ack", () => send(message));
+    if (!await observeConnectorPolicyStage(
+      "generation_after_ack", () => this.isCurrent(authority)
+    )) {
+      throw new StalePolicyAuthorityError();
+    }
     return exactPolicyAcknowledgement(settled, message);
   }
 

--- a/services/server/src/relay-policy.test.ts
+++ b/services/server/src/relay-policy.test.ts
@@ -6,6 +6,7 @@ import { canonicalJson, canonicalSha256 } from "./canonical-json.js";
 import {
   buildPolicySnapshot,
   normalizePolicyGrant,
+  observeConnectorPolicyStage,
   policyGrantCreatedAtIso,
   PolicySequenceExhaustedError,
   resolvePolicyAppliedAck
@@ -14,7 +15,38 @@ import type { DatabasePool } from "./database-types.js";
 
 const databases: DatabasePool[] = [];
 afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   await Promise.all(databases.splice(0).map((db) => db.end()));
+});
+
+describe("connector policy stage diagnostics", () => {
+  it("reports only a delayed stage and its privacy-safe outcome", async () => {
+    vi.useFakeTimers();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let settle!: (value: string) => void;
+    const operation = new Promise<string>((resolve) => { settle = resolve; });
+    const observed = observeConnectorPolicyStage("snapshot_build", () => operation);
+
+    await vi.advanceTimersByTimeAsync(2_001);
+    expect(warning).toHaveBeenCalledWith("connector policy stage delayed", {
+      class: "delivery_unavailable",
+      stage: "snapshot_build"
+    });
+    settle("done");
+    await expect(observed).resolves.toBe("done");
+    expect(warning).toHaveBeenLastCalledWith("connector policy delayed stage settled", {
+      stage: "snapshot_build",
+      outcome: "ok"
+    });
+  });
+
+  it("does not log a stage that settles within the threshold", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await expect(observeConnectorPolicyStage("generation_before", async () => true))
+      .resolves.toBe(true);
+    expect(warning).not.toHaveBeenCalled();
+  });
 });
 
 describe("connector policy sequence", () => {

--- a/services/server/src/relay-policy.ts
+++ b/services/server/src/relay-policy.ts
@@ -9,6 +9,48 @@ import type { DatabasePool } from "./db.js";
 import { ConnectorOperationError } from "./relay-errors.js";
 
 const MAX_POLICY_SEQUENCE = BigInt(Number.MAX_SAFE_INTEGER);
+const POLICY_STAGE_DELAY_MS = 2_000;
+
+export type ConnectorPolicyStage =
+  | "database_checkout"
+  | "transaction_begin"
+  | "connector_sequence_update"
+  | "grant_inventory"
+  | "transaction_commit"
+  | "generation_before"
+  | "snapshot_build"
+  | "generation_after_build"
+  | "generation_after_ack"
+  | "connector_lookup"
+  | "transaction_rollback"
+  | "policy_delivery_ack"
+  | "replacement_broadcast"
+  | "initial_policy";
+
+/** Privacy-safe timing discriminator for production-only policy stalls. */
+export async function observeConnectorPolicyStage<T>(
+  stage: ConnectorPolicyStage,
+  operation: () => Promise<T>
+): Promise<T> {
+  let delayed = false;
+  const timer = setTimeout(() => {
+    delayed = true;
+    console.warn("connector policy stage delayed", {
+      class: "delivery_unavailable",
+      stage
+    });
+  }, POLICY_STAGE_DELAY_MS);
+  try {
+    const result = await operation();
+    if (delayed) console.warn("connector policy delayed stage settled", { stage, outcome: "ok" });
+    return result;
+  } catch (error) {
+    if (delayed) console.warn("connector policy delayed stage settled", { stage, outcome: "error" });
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 export class PolicySequenceExhaustedError extends Error {
   readonly code = "policy_sequence_exhausted";
@@ -169,18 +211,22 @@ export async function buildPolicySnapshot(
   isStillCurrent: () => boolean = () => true,
   mode: PolicyMode = "lease_v1"
 ): Promise<PolicySnapshot | null> {
-  const connection = await db.connect();
+  const connection = await observeConnectorPolicyStage("database_checkout", () => db.connect());
+  const rollback = () => observeConnectorPolicyStage(
+    "transaction_rollback", () => connection.query("ROLLBACK")
+  );
   try {
     if (!isStillCurrent()) return null;
-    await connection.query("BEGIN");
+    await observeConnectorPolicyStage("transaction_begin", () => connection.query("BEGIN"));
     if (!isStillCurrent()) {
-      await connection.query("ROLLBACK");
+      await rollback();
       return null;
     }
-    const active = await connection.query<{
-      policy_sequence: string | number;
-      database_now: Date | string;
-    }>(
+    const active = await observeConnectorPolicyStage("connector_sequence_update", () =>
+      connection.query<{
+        policy_sequence: string | number;
+        database_now: Date | string;
+      }>(
       `UPDATE connectors
        SET policy_sequence = policy_sequence + 1
        WHERE id = $1 AND revoked_at IS NULL
@@ -189,23 +235,24 @@ export async function buildPolicySnapshot(
          AND user_id IN (SELECT id FROM users WHERE suspended_at IS NULL)
        RETURNING policy_sequence, now() AS database_now`,
       [connectorId, MAX_POLICY_SEQUENCE.toString(), expectedRelayGeneration ?? null]
-    );
+    ));
     if (!active.rows[0]) {
-      const existing = await connection.query<{ policy_sequence: string | number }>(
+      const existing = await observeConnectorPolicyStage("connector_lookup", () =>
+        connection.query<{ policy_sequence: string | number }>(
         `SELECT policy_sequence FROM connectors
          WHERE id = $1 AND revoked_at IS NULL
            AND ($2::bigint IS NULL OR relay_generation = $2::bigint)
            AND user_id IN (SELECT id FROM users WHERE suspended_at IS NULL)`,
         [connectorId, expectedRelayGeneration ?? null]
-      );
-      await connection.query("ROLLBACK");
+      ));
+      await rollback();
       if (existing.rows[0]
           && BigInt(existing.rows[0].policy_sequence) >= MAX_POLICY_SEQUENCE) {
         throw new PolicySequenceExhaustedError();
       }
       return null;
     }
-    const grants = await connection.query<{
+    const grants = await observeConnectorPolicyStage("grant_inventory", () => connection.query<{
       id: string; application_id: string; application_name: string;
       application_distribution: "web" | "portable"; application_homepage: string;
       application_project_url: string | null; application_origin: string;
@@ -232,7 +279,7 @@ export async function buildPolicySnapshot(
          AND g.activated_at IS NOT NULL
        ORDER BY g.id`,
       [connectorId]
-    );
+    ));
     const sequenceValue = BigInt(active.rows[0].policy_sequence);
     if (sequenceValue > MAX_POLICY_SEQUENCE) throw new PolicySequenceExhaustedError();
     const sequence = Number(sequenceValue);
@@ -241,7 +288,7 @@ export async function buildPolicySnapshot(
       ...grant,
       collection_id: grant.local_id
     }));
-    await connection.query("COMMIT");
+    await observeConnectorPolicyStage("transaction_commit", () => connection.query("COMMIT"));
     if (mode === "legacy_ack_v0") {
       return {
         type: "policy_snapshot",
@@ -267,7 +314,7 @@ export async function buildPolicySnapshot(
       ...policyBody
     };
   } catch (error) {
-    await connection.query("ROLLBACK");
+    await rollback();
     throw error;
   } finally {
     connection.release();

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -20,7 +20,9 @@ import {
 } from "./relay-broker.js";
 import { ConnectorOperationError, RelayUnavailableError } from "./relay-errors.js";
 import { RelayFileBridge } from "./relay-file.js";
-import { resolvePolicyAppliedAck, type PolicyMode } from "./relay-policy.js";
+import {
+  observeConnectorPolicyStage, resolvePolicyAppliedAck, type PolicyMode
+} from "./relay-policy.js";
 import {
   ExactPolicyPublisher, handlePolicyPushCommand, RelayPolicySession,
   requestPolicyPush, type ExactPolicyAcknowledgement
@@ -492,14 +494,15 @@ export class RelayHub {
     });
 
     try {
-      await this.broker.publishReplacement(connectorId, generation);
+      await observeConnectorPolicyStage("replacement_broadcast", () =>
+        this.broker.publishReplacement(connectorId, generation));
     } catch (error) {
       // The generation in PostgreSQL is the hard fence. Replacement broadcast
       // only accelerates closing a stale socket when the broker is available.
       if (!(error instanceof RelayBrokerUnavailableError)) throw error;
     }
     try {
-      await session.policy.start();
+      await observeConnectorPolicyStage("initial_policy", () => session.policy.start());
       if (this.connectors.get(connectorId) === session
           && session.generation === generation
           && session.socket === socket

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -20,9 +20,7 @@ import {
 } from "./relay-broker.js";
 import { ConnectorOperationError, RelayUnavailableError } from "./relay-errors.js";
 import { RelayFileBridge } from "./relay-file.js";
-import {
-  observeConnectorPolicyStage, resolvePolicyAppliedAck, type PolicyMode
-} from "./relay-policy.js";
+import { observeConnectorPolicyStage, resolvePolicyAppliedAck, type PolicyMode } from "./relay-policy.js";
 import {
   ExactPolicyPublisher, handlePolicyPushCommand, RelayPolicySession,
   requestPolicyPush, type ExactPolicyAcknowledgement


### PR DESCRIPTION
## Summary
- emit delayed-only privacy-safe stage markers across post-welcome policy startup
- distinguish broker replacement, generation checks, PostgreSQL checkout/transaction/update/inventory/commit/rollback, snapshot construction, delivery, and acknowledgement
- log only fixed stage/class/outcome fields; no connector IDs, grants, request IDs, revisions, counts, or credentials
- add timer/fast-path regressions

## Why
Exact signed beta.92 and beta.90 staging connectors receive `relay_welcome` but remain awaiting initial policy. Static analysis cannot distinguish pre-send database/generation stall from delivery/acknowledgement without these four-phase markers.

## Verification
- `pnpm --filter @mdbase/connect-server typecheck`
- `pnpm --filter @mdbase/connect-server test -- relay-policy.test.ts` (401 passed, 7 skipped)
- `git diff --check`
- adversarial privacy/coverage audit: ACCEPT