### PR TITLE
Trace fast connector policy failures

### DIFF
--- a/services/server/src/relay-policy.test.ts
+++ b/services/server/src/relay-policy.test.ts
@@ -41,11 +41,25 @@ describe("connector policy stage diagnostics", () => {
     });
   });
 
-  it("does not log a stage that settles within the threshold", async () => {
+  it("does not log a successful stage that settles within the threshold", async () => {
     const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     await expect(observeConnectorPolicyStage("generation_before", async () => true))
       .resolves.toBe(true);
     expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("reports a fast failure without exposing the error", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const failure = new Error("private provider detail");
+    await expect(observeConnectorPolicyStage("generation_before", async () => {
+      throw failure;
+    })).rejects.toBe(failure);
+    expect(warning).toHaveBeenCalledWith("connector policy stage failed", {
+      class: "delivery_unavailable",
+      stage: "generation_before",
+      outcome: "error"
+    });
+    expect(JSON.stringify(warning.mock.calls)).not.toContain(failure.message);
   });
 });
 

--- a/services/server/src/relay-policy.ts
+++ b/services/server/src/relay-policy.ts
@@ -45,7 +45,15 @@ export async function observeConnectorPolicyStage<T>(
     if (delayed) console.warn("connector policy delayed stage settled", { stage, outcome: "ok" });
     return result;
   } catch (error) {
-    if (delayed) console.warn("connector policy delayed stage settled", { stage, outcome: "error" });
+    if (delayed) {
+      console.warn("connector policy delayed stage settled", { stage, outcome: "error" });
+    } else {
+      console.warn("connector policy stage failed", {
+        class: "delivery_unavailable",
+        stage,
+        outcome: "error"
+      });
+    }
     throw error;
   } finally {
     clearTimeout(timer);


### PR DESCRIPTION
## Summary
- report privacy-safe policy-stage failures even when they settle before the delayed-stage threshold
- keep fast successes silent and preserve delayed-stage diagnostics
- prove error details never enter logs

## Motivation
The signed beta.92/beta.90 staging reproduction produced no delayed-stage marker. A fast policy-stage failure may therefore be silently retried or suppressed before the client remains awaiting policy. This diagnostic closes that observability gap without logging connector IDs, grants, credentials, record bodies, provider errors, or payloads.

## Validation
- `cd services/server && pnpm test -- --run src/relay-policy.test.ts` (402 passed, 7 skipped)
- `cd services/server && pnpm typecheck`
- `pnpm check:architecture`
- `git diff --check`
- independent privacy/control-flow review: ACCEPT