### PR TITLE
Classify connector relay closes

### DIFF
--- a/services/server/src/relay-policy.test.ts
+++ b/services/server/src/relay-policy.test.ts
@@ -9,6 +9,7 @@ import {
   observeConnectorPolicyStage,
   policyGrantCreatedAtIso,
   PolicySequenceExhaustedError,
+  reportConnectorRelayClose,
   resolvePolicyAppliedAck
 } from "./relay-policy.js";
 import type { DatabasePool } from "./database-types.js";
@@ -60,6 +61,22 @@ describe("connector policy stage diagnostics", () => {
       outcome: "error"
     });
     expect(JSON.stringify(warning.mock.calls)).not.toContain(failure.message);
+  });
+
+  it.each([
+    [4001, "replacement", true],
+    [4003, "non_normal", false],
+    [1000, "normal", true],
+    [1001, "normal", false],
+    [1006, "non_normal", true]
+  ])("classifies relay close code %i without attributing peer details", (code, closeClass, ready) => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    reportConnectorRelayClose(code, ready);
+    expect(info).toHaveBeenCalledWith("connector relay closed", {
+      close_class: closeClass,
+      ready
+    });
+    expect(JSON.stringify(info.mock.calls)).not.toContain(String(code));
   });
 });
 

--- a/services/server/src/relay-policy.ts
+++ b/services/server/src/relay-policy.ts
@@ -60,6 +60,15 @@ export async function observeConnectorPolicyStage<T>(
   }
 }
 
+export function reportConnectorRelayClose(code: number, ready: boolean): void {
+  const closeClass = code === 4001
+    ? "replacement"
+    : code === 1000 || code === 1001
+      ? "normal"
+      : "non_normal";
+  console.info("connector relay closed", { close_class: closeClass, ready });
+}
+
 export class PolicySequenceExhaustedError extends Error {
   readonly code = "policy_sequence_exhausted";
 

--- a/services/server/src/relay-renewal.test.ts
+++ b/services/server/src/relay-renewal.test.ts
@@ -69,10 +69,10 @@ class PolicySocket extends EventEmitter {
     })), false);
   }
 
-  close(): void {
+  close(code = 1000): void {
     if (this.readyState === 3) return;
     this.readyState = 3;
-    this.emit("close");
+    this.emit("close", code);
   }
 }
 
@@ -222,6 +222,32 @@ async function settleAsync(): Promise<void> {
 }
 
 describe("exact-session policy renewal scheduler", () => {
+  it("reports whether an actual socket close follows session readiness", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const readyFixture = await fixture();
+    const readySocket = new PolicySocket();
+    await attach(readyFixture.relay, readyFixture.connectorId, readySocket);
+    readySocket.close(1000);
+    expect(info).toHaveBeenCalledWith("connector relay closed", {
+      close_class: "normal",
+      ready: true
+    });
+
+    const pendingFixture = await fixture();
+    const pendingSocket = new PolicySocket();
+    pendingSocket.hold = true;
+    const attaching = pendingFixture.relay.attach(
+      pendingFixture.connectorId, pendingSocket as unknown as WebSocket, hello()
+    );
+    await eventually(() => expect(pendingSocket.held).toHaveLength(1));
+    pendingSocket.close(4001);
+    await expect(attaching).rejects.toBeDefined();
+    expect(info).toHaveBeenCalledWith("connector relay closed", {
+      close_class: "replacement",
+      ready: false
+    });
+  });
+
   it("does not let a requested push overtake a delayed initial build", async () => {
     const base = await createDatabase("memory");
     databases.push(base);

--- a/services/server/src/relay.ts
+++ b/services/server/src/relay.ts
@@ -20,7 +20,7 @@ import {
 } from "./relay-broker.js";
 import { ConnectorOperationError, RelayUnavailableError } from "./relay-errors.js";
 import { RelayFileBridge } from "./relay-file.js";
-import { observeConnectorPolicyStage, resolvePolicyAppliedAck, type PolicyMode } from "./relay-policy.js";
+import { observeConnectorPolicyStage, reportConnectorRelayClose, resolvePolicyAppliedAck, type PolicyMode } from "./relay-policy.js";
 import {
   ExactPolicyPublisher, handlePolicyPushCommand, RelayPolicySession,
   requestPolicyPush, type ExactPolicyAcknowledgement
@@ -483,7 +483,8 @@ export class RelayHub {
       capabilities: [...RELAY_CAPABILITIES],
       contract_support: CONNECT_CONTRACT_SUPPORT
     }));
-    socket.once("close", () => {
+    socket.once("close", (code) => {
+      reportConnectorRelayClose(code, session.ready);
       const current = this.connectors.get(connectorId);
       if (current === session) this.connectors.delete(connectorId);
       session.policy.stop(new RelayUnavailableError());


### PR DESCRIPTION
## Summary
- emit a privacy-safe neutral class and readiness bit when an attached connector websocket closes
- distinguish replacement, normal, and non-normal closes without logging codes, reasons, IDs, or payloads
- cover actual RelayHub closes both before and after initial policy readiness

## Motivation
Signed beta.92 and beta.90 both return valid exact policy acknowledgements, proving the client reached Connected before sending the acknowledgement, but polling never observes a durable Connected state. This diagnostic distinguishes immediate replacement/reconnect from status-path failure.

## Validation
- server Vitest: 408 passed, 7 skipped
- server typecheck
- architecture check
- diff check
- independent adversarial review: ACCEPT