### PR TITLE
Keep password account snapshots beta-compatible

### DIFF
--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -78,6 +78,52 @@ describe("mdbase connect server", () => {
     }
   });
 
+  it("keeps beta connector account snapshots decodable for password identities", async () => {
+    const db = await createDatabase("memory");
+    resources.push(() => db.end());
+    const { app } = await buildApp({
+      db,
+      devAuth: true,
+      publicUrl: "http://connect.test"
+    });
+    resources.push(() => app.close());
+
+    const session = await app.inject({
+      method: "POST",
+      url: "/v1/dev/session",
+      payload: { name: "Acceptance user", email: "acceptance@example.com" }
+    });
+    const setCookie = session.headers["set-cookie"]!;
+    const cookie = (Array.isArray(setCookie) ? setCookie[0] : setCookie).split(";")[0];
+    await db.query(
+      `INSERT INTO email_identities
+         (id, user_id, email, normalized_email, verified_at, is_primary)
+       SELECT $1, id, $2, $2, now(), true FROM users WHERE email = $2`,
+      [randomUUID(), "acceptance@example.com"]
+    );
+    await db.query("UPDATE users SET email = NULL WHERE email = $1", ["acceptance@example.com"]);
+
+    const connector = await app.inject({
+      method: "POST",
+      url: "/v1/connectors",
+      headers: { cookie },
+      payload: { name: "Acceptance computer" }
+    });
+    expect(connector.statusCode).toBe(201);
+    const control = await app.inject({
+      method: "GET",
+      url: "/v1/connectors/control",
+      headers: { authorization: `Bearer ${connector.json().token}` }
+    });
+
+    expect(control.statusCode).toBe(200);
+    expect(control.json().account).toMatchObject({
+      connector_name: "Acceptance computer",
+      user_name: "Acceptance user",
+      user_email: "acceptance@example.com"
+    });
+  });
+
   it("publishes the runtime editor handoff without baking it into the portal", async () => {
     const db = await createDatabase("memory");
     resources.push(() => db.end());

--- a/services/server/src/features/connectors/control-routes.ts
+++ b/services/server/src/features/connectors/control-routes.ts
@@ -24,11 +24,15 @@ export function registerConnectorControlRoutes(
       user_email: string;
     }>(
       `SELECT c.id AS connector_id, c.name AS connector_name,
-              u.name AS user_name,
-              COALESCE(i.email, '@' || i.login, u.email) AS user_email
+              COALESCE(u.name, '') AS user_name,
+              COALESCE(i.email, '@' || i.login, password_email.email, u.email, '') AS user_email
        FROM connectors c
        JOIN users u ON u.id = c.user_id
        LEFT JOIN external_identities i ON i.user_id = u.id
+       LEFT JOIN email_identities password_email
+         ON password_email.user_id = u.id
+        AND password_email.is_primary = true
+        AND password_email.retired_at IS NULL
        WHERE c.id = $1`,
       [connector.id]
     );


### PR DESCRIPTION
The connector control snapshot omitted password identities when users.email was null, emitting user_email:null and making exact beta.92 and beta.90 clients fail AccessSnapshot decoding after relay readiness. Join the active primary email identity and retain string fallbacks required by beta clients. Adds a password-identity regression. Server suite (409 pass), typecheck, architecture, diff check, and adversarial review pass.