### PR TITLE
Explain hosted, local, and synced collections in starter content

### DIFF
--- a/crates/connect-hosted-provider/src/template.rs
+++ b/crates/connect-hosted-provider/src/template.rs
@@ -82,6 +82,9 @@ fn onboarding_records() -> Vec<StoredDocument> {
                 "Build with mdbase.md" => {
                     include_str!("../../../templates/onboarding/v1/Build with mdbase.md")
                 }
+                "Where your collection lives.md" => {
+                    include_str!("../../../templates/onboarding/v1/Where your collection lives.md")
+                }
                 path => panic!("onboarding template record has no embedded document: {path}"),
             };
             starter_record(&record.record_id, &record.path, document)
@@ -169,7 +172,7 @@ mod tests {
     #[test]
     fn onboarding_template_contains_a_small_editable_start() {
         let template = resources("onboarding", "UTC").unwrap();
-        assert_eq!(template.records.len(), 3);
+        assert_eq!(template.records.len(), 4);
         assert_eq!(
             template
                 .records
@@ -193,5 +196,10 @@ mod tests {
         assert!(template.records[2]
             .document
             .contains("developer documentation"));
+        assert_eq!(template.records[3].path, "Where your collection lives.md");
+        assert!(template.records[3]
+            .document
+            .contains("A synced folder is not a backup"));
+        assert!(template.records[3].document.contains("Continue in browser"));
     }
 }

--- a/templates/onboarding/v1/How collections work.md
+++ b/templates/onboarding/v1/How collections work.md
@@ -4,4 +4,4 @@ A collection is a set of Markdown records with one authority. This starter colle
 
 Apps never receive access just because you have an account. When an app asks to connect, mdbase shows you the collection and permissions it wants. You approve that grant explicitly and can revoke it later.
 
-You can also mirror a hosted collection to a local folder with the desktop connector. The Markdown stays useful with or without a particular app.
+Read [[Where your collection lives]] to compare hosted and local collections and sync this collection to a folder with the desktop connector.

--- a/templates/onboarding/v1/Start here.md
+++ b/templates/onboarding/v1/Start here.md
@@ -13,4 +13,5 @@ Everything here is ordinary Markdown. The editor is one view of the collection, 
 ## When you are ready
 
 - Read [[How collections work]].
+- Learn [[Where your collection lives]] and how to sync it to your computer.
 - Open [[Build with mdbase]] when you want to connect another app or build one of your own.

--- a/templates/onboarding/v1/Where your collection lives.md
+++ b/templates/onboarding/v1/Where your collection lives.md
@@ -1,0 +1,63 @@
+# Where your collection lives
+
+Every mdbase collection has one **main copy**. The main copy can be hosted by mdbase or kept in a folder on your computer.
+
+Apps work with the collection in the same way either way. The difference is where the main copy lives and what must be online for apps to reach it.
+
+## Hosted by mdbase
+
+For a hosted collection, mdbase keeps the main copy available for you.
+
+- Approved apps can reach it without your computer being online.
+- You can use it from the web editor and other connected apps.
+- You can optionally sync its Markdown to a folder on your computer.
+
+This starter collection is hosted by mdbase.
+
+## On this computer
+
+For a local collection, a folder on your computer is the main copy.
+
+- The files remain in the folder you chose.
+- Adding the folder to the desktop connector does not upload or move it.
+- The connector makes the collection available to approved apps.
+- Your computer and the connector must be online for apps on other devices to reach it.
+
+This is useful when you want your own computer to remain the authority for the collection.
+
+## A synced folder is still a hosted collection
+
+You can sync a hosted collection to a folder on your computer. This is sometimes called a local mirror.
+
+The folder contains ordinary Markdown, but it is not a separate collection. The hosted copy remains the main copy, and the desktop connector keeps the two in sync.
+
+You can choose how the folder behaves:
+
+- **Sync edits both ways** downloads hosted changes and sends local edits back to mdbase.
+- **Download updates only** keeps a read-only local view of the hosted collection. Do not edit this folder; local changes are not uploaded and can prevent it from syncing.
+
+With two-way sync, if the same record changes in two places, mdbase does not silently choose one version. The connector shows the conflict so you can decide what to keep.
+
+A synced folder is not a backup: deletions and other changes may also be synchronized. Use your normal backup tools if you want separate history or recovery copies.
+
+## Sync this collection to your computer
+
+1. [Install and open the desktop connector](https://mdbase.dev/downloads/).
+2. Select **Continue in browser**, then sign in and approve the computer.
+3. Return to the editor. Open **Connect**, then **Storage & sync** for this collection.
+4. Select **Sync a folder**. The desktop connector opens to this collection.
+5. Choose a new or empty folder on your computer for this collection.
+6. Choose **Sync edits both ways** or **Download updates only**.
+7. Select **Start syncing**.
+
+The connector downloads the collection and continues syncing in the background. You can open the folder with Obsidian, a text editor, command-line tools, or anything else that works with Markdown.
+
+## Which should you choose?
+
+Choose a collection **hosted by mdbase** when you want it to remain available without depending on one computer.
+
+Choose a collection **on this computer** when you want a particular folder and computer to remain its main copy.
+
+Add a **synced folder** when you want the availability of a hosted collection and the freedom of working with ordinary local files.
+
+You are not locked into the first arrangement you choose. Moving the main copy is a separate, explicit action, so mdbase never turns two copies into competing authorities without asking you.

--- a/templates/onboarding/v1/template.json
+++ b/templates/onboarding/v1/template.json
@@ -14,6 +14,10 @@
     {
       "record_id": "019c0000-0000-7000-8000-000000000003",
       "path": "Build with mdbase.md"
+    },
+    {
+      "record_id": "019c0000-0000-7000-8000-000000000004",
+      "path": "Where your collection lives.md"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add a starter document explaining where a collection's main copy lives
- distinguish hosted collections, computer-owned collections, and synced folders
- document the current desktop connector flow for syncing a hosted collection locally
- link the guide from the existing starter notes and embed it in hosted onboarding provisioning

## Testing

- `cargo fmt --all`
- `cargo test -p mdbase-connect-hosted-provider` (122 passed; database- and credential-dependent tests ignored as expected)
- `git diff --check`
- verified `https://mdbase.dev/downloads/` responds successfully
