### PR TITLE
Accept lock resources in authority imports

### DIFF
--- a/crates/connect-hosted-provider/src/provider/authority_imports.rs
+++ b/crates/connect-hosted-provider/src/provider/authority_imports.rs
@@ -33,7 +33,7 @@ impl HostedProvider {
                 || resource.document.len() as u64 > self.limits.max_bytes_per_document
                 || !matches!(
                     resource.kind.as_str(),
-                    "configuration" | "contract" | "schema" | "type" | "view"
+                    "configuration" | "lock" | "contract" | "schema" | "type" | "view"
                 )
             {
                 return Err(ApiError::bad_request(

--- a/crates/connect-hosted-provider/src/provider/tests.rs
+++ b/crates/connect-hosted-provider/src/provider/tests.rs
@@ -548,11 +548,18 @@ fn portable_imports_are_canonicalized_by_rust_including_first_class_resources() 
     let contract_document = "---\nkind: mdbase.contract\ncontract_type: record\nid: example.task\nversion: 1.0.0\nrecord_schema:\n  dialect: json-schema-2020-12\n  ref: ../_schemas/task.json\n---\n";
     let schema_document =
         "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\"}\n";
+    let type_pack_lock = "kind: mdbase.type-pack-lock\nlock_version: 1\npacks: []\n";
+    let provision_lock = "kind: mdbase.provision-lock\nlock_version: 1\ncontributions: []\n";
     let record_document = "---\ntitle: One\n---\n\nBody\n";
     let opaque_document = "---\ntitle: [unterminated\n---\nOpaque body\n";
     let workspace = AuthorityWorkspace::materialize(
         [
             ("mdbase.yaml".to_string(), configuration.to_string()),
+            ("mdbase.lock.yaml".to_string(), type_pack_lock.to_string()),
+            (
+                "mdbase.provisions.yaml".to_string(),
+                provision_lock.to_string(),
+            ),
             (
                 "_contracts/task.md".to_string(),
                 contract_document.to_string(),
@@ -645,6 +652,13 @@ fn portable_imports_are_canonicalized_by_rust_including_first_class_resources() 
     assert_eq!(opaque.body, opaque_document);
     assert_eq!(opaque.document, opaque_document);
     assert_eq!(opaque.types, ["task"]);
+    for path in ["mdbase.lock.yaml", "mdbase.provisions.yaml"] {
+        assert!(manifest
+            .resources
+            .documents
+            .iter()
+            .any(|resource| resource.kind == "lock" && resource.path == path));
+    }
     assert!(manifest
         .resources
         .documents

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -3386,6 +3386,17 @@ async function localAuthorityImportE2E(
     body: snapshot.manifest
   });
   assert.equal(rejected.status, 401);
+  const unsupportedManifest = structuredClone(snapshot.manifest);
+  unsupportedManifest.resources.documents.find(
+    (resource) => resource.kind === "lock"
+  ).kind = "unsupported";
+  const rejectedKind = await absoluteRequest(begun.body.import.manifest_url, {
+    method: "PUT",
+    token: begun.body.import.access_token,
+    body: unsupportedManifest
+  });
+  assert.equal(rejectedKind.status, 400, JSON.stringify(rejectedKind.body));
+  assert.equal(rejectedKind.body.error.code, "invalid_authority_import_manifest");
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const manifest = await absoluteRequest(begun.body.import.manifest_url, {
       method: "PUT",
@@ -3510,6 +3521,14 @@ async function localAuthorityImportE2E(
   assert.ok(importedResources.some(
     (resource) => resource.kind === "view" && resource.path === "views/imported.base"
   ));
+  for (const expected of snapshot.manifest.resources.documents.filter(
+    (resource) => resource.kind === "lock"
+  )) {
+    assert.deepEqual(
+      importedResources.find((resource) => resource.path === expected.path),
+      expected
+    );
+  }
   const importedFilePage = await importedTransport.fileSnapshot(importedSession.snapshot_id);
   assert.equal(importedFilePage.files.length, snapshot.files.length);
   const importedFile = importedFilePage.files[0];
@@ -3759,6 +3778,8 @@ function localAuthoritySnapshot(collectionId, recordCount) {
   ].join("\n");
   const typeDocument = "---\nkind: mdbase.type\nname: task\nversion: 1\nmatch:\n  path_glob: notes/**/*.md\nschema:\n  dialect: json-schema-2020-12\n  value:\n    type: object\n    properties:\n      title: { type: string }\n---\n";
   const viewDocument = "views: []\n";
+  const typePackLock = "kind: mdbase.type-pack-lock\nlock_version: 1\npacks: []\n";
+  const provisionLock = "kind: mdbase.provision-lock\nlock_version: 1\ncontributions: []\n";
   const resources = [
     {
       path: "mdbase.yaml",
@@ -3771,6 +3792,18 @@ function localAuthoritySnapshot(collectionId, recordCount) {
       kind: "type",
       revision: `sha256:${sha256Hex(typeDocument)}`,
       document: typeDocument
+    },
+    {
+      path: "mdbase.lock.yaml",
+      kind: "lock",
+      revision: `sha256:${sha256Hex(typePackLock)}`,
+      document: typePackLock
+    },
+    {
+      path: "mdbase.provisions.yaml",
+      kind: "lock",
+      revision: `sha256:${sha256Hex(provisionLock)}`,
+      document: provisionLock
     },
     {
       path: "views/imported.base",


### PR DESCRIPTION
## Summary

- admit the protocol's existing `lock` resource kind during hosted authority import
- cover both `mdbase.lock.yaml` and `mdbase.provisions.yaml` in canonicalization tests
- exercise admission, finalization, persistence, and sync round-trip in the hosted provider system suite
- retain explicit rejection coverage for unsupported resource kinds

## Why

Complete local-authority snapshots include mdbase lock resources, but the hosted provider's manifest allowlist omitted `lock`. Transfers of collections with installed type packs therefore failed with `invalid_authority_import_manifest` before canonicalization.

The protocol, mdbase snapshot engine, hosted persistence schema, and finalization path already support locks; this updates the stale admission boundary without broadening it to unknown resource kinds.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test -p mdbase-connect-hosted-provider`
- `pnpm typecheck`
- `pnpm test:fast`
- `pnpm test:system --suite provider --no-prepare`
