### PR TITLE
Prepare v0.1.0-beta.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.1.0-beta.93
+
+Beta.93 consolidates collection semantics behind typed, capability-bound
+runtime APIs and completes cross-platform authority safety.
+
+- Local and hosted reads, queries, mutations, batches, and runtime receipts now
+  share canonical typed outcomes while preserving exact v0.3 wire behavior and
+  durable replay.
+- Collection snapshots are fallible and deterministic; merged-spec resolution
+  uses one Unicode-aware, target-filtered ranking contract with bounded
+  selection evidence.
+- Every post-open filesystem operation, watcher rescan, cache decision, and
+  publication remains bound to the acquired collection authority instead of
+  reacquiring an ambient display path.
+- Capture, cancellation, journal recovery, and compatibility seams are bounded,
+  checked, authenticated, and covered by enforceable retirement inventories.
+- Unix and Windows publication is capability-relative and atomic. Windows uses
+  destination-replacing handle-relative rename, delete-sharing readers, and
+  bounded sharing-denial retries without a remove-then-rename fallback.
+- Hosted mutation receipts and exact journal replay report the authoritative
+  persisted database mtime rather than temporary staging metadata.
+
 ## 0.1.0-beta.92
 
 Beta.92 restores relay compatibility with signed beta.90 connectors while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.92"
+version = "0.1.0-beta.93"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.92" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.93" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.92",
+  "version": "0.1.0-beta.93",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -193,7 +193,7 @@ describe("mdbase connect server", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       status: "ready",
       provider: {
-        version: "0.1.0-beta.92",
+        version: "0.1.0-beta.93",
         capabilities: [
           ...HOSTED_PROVIDER_REQUIRED_CAPABILITIES,
           HOSTED_CANDIDATE_B_ACTIVATION_CAPABILITY


### PR DESCRIPTION
## Summary
- advance the workspace release identity to v0.1.0-beta.93
- document the typed authority-safety architecture campaign
- refresh both reproducible Cargo locks

## Verification
- pnpm version:check
- pnpm check:release-readiness
- pnpm typecheck
- pnpm test
- cargo fmt --all --check
- cargo clippy --locked --workspace --all-targets -- -D warnings
- node scripts/check-architecture.mjs
- node scripts/check-workspace-pins.mjs