### PR TITLE
Allow explicit ops worktrees for LAB deploys

### DIFF
--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -49,3 +49,27 @@ registry digest.
 Schema versions are monotonic. Readers fail closed on unknown versions and
 unknown, missing, duplicated, mutable, wrong-platform, or wrong-repository
 components.
+
+## Local LAB experiments
+
+`pnpm deploy:lab --confirm LAB` builds the current checkout, pushes immutable
+LAB-only images, and delegates mutation and rollback state to the adjacent
+private `mdbase-cloud-ops` checkout. The resulting state is disposable and
+cannot authorize promotion.
+
+When testing unreleased ops changes from a worktree, select that checkout
+explicitly with an absolute canonical path:
+
+```sh
+MDBASE_CLOUD_OPS_CHECKOUT=/absolute/path/to/mdbase-cloud-ops \
+  pnpm deploy:lab --confirm LAB
+```
+
+The command still verifies the checkout's Git top level, private repository
+origin, and fixed executable. Omit the variable for ordinary use. Roll back with
+the exact state path printed by deployment:
+
+```sh
+MDBASE_CLOUD_OPS_CHECKOUT=/absolute/path/to/mdbase-cloud-ops \
+  pnpm deploy:lab --rollback /absolute/path/to/state.json --confirm LAB
+```

--- a/scripts/deploy-lab-local.mjs
+++ b/scripts/deploy-lab-local.mjs
@@ -136,22 +136,30 @@ export function parseRollbackArgs(args) {
 }
 
 export async function resolveCloudOpsCommand({ root, run, environment }) {
-  const commonDirectory = (await run("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
-    cwd: root,
-    env: environment,
-    capture: true
-  })).trim();
-  if (!commonDirectory.startsWith("/") || commonDirectory.length < 3) {
-    throw new Error("Cannot derive the canonical mdbase projects directory from Git.");
+  let expectedRoot;
+  if (environment.MDBASE_CLOUD_OPS_CHECKOUT !== undefined) {
+    if (!environment.MDBASE_CLOUD_OPS_CHECKOUT.startsWith("/")) {
+      throw new Error("MDBASE_CLOUD_OPS_CHECKOUT must be an absolute path.");
+    }
+    expectedRoot = environment.MDBASE_CLOUD_OPS_CHECKOUT;
+  } else {
+    const commonDirectory = (await run("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+      cwd: root,
+      env: environment,
+      capture: true
+    })).trim();
+    if (!commonDirectory.startsWith("/") || commonDirectory.length < 3) {
+      throw new Error("Cannot derive the canonical mdbase projects directory from Git.");
+    }
+    expectedRoot = resolve(commonDirectory, "..", "..", "mdbase-cloud-ops");
   }
-  const expectedRoot = resolve(commonDirectory, "..", "..", "mdbase-cloud-ops");
   let canonicalRoot;
   try {
     canonicalRoot = await realpath(expectedRoot);
   } catch {
     throw new Error(`Canonical sibling mdbase-cloud-ops checkout is unavailable at ${expectedRoot}.`);
   }
-  if (canonicalRoot !== expectedRoot) throw new Error("Canonical mdbase-cloud-ops checkout must not be reached through a symlink.");
+  if (canonicalRoot !== expectedRoot) throw new Error("Selected mdbase-cloud-ops checkout must be canonical and must not be reached through a symlink or relative segment.");
   const topLevel = (await run("git", ["rev-parse", "--show-toplevel"], {
     cwd: canonicalRoot,
     env: environment,

--- a/scripts/deploy-lab-local.test.mjs
+++ b/scripts/deploy-lab-local.test.mjs
@@ -92,6 +92,37 @@ test("default ops discovery derives and validates the canonical sibling checkout
   }
 });
 
+test("an explicit canonical ops worktree is validated without falling back to the sibling checkout", async () => {
+  const projects = await mkdtemp(resolve(tmpdir(), "mdbase-explicit-ops-"));
+  const connectRoot = resolve(projects, "mdbase-connect");
+  const ops = resolve(projects, "ops-worktree");
+  const command = resolve(ops, "bin/deploy-local-lab");
+  await mkdir(connectRoot, { recursive: true });
+  await mkdir(resolve(ops, "bin"), { recursive: true });
+  await writeFile(command, "#!/bin/sh\n", { mode: 0o700 });
+  await chmod(command, 0o700);
+  try {
+    const run = async (_command, args, options) => {
+      assert(!args.includes("--git-common-dir"));
+      if (args.includes("--show-toplevel")) { assert.equal(options.cwd, ops); return `${ops}\n`; }
+      if (args[0] === "remote") return "https://github.com/mdbase-dev/mdbase-cloud-ops.git\n";
+      throw new Error(`unexpected explicit discovery command: ${args.join(" ")}`);
+    };
+    assert.equal(await resolveCloudOpsCommand({
+      root: connectRoot,
+      run,
+      environment: { MDBASE_CLOUD_OPS_CHECKOUT: ops }
+    }), command);
+    await assert.rejects(resolveCloudOpsCommand({
+      root: connectRoot,
+      run,
+      environment: { MDBASE_CLOUD_OPS_CHECKOUT: "relative/ops" }
+    }), /absolute path/u);
+  } finally {
+    await rm(projects, { recursive: true, force: true });
+  }
+});
+
 test("rollback delegates directly to the fixed local LAB command", async () => {
   const calls = [];
   const state = "/private/state.json";


### PR DESCRIPTION
## Summary
- allow `pnpm deploy:lab` to select an absolute canonical `mdbase-cloud-ops` worktree
- retain Git top-level, private-origin, and fixed-command validation
- document deployment and exact-state rollback from an unreleased ops checkout

## Validation
- `fnm exec --using=v24.19.0 node --test scripts/deploy-lab-local.test.mjs`
- `fnm exec --using=v24.19.0 pnpm typecheck`
- live local LAB deployment through mdbase-cloud-ops PR #336
- browser create/read/update/revoke/cleanup acceptance
- exact-state LAB rollback to the prior release

Depends on mdbase-cloud-ops#336 for the cohesive release front door being exercised.