### PR TITLE
Prevent projection format release regressions

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,5 +1,6 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.69
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:1f157b98560fe4572b36425cc574e474e3c59469dbd5ec721783e29db0a310b2
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:c233855520ab7b4fa0e2a6576bebb29cdfa029eef57ad327cd303aebb3516888
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.93
+MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=e0f7f7da316ed59cac2c2626bd15643c651cf89f
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:96c1b67ff43c9f05e22c964ddd179ddadfcf2cfda8add2b64bb6c3a33b252b0d
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:1f34a438fabfcda81a984f5816c51206161d6e7074223f0d473531e3b1661db6

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -279,13 +279,14 @@ jobs:
     env:
       DATABASE_URL: postgres://mdbase:previous-release-upgrade@127.0.0.1:5432/mdbase_connect_upgrade
       CANDIDATE_IMAGE: mdbase-connect-server:upgrade-candidate
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Exercise the previous-server upgrade contract
         run: test/upgrade/server-from-previous
 
   previous-provider-upgrade:
-    name: Previous provider notification recovery
+    name: Immediate-predecessor provider persisted-state upgrade
     needs: classify
     if: needs.classify.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
@@ -307,9 +308,10 @@ jobs:
     env:
       DATABASE_URL: postgres://mdbase:previous-provider-upgrade@127.0.0.1:5432/mdbase_provider_upgrade
       CANDIDATE_IMAGE: mdbase-connect-hosted-provider:upgrade-candidate
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Exercise the previous-provider recovery contract
+      - name: Exercise immediate-predecessor persisted-state recovery
         run: test/upgrade/provider-from-previous
 
   hosted-provider-rust:

--- a/crates/connect-hosted-provider/src/provider/diagnostics.rs
+++ b/crates/connect-hosted-provider/src/provider/diagnostics.rs
@@ -160,10 +160,14 @@ impl HostedProvider {
                       IS DISTINCT FROM collection.active_catalog_revision)
                      AS catalog_stale,
                    (generation.projection_format_version
-                      IS DISTINCT FROM collection.active_projection_format_version)
+                      IS DISTINCT FROM collection.active_projection_format_version
+                     OR (collection.active_projection_format_version IS NOT NULL
+                         AND collection.active_projection_format_version <> $1))
                      AS format_version_mismatch,
                    (generation.semantic_engine_version
-                      IS DISTINCT FROM collection.active_semantic_engine_version)
+                      IS DISTINCT FROM collection.active_semantic_engine_version
+                     OR (collection.active_semantic_engine_version IS NOT NULL
+                         AND collection.active_semantic_engine_version <> $2))
                      AS engine_version_mismatch,
                    (generation.integrity_epoch
                       IS DISTINCT FROM generation.integrity_verified_epoch)
@@ -178,8 +182,12 @@ impl HostedProvider {
                           IS DISTINCT FROM collection.active_catalog_revision
                      OR generation.projection_format_version
                           IS DISTINCT FROM collection.active_projection_format_version
+                     OR (collection.active_projection_format_version IS NOT NULL
+                         AND collection.active_projection_format_version <> $1)
                      OR generation.semantic_engine_version
                           IS DISTINCT FROM collection.active_semantic_engine_version
+                     OR (collection.active_semantic_engine_version IS NOT NULL
+                         AND collection.active_semantic_engine_version <> $2)
                      OR generation.integrity_epoch
                           IS DISTINCT FROM generation.integrity_verified_epoch)
                      AS unready
@@ -191,6 +199,10 @@ impl HostedProvider {
                  WHERE collection.state = 'active'
                ) causes"#,
         )
+        .bind(i64::from(
+            mdbase::runtime::SEMANTIC_PROJECTION_FORMAT_VERSION,
+        ))
+        .bind(mdbase::VERSION)
         .fetch_one(&self.pool)
         .await?;
         let count =

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -2074,6 +2074,88 @@ async fn diagnostics_attribute_unready_collections_to_a_cause() {
     // causes rather than on absolute counts.
     let unready_before = readiness.unready;
     let stale_before = readiness.resource_revision_stale;
+    let format_mismatch_before = readiness.format_version_mismatch;
+    let engine_mismatch_before = readiness.engine_version_mismatch;
+
+    // A predecessor can leave a perfectly consistent collection/generation
+    // binding that is nevertheless stale for this running binary. Diagnostics
+    // must compare persisted identity with the runtime, not only both stored
+    // halves with each other.
+    let stale_format =
+        i32::try_from(mdbase::runtime::SEMANTIC_PROJECTION_FORMAT_VERSION).unwrap() + 1;
+    let stale_engine = "diagnostics-stale-semantic-engine";
+    sqlx::query(
+        r#"UPDATE hosted_provider_projection_generations
+           SET projection_format_version = $2, semantic_engine_version = $3
+           WHERE collection_id = $1
+             AND generation_id = (
+               SELECT active_projection_generation_id
+               FROM hosted_provider_collections WHERE id = $1
+             )"#,
+    )
+    .bind(fixture.collection_id)
+    .bind(stale_format)
+    .bind(stale_engine)
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"UPDATE hosted_provider_collections
+           SET active_projection_format_version = $2,
+               active_semantic_engine_version = $3
+           WHERE id = $1"#,
+    )
+    .bind(fixture.collection_id)
+    .bind(stale_format)
+    .bind(stale_engine)
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
+
+    let stale_runtime = fixture.provider.hosted_diagnostics().await;
+    let readiness = match &stale_runtime.projection_readiness {
+        DiagnosticSection::Ok { value } => *value,
+        DiagnosticSection::Unavailable { reason } => {
+            panic!("projection readiness unavailable: {reason}")
+        }
+    };
+    assert_eq!(readiness.unready, unready_before + 1);
+    assert_eq!(
+        readiness.format_version_mismatch,
+        format_mismatch_before + 1
+    );
+    assert_eq!(
+        readiness.engine_version_mismatch,
+        engine_mismatch_before + 1
+    );
+
+    sqlx::query(
+        r#"UPDATE hosted_provider_projection_generations
+           SET projection_format_version = $2, semantic_engine_version = $3
+           WHERE collection_id = $1
+             AND generation_id = (
+               SELECT active_projection_generation_id
+               FROM hosted_provider_collections WHERE id = $1
+             )"#,
+    )
+    .bind(fixture.collection_id)
+    .bind(i32::try_from(mdbase::runtime::SEMANTIC_PROJECTION_FORMAT_VERSION).unwrap())
+    .bind(mdbase::VERSION)
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r#"UPDATE hosted_provider_collections
+           SET active_projection_format_version = $2,
+               active_semantic_engine_version = $3
+           WHERE id = $1"#,
+    )
+    .bind(fixture.collection_id)
+    .bind(i32::try_from(mdbase::runtime::SEMANTIC_PROJECTION_FORMAT_VERSION).unwrap())
+    .bind(mdbase::VERSION)
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
 
     // Strand the binding the way a view mutation did on 2026-08-18: advance the
     // collection's resource revision while the generation keeps the old one.

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -49,3 +49,27 @@ registry digest.
 Schema versions are monotonic. Readers fail closed on unknown versions and
 unknown, missing, duplicated, mutable, wrong-platform, or wrong-repository
 components.
+
+## Local LAB experiments
+
+`pnpm deploy:lab --confirm LAB` builds the current checkout, pushes immutable
+LAB-only images, and delegates mutation and rollback state to the adjacent
+private `mdbase-cloud-ops` checkout. The resulting state is disposable and
+cannot authorize promotion.
+
+When testing unreleased ops changes from a worktree, select that checkout
+explicitly with an absolute canonical path:
+
+```sh
+MDBASE_CLOUD_OPS_CHECKOUT=/absolute/path/to/mdbase-cloud-ops \
+  pnpm deploy:lab --confirm LAB
+```
+
+The command still verifies the checkout's Git top level, private repository
+origin, and fixed executable. Omit the variable for ordinary use. Roll back with
+the exact state path printed by deployment:
+
+```sh
+MDBASE_CLOUD_OPS_CHECKOUT=/absolute/path/to/mdbase-cloud-ops \
+  pnpm deploy:lab --rollback /absolute/path/to/state.json --confirm LAB
+```

--- a/scripts/deploy-lab-local.mjs
+++ b/scripts/deploy-lab-local.mjs
@@ -136,22 +136,30 @@ export function parseRollbackArgs(args) {
 }
 
 export async function resolveCloudOpsCommand({ root, run, environment }) {
-  const commonDirectory = (await run("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
-    cwd: root,
-    env: environment,
-    capture: true
-  })).trim();
-  if (!commonDirectory.startsWith("/") || commonDirectory.length < 3) {
-    throw new Error("Cannot derive the canonical mdbase projects directory from Git.");
+  let expectedRoot;
+  if (environment.MDBASE_CLOUD_OPS_CHECKOUT !== undefined) {
+    if (!environment.MDBASE_CLOUD_OPS_CHECKOUT.startsWith("/")) {
+      throw new Error("MDBASE_CLOUD_OPS_CHECKOUT must be an absolute path.");
+    }
+    expectedRoot = environment.MDBASE_CLOUD_OPS_CHECKOUT;
+  } else {
+    const commonDirectory = (await run("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+      cwd: root,
+      env: environment,
+      capture: true
+    })).trim();
+    if (!commonDirectory.startsWith("/") || commonDirectory.length < 3) {
+      throw new Error("Cannot derive the canonical mdbase projects directory from Git.");
+    }
+    expectedRoot = resolve(commonDirectory, "..", "..", "mdbase-cloud-ops");
   }
-  const expectedRoot = resolve(commonDirectory, "..", "..", "mdbase-cloud-ops");
   let canonicalRoot;
   try {
     canonicalRoot = await realpath(expectedRoot);
   } catch {
     throw new Error(`Canonical sibling mdbase-cloud-ops checkout is unavailable at ${expectedRoot}.`);
   }
-  if (canonicalRoot !== expectedRoot) throw new Error("Canonical mdbase-cloud-ops checkout must not be reached through a symlink.");
+  if (canonicalRoot !== expectedRoot) throw new Error("Selected mdbase-cloud-ops checkout must be canonical and must not be reached through a symlink or relative segment.");
   const topLevel = (await run("git", ["rev-parse", "--show-toplevel"], {
     cwd: canonicalRoot,
     env: environment,

--- a/scripts/deploy-lab-local.test.mjs
+++ b/scripts/deploy-lab-local.test.mjs
@@ -92,6 +92,37 @@ test("default ops discovery derives and validates the canonical sibling checkout
   }
 });
 
+test("an explicit canonical ops worktree is validated without falling back to the sibling checkout", async () => {
+  const projects = await mkdtemp(resolve(tmpdir(), "mdbase-explicit-ops-"));
+  const connectRoot = resolve(projects, "mdbase-connect");
+  const ops = resolve(projects, "ops-worktree");
+  const command = resolve(ops, "bin/deploy-local-lab");
+  await mkdir(connectRoot, { recursive: true });
+  await mkdir(resolve(ops, "bin"), { recursive: true });
+  await writeFile(command, "#!/bin/sh\n", { mode: 0o700 });
+  await chmod(command, 0o700);
+  try {
+    const run = async (_command, args, options) => {
+      assert(!args.includes("--git-common-dir"));
+      if (args.includes("--show-toplevel")) { assert.equal(options.cwd, ops); return `${ops}\n`; }
+      if (args[0] === "remote") return "https://github.com/mdbase-dev/mdbase-cloud-ops.git\n";
+      throw new Error(`unexpected explicit discovery command: ${args.join(" ")}`);
+    };
+    assert.equal(await resolveCloudOpsCommand({
+      root: connectRoot,
+      run,
+      environment: { MDBASE_CLOUD_OPS_CHECKOUT: ops }
+    }), command);
+    await assert.rejects(resolveCloudOpsCommand({
+      root: connectRoot,
+      run,
+      environment: { MDBASE_CLOUD_OPS_CHECKOUT: "relative/ops" }
+    }), /absolute path/u);
+  } finally {
+    await rm(projects, { recursive: true, force: true });
+  }
+});
+
 test("rollback delegates directly to the fixed local LAB command", async () => {
   const calls = [];
   const state = "/private/state.json";

--- a/scripts/lib/upgrade-test-contract.test.mjs
+++ b/scripts/lib/upgrade-test-contract.test.mjs
@@ -20,6 +20,76 @@ test("upgrade workflows delegate scenario behavior to versioned test programs", 
   assert.doesNotMatch(workflow, /INSERT INTO hosted_provider_/);
 });
 
+test("upgrade pins the exact immediate predecessor", async () => {
+  const fixture = await readFile(
+    resolve(repoRoot, ".github/previous-release.env"),
+    "utf8"
+  );
+  assert.equal(fixture, `# Exact server image from the release immediately preceding this candidate.
+# Update this file as part of each release-preparation change.
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.93
+MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=e0f7f7da316ed59cac2c2626bd15643c651cf89f
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:96c1b67ff43c9f05e22c964ddd179ddadfcf2cfda8add2b64bb6c3a33b252b0d
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:1f34a438fabfcda81a984f5816c51206161d6e7074223f0d473531e3b1661db6
+`);
+});
+
+test("both upgrade programs execute release and pulled-image verification", async () => {
+  const helpers = await readFile(resolve(repoRoot, "test/upgrade/lib.sh"), "utf8");
+  assert.match(helpers, /upgrade_verify_previous_release\(\)/);
+  assert.match(helpers, /api\.github\.com\/repos\/mdbase-dev\/mdbase-connect\/releases\?per_page=100/);
+  assert.match(helpers, /git -C "\$repo_root" ls-remote --exit-code --tags origin/);
+  assert.match(helpers, /"refs\/tags\/\$release\^\{\}"/);
+  assert.match(helpers, /upgrade_verify_previous_image\(\)/);
+  assert.match(helpers, /docker image inspect "\$image"/);
+  assert.match(helpers, /org\.opencontainers\.image\.source/);
+  assert.match(helpers, /org\.opencontainers\.image\.revision/);
+
+  for (const [script, imageVariable] of [
+    ["test/upgrade/server-from-previous", "MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE"],
+    ["test/upgrade/provider-from-previous", "MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE"]
+  ]) {
+    const program = await readFile(resolve(repoRoot, script), "utf8");
+    const releaseCheck = program.indexOf('upgrade_verify_previous_release "$repo_root"');
+    const pull = program.indexOf(`docker pull "$${imageVariable}"`);
+    const imageCheck = program.indexOf(`upgrade_verify_previous_image "$${imageVariable}"`);
+    assert.ok(releaseCheck >= 0 && releaseCheck < pull, `${script} must verify the release before use`);
+    assert.ok(pull >= 0 && imageCheck > pull, `${script} must inspect the image after pulling it`);
+  }
+});
+
+test("candidate writes predecessor state before explicit projection work", async () => {
+  const program = await readFile(
+    resolve(repoRoot, "test/upgrade/provider-from-previous"),
+    "utf8"
+  );
+  const writePhase = program.indexOf(
+    "upgrade_phase 'writing predecessor-created persisted state before projection rebuild'"
+  );
+  const write = program.indexOf('"$(exact_mutation_body "$previous_revision")"', writePhase);
+  const readBack = program.indexOf("pre_rebuild_snapshot=$(provider_get", write);
+  const firstProjectionWork = program.indexOf("run_projection_indexer ", writePhase);
+  const verify = program.indexOf("run_projection_indexer verify", readBack);
+  const recovery = program.indexOf("upgrade_phase 'requiring candidate recovery readiness'", verify);
+  const finalVerify = program.indexOf(
+    "upgrade_phase 'verifying projections after final provider restart'",
+    recovery
+  );
+  assert.ok(writePhase >= 0 && write > writePhase, "pre-rebuild write is missing");
+  assert.ok(readBack > write, "exact read-back must follow the pre-rebuild write");
+  assert.ok(verify > readBack, "read-only projection verification must remain post-write");
+  assert.ok(recovery > verify, "notification recovery must follow projection verification");
+  assert.ok(finalVerify > recovery, "projection verification must run again after final restart");
+  assert.match(program, /\.status == "ready"[\s\S]*\.notifications\.configured == true[\s\S]*\.notifications\.recovery == "ok"[\s\S]*\.projections\.degraded_collections == 0/);
+  assert.equal(
+    firstProjectionWork,
+    verify,
+    "no explicit projection command may precede the write/read-back"
+  );
+  assert.doesNotMatch(program, /run_projection_indexer cutover/);
+  assert.doesNotMatch(program, /finalize-hosted-query-admission\.sql/);
+});
+
 test("upgrade shell programs are syntactically valid", async () => {
   for (const script of [
     "test/upgrade/lib.sh",

--- a/test/upgrade/lib.sh
+++ b/test/upgrade/lib.sh
@@ -16,6 +16,103 @@ upgrade_require() {
   done
 }
 
+upgrade_verify_previous_release() {
+  local repo_root=$1
+  local release=${MDBASE_CONNECT_PREVIOUS_RELEASE:-}
+  local commit=${MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT:-}
+  local releases_json refs ref_hash ref_name peeled_commit=
+  local -a curl_headers=()
+
+  if [[ ! $release =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+    printf 'Malformed MDBASE_CONNECT_PREVIOUS_RELEASE: %s\n' "$release" >&2
+    return 2
+  fi
+  if [[ ! $commit =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'Malformed MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT: %s\n' "$commit" >&2
+    return 2
+  fi
+  if [[ -n ${GITHUB_TOKEN:-} ]]; then
+    curl_headers=(--header "authorization: Bearer $GITHUB_TOKEN")
+  fi
+  if ! releases_json=$(curl --fail-with-body --silent --show-error \
+    --connect-timeout 5 --max-time 20 --retry 2 --retry-all-errors \
+    --header 'accept: application/vnd.github+json' \
+    "${curl_headers[@]}" \
+    'https://api.github.com/repos/mdbase-dev/mdbase-connect/releases?per_page=100'); then
+    printf 'Could not query bounded GitHub release metadata.\n' >&2
+    return 1
+  fi
+  if ! jq -e --arg expected "$release" '
+    type == "array" and
+    length <= 100 and
+    all(.[]; type == "object" and (.draft | type) == "boolean" and (.tag_name | type) == "string") and
+    ([.[] | select(.draft == false)] | length) > 0 and
+    ([.[] | select(.draft == false)][0].tag_name == $expected) and
+    ([.[] | select(.draft == false and .tag_name == $expected)] | length) == 1
+  ' <<<"$releases_json" >/dev/null; then
+    printf '%s is not the unique newest non-draft mdbase-connect GitHub release.\n' "$release" >&2
+    return 1
+  fi
+
+  if ! refs=$(timeout 30s git -C "$repo_root" ls-remote --exit-code --tags origin \
+    "refs/tags/$release" "refs/tags/$release^{}"); then
+    printf 'Could not resolve annotated release tag %s from origin.\n' "$release" >&2
+    return 1
+  fi
+  local tag_ref_count=0 peeled_ref_count=0
+  while IFS=$'\t' read -r ref_hash ref_name; do
+    if [[ ! $ref_hash =~ ^[0-9a-f]{40}$ ]]; then
+      printf 'Malformed origin ref while resolving %s.\n' "$release" >&2
+      return 1
+    fi
+    case "$ref_name" in
+      "refs/tags/$release") ((tag_ref_count += 1)) ;;
+      "refs/tags/$release^{}")
+        ((peeled_ref_count += 1))
+        peeled_commit=$ref_hash
+        ;;
+      *)
+        printf 'Unexpected origin ref while resolving %s: %s\n' "$release" "$ref_name" >&2
+        return 1
+        ;;
+    esac
+  done <<<"$refs"
+  if ((tag_ref_count != 1 || peeled_ref_count != 1)) || [[ $peeled_commit != "$commit" ]]; then
+    printf 'Annotated origin tag %s does not peel exactly once to expected commit %s.\n' \
+      "$release" "$commit" >&2
+    return 1
+  fi
+}
+
+upgrade_verify_previous_image() {
+  local image=$1
+  local commit=${MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT:-}
+  local expected_source=https://github.com/mdbase-dev/mdbase-connect
+  local inspection
+
+  if [[ ! $image =~ ^ghcr\.io/mdbase-dev/mdbase-connect(-hosted-provider|-server)@sha256:[0-9a-f]{64}$ ]]; then
+    printf 'Malformed previous image digest reference: %s\n' "$image" >&2
+    return 2
+  fi
+  if [[ ! $commit =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'Malformed expected previous image revision: %s\n' "$commit" >&2
+    return 2
+  fi
+  if ! inspection=$(docker image inspect "$image"); then
+    printf 'Could not inspect pulled previous image: %s\n' "$image" >&2
+    return 1
+  fi
+  if ! jq -e --arg source "$expected_source" --arg revision "$commit" '
+    type == "array" and length == 1 and
+    .[0].Config.Labels["org.opencontainers.image.source"] == $source and
+    .[0].Config.Labels["org.opencontainers.image.revision"] == $revision
+  ' <<<"$inspection" >/dev/null; then
+    printf 'Previous image %s does not uniquely identify source %s at revision %s.\n' \
+      "$image" "$expected_source" "$commit" >&2
+    return 1
+  fi
+}
+
 upgrade_wait_http() {
   local url=$1
   local description=$2

--- a/test/upgrade/provider-from-previous
+++ b/test/upgrade/provider-from-previous
@@ -23,7 +23,6 @@ UPGRADE_MUTATION_ID=66666666-6666-4666-8666-666666666666
 UPGRADE_NEXT_MUTATION_ID=88888888-8888-4888-8888-888888888888
 UPGRADE_RECORD_ID=77777777-7777-4777-8777-777777777777
 UPGRADE_REPLICA_TOKEN=previous-provider-upgrade-replica-token
-CUTOVER_OWNER_TOKEN=99999999-9999-4999-8999-999999999991
 UPGRADE_DATABASE_PORT=${UPGRADE_DATABASE_PORT:-5432}
 UPGRADE_PROVIDER_PORT=${UPGRADE_PROVIDER_PORT:-8790}
 UPGRADE_PROVIDER_URL="http://127.0.0.1:$UPGRADE_PROVIDER_PORT"
@@ -31,29 +30,18 @@ export PROVIDER_INTERNAL_TOKEN PROVIDER_MASTER_KEY
 export MDBASE_CONNECT_R2_ENDPOINT MDBASE_CONNECT_R2_BUCKET
 export MDBASE_CONNECT_R2_ACCESS_KEY_ID MDBASE_CONNECT_R2_SECRET_ACCESS_KEY
 export MDBASE_CONNECT_ALLOW_INSECURE_R2
-upgrade_require DATABASE_URL MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE
+upgrade_require \
+  DATABASE_URL \
+  MDBASE_CONNECT_PREVIOUS_RELEASE \
+  MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT \
+  MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE
+upgrade_verify_previous_release "$repo_root"
 
 r2_pid=
-terminate_cutover_lock_holder() {
-  docker run --rm --network host \
-    --env PGPASSWORD=previous-provider-upgrade \
-    postgres:18-alpine \
-    psql --host 127.0.0.1 --port "$UPGRADE_DATABASE_PORT" \
-      --username mdbase --dbname mdbase_provider_upgrade \
-      --set ON_ERROR_STOP=1 \
-      --command "SELECT pg_terminate_backend(pid)
-                 FROM pg_stat_activity
-                 WHERE application_name = 'mdbase-provider-cutover-lock-holder'
-                   AND pid <> pg_backend_pid()" \
-    >/dev/null 2>&1 || true
-}
-
 cleanup() {
-  terminate_cutover_lock_holder
   for container in \
     mdbase-provider-previous \
     mdbase-provider-previous-migration \
-    mdbase-provider-cutover-lock \
     mdbase-provider-upgrade-candidate
   do
     docker logs "$container" >/dev/null 2>&1 || true
@@ -102,6 +90,42 @@ provider_json() {
     "$UPGRADE_PROVIDER_URL$path"
 }
 
+provider_get() {
+  local path=$1
+  local token=${2:-$PROVIDER_INTERNAL_TOKEN}
+  curl --fail-with-body --silent --show-error \
+    --header "authorization: Bearer $token" \
+    "$UPGRADE_PROVIDER_URL$path"
+}
+
+start_candidate_provider() {
+  docker run --detach --name mdbase-provider-upgrade-candidate \
+    --network host \
+    --env DATABASE_URL \
+    --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
+    --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
+    --env MDBASE_CONNECT_CONTROL_PLANE_URL=http://127.0.0.1:9 \
+    --env MDBASE_CONNECT_R2_ENDPOINT \
+    --env MDBASE_CONNECT_R2_BUCKET \
+    --env MDBASE_CONNECT_R2_ACCESS_KEY_ID \
+    --env MDBASE_CONNECT_R2_SECRET_ACCESS_KEY \
+    --env MDBASE_CONNECT_ALLOW_INSECURE_R2 \
+    --env PORT="$UPGRADE_PROVIDER_PORT" \
+    "$CANDIDATE_IMAGE" >/dev/null
+}
+
+wait_candidate_provider() {
+  local attempt
+  for attempt in {1..30}; do
+    if curl --silent --output /dev/null "$UPGRADE_PROVIDER_URL/ready"; then
+      return 0
+    fi
+    sleep 1
+  done
+  printf 'Candidate provider did not begin serving HTTP.\n' >&2
+  return 1
+}
+
 seed_previous_sync_receipt() {
   provider_json PUT "/internal/v1/accounts/$UPGRADE_ACCOUNT_ID" \
     '{"entitlement_revision":1,"hosted_storage_bytes":1073741824,"retained_file_bytes":2147483648,"max_document_bytes":2097152,"max_single_file_bytes":262144000,"max_mirror_replicas_per_collection":10,"max_application_replicas_per_collection":10,"max_hosted_collections":10,"max_files_per_collection":10000}' >/dev/null
@@ -118,7 +142,7 @@ previous_mutation_body() {
     --arg mutation_id "$UPGRADE_MUTATION_ID" \
     --arg replica_id "$UPGRADE_REPLICA_ID" \
     --arg record_id "$UPGRADE_RECORD_ID" \
-    --arg document $'---\ntitle: Preserved beta receipt\n---\n\nExact beta69 bytes.\n' \
+    --arg document $'---\ntitle: Preserved predecessor receipt\n---\n\nExact predecessor bytes.\n' \
     '{mutation_id:$mutation_id,replica_id:$replica_id,scope_epoch:1,operation:"put",record_id:$record_id,path:"upgrade/receipt.md",document:$document,created_at:"2026-08-04T00:00:00Z"}'
 }
 
@@ -315,6 +339,7 @@ fi
 
 upgrade_phase 'creating the previous provider schema'
 docker pull "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE"
+upgrade_verify_previous_image "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE"
 start_previous_provider mdbase-provider-previous false
 
 upgrade_phase 'seeding an encrypted previous-release sync receipt'
@@ -336,123 +361,72 @@ docker run --rm --interactive --network host \
 upgrade_phase 'reopening persisted state with the previous release'
 start_previous_provider mdbase-provider-previous-migration
 previous_contract=$(query_notification_contract)
-printf 'Previous release notification contract: %s\n' "$previous_contract"
+printf 'Previous release (%s at %s) notification contract: %s\n' \
+  "$MDBASE_CONNECT_PREVIOUS_RELEASE" \
+  "$MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT" \
+  "$previous_contract"
 [[ $previous_contract == "mdbase.runtime.timer.fired|1.0.0" ]]
+
+upgrade_phase 'writing predecessor-created persisted state before projection rebuild'
+start_candidate_provider
+wait_candidate_provider
+if ! exact_receipt=$(provider_json POST \
+  "/v1/authorities/$UPGRADE_COLLECTION_ID/sync/mutations" \
+  "$(exact_mutation_body "$previous_revision")" "$UPGRADE_REPLICA_TOKEN"); then
+  printf 'Candidate pre-rebuild mutation failed: %s\n' "$exact_receipt" >&2
+  exit 1
+fi
+printf 'Candidate pre-rebuild mutation receipt: %s\n' "$exact_receipt"
+jq -e '
+  .status == "applied" and
+  .record.path == "upgrade/receipt.md" and
+  .record.document == "---\ntitle: Exact beta receipt\n---\n\nExact bytes.\n"
+' <<<"$exact_receipt" >/dev/null
+snapshot_session=$(provider_json POST \
+  "/v1/authorities/$UPGRADE_COLLECTION_ID/sync/sessions" '' \
+  "$UPGRADE_REPLICA_TOKEN")
+snapshot_id=$(jq -er '.snapshot_id' <<<"$snapshot_session")
+pre_rebuild_snapshot=$(provider_get \
+  "/v1/authorities/$UPGRADE_COLLECTION_ID/sync/snapshot?snapshot_id=$snapshot_id" \
+  "$UPGRADE_REPLICA_TOKEN")
+jq -e --arg record_id "$UPGRADE_RECORD_ID" '
+  [.records[] | select(
+    .record_id == $record_id and
+    .path == "upgrade/receipt.md" and
+    .document == "---\ntitle: Exact beta receipt\n---\n\nExact bytes.\n"
+  )] | length == 1
+' <<<"$pre_rebuild_snapshot" >/dev/null
+upgrade_remove_container mdbase-provider-upgrade-candidate
+
 canonical_inventory_before=$(query_canonical_authority_inventory)
-printf 'Previous release canonical authority inventory: sha256:%s\n' \
+printf 'Pre-verify candidate canonical authority inventory: sha256:%s\n' \
   "$canonical_inventory_before"
 
-upgrade_phase 'indexing the complete preserved authority with the bounded cutover operator'
-docker run --detach --name mdbase-provider-cutover-lock --network host \
-  --env PGPASSWORD=previous-provider-upgrade \
-  --env PGAPPNAME=mdbase-provider-cutover-lock-holder \
-  postgres:18-alpine \
-  psql --host 127.0.0.1 --port "$UPGRADE_DATABASE_PORT" \
-    --username mdbase --dbname mdbase_provider_upgrade \
-    --set ON_ERROR_STOP=1 \
-    --command "SELECT pg_advisory_lock(hashtextextended('mdbase-candidate-b-cutover-v1', 0)); SELECT pg_sleep(30)" \
-  >/dev/null
-for _ in {1..30}; do
-  lock_count=$(docker run --rm --network host \
-    --env PGPASSWORD=previous-provider-upgrade \
-    postgres:18-alpine \
-    psql --host 127.0.0.1 --port "$UPGRADE_DATABASE_PORT" \
-      --username mdbase --dbname mdbase_provider_upgrade \
-      --tuples-only --no-align \
-      --command "SELECT count(*)
-                 FROM pg_locks
-                 JOIN pg_stat_activity USING (pid)
-                 WHERE locktype = 'advisory'
-                   AND granted
-                   AND application_name = 'mdbase-provider-cutover-lock-holder'" |
-    tr -d '[:space:]')
-  [[ $lock_count != 0 ]] && break
-  sleep 1
-done
-[[ ${lock_count:-0} != 0 ]]
-if lock_result=$(run_projection_indexer cutover \
-  --owner-token 99999999-9999-4999-8999-999999999990 \
-  --max-seconds 30)
-then
-  printf 'Projection cutover unexpectedly ignored the global PostgreSQL lock.\n' >&2
-  exit 1
-fi
-jq -e '
-  .ok == false and
-  .command == "cutover" and
-  .result.outcome == "projection_cutover_lock_unavailable" and
-  .result.phase == "global_lock"
-' <<<"$lock_result" >/dev/null
-terminate_cutover_lock_holder
-upgrade_remove_container mdbase-provider-cutover-lock
-
-if bounded_result=$(run_projection_indexer cutover \
-  --owner-token "$CUTOVER_OWNER_TOKEN" \
-  --page-limit 1 \
-  --batches-per-collection 1 \
-  --max-collections 10 \
-  --max-batches 1 \
-  --max-pages 10 \
-  --max-seconds 120)
-then
-  printf 'Projection cutover unexpectedly completed inside the one-batch test budget.\n' >&2
-  exit 1
-fi
-jq -e '
-  .ok == false and
-  .command == "cutover" and
-  .result.outcome == "projection_cutover_batch_budget_exceeded" and
-  .result.complete_inventory == false and
-  .result.collections_verified == 0 and
-  .result.batches_advanced == 1 and
-  .result.blocked_collection_id == "33333333-3333-4333-8333-333333333333"
-' <<<"$bounded_result" >/dev/null
-verify_result=$(run_projection_indexer cutover \
-  --owner-token "$CUTOVER_OWNER_TOKEN" \
-  --page-limit 1 \
-  --batches-per-collection 16 \
-  --max-collections 10 \
-  --max-batches 160 \
-  --max-pages 10 \
-  --max-seconds 120)
+upgrade_phase 'verifying the write-through projection without normalization'
+post_write_verify=$(run_projection_indexer verify --limit 100)
 jq -e '
   .ok == true and
-  .command == "cutover" and
-  .result.outcome == "complete" and
-  .result.complete_inventory == true and
-  .result.pages_visited == 1 and
-  .result.collections_verified == 1 and
-  .result.batches_advanced > 0 and
-  .result.blocked_collection_id == null
-' <<<"$verify_result" >/dev/null
-canonical_inventory_after_index=$(query_canonical_authority_inventory)
-printf 'Indexed candidate canonical authority inventory: sha256:%s\n' \
-  "$canonical_inventory_after_index"
-[[ $canonical_inventory_after_index == "$canonical_inventory_before" ]]
+  .command == "verify" and
+  (.result.collections | length) == 1 and
+  .result.collections[0].verified == true
+' <<<"$post_write_verify" >/dev/null
+canonical_inventory_after_verify=$(query_canonical_authority_inventory)
+printf 'Verified candidate canonical authority inventory: sha256:%s\n' \
+  "$canonical_inventory_after_verify"
+[[ $canonical_inventory_after_verify == "$canonical_inventory_before" ]]
 
 upgrade_phase 'requiring candidate recovery readiness'
-docker run --detach --name mdbase-provider-upgrade-candidate \
-  --network host \
-  --env DATABASE_URL \
-  --env MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN="$PROVIDER_INTERNAL_TOKEN" \
-  --env MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY="$PROVIDER_MASTER_KEY" \
-  --env MDBASE_CONNECT_CONTROL_PLANE_URL=http://127.0.0.1:9 \
-  --env MDBASE_CONNECT_R2_ENDPOINT \
-  --env MDBASE_CONNECT_R2_BUCKET \
-  --env MDBASE_CONNECT_R2_ACCESS_KEY_ID \
-  --env MDBASE_CONNECT_R2_SECRET_ACCESS_KEY \
-  --env MDBASE_CONNECT_ALLOW_INSECURE_R2 \
-  --env PORT="$UPGRADE_PROVIDER_PORT" \
-  "$CANDIDATE_IMAGE" >/dev/null
+start_candidate_provider
 
 recovered=false
-for attempt in {1..30}; do
+for _ in {1..30}; do
   readiness=$(curl --silent "$UPGRADE_PROVIDER_URL/ready" || true)
   if jq -e '
     .status == "ready" and
     .notifications.configured == true and
     .notifications.recovery == "ok" and
-    .notifications.consecutive_failures == 0
+    .notifications.consecutive_failures == 0 and
+    .projections.degraded_collections == 0
   ' <<<"$readiness" >/dev/null; then
     recovered=true
     break
@@ -461,33 +435,18 @@ for attempt in {1..30}; do
 done
 if ! $recovered; then
   docker logs mdbase-provider-upgrade-candidate
-  printf 'Candidate provider did not recover upgraded notification state.\n' >&2
+  printf 'Candidate provider did not recover notification and projection readiness.\n' >&2
   exit 1
 fi
 
-upgrade_phase 'finalizing candidate admission after recovery readiness'
-for admission_step in \
-  'open-hosted-query-admission-provisional.sql:lease_seconds=180' \
-  'finalize-hosted-query-admission.sql:'
-do
-  admission_file=${admission_step%%:*}
-  admission_variable=${admission_step#*:}
-  admission_arguments=(
-    --host 127.0.0.1 --port "$UPGRADE_DATABASE_PORT"
-    --username mdbase --dbname mdbase_provider_upgrade
-    --set ON_ERROR_STOP=1 --set "fence_token=$CUTOVER_OWNER_TOKEN"
-  )
-  if [[ -n $admission_variable ]]; then
-    admission_arguments+=(--set "$admission_variable")
-  fi
-  docker run --rm --network host \
-    --env PGPASSWORD=previous-provider-upgrade \
-    --entrypoint psql \
-    "$CANDIDATE_IMAGE" \
-    "${admission_arguments[@]}" \
-    --file "/usr/local/share/mdbase-connect/postgres/$admission_file" \
-    >/dev/null
-done
+upgrade_phase 'verifying projections after final provider restart'
+final_verify=$(run_projection_indexer verify --limit 100)
+jq -e '
+  .ok == true and
+  .command == "verify" and
+  (.result.collections | length) == 1 and
+  .result.collections[0].verified == true
+' <<<"$final_verify" >/dev/null
 
 contract=$(query_notification_contract true)
 printf 'Recovered notification contract: %s\n' "$contract"
@@ -504,36 +463,4 @@ printf 'Recovered candidate canonical authority inventory: sha256:%s\n' \
   "$canonical_inventory_after_recovery"
 [[ $canonical_inventory_after_recovery == "$canonical_inventory_before" ]]
 
-if ! replayed_receipt=$(provider_json POST \
-  "/v1/authorities/$UPGRADE_COLLECTION_ID/sync/mutations" \
-  "$(previous_mutation_body)" "$UPGRADE_REPLICA_TOKEN"); then
-  printf 'Beta69 receipt replay failed: %s\n' "$replayed_receipt" >&2
-  exit 1
-fi
-printf 'Replayed beta69 receipt: %s\n' "$replayed_receipt"
-jq -e '
-  .status == "applied" and
-  .record.path == "upgrade/receipt.md" and
-  .record.document == "---\ntitle: Preserved beta receipt\n---\n\nExact beta69 bytes.\n"
-' <<<"$replayed_receipt" >/dev/null
-canonical_inventory_after_replay=$(query_canonical_authority_inventory)
-printf 'Replayed candidate canonical authority inventory: sha256:%s\n' \
-  "$canonical_inventory_after_replay"
-[[ $canonical_inventory_after_replay == "$canonical_inventory_before" ]]
-
-if ! exact_receipt=$(provider_json POST \
-  "/v1/authorities/$UPGRADE_COLLECTION_ID/sync/mutations" \
-  "$(exact_mutation_body "$previous_revision")" "$UPGRADE_REPLICA_TOKEN"); then
-  printf 'Candidate exact mutation failed: %s\n' "$exact_receipt" >&2
-  exit 1
-fi
-printf 'Candidate exact mutation receipt: %s\n' "$exact_receipt"
-jq -e '
-  .status == "applied" and
-  .record.path == "upgrade/receipt.md" and
-  .record.document == "---\ntitle: Exact beta receipt\n---\n\nExact bytes.\n"
-' <<<"$exact_receipt" >/dev/null
-post_write_verify=$(run_projection_indexer verify --limit 100)
-jq -e '.ok == true and .result.collections[0].verified == true' \
-  <<<"$post_write_verify" >/dev/null
-printf 'Previous provider notification recovery path passed.\n'
+printf 'Immediate-predecessor persisted-state upgrade path passed.\n'

--- a/test/upgrade/server-from-previous
+++ b/test/upgrade/server-from-previous
@@ -11,7 +11,12 @@ source "$repo_root/.github/previous-release.env"
 CANDIDATE_IMAGE=${CANDIDATE_IMAGE:-mdbase-connect-server:upgrade-candidate}
 UPGRADE_SERVER_PORT=${UPGRADE_SERVER_PORT:-8787}
 UPGRADE_SERVER_URL="http://127.0.0.1:$UPGRADE_SERVER_PORT"
-upgrade_require DATABASE_URL MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE
+upgrade_require \
+  DATABASE_URL \
+  MDBASE_CONNECT_PREVIOUS_RELEASE \
+  MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT \
+  MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE
+upgrade_verify_previous_release "$repo_root"
 
 cleanup() {
   docker logs mdbase-connect-upgrade-candidate >/dev/null 2>&1 || true
@@ -27,6 +32,7 @@ docker build \
 
 upgrade_phase 'creating the previous release schema'
 docker pull "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE"
+upgrade_verify_previous_image "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE"
 docker run --rm --network host \
   --env DATABASE_URL \
   "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE" \


### PR DESCRIPTION
## Summary
- diagnose persisted projection format and engine drift against the running runtime
- pin and verify the exact latest predecessor release, commit, and image provenance
- attempt and read back a candidate write before any projection verification or normalization
- require zero degraded projections and verified projection state after restart

## Validation
- full provider persisted-state upgrade scenario against beta.93
- full server upgrade scenario against beta.93
- focused PostgreSQL projection diagnostics regression
- `cargo check --locked -p mdbase-connect-hosted-provider`
- all 98 `scripts/lib/*.test.mjs` tests
- ShellCheck, rustfmt, and diff checks

Companion to mdbase-cloud-ops#338.