### PR TITLE
Keep semantic reads available during projection cutover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ authorization and strengthens release compatibility gates.
   projection normalization, runtime diagnostics compare persisted projections
   with the running engine, and release tooling blocks undeclared projection
   format or semantic-engine transitions.
+- A live projection-cutover lease admits semantic queries while canonical,
+  synchronization, file, import, and provider-control writes remain fenced.
 
 ## 0.1.0-beta.93
 

--- a/crates/connect-hosted-provider/src/bin/mdbase-hosted-projection-indexer.rs
+++ b/crates/connect-hosted-provider/src/bin/mdbase-hosted-projection-indexer.rs
@@ -461,6 +461,11 @@ async fn run(arguments: Arguments) -> ApiResult<Envelope> {
             )
         }
         Command::Verify(page) => {
+            // An independent post-cutover verification is also the live
+            // semantic read-back gate. It must use the same admission class as
+            // hosted queries so a provisional lease cannot accidentally admit
+            // canonical writes while verification runs.
+            let admission = provider.acquire_runtime_read_admission().await?;
             let plan = provider
                 .projection_index_plan(page.after, page.limit)
                 .await?;
@@ -474,6 +479,7 @@ async fn run(arguments: Arguments) -> ApiResult<Envelope> {
             }
             let page_verified = verifications.iter().all(|result| result.verified);
             let ok = plan.migration_ledger_valid && plan.schema_valid && page_verified;
+            admission.commit().await?;
             (
                 ok,
                 "verify",

--- a/crates/connect-hosted-provider/src/bin/mdbase-hosted-projection-indexer.rs
+++ b/crates/connect-hosted-provider/src/bin/mdbase-hosted-projection-indexer.rs
@@ -320,6 +320,7 @@ async fn run(arguments: Arguments) -> ApiResult<Envelope> {
         }
     }
     let cutover_connection = cutover_budget.is_some();
+    let verification_connection = matches!(&arguments.command, Command::Verify(_));
     let provider_future = async {
         if cutover_connection {
             HostedProvider::connect_pre_migrated(
@@ -336,6 +337,14 @@ async fn run(arguments: Arguments) -> ApiResult<Envelope> {
                     .command
                     .cutover_owner_token()
                     .expect("cutover connection has an owner"),
+            )
+            .await
+        } else if verification_connection {
+            HostedProvider::connect_for_verification(
+                &database_url,
+                crypto,
+                ProviderLimits::default(),
+                Arc::new(ProjectionOnlyBlobStore),
             )
             .await
         } else {

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -319,10 +319,9 @@ pub fn app(state: AppState) -> Router {
         )
         .layer(DefaultBodyLimit::max(MAX_IMPORT_BODY_BYTES))
         .route_layer(middleware::from_fn(require_bearer_request));
-    let admitted = Router::new()
+    let write_admitted = Router::new()
         .merge(internal)
         .merge(sync)
-        .merge(operations)
         .merge(files)
         .merge(imports)
         .route_layer(middleware::from_fn_with_state(
@@ -331,7 +330,8 @@ pub fn app(state: AppState) -> Router {
         ));
     Router::new()
         .merge(diagnostic_routes(state.clone()))
-        .merge(admitted)
+        .merge(write_admitted)
+        .merge(operations)
         .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(cors)
         .layer(PropagateRequestIdLayer::new(request_id_header.clone()))
@@ -914,6 +914,11 @@ async fn operation(
         ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
     })?;
     let recovery_only = mdbase_connect_protocol::is_mutating_operation(&operation, &request.input);
+    let admission = if recovery_only {
+        state.provider.acquire_runtime_admission().await?
+    } else {
+        state.provider.acquire_runtime_read_admission().await?
+    };
     let authorization = if recovery_only {
         state
             .provider
@@ -958,20 +963,20 @@ async fn operation(
         .provider
         .record_operation_protocol_usage(collection_id, request.protocol_version)
         .await?;
-    Ok(Json(
-        serde_json::to_value(OperationResponse {
-            protocol_version: request.protocol_version,
-            request_id: request.request_id,
-            ok: true,
-            result: Some(result),
-            problem: None,
-        })
-        .map_err(|error| {
-            ApiError::internal(format!(
-                "Hosted operation response could not serialize: {error}"
-            ))
-        })?,
-    ))
+    let response = serde_json::to_value(OperationResponse {
+        protocol_version: request.protocol_version,
+        request_id: request.request_id,
+        ok: true,
+        result: Some(result),
+        problem: None,
+    })
+    .map_err(|error| {
+        ApiError::internal(format!(
+            "Hosted operation response could not serialize: {error}"
+        ))
+    })?;
+    admission.commit().await?;
+    Ok(Json(response))
 }
 
 #[cfg(test)]

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -50,7 +50,7 @@ mod files;
 mod projections;
 
 use accounts::account_routes;
-use authentication::{bearer, is_query_cursor_release, request_origin, request_proof};
+use authentication::{bearer, request_origin, request_proof};
 use authority_import_files::{
     commit_authority_import_file_upload, open_authority_import_file_upload,
     prepare_authority_import_file_part,
@@ -914,9 +914,9 @@ async fn operation(
         ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
     })?;
     let recovery_only = mdbase_connect_protocol::is_mutating_operation(&operation, &request.input);
-    // Cursor release changes bounded query metadata only; keep authorized,
-    // identity-bound cleanup available while semantic reads are suspended.
-    let cursor_release = is_query_cursor_release(&operation, &request.input, recovery_only);
+    let cursor_release = !recovery_only
+        && matches!(operation.as_str(), "query" | "execute_view")
+        && HostedProvider::is_valid_query_cursor_release(&request.input);
     let admission = if cursor_release {
         None
     } else if recovery_only {

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -50,7 +50,7 @@ mod files;
 mod projections;
 
 use accounts::account_routes;
-use authentication::{bearer, request_origin, request_proof};
+use authentication::{bearer, is_query_cursor_release, request_origin, request_proof};
 use authority_import_files::{
     commit_authority_import_file_upload, open_authority_import_file_upload,
     prepare_authority_import_file_part,
@@ -900,12 +900,6 @@ async fn collection_type_candidates(
     Ok(Json(json!({ "types": types })))
 }
 
-fn is_query_cursor_release(operation: &str, input: &Value, mutating: bool) -> bool {
-    !mutating
-        && matches!(operation, "query" | "execute_view")
-        && input.get("release_cursor").is_some()
-}
-
 async fn operation(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -920,10 +914,8 @@ async fn operation(
         ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
     })?;
     let recovery_only = mdbase_connect_protocol::is_mutating_operation(&operation, &request.input);
-    // Cursor release changes bounded query-runtime metadata only. Keep cleanup
-    // available while reads are suspended or a cutover lease expires; the
-    // provider still authorizes the request and binds the cursor to the exact
-    // collection, replica, scope epoch, and query kind before deletion.
+    // Cursor release changes bounded query metadata only; keep authorized,
+    // identity-bound cleanup available while semantic reads are suspended.
     let cursor_release = is_query_cursor_release(&operation, &request.input, recovery_only);
     let admission = if cursor_release {
         None
@@ -997,16 +989,6 @@ async fn operation(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cursor_release_exemption_is_closed_to_query_operations() {
-        let release = json!({"release_cursor": "opaque"});
-        assert!(is_query_cursor_release("query", &release, false));
-        assert!(is_query_cursor_release("execute_view", &release, false));
-        assert!(!is_query_cursor_release("describe", &release, false));
-        assert!(!is_query_cursor_release("query", &release, true));
-        assert!(!is_query_cursor_release("query", &json!({}), false));
-    }
 
     #[test]
     fn internal_credentials_are_checked_by_digest() {

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -914,10 +914,17 @@ async fn operation(
         ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
     })?;
     let recovery_only = mdbase_connect_protocol::is_mutating_operation(&operation, &request.input);
-    let admission = if recovery_only {
-        state.provider.acquire_runtime_admission().await?
+    // Cursor release changes bounded query-runtime metadata only. Keep cleanup
+    // available while reads are suspended or a cutover lease expires; the
+    // provider still authorizes the request and binds the cursor to the exact
+    // collection, replica, scope epoch, and query kind before deletion.
+    let cursor_release = !recovery_only && request.input.get("release_cursor").is_some();
+    let admission = if cursor_release {
+        None
+    } else if recovery_only {
+        Some(state.provider.acquire_runtime_admission().await?)
     } else {
-        state.provider.acquire_runtime_read_admission().await?
+        Some(state.provider.acquire_runtime_read_admission().await?)
     };
     let authorization = if recovery_only {
         state
@@ -975,7 +982,9 @@ async fn operation(
             "Hosted operation response could not serialize: {error}"
         ))
     })?;
-    admission.commit().await?;
+    if let Some(admission) = admission {
+        admission.commit().await?;
+    }
     Ok(Json(response))
 }
 

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -900,6 +900,12 @@ async fn collection_type_candidates(
     Ok(Json(json!({ "types": types })))
 }
 
+fn is_query_cursor_release(operation: &str, input: &Value, mutating: bool) -> bool {
+    !mutating
+        && matches!(operation, "query" | "execute_view")
+        && input.get("release_cursor").is_some()
+}
+
 async fn operation(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -918,7 +924,7 @@ async fn operation(
     // available while reads are suspended or a cutover lease expires; the
     // provider still authorizes the request and binds the cursor to the exact
     // collection, replica, scope epoch, and query kind before deletion.
-    let cursor_release = !recovery_only && request.input.get("release_cursor").is_some();
+    let cursor_release = is_query_cursor_release(&operation, &request.input, recovery_only);
     let admission = if cursor_release {
         None
     } else if recovery_only {
@@ -991,6 +997,16 @@ async fn operation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cursor_release_exemption_is_closed_to_query_operations() {
+        let release = json!({"release_cursor": "opaque"});
+        assert!(is_query_cursor_release("query", &release, false));
+        assert!(is_query_cursor_release("execute_view", &release, false));
+        assert!(!is_query_cursor_release("describe", &release, false));
+        assert!(!is_query_cursor_release("query", &release, true));
+        assert!(!is_query_cursor_release("query", &json!({}), false));
+    }
 
     #[test]
     fn internal_credentials_are_checked_by_digest() {

--- a/crates/connect-hosted-provider/src/http/authentication.rs
+++ b/crates/connect-hosted-provider/src/http/authentication.rs
@@ -3,7 +3,6 @@ use mdbase_connect_protocol::{
     AUTHORITY_PROOF_NONCE_HEADER, AUTHORITY_PROOF_SIGNATURE_HEADER,
     AUTHORITY_PROOF_TIMESTAMP_HEADER, AUTHORITY_PROOF_VERSION_HEADER,
 };
-use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
@@ -83,12 +82,6 @@ fn header_text<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
         .and_then(|value| value.to_str().ok())
 }
 
-pub(super) fn is_query_cursor_release(operation: &str, input: &Value, mutating: bool) -> bool {
-    !mutating
-        && matches!(operation, "query" | "execute_view")
-        && input.get("release_cursor").is_some()
-}
-
 pub(super) fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
     headers
         .get(AUTHORIZATION)
@@ -98,20 +91,4 @@ pub(super) fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
         .ok_or_else(|| {
             ApiError::unauthorized("missing_bearer_token", "A bearer credential is required.")
         })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn cursor_release_exemption_is_closed_to_query_operations() {
-        let release = json!({"release_cursor": "opaque"});
-        assert!(is_query_cursor_release("query", &release, false));
-        assert!(is_query_cursor_release("execute_view", &release, false));
-        assert!(!is_query_cursor_release("describe", &release, false));
-        assert!(!is_query_cursor_release("query", &release, true));
-        assert!(!is_query_cursor_release("query", &json!({}), false));
-    }
 }

--- a/crates/connect-hosted-provider/src/http/authentication.rs
+++ b/crates/connect-hosted-provider/src/http/authentication.rs
@@ -3,6 +3,7 @@ use mdbase_connect_protocol::{
     AUTHORITY_PROOF_NONCE_HEADER, AUTHORITY_PROOF_SIGNATURE_HEADER,
     AUTHORITY_PROOF_TIMESTAMP_HEADER, AUTHORITY_PROOF_VERSION_HEADER,
 };
+use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
@@ -82,6 +83,12 @@ fn header_text<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
         .and_then(|value| value.to_str().ok())
 }
 
+pub(super) fn is_query_cursor_release(operation: &str, input: &Value, mutating: bool) -> bool {
+    !mutating
+        && matches!(operation, "query" | "execute_view")
+        && input.get("release_cursor").is_some()
+}
+
 pub(super) fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
     headers
         .get(AUTHORIZATION)
@@ -91,4 +98,20 @@ pub(super) fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
         .ok_or_else(|| {
             ApiError::unauthorized("missing_bearer_token", "A bearer credential is required.")
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn cursor_release_exemption_is_closed_to_query_operations() {
+        let release = json!({"release_cursor": "opaque"});
+        assert!(is_query_cursor_release("query", &release, false));
+        assert!(is_query_cursor_release("execute_view", &release, false));
+        assert!(!is_query_cursor_release("describe", &release, false));
+        assert!(!is_query_cursor_release("query", &release, true));
+        assert!(!is_query_cursor_release("query", &json!({}), false));
+    }
 }

--- a/crates/connect-hosted-provider/src/provider/admission.rs
+++ b/crates/connect-hosted-provider/src/provider/admission.rs
@@ -1,10 +1,28 @@
 use super::*;
 
 impl HostedProvider {
-    /// Hold the database-wide shared admission lock for a complete HTTP
-    /// data/control request. The exclusive cutover transaction cannot persist
-    /// its fence until every already-admitted request has finished.
+    /// Hold the database-wide shared admission lock for a complete request
+    /// that can change canonical or projection-relevant state. A cutover lease
+    /// never admits this class while semantic reads exercise the candidate.
     pub async fn acquire_runtime_admission(&self) -> ApiResult<Transaction<'static, Postgres>> {
+        self.acquire_runtime_admission_class(false).await
+    }
+
+    /// Hold the database-wide shared admission lock for a semantic query. A
+    /// live cutover lease admits queries after the exclusive drain; rollback
+    /// fences, expired leases, and fully suspended admission do not. Query
+    /// cursor lifecycle and protocol accounting may still update bounded
+    /// runtime metadata, but cannot change canonical records or projections.
+    pub async fn acquire_runtime_read_admission(
+        &self,
+    ) -> ApiResult<Transaction<'static, Postgres>> {
+        self.acquire_runtime_admission_class(true).await
+    }
+
+    async fn acquire_runtime_admission_class(
+        &self,
+        read_only: bool,
+    ) -> ApiResult<Transaction<'static, Postgres>> {
         let mut transaction = self.pool.begin().await?;
         // The session default is intentionally short, but this transaction is
         // the operation-lifetime admission permit. It must never disappear
@@ -22,13 +40,15 @@ impl HostedProvider {
                     AND (
                       admission_fence_token IS NULL
                       OR (
-                        admission_fence_kind = 'cutover'
+                        $1
+                        AND admission_fence_kind = 'cutover'
                         AND admission_lease_expires_at > clock_timestamp()
                       )
                     )
                FROM hosted_provider_runtime_control
                WHERE singleton = true"#,
         )
+        .bind(read_only)
         .fetch_optional(&mut *transaction)
         .await?
         .unwrap_or(false);

--- a/crates/connect-hosted-provider/src/provider/lifecycle.rs
+++ b/crates/connect-hosted-provider/src/provider/lifecycle.rs
@@ -69,6 +69,7 @@ impl HostedProvider {
         run_migrations: bool,
         cutover_connection: Option<(Duration, Uuid)>,
     ) -> ApiResult<Self> {
+        let initialize_database_key = run_migrations || cutover_connection.is_some();
         let started = Instant::now();
         let mut retry_delay = Duration::from_millis(100);
         loop {
@@ -81,7 +82,11 @@ impl HostedProvider {
                 } else {
                     Ok(())
                 } {
-                    Ok(()) => match verify_database_key(&pool, &crypto).await {
+                    Ok(()) => match if initialize_database_key {
+                        verify_database_key(&pool, &crypto).await
+                    } else {
+                        verify_stored_database_key_for_startup(&pool, &crypto).await
+                    } {
                         Ok(()) => {
                             let query_pool = hosted_query_pool_options()
                                 .connect_lazy(database_url)

--- a/crates/connect-hosted-provider/src/provider/lifecycle.rs
+++ b/crates/connect-hosted-provider/src/provider/lifecycle.rs
@@ -24,6 +24,18 @@ impl HostedProvider {
         .await
     }
 
+    /// Connect without running startup migrations for an independent semantic
+    /// read-back under runtime read admission. The candidate service or fixed
+    /// cutover command must already have applied and verified the exact ledger.
+    pub async fn connect_for_verification(
+        database_url: &str,
+        crypto: ProviderCrypto,
+        limits: ProviderLimits,
+        blob_store: Arc<dyn BlobStore>,
+    ) -> ApiResult<Self> {
+        Self::connect_internal(database_url, crypto, limits, blob_store, None, false, None).await
+    }
+
     /// Connect after a cutover operator has applied the reviewed migration
     /// ledger on the exact PostgreSQL session that owns the global cutover
     /// lock. This deliberately cannot migrate on a second pooled session.

--- a/crates/connect-hosted-provider/src/provider/operation_queries/entrypoints.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/entrypoints.rs
@@ -1,4 +1,11 @@
 impl HostedProvider {
+    pub(crate) fn is_valid_query_cursor_release(input: &Value) -> bool {
+        input
+            .get("release_cursor")
+            .and_then(Value::as_str)
+            .is_some_and(|cursor| decode_query_cursor(cursor).is_ok())
+    }
+
     pub(super) async fn execute_hosted_query(
         &self,
         collection_id: Uuid,

--- a/crates/connect-hosted-provider/src/provider/operation_queries/tests.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/tests.rs
@@ -7,6 +7,15 @@ mod tests {
         let id = Uuid::new_v4();
         let token = encode_query_cursor(id);
         assert_eq!(decode_query_cursor(&token).unwrap(), id);
+        assert!(HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": token.clone()
+        })));
+        assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": null
+        })));
+        assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": token.clone() + "="
+        })));
         assert_eq!(
             decode_query_cursor(&(token + "=")).unwrap_err().code,
             "invalid_query_cursor"

--- a/crates/connect-hosted-provider/src/provider/persistence.rs
+++ b/crates/connect-hosted-provider/src/provider/persistence.rs
@@ -31,6 +31,21 @@ pub(super) async fn verify_database_key(
         .map_err(DatabaseKeyError::Invalid)
 }
 
+pub(super) async fn verify_stored_database_key_for_startup(
+    pool: &PgPool,
+    crypto: &ProviderCrypto,
+) -> Result<(), DatabaseKeyError> {
+    let key_check: Vec<u8> =
+        sqlx::query_scalar("SELECT key_check FROM hosted_provider_metadata WHERE singleton = true")
+            .fetch_one(pool)
+            .await
+            .map_err(DatabaseKeyError::Database)?;
+    crypto
+        .verify_key_check(&key_check)
+        .await
+        .map_err(DatabaseKeyError::Invalid)
+}
+
 pub(super) async fn verify_stored_database_key(
     pool: &PgPool,
     crypto: &ProviderCrypto,

--- a/crates/connect-hosted-provider/src/provider/tests.rs
+++ b/crates/connect-hosted-provider/src/provider/tests.rs
@@ -279,7 +279,7 @@ fn beta69_rollback_preparation_is_fenced_and_preserves_canonical_tables() {
     assert!(resume.contains("GET DIAGNOSTICS affected_rows = ROW_COUNT"));
     assert!(resume.contains("affected_rows <> 1"));
     assert!(provisional.contains("admission_lease_expires_at"));
-    assert!(provisional.contains("lease_seconds < 30 OR lease_seconds > 600"));
+    assert!(provisional.contains("lease_seconds < 30 OR lease_seconds > 3600"));
     assert!(provisional.contains("admission_owner_expires_at >"));
     assert!(finalize.contains("admission_lease_expires_at > clock_timestamp()"));
     assert!(finalize.contains("admission_fence_token = NULL"));

--- a/crates/connect-hosted-provider/tests/projection_lifecycle.rs
+++ b/crates/connect-hosted-provider/tests/projection_lifecycle.rs
@@ -4314,7 +4314,7 @@ async fn candidate_b_projection_digest_binds_and_refreshes_the_temporal_end() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires MDBASE_PROJECTION_DATABASE_URL; run against a disposable PostgreSQL database"]
-async fn candidate_b_rollback_fence_drains_inflight_queries_and_allows_cursor_release() {
+async fn runtime_admission_separates_cutover_reads_from_fenced_writes() {
     let database_url = std::env::var("MDBASE_PROJECTION_DATABASE_URL")
         .expect("MDBASE_PROJECTION_DATABASE_URL is required");
     let fixture = FileLifecycleFixture::new(&database_url).await;
@@ -4422,8 +4422,45 @@ async fn candidate_b_rollback_fence_drains_inflight_queries_and_allows_cursor_re
                suspension_reason = NULL,
                admission_fence_token = '11111111-1111-4111-8111-111111111111',
                admission_fence_kind = 'cutover',
-               admission_lease_expires_at = clock_timestamp() - interval '1 second',
+               admission_lease_expires_at = clock_timestamp() + interval '1 hour',
                admission_owner_expires_at = clock_timestamp() + interval '1 hour',
+               updated_at = now()
+           WHERE singleton = true"#,
+    )
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
+    fixture
+        .provider
+        .acquire_runtime_read_admission()
+        .await
+        .unwrap()
+        .commit()
+        .await
+        .unwrap();
+    let fenced_write = fixture
+        .provider
+        .acquire_runtime_admission()
+        .await
+        .unwrap_err();
+    assert_eq!(fenced_write.code, "hosted_query_admission_suspended");
+    let cutover_read = fixture
+        .provider
+        .operation(
+            fixture.collection_id,
+            &application_token,
+            "query",
+            Uuid::new_v4(),
+            json!({"limit": 1}),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(cutover_read["valid"], true);
+
+    sqlx::query(
+        r#"UPDATE hosted_provider_runtime_control
+           SET admission_lease_expires_at = clock_timestamp() - interval '1 second',
                updated_at = now()
            WHERE singleton = true"#,
     )

--- a/deploy/postgres/open-hosted-query-admission-provisional.sql
+++ b/deploy/postgres/open-hosted-query-admission-provisional.sql
@@ -12,9 +12,9 @@ DECLARE
   requested_token uuid := current_setting('mdbase.admission_fence_token')::uuid;
   lease_seconds integer := current_setting('mdbase.admission_lease_seconds')::integer;
 BEGIN
-  IF lease_seconds < 30 OR lease_seconds > 600 THEN
+  IF lease_seconds < 30 OR lease_seconds > 3600 THEN
     RAISE EXCEPTION
-      'hosted_admission_provisional_open_failed: lease must be between 30 and 600 seconds';
+      'hosted_admission_provisional_open_failed: lease must be between 30 and 3600 seconds';
   END IF;
   UPDATE hosted_provider_runtime_control
   SET query_admission_suspended = false,


### PR DESCRIPTION
## Summary
- split hosted runtime admission between semantic queries and projection-relevant writes
- permit queries only under a live cutover lease while all canonical, sync, file, import, and control routes remain fenced
- cover suspended, live-cutover, expired-lease, and write-denial behavior against disposable PostgreSQL

## Verification
- `cargo test -p mdbase-connect-hosted-provider --lib`
- `cargo clippy -p mdbase-connect-hosted-provider --all-targets -- -D warnings`
- ignored PostgreSQL `runtime_admission_separates_cutover_reads_from_fenced_writes`
- `cargo fmt --all -- --check`