### PR TITLE
Keep suspended cursor cleanup strictly read-only

### DIFF
--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -50,7 +50,7 @@ mod files;
 mod projections;
 
 use accounts::account_routes;
-use authentication::{bearer, is_query_cursor_release, request_origin, request_proof};
+use authentication::{bearer, request_origin, request_proof};
 use authority_import_files::{
     commit_authority_import_file_upload, open_authority_import_file_upload,
     prepare_authority_import_file_part,
@@ -914,9 +914,9 @@ async fn operation(
         ApiError::bad_request("invalid_json", "The hosted operation body is invalid.")
     })?;
     let recovery_only = mdbase_connect_protocol::is_mutating_operation(&operation, &request.input);
-    // Cursor release changes bounded query metadata only; keep authorized,
-    // identity-bound cleanup available while semantic reads are suspended.
-    let cursor_release = is_query_cursor_release(&operation, &request.input, recovery_only);
+    let cursor_release = !recovery_only
+        && matches!(operation.as_str(), "query" | "execute_view")
+        && HostedProvider::is_valid_query_cursor_release(&request.input);
     let admission = if cursor_release {
         None
     } else if recovery_only {

--- a/crates/connect-hosted-provider/src/http.rs
+++ b/crates/connect-hosted-provider/src/http.rs
@@ -50,7 +50,7 @@ mod files;
 mod projections;
 
 use accounts::account_routes;
-use authentication::{bearer, request_origin, request_proof};
+use authentication::{authorize_operation, bearer, request_origin, request_proof};
 use authority_import_files::{
     commit_authority_import_file_upload, open_authority_import_file_upload,
     prepare_authority_import_file_part,
@@ -58,7 +58,6 @@ use authority_import_files::{
 use diagnostics::diagnostic_routes;
 use files::file_routes;
 use projections::projection_routes;
-
 const MAX_BODY_BYTES: usize = 3 * 1024 * 1024;
 // Record imports are paged, but a page can contain several large canonical
 // documents. Provider quotas and the concurrency gate bound parsed work.
@@ -924,17 +923,16 @@ async fn operation(
     } else {
         Some(state.provider.acquire_runtime_read_admission().await?)
     };
-    let authorization = if recovery_only {
-        state
-            .provider
-            .authorize_replay_request(collection_id, token, origin, proof.as_ref())
-            .await?
-    } else {
-        state
-            .provider
-            .authorize_request(collection_id, token, origin, proof.as_ref())
-            .await?
-    };
+    let authorization = authorize_operation(
+        &state.provider,
+        collection_id,
+        token,
+        origin,
+        proof.as_ref(),
+        recovery_only,
+        cursor_release,
+    )
+    .await?;
     if !authorization.permits_operation_transport(request.protocol_version, recovery_only) {
         return Err(ApiError::bad_request(
             "transport_protocol_incompatible",
@@ -962,12 +960,13 @@ async fn operation(
             origin,
         )
         .await?;
-    // A retired credential reaches this point only after exact terminal replay.
-    // Do not let a rejected replay attempt create protocol-observation state.
-    state
-        .provider
-        .record_operation_protocol_usage(collection_id, request.protocol_version)
-        .await?;
+    // Cursor cleanup may only delete query-runtime cursor state during suspension.
+    if !cursor_release {
+        state
+            .provider
+            .record_operation_protocol_usage(collection_id, request.protocol_version)
+            .await?;
+    }
     let response = serde_json::to_value(OperationResponse {
         protocol_version: request.protocol_version,
         request_id: request.request_id,

--- a/crates/connect-hosted-provider/src/http/authentication.rs
+++ b/crates/connect-hosted-provider/src/http/authentication.rs
@@ -3,7 +3,6 @@ use mdbase_connect_protocol::{
     AUTHORITY_PROOF_NONCE_HEADER, AUTHORITY_PROOF_SIGNATURE_HEADER,
     AUTHORITY_PROOF_TIMESTAMP_HEADER, AUTHORITY_PROOF_VERSION_HEADER,
 };
-use serde_json::Value;
 use uuid::Uuid;
 
 use crate::{
@@ -83,12 +82,6 @@ fn header_text<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
         .and_then(|value| value.to_str().ok())
 }
 
-pub(super) fn is_query_cursor_release(operation: &str, input: &Value, mutating: bool) -> bool {
-    !mutating
-        && matches!(operation, "query" | "execute_view")
-        && input.get("release_cursor").is_some()
-}
-
 pub(super) fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
     headers
         .get(AUTHORIZATION)
@@ -98,20 +91,4 @@ pub(super) fn bearer(headers: &HeaderMap) -> ApiResult<&str> {
         .ok_or_else(|| {
             ApiError::unauthorized("missing_bearer_token", "A bearer credential is required.")
         })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn cursor_release_exemption_is_closed_to_query_operations() {
-        let release = json!({"release_cursor": "opaque"});
-        assert!(is_query_cursor_release("query", &release, false));
-        assert!(is_query_cursor_release("execute_view", &release, false));
-        assert!(!is_query_cursor_release("describe", &release, false));
-        assert!(!is_query_cursor_release("query", &release, true));
-        assert!(!is_query_cursor_release("query", &json!({}), false));
-    }
 }

--- a/crates/connect-hosted-provider/src/http/authentication.rs
+++ b/crates/connect-hosted-provider/src/http/authentication.rs
@@ -7,8 +7,32 @@ use uuid::Uuid;
 
 use crate::{
     error::{ApiError, ApiResult},
-    provider::AuthorityRequestProof,
+    provider::{AuthorityRequestProof, AuthorizedRequest, HostedProvider},
 };
+
+pub(super) async fn authorize_operation(
+    provider: &HostedProvider,
+    collection_id: Uuid,
+    token: &str,
+    origin: Option<&str>,
+    proof: Option<&AuthorityRequestProof>,
+    recovery_only: bool,
+    cursor_release: bool,
+) -> ApiResult<AuthorizedRequest> {
+    if cursor_release {
+        provider
+            .authorize_cursor_release_request(collection_id, token, origin, proof)
+            .await
+    } else if recovery_only {
+        provider
+            .authorize_replay_request(collection_id, token, origin, proof)
+            .await
+    } else {
+        provider
+            .authorize_request(collection_id, token, origin, proof)
+            .await
+    }
+}
 
 pub(super) fn request_origin(headers: &HeaderMap) -> Option<&str> {
     headers

--- a/crates/connect-hosted-provider/src/provider/operation_queries/entrypoints.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/entrypoints.rs
@@ -1,9 +1,12 @@
 impl HostedProvider {
     pub(crate) fn is_valid_query_cursor_release(input: &Value) -> bool {
-        input
-            .get("release_cursor")
-            .and_then(Value::as_str)
-            .is_some_and(|cursor| decode_query_cursor(cursor).is_ok())
+        input.as_object().is_some_and(|object| {
+            object.len() == 1
+                && object
+                    .get("release_cursor")
+                    .and_then(Value::as_str)
+                    .is_some_and(|cursor| decode_query_cursor(cursor).is_ok())
+        })
     }
 
     pub(super) async fn execute_hosted_query(

--- a/crates/connect-hosted-provider/src/provider/operation_queries/entrypoints.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/entrypoints.rs
@@ -1,4 +1,11 @@
 impl HostedProvider {
+    pub(crate) fn is_valid_query_cursor_release(input: &Value) -> bool {
+        input
+            .get("release_cursor")
+            .and_then(Value::as_str)
+            .is_some_and(|cursor| decode_query_cursor(cursor).is_ok())
+    }
+
     pub(super) async fn execute_hosted_query(
         &self,
         collection_id: Uuid,

--- a/crates/connect-hosted-provider/src/provider/operation_queries/provider_impl.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/provider_impl.rs
@@ -137,13 +137,18 @@ impl HostedProvider {
         request_kind: HostedQueryRequestKind,
         cancellation_cleanup: Option<tokio::sync::oneshot::Sender<bool>>,
     ) -> ApiResult<OperationResult> {
-        if let Some(release) = input.get("release_cursor") {
-            let cursor = release.as_str().ok_or_else(|| {
-                ApiError::bad_request(
-                    "invalid_query_cursor",
-                    "The hosted query cursor must be an opaque string.",
-                )
-            })?;
+        if input.get("release_cursor").is_some() {
+            let cursor = input
+                .as_object()
+                .filter(|object| object.len() == 1)
+                .and_then(|object| object.get("release_cursor"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ApiError::bad_request(
+                        "invalid_query_cursor",
+                        "The release cursor must be the only input field and contain an opaque cursor.",
+                    )
+                })?;
             let cursor_id = decode_query_cursor(cursor)?;
             sqlx::query(
                 r#"DELETE FROM hosted_provider_query_cursors
@@ -157,7 +162,6 @@ impl HostedProvider {
             .bind(request_kind.as_str())
             .execute(&self.pool)
             .await?;
-            cleanup_base_query_invocations(&self.pool, collection_id, None).await?;
             return Ok(empty_query_result());
         }
         let page_input_digest = query_page_input_digest(request_kind, input)?;

--- a/crates/connect-hosted-provider/src/provider/operation_queries/tests.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/tests.rs
@@ -16,6 +16,14 @@ mod tests {
         assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
             "release_cursor": token.clone() + "="
         })));
+        assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": token.clone(),
+            "cursor": token.clone()
+        })));
+        assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": token.clone(),
+            "extra": true
+        })));
         assert_eq!(
             decode_query_cursor(&(token + "=")).unwrap_err().code,
             "invalid_query_cursor"

--- a/crates/connect-hosted-provider/src/provider/operation_queries/tests.rs
+++ b/crates/connect-hosted-provider/src/provider/operation_queries/tests.rs
@@ -7,6 +7,15 @@ mod tests {
         let id = Uuid::new_v4();
         let token = encode_query_cursor(id);
         assert_eq!(decode_query_cursor(&token).unwrap(), id);
+        assert!(HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": token.clone()
+        })));
+        assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": null
+        })));
+        assert!(!HostedProvider::is_valid_query_cursor_release(&json!({
+            "release_cursor": token.clone() + "="
+        })));
         assert_eq!(
             decode_query_cursor(&(token + "=")).unwrap_err().code,
             "invalid_query_cursor"

--- a/crates/connect-hosted-provider/src/provider/replicas.rs
+++ b/crates/connect-hosted-provider/src/provider/replicas.rs
@@ -302,6 +302,7 @@ impl HostedProvider {
             request_origin,
             proof,
             false,
+            true,
         )
         .await
     }
@@ -319,6 +320,25 @@ impl HostedProvider {
             request_origin,
             proof,
             true,
+            true,
+        )
+        .await
+    }
+
+    pub(crate) async fn authorize_cursor_release_request(
+        &self,
+        collection_id: Uuid,
+        token: &str,
+        request_origin: Option<&str>,
+        proof: Option<&AuthorityRequestProof>,
+    ) -> ApiResult<AuthorizedRequest> {
+        self.authorize_request_with_retired_replay(
+            collection_id,
+            token,
+            request_origin,
+            proof,
+            false,
+            false,
         )
         .await
     }
@@ -330,6 +350,7 @@ impl HostedProvider {
         request_origin: Option<&str>,
         proof: Option<&AuthorityRequestProof>,
         allow_retired_replay: bool,
+        consume_proof_nonce: bool,
     ) -> ApiResult<AuthorizedRequest> {
         // Originless mirror traffic is authenticated again inside the requested
         // operation. Avoid a duplicate database round trip for that hot path.
@@ -407,7 +428,7 @@ impl HostedProvider {
                         )
                     })?;
                     verify_hosted_request_proof(public_key, token, proof)?;
-                    if !retired_credential {
+                    if !retired_credential && consume_proof_nonce {
                         let inserted = sqlx::query(
                             r#"INSERT INTO hosted_provider_request_proofs (replica_id, nonce)
                                VALUES ($1, $2)

--- a/crates/connect-hosted-provider/tests/operation_dispatch.rs
+++ b/crates/connect-hosted-provider/tests/operation_dispatch.rs
@@ -147,7 +147,11 @@ async fn retired_application_credentials_replay_only_exact_terminal_mutations() 
                 allowed_types: Vec::new(),
                 contract_scope: Vec::new(),
                 full_collection: true,
-                allowed_operations: vec!["changes".to_string(), "create".to_string()],
+                allowed_operations: vec![
+                    "changes".to_string(),
+                    "create".to_string(),
+                    "query".to_string(),
+                ],
                 operation_transport_protocol: Some(3),
                 operation_transport_recovery_protocols: vec![2],
                 file_capability: None,
@@ -162,6 +166,69 @@ async fn retired_application_credentials_replay_only_exact_terminal_mutations() 
         )
         .await
         .expect("canonical application replica is registered");
+
+    sqlx::query(
+        r#"UPDATE hosted_provider_runtime_control
+           SET query_admission_suspended = true,
+               admission_fence_token = $1,
+               admission_fence_kind = 'rollback',
+               admission_lease_expires_at = NULL,
+               admission_owner_expires_at = NULL"#,
+    )
+    .bind(Uuid::new_v4())
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let state = AppState::new(fixture.provider.clone(), &"internal-test-token-".repeat(2)).unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app(state)).await.unwrap() });
+    let query_target = format!("/v1/authorities/{}/operations/query", fixture.collection_id);
+    let cursor_body = serde_json::to_vec(&json!({
+        "protocol_version": 3,
+        "request_id": Uuid::now_v7(),
+        "input": {"release_cursor": format!("hq1.{}", URL_SAFE_NO_PAD.encode(Uuid::new_v4().as_bytes()))}
+    }))
+    .unwrap();
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let cursor_release = reqwest::Client::new()
+        .post(format!("http://{address}{query_target}"))
+        .headers(signed_application_headers(
+            &signing_key,
+            &token,
+            "POST",
+            &query_target,
+            &cursor_body,
+        ))
+        .header("content-type", "application/json")
+        .body(cursor_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cursor_release.status(), reqwest::StatusCode::OK);
+    let cursor_nonce_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM hosted_provider_request_proofs WHERE replica_id = $1",
+    )
+    .bind(replica_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        cursor_nonce_count, 0,
+        "cursor cleanup consumes no proof nonce"
+    );
+    server.abort();
+    sqlx::query(
+        r#"UPDATE hosted_provider_runtime_control
+           SET query_admission_suspended = false,
+               admission_fence_token = NULL,
+               admission_fence_kind = NULL,
+               admission_lease_expires_at = NULL,
+               admission_owner_expires_at = NULL"#,
+    )
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
 
     let request_id = Uuid::now_v7();
     let input = json!({"path": "retired/exact.md", "frontmatter": {"title": "Exact"}});

--- a/crates/connect-hosted-provider/tests/operation_dispatch.rs
+++ b/crates/connect-hosted-provider/tests/operation_dispatch.rs
@@ -179,6 +179,22 @@ async fn retired_application_credentials_replay_only_exact_terminal_mutations() 
     .execute(&fixture.pool)
     .await
     .unwrap();
+    let unrelated_invocation_id = Uuid::new_v4();
+    sqlx::query(
+        r#"INSERT INTO hosted_provider_base_query_invocations (
+             invocation_id, collection_id, replica_id, scope_epoch, base_plan,
+             base_context, base_operation_clock, hard_expires_at
+           )
+           SELECT $1, collection_id, id, scope_epoch, '{}'::jsonb,
+                  NULL, 'test', now() - interval '1 minute'
+           FROM hosted_provider_replicas
+           WHERE id = $2"#,
+    )
+    .bind(unrelated_invocation_id)
+    .bind(replica_id)
+    .execute(&fixture.pool)
+    .await
+    .unwrap();
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let state = AppState::new(fixture.provider.clone(), &"internal-test-token-".repeat(2)).unwrap();
@@ -206,6 +222,45 @@ async fn retired_application_credentials_replay_only_exact_terminal_mutations() 
         .await
         .unwrap();
     assert_eq!(cursor_release.status(), reqwest::StatusCode::OK);
+    let unrelated_invocation_remains: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM hosted_provider_base_query_invocations WHERE invocation_id = $1)",
+    )
+    .bind(unrelated_invocation_id)
+    .fetch_one(&fixture.pool)
+    .await
+    .unwrap();
+    assert!(
+        unrelated_invocation_remains,
+        "cursor cleanup does not perform opportunistic maintenance"
+    );
+    let conflicting_body = serde_json::to_vec(&json!({
+        "protocol_version": 3,
+        "request_id": Uuid::now_v7(),
+        "input": {
+            "release_cursor": format!("hq1.{}", URL_SAFE_NO_PAD.encode(Uuid::new_v4().as_bytes())),
+            "cursor": "conflicting"
+        }
+    }))
+    .unwrap();
+    let conflicting_release = reqwest::Client::new()
+        .post(format!("http://{address}{query_target}"))
+        .headers(signed_application_headers(
+            &signing_key,
+            &token,
+            "POST",
+            &query_target,
+            &conflicting_body,
+        ))
+        .header("content-type", "application/json")
+        .body(conflicting_body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        conflicting_release.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "conflicting cursor inputs cannot bypass suspended admission"
+    );
     let cursor_nonce_count: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM hosted_provider_request_proofs WHERE replica_id = $1",
     )


### PR DESCRIPTION
## Summary
- validate query/execute_view release cursors before bypassing suspended read admission
- authorize valid cursor cleanup without consuming request-proof nonces
- suppress protocol-observation writes so the only suspended-path mutation is query-runtime cursor deletion
- cover the signed HTTP path while admission is suspended

## Validation
- `pnpm check:architecture`
- `cargo fmt --all -- --check`
- `cargo clippy -p mdbase-connect-hosted-provider --all-targets -- -D warnings`
- `cargo test -p mdbase-connect-hosted-provider --lib` (131 passed, 3 ignored)
- ignored PostgreSQL integration: `retired_application_credentials_replay_only_exact_terminal_mutations`
- `git diff --check`