### PR TITLE
Initialize Editor deploy module before CLI dispatch

### DIFF
--- a/scripts/deploy-editor-dev.mjs
+++ b/scripts/deploy-editor-dev.mjs
@@ -59,10 +59,6 @@ export const developmentDeployment = developmentDeployments.lab;
 const repoRoot = resolve(import.meta.dirname, "..");
 assertDeploymentIsolation();
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  await deployDevelopmentEditor(process.env);
-}
-
 export async function deployDevelopmentEditor(
   environment,
   run = runCommand,
@@ -950,4 +946,8 @@ async function spawnCommand(command, args, { cwd, env, capture }) {
   });
   if (exitCode !== 0) throw new Error(`${command} ${args.join(" ")} exited with code ${exitCode}.`);
   return capture ? Buffer.concat(stdout).toString("utf8") : undefined;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await deployDevelopmentEditor(process.env);
 }

--- a/scripts/deploy-editor-dev.test.mjs
+++ b/scripts/deploy-editor-dev.test.mjs
@@ -94,6 +94,15 @@ function successfulGitCapture(command, args) {
   throw new Error(`Unexpected git command ${args.join(" ")}`);
 }
 
+test("CLI dispatch runs only after report filesystem initialization", async () => {
+  const source = await readFile(resolve(root, "scripts/deploy-editor-dev.mjs"), "utf8");
+  const initialization = source.indexOf("const reportFileSystem =");
+  const dispatch = source.indexOf("if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1])");
+  assert.ok(initialization >= 0);
+  assert.ok(dispatch > initialization);
+  assert.equal(source.indexOf("if (process.argv[1]", dispatch + 1), -1);
+});
+
 test("pinned Wrangler CLI exposes the expected Pages contract and no JSON flag", () => {
   const version = spawnSync("pnpm", ["exec", "wrangler", "--version"], { cwd: root, encoding: "utf8" });
   assert.equal(version.status, 0, version.stderr);


### PR DESCRIPTION
## Summary

- move the direct Editor deployment entrypoint after module initialization
- prevent Node 24 from calling `reservePrivateJsonReport` while `reportFileSystem` is still in its temporal dead zone
- add a regression asserting CLI dispatch follows report-filesystem initialization

## Release impact

The signed LAB beta.94 services successfully activated migration 38 and projection format 6, but exact Editor qualification stopped before Cloudflare mutation with `Cannot access 'reportFileSystem' before initialization`. Candidate services remain live and no predecessor rollback is permitted after activation. This fix allows a freshly signed candidate to complete the ordinary exact LAB qualification path.

## Validation

- Node 24.19.0
- `pnpm test` (all passing)
- `pnpm typecheck`
- focused Editor deployment tests: 21/21
- `git diff --check`
- independent focused review: no findings
