### PR TITLE
Publish signed bundles for Editor release changes

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -95,6 +95,7 @@ jobs:
           parent=$(git rev-parse "$SOURCE_COMMIT^")
           if git diff --quiet "$parent" "$SOURCE_COMMIT" -- \
             Cargo.toml \
+            apps/editor \
             apps/portal \
             config \
             crates \
@@ -112,7 +113,8 @@ jobs:
             pnpm-lock.yaml \
             pnpm-workspace.yaml \
             services/mcp \
-            services/server
+            services/server \
+            scripts/deploy-editor-dev.mjs
           then
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/deploy-editor-dev.mjs
+++ b/scripts/deploy-editor-dev.mjs
@@ -948,6 +948,7 @@ async function spawnCommand(command, args, { cwd, env, capture }) {
   return capture ? Buffer.concat(stdout).toString("utf8") : undefined;
 }
 
+// Keep direct dispatch after every module-scoped runtime dependency is initialized.
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   await deployDevelopmentEditor(process.env);
 }

--- a/scripts/deploy-editor-dev.test.mjs
+++ b/scripts/deploy-editor-dev.test.mjs
@@ -103,6 +103,12 @@ test("CLI dispatch runs only after report filesystem initialization", async () =
   assert.equal(source.indexOf("if (process.argv[1]", dispatch + 1), -1);
 });
 
+test("Editor release source changes trigger signed image-bundle publication", async () => {
+  const workflow = await readFile(resolve(root, ".github/workflows/publish-images.yml"), "utf8");
+  assert.match(workflow, /Cargo\.toml \\\n\s+apps\/editor \\\n\s+apps\/portal/u);
+  assert.match(workflow, /services\/server \\\n\s+scripts\/deploy-editor-dev\.mjs/u);
+});
+
 test("pinned Wrangler CLI exposes the expected Pages contract and no JSON flag", () => {
   const version = spawnSync("pnpm", ["exec", "wrangler", "--version"], { cwd: root, encoding: "utf8" });
   assert.equal(version.status, 0, version.stderr);


### PR DESCRIPTION
## Summary

- treat `apps/editor` and the exact Editor deployment script as release-managed inputs
- rebuild and attest the four immutable product images when those inputs change so an exact-commit signed release bundle is produced
- lock both pathspecs with a regression test

## Why

Product commit `e1f1321a...` fixed the exact Editor CLI but its automatic publication run skipped all publish jobs because the change detector omitted Editor release inputs. Private beta.94 preparation correctly refused that commit because it had no signed bundle artifact. Exact source identity requires a fresh signed bundle; reusing the prior candidate bundle is forbidden.

## Validation

- Node 24.19.0
- focused Editor deployment tests: 22/22
- workflow pathspec regression
- `git diff --check`
- independent review finding fixed (`apps/editor` added alongside the deployment script)
