### PR TITLE
Wait for Editor command output to drain

### DIFF
--- a/scripts/deploy-editor-dev.mjs
+++ b/scripts/deploy-editor-dev.mjs
@@ -334,7 +334,7 @@ async function deployStagingEditor(environment, deployment, run, root) {
   console.log(`STAGING editor deployed: ${deployment.editorOrigin}/`);
 }
 
-export async function qualifyExactLabRelease(environment, capture, root = repoRoot) {
+export async function qualifyExactLabRelease(environment, capture = captureCommand, root = repoRoot) {
   const expected = environment.MDBASE_LAB_EXPECTED_COMMIT?.trim() ?? "";
   if (!/^[0-9a-f]{40}$/u.test(expected)) {
     throw new Error("MDBASE_LAB_EXPECTED_COMMIT must be a full lowercase 40-hex commit.");
@@ -939,7 +939,7 @@ async function spawnCommand(command, args, { cwd, env, capture }) {
   }
   const exitCode = await new Promise((resolveExit, rejectExit) => {
     child.once("error", rejectExit);
-    child.once("exit", (code, signal) => {
+    child.once("close", (code, signal) => {
       if (signal) rejectExit(new Error(`${command} was stopped by ${signal}.`));
       else resolveExit(code);
     });

--- a/scripts/deploy-editor-dev.test.mjs
+++ b/scripts/deploy-editor-dev.test.mjs
@@ -255,6 +255,34 @@ test("source qualification rejects dirty, wrong HEAD, wrong origin, and invalid 
   }
 });
 
+test("source qualification waits for command output streams to close", async () => {
+  const sourceRoot = await mkdtemp(resolve(tmpdir(), "mdbase-delayed-git-root-"));
+  const commandDirectory = await mkdtemp(resolve(tmpdir(), "mdbase-delayed-git-bin-"));
+  const reportDirectory = await mkdtemp(resolve(tmpdir(), "mdbase-delayed-git-report-"));
+  const reportPath = resolve(reportDirectory, "report.json");
+  const git = resolve(commandDirectory, "git");
+  await writeFile(git, `#!/bin/sh
+case "$1" in
+  rev-parse) printf '%s\\n' '${commit}' ;;
+  status) exit 0 ;;
+  remote) (sleep 0.1; printf '%s\\n' 'https://github.com/mdbase-dev/mdbase-connect.git') & ;;
+  *) exit 1 ;;
+esac
+`, { mode: 0o700 });
+
+  const qualification = await qualifyExactLabRelease({
+    ...labEnvironment,
+    PATH: `${commandDirectory}:${process.env.PATH}`,
+    MDBASE_LAB_DEPLOYMENT_REPORT: reportPath
+  }, undefined, sourceRoot);
+  assert.deepEqual(qualification, {
+    commit,
+    clean: true,
+    repository: "mdbase-dev/mdbase-connect",
+    reportPath
+  });
+});
+
 test("report reservation keeps the final path absent and rejects existing evidence or sidecar replacement", async () => {
   const directory = await mkdtemp(resolve(tmpdir(), "mdbase-report-"));
   const path = resolve(directory, "report.json");


### PR DESCRIPTION
## Summary
- wait for child-process `close` before consuming captured command output
- make exact LAB qualification directly exercise its production capture path
- add a deterministic delayed-pipe regression for the false origin rejection

## Incident
The exact Git origin command exited successfully, but a descendant-held stdout pipe had not closed. Resolving on `exit` intermittently returned an empty string and falsely rejected the canonical origin before Wrangler submission. Both observed LAB failures occurred before Cloudflare mutation.

## Validation
- Node 24.19.0: `node --test scripts/deploy-editor-dev.test.mjs` (23/23)
- Node syntax checks
- `git diff --check`
- independent adversarial review: no actionable findings