### PR TITLE
Qualify canonical Editor cache policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ authorization and strengthens release compatibility gates.
   format or semantic-engine transitions.
 - A live projection-cutover lease admits semantic queries while canonical,
   synchronization, file, import, and provider-control writes remain fenced.
+- Exact Editor qualification preserves immediate revalidation on immutable
+  Pages assets while separately verifying the canonical domain's bounded,
+  managed four-hour edge cache policy.
 
 ## 0.1.0-beta.93
 

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -85,9 +85,14 @@ allowlisted `candidate-b` production branch and canonical custom origin
 origins are static and disjoint from staging and production; the deploy command
 has no target override. Operations must independently record and validate the
 Pages project, `candidate-b` production branch, canonical domain, and managed
-Cloudflare account before each qualified release. If Cloudflare configuration
-no longer matches this repository contract, an operator must correct and
-document that prerequisite before using the command. Do not guess a replacement
+Cloudflare account before each qualified release. The immutable Pages origin
+must serve the repository's asset cache policy exactly. The canonical custom
+domain has a separately managed, exact edge transformation to `Cache-Control:
+public, max-age=14400, must-revalidate` for `/assets/*`; the manifest remains
+`no-store` and all security headers remain exact on both origins. Any other
+canonical cache policy fails qualification. If Cloudflare configuration no
+longer matches this repository contract, an operator must correct and document
+that prerequisite before using the command. Do not guess a replacement
 branch or attach the LAB domain from this script.
 
 A LAB upload is an explicit exact-commit release, not a working-tree preview.
@@ -124,8 +129,11 @@ After upload, the command compares deployable files served by both the immutable
 deployment origin and canonical LAB origin byte-for-byte with local `dist`.
 Cloudflare's supported root routing is explicit: local `index.html` is fetched
 at `/`, while other implicit HTML routes are rejected. Pages `_headers` and
-`_redirects` control files are validated locally rather than fetched, and
-resulting security and cache headers are checked remotely. The manifest
+`_redirects` control files are validated locally rather than fetched. Security
+headers and the manifest cache policy are checked exactly on both origins. The
+immutable origin's asset cache header must match `_headers`; the canonical
+origin must match the separately managed exact four-hour edge policy documented
+above. The manifest
 homepage, redirects, Connect origin, and full build revision must all match. In
 the report contract, `verification.assertions.build_revision` is the boolean
 qualification result; the exact commit remains in `source.commit` and

--- a/scripts/deploy-editor-dev.mjs
+++ b/scripts/deploy-editor-dev.mjs
@@ -482,6 +482,17 @@ export async function verifyExactDeployment({
   cacheKey = () => randomUUID(),
   delay = (milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
 }) {
+  const normalizedCanonicalOrigin = exactHttpsOrigin(canonicalOrigin, "canonical origin");
+  if (!Array.isArray(origins) || origins.length !== 2) {
+    throw new Error("Exact deployment verification requires immutable and canonical origins.");
+  }
+  const normalizedOrigins = origins.map((origin, index) => exactHttpsOrigin(origin, index === 0 ? "immutable origin" : "canonical origin"));
+  if (normalizedOrigins[0] === normalizedOrigins[1]
+    || normalizedOrigins[1] !== normalizedCanonicalOrigin
+    || normalizedOrigins[0] === normalizedCanonicalOrigin) {
+    throw new Error("Exact deployment verification origins are not in distinct immutable and canonical roles.");
+  }
+
   const { files, controls } = await deploymentFiles(directory);
   if (files.length === 0) throw new Error(`No deployment files found in ${directory}.`);
   const manifestEntry = files.find(({ path }) => path === ".well-known/mdbase-app.json");
@@ -510,7 +521,7 @@ export async function verifyExactDeployment({
             if (finalUrl.origin !== origin || finalUrl.pathname !== remotePath) {
               throw new Error(`${file.path} escaped the expected deployment origin or path.`);
             }
-            assertRemoteHeaders(response.headers, file.path, headerPolicy);
+            assertRemoteHeaders(response.headers, file.path, headerPolicy, origin === canonicalOrigin);
             return Buffer.from(await response.arrayBuffer());
           });
           if (!actual.equals(file.content)) throw new Error(`${file.path} at ${origin} does not match local deployment content.`);
@@ -621,15 +632,33 @@ function parseHeadersFile(source) {
   return sections;
 }
 
-function assertRemoteHeaders(headers, path, policy) {
+function exactHttpsOrigin(value, label) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Exact deployment ${label} is invalid.`);
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.origin !== value || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`Exact deployment ${label} must be a normalized HTTPS origin.`);
+  }
+  return url.origin;
+}
+
+function assertRemoteHeaders(headers, path, policy, canonical) {
   for (const [name, expected] of policy.global) {
     if (headers.get(name) !== expected) throw new Error(`${path} is missing expected ${name}.`);
   }
   if (path === ".well-known/mdbase-app.json" && headers.get("cache-control") !== policy.manifest.get("cache-control")) {
     throw new Error("Remote manifest cache policy does not match _headers.");
   }
-  if (path.startsWith("assets/") && headers.get("cache-control") !== policy.assets.get("cache-control")) {
-    throw new Error("Remote asset cache policy does not match _headers.");
+  if (path.startsWith("assets/")) {
+    const expected = canonical
+      ? "public, max-age=14400, must-revalidate"
+      : policy.assets.get("cache-control");
+    if (headers.get("cache-control") !== expected) {
+      throw new Error(`Remote ${canonical ? "canonical" : "immutable"} asset cache policy is not exact.`);
+    }
   }
 }
 

--- a/scripts/deploy-editor-dev.test.mjs
+++ b/scripts/deploy-editor-dev.test.mjs
@@ -567,6 +567,38 @@ test("exact verifier checks immutable and canonical bytes, revision, headers, an
   assert.deepEqual(result.control_files.map(({ path }) => path), ["_headers", "_redirects"]);
 });
 
+test("exact verifier rejects missing, duplicated, omitted, reordered, or non-normalized origin roles", async () => {
+  const fixture = await deploymentFixture();
+  for (const origins of [
+    [],
+    [deploymentUrl],
+    [deploymentUrl, deploymentUrl],
+    [deploymentUrl, "https://other.example"],
+    ["https://editor-lab.mdbase.dev", deploymentUrl],
+    [deploymentUrl, "https://editor-lab.mdbase.dev/"]
+  ]) {
+    await assert.rejects(verifyExactDeployment({
+      ...fixture.options,
+      origins,
+      fetchImplementation: fixture.fetch([])
+    }), /origins|origin must be a normalized HTTPS origin/u);
+  }
+});
+
+test("exact verifier requires distinct exact immutable and canonical asset cache policies", async () => {
+  for (const options of [
+    { immutableAssetCacheControl: "public, max-age=14400, must-revalidate" },
+    { canonicalAssetCacheControl: "public, max-age=0, must-revalidate" },
+    { canonicalAssetCacheControl: "public, max-age=14400" }
+  ]) {
+    const fixture = await deploymentFixture(options);
+    await assert.rejects(verifyExactDeployment({
+      ...fixture.options,
+      fetchImplementation: fixture.fetch([])
+    }), /asset cache policy is not exact/u);
+  }
+});
+
 test("exact verifier rejects unconfigured implicit HTML routes", async () => {
   const fixture = await deploymentFixture();
   await writeFile(resolve(fixture.options.directory, "about.html"), "<!doctype html>\n");
@@ -705,7 +737,14 @@ function reportIo(directory, beforeLink = async () => undefined) {
   return { io, directorySyncs: () => syncCount, syncEvents: () => syncEvents };
 }
 
-async function deploymentFixture({ immutableStalePath = null, canonicalStaleAttempts = 0, redirectEscape = false, missingHeader = null } = {}) {
+async function deploymentFixture({
+  immutableStalePath = null,
+  canonicalStaleAttempts = 0,
+  redirectEscape = false,
+  missingHeader = null,
+  immutableAssetCacheControl = "public, max-age=0, must-revalidate",
+  canonicalAssetCacheControl = "public, max-age=14400, must-revalidate"
+} = {}) {
   const directory = await mkdtemp(resolve(tmpdir(), "mdbase-editor-dist-"));
   const canonicalOrigin = "https://editor-lab.mdbase.dev";
   const connectOrigin = "https://connect-lab.mdbase.dev";
@@ -759,7 +798,11 @@ async function deploymentFixture({ immutableStalePath = null, canonicalStaleAtte
         "content-security-policy": csp
       };
       if (path === ".well-known/mdbase-app.json") globalHeaders["cache-control"] = "no-store";
-      if (path.startsWith("assets/")) globalHeaders["cache-control"] = "public, max-age=0, must-revalidate";
+      if (path.startsWith("assets/")) {
+        globalHeaders["cache-control"] = url.origin === canonicalOrigin
+          ? canonicalAssetCacheControl
+          : immutableAssetCacheControl;
+      }
       if (missingHeader) delete globalHeaders[missingHeader];
       let body = content;
       if (url.origin === deploymentUrl && immutableStalePath === path) body = Buffer.concat([body, Buffer.from("stale")]);


### PR DESCRIPTION
LAB proved that Cloudflare preserves the repository asset revalidation policy on the immutable Pages origin while the canonical custom domain applies its managed exact four-hour edge policy.

This keeps immutable assets at `max-age=0`, verifies the canonical policy exactly as `max-age=14400`, and preserves exact security headers, manifest `no-store`, and byte/revision checks on both origins. It also makes origin roles fail closed.

Validation:
- Node 24 deployment suite: 25/25
- Node 24 package + Editor build
- CSP validation
- syntax and `git diff --check`
- independent adversarial review, with its origin-role finding resolved