### PR TITLE
Prepare beta.95 compatibility prelude release identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/connect-agent/src/admission.rs
+++ b/crates/connect-agent/src/admission.rs
@@ -167,13 +167,23 @@ impl Drop for QueueTicket {
     }
 }
 
+#[cfg(test)]
+#[path = "admission/tests/diagnostics.rs"]
+mod diagnostics;
+#[cfg(test)]
+use diagnostics::AdmissionTrace;
+
 #[derive(Debug)]
 pub(crate) struct AdmissionPermit {
+    #[cfg(test)]
+    trace_id: u64,
     _permits: Vec<OwnedSemaphorePermit>,
     pub queue_wait_us: u64,
 }
 
 pub(crate) struct AdmissionScheduler {
+    #[cfg(test)]
+    trace: Arc<AdmissionTrace>,
     limits: AdmissionLimits,
     operations: Arc<Semaphore>,
     reads: Arc<Semaphore>,
@@ -201,6 +211,8 @@ impl AdmissionScheduler {
         debug_assert!(limits.reads_per_grant < limits.operations_per_grant);
         debug_assert!(limits.background_per_grant < limits.reads_per_grant);
         Self {
+            #[cfg(test)]
+            trace: Arc::new(AdmissionTrace::default()),
             limits,
             operations: Arc::new(Semaphore::new(limits.operations)),
             reads: Arc::new(Semaphore::new(limits.reads)),
@@ -230,6 +242,13 @@ impl AdmissionScheduler {
         deadline: TokioInstant,
     ) -> Result<AdmissionPermit, AdmissionError> {
         let started = Instant::now();
+        #[cfg(test)]
+        let trace_id = self
+            .trace
+            .next
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        #[cfg(test)]
+        self.trace.record(trace_id, request.class, "requested");
         let ticket = QueueTicket::new(
             self.queue_counts.clone(),
             self.limits,
@@ -271,7 +290,25 @@ impl AdmissionScheduler {
                     acquire_before(self.operation_grant_semaphore(request.grant_id), deadline)
                         .await?,
                 );
-                permits.push(acquire_before(self.reads.clone(), deadline).await?);
+                let read = acquire_before(self.reads.clone(), deadline);
+                #[cfg(test)]
+                let read = {
+                    use std::future::Future;
+                    let mut read = std::pin::pin!(read);
+                    let mut observed = false;
+                    std::future::poll_fn(|cx| {
+                        let result = read.as_mut().poll(cx);
+                        if result.is_pending() && !observed {
+                            observed = true;
+                            self.trace.record(trace_id, request.class, "read_pending");
+                        }
+                        result
+                    })
+                    .await
+                };
+                #[cfg(not(test))]
+                let read = read.await;
+                permits.push(read?);
                 permits.push(acquire_before(self.operations.clone(), deadline).await?);
             }
             WorkClass::Background => {
@@ -292,7 +329,11 @@ impl AdmissionScheduler {
             }
         }
         drop(ticket);
+        #[cfg(test)]
+        self.trace.record(trace_id, request.class, "admitted");
         Ok(AdmissionPermit {
+            #[cfg(test)]
+            trace_id,
             _permits: permits,
             queue_wait_us: started.elapsed().as_micros().min(u128::from(u64::MAX)) as u64,
         })

--- a/crates/connect-agent/src/admission/tests/diagnostics.rs
+++ b/crates/connect-agent/src/admission/tests/diagnostics.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+/// Instance-local, bounded diagnostics: no payloads, paths, or authority identifiers.
+#[derive(Debug)]
+pub(crate) struct AdmissionTrace {
+    started: Instant,
+    pub(super) next: std::sync::atomic::AtomicU64,
+    events: Mutex<std::collections::VecDeque<(u128, u64, WorkClass, &'static str)>>,
+    changed: tokio::sync::Notify,
+}
+
+impl Default for AdmissionTrace {
+    fn default() -> Self {
+        Self {
+            started: Instant::now(),
+            next: std::sync::atomic::AtomicU64::new(0),
+            events: Mutex::new(std::collections::VecDeque::new()),
+            changed: tokio::sync::Notify::new(),
+        }
+    }
+}
+
+impl AdmissionTrace {
+    pub fn record(&self, id: u64, class: WorkClass, stage: &'static str) {
+        let mut events = self.events.lock().unwrap();
+        if events.len() == 128 {
+            events.pop_front();
+        }
+        events.push_back((self.started.elapsed().as_micros(), id, class, stage));
+        drop(events);
+        self.changed.notify_one();
+    }
+
+    pub fn snapshot(&self) -> Vec<(u128, u64, WorkClass, &'static str)> {
+        self.events.lock().unwrap().iter().copied().collect()
+    }
+
+    pub async fn wait_for_pending_reads(&self, count: usize) {
+        loop {
+            let changed = self.changed.notified();
+            if self
+                .snapshot()
+                .iter()
+                .filter(|event| event.3 == "read_pending")
+                .count()
+                >= count
+            {
+                return;
+            }
+            changed.await;
+        }
+    }
+}
+
+impl AdmissionScheduler {
+    pub(crate) fn trace(&self) -> &Arc<AdmissionTrace> {
+        &self.trace
+    }
+}
+
+impl AdmissionPermit {
+    pub(crate) fn trace_id(&self) -> u64 {
+        self.trace_id
+    }
+}

--- a/crates/connect-agent/src/server/control.rs
+++ b/crates/connect-agent/src/server/control.rs
@@ -413,7 +413,23 @@ impl AgentState {
         let state = Arc::clone(self);
         let execution = operation_executor::spawn_blocking(class, move || {
             let _permit = permit;
-            state.execute_local_operation(collection_id, &operation, &input, &worker_cancellation)
+            #[cfg(test)]
+            let mutation_trace = (class == WorkClass::Mutation).then_some(_permit.trace_id());
+            #[cfg(test)]
+            if let Some(id) = mutation_trace {
+                state
+                    .admission()
+                    .trace()
+                    .record(id, class, "worker_entered");
+            }
+            state.execute_local_operation(
+                collection_id,
+                &operation,
+                &input,
+                &worker_cancellation,
+                #[cfg(test)]
+                mutation_trace,
+            )
         });
         if class == WorkClass::Mutation {
             return execution.await.map_err(local_operation_task_error)?;

--- a/crates/connect-agent/src/server/scoped_operations.rs
+++ b/crates/connect-agent/src/server/scoped_operations.rs
@@ -7,7 +7,16 @@ impl AgentState {
         operation: &str,
         input: &serde_json::Value,
         cancellation: &mdbase::OperationCancellation,
+        #[cfg(test)] mutation_trace: Option<u64>,
     ) -> Result<serde_json::Value, ConnectError> {
+        #[cfg(test)]
+        let record = |stage| {
+            if let Some(id) = mutation_trace {
+                self.admission()
+                    .trace()
+                    .record(id, crate::admission::WorkClass::Mutation, stage);
+            }
+        };
         let started = Instant::now();
         let synchronize_us = std::cell::Cell::new(0_u64);
         let result = self.registry.operation_synchronized_cancellable(
@@ -17,11 +26,17 @@ impl AgentState {
             cancellation,
             || {
                 let synchronize_started = Instant::now();
+                #[cfg(test)]
+                record("execution_complete");
                 let finalized = self.watcher.finalize(collection_id);
+                #[cfg(test)]
+                record("finalization_complete");
                 synchronize_us.set(elapsed_us(synchronize_started));
                 finalized
             },
         );
+        #[cfg(test)]
+        record("worker_complete");
         profile_operation("control", operation, started, synchronize_us.get(), &result);
         result
     }

--- a/crates/connect-agent/src/server/tests.rs
+++ b/crates/connect-agent/src/server/tests.rs
@@ -392,13 +392,16 @@ async fn bounds_local_control_request_memory() {
 async fn local_collection_operations_share_admission_without_blocking_control() {
     use crate::admission::{AdmissionRequest, WorkClass};
 
-    let test_root = std::env::temp_dir().join(format!(
-        "mdbase-connect-local-admission-test-{}",
-        uuid::Uuid::new_v4()
-    ));
-    let registry = CollectionRegistry::open(test_root.join("state")).unwrap();
+    use futures_util::FutureExt;
+
+    let fixture = tempfile::tempdir().unwrap();
+    let registry = CollectionRegistry::open(fixture.path().join("state")).unwrap();
     let collection = registry
-        .create(test_root.join("collection"), Some("Local admission"), "UTC")
+        .create(
+            fixture.path().join("collection"),
+            Some("Local admission"),
+            "UTC",
+        )
         .unwrap();
     let watcher = CollectionWatchService::start(registry.clone());
     let state = Arc::new(AgentState::new(registry, watcher, None));
@@ -419,60 +422,135 @@ async fn local_collection_operations_share_admission_without_blocking_control() 
         );
     }
 
-    let queued_state = state.clone();
-    let queued = tokio::spawn(async move {
-        queued_state
-            .execute(ControlRequest::new(ControlCommand::CollectionOperation(
-                mdbase_connect_protocol::CollectionOperationParams {
-                    collection_id: collection.id,
-                    operation: "query".to_string(),
-                    input: serde_json::json!({ "limit": 1 }),
-                },
-            )))
-            .await
-    });
-    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-    assert!(
-        !queued.is_finished(),
-        "a local read must wait behind the shared read limit"
-    );
-
-    let mutation = tokio::time::timeout(
-        std::time::Duration::from_secs(2),
-        state.execute(ControlRequest::new(ControlCommand::CollectionOperation(
-            mdbase_connect_protocol::CollectionOperationParams {
-                collection_id: collection.id,
-                operation: "create".to_string(),
-                input: serde_json::json!({
-                    "path": "mutation-capacity.md",
-                    "frontmatter": { "title": "Reserved mutation capacity" },
-                    "body": "The queued local read did not consume this slot."
-                }),
-            },
-        ))),
-    )
-    .await
-    .expect("queued local reads must leave the mutation lane available");
-    assert!(mutation.ok, "{:?}", mutation.error);
-    assert_eq!(mutation.result.unwrap()["valid"], true);
-
-    let ping = tokio::time::timeout(
-        std::time::Duration::from_millis(250),
-        state.execute(ControlRequest::new(ControlCommand::Ping)),
-    )
-    .await
-    .expect("queued collection work must not block local control");
-    assert!(ping.ok);
-
-    drop(held_reads.pop());
-    let response = tokio::time::timeout(std::time::Duration::from_secs(2), queued)
+    let trace = state.admission().trace().clone();
+    let mut queries = tokio::task::JoinSet::new();
+    for _ in 0..2 {
+        let state = state.clone();
+        queries.spawn(async move {
+            state
+                .execute(ControlRequest::new(ControlCommand::CollectionOperation(
+                    mdbase_connect_protocol::CollectionOperationParams {
+                        collection_id: collection.id,
+                        operation: "query".to_string(),
+                        input: serde_json::json!({ "limit": 1 }),
+                    },
+                )))
+                .await
+        });
+    }
+    let mut mutation_task = None;
+    // Capture assertion failures so workers and the finalizer stop before TempDir removal.
+    let outcome = std::panic::AssertUnwindSafe(async {
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            trace.wait_for_pending_reads(2),
+        )
         .await
-        .expect("the admitted local query must finish")
-        .unwrap();
-    assert!(response.ok, "{:?}", response.error);
+        .expect("both local reads must actually queue at shared read admission");
+        let pending = trace
+            .snapshot()
+            .into_iter()
+            .filter(|event| event.3 == "read_pending")
+            .map(|event| event.1)
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(pending.len(), 2);
+        assert!(
+            queries.try_join_next().is_none(),
+            "queued reads must not finish"
+        );
 
-    drop(held_reads);
-    fs::remove_dir_all(test_root).unwrap();
+        let mutation_state = state.clone();
+        mutation_task = Some(tokio::spawn(async move {
+            mutation_state
+                .execute(ControlRequest::new(ControlCommand::CollectionOperation(
+                    mdbase_connect_protocol::CollectionOperationParams {
+                        collection_id: collection.id,
+                        operation: "create".to_string(),
+                        input: serde_json::json!({
+                            "path": "mutation-capacity.md",
+                            "frontmatter": { "title": "Reserved mutation capacity" },
+                            "body": "The queued local reads did not consume this slot."
+                        }),
+                    },
+                )))
+                .await
+        }));
+        let (mutation, ping) = tokio::join!(
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                mutation_task.as_mut().unwrap()
+            ),
+            tokio::time::timeout(
+                std::time::Duration::from_millis(250),
+                state.execute(ControlRequest::new(ControlCommand::Ping))
+            ),
+        );
+        let mutation = mutation.expect("queued local reads must leave the mutation lane available");
+        mutation_task = None;
+        let mutation = mutation.expect("mutation worker must not panic");
+        assert!(mutation.ok, "mutation must succeed");
+        assert!(
+            mutation.result.unwrap()["valid"] == true,
+            "mutation must be valid"
+        );
+        assert!(
+            ping.expect("queued collection work must not block local control")
+                .ok
+        );
+        let events = trace.snapshot();
+        let admitted = events
+            .iter()
+            .find(|event| event.2 == WorkClass::Mutation && event.3 == "admitted")
+            .expect("mutation must be admitted")
+            .1;
+        for stage in [
+            "worker_entered",
+            "execution_complete",
+            "finalization_complete",
+            "worker_complete",
+        ] {
+            assert!(
+                events
+                    .iter()
+                    .any(|event| event.1 == admitted && event.3 == stage),
+                "missing {stage}"
+            );
+        }
+        assert!(!events
+            .iter()
+            .any(|event| pending.contains(&event.1) && event.3 == "admitted"));
+        // Never release read capacity until the real mutation has succeeded.
+        held_reads.clear();
+        for _ in 0..2 {
+            let response =
+                tokio::time::timeout(std::time::Duration::from_secs(2), queries.join_next())
+                    .await
+                    .expect("the admitted local query must finish")
+                    .unwrap()
+                    .unwrap();
+            assert!(response.ok, "query must succeed");
+            let result = response.result.unwrap();
+            assert!(
+                result["result"]["results"][0]["path"] == "mutation-capacity.md",
+                "each query must see the successfully created record"
+            );
+        }
+    })
+    .catch_unwind()
+    .await;
+    let timeline = trace.snapshot();
+    held_reads.clear();
+    // Drain rather than abort: a read's blocking worker may still own the state.
+    while queries.join_next().await.is_some() {}
+    if let Some(task) = mutation_task {
+        let _ = task.await;
+    }
+    drop(state); // Joins the finalizer before removing the fixture, including failure paths.
+    drop(fixture);
+    if let Err(panic) = outcome {
+        eprintln!("local admission timeline (microseconds, request, class, stage): {timeline:?}");
+        std::panic::resume_unwind(panic);
+    }
 }
 
 #[test]

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.94"
+version = "0.1.0-beta.95"
 dependencies = [
  "chrono",
  "mdbase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.94" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.95" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.94",
+  "version": "0.1.0-beta.95",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Scope

Prepare the compatibility prelude as **0.1.0-beta.95** on top of merged PR397 (`9ef85916e9cb973cee91c9dc7d255ff453e567f1`). That merge passed exact-main CI and signed publication, but retained the beta.94 version. The existing beta.94 tag remains immutable and unchanged.

The initial identity commit contains only release-version substitutions: 14 JS package manifests, Rust workspace and owned entries in both Cargo locks, and MCP's advertised version. Verified every changed file differs solely by `0.1.0-beta.94` → `0.1.0-beta.95`. No external dependency updates, runtime-policy changes, migration edits, or previous-release pin changes.

## Admission regression diagnostics

CI at `f4242c17` exposed an unreproduced two-second end-to-end mutation timeout in the existing daemon admission test. `a1487825` adds instance-local, bounded `cfg(test)` stage diagnostics and queues two real reads instead of inferring queuing from a 25ms sleep. Mutation/Ping/query deadlines remain 2s/250ms/2s, successful writes and query visibility remain required, and cleanup joins owned workers. No production admission order, limits, dependencies, or behavior changed.

An operations-before-reads mutant fails the mutation-availability assertion with both queued reads observed and no mutation admission. Restored order passed 20 repeats, three parallel daemon suites, locked workspace tests, strict Clippy, formatting and architecture checks. Parent reran the daemon suite and non-test library check successfully. The original CI timeout cause remains unproven; exact-head CI is required again.

## Checks

- Frozen pnpm install
- Exact `pnpm version:check v0.1.0-beta.95`
- Release component inventory and readiness checks
- Locked Cargo metadata
- Diff/version-only verification

Full CI required for this exact head and the resulting main commit before its normal signed image publication. No public tag will be created before signed staging acceptance/soak. LAB/staging preparation must use the new exact publication, not the prior beta.94-version bundle.

Fresh application issuance remains v1 only. Strict v2 readers/recovery remain. The schema38→41 deployment safety stop is still closed pending qualification; this PR does not waive or authorize that transition. User production intent is recorded, but no services have been deployed.

