### PR TITLE
Fix paginated read timeouts and support lightweight Pickle inboxes

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -731,6 +731,54 @@ describe("provider-neutral collection client", () => {
     });
   });
 
+  it("delivers completed query data without waiting for cursor cleanup", async () => {
+    vi.useFakeTimers();
+    const calls: Array<Record<string, unknown>> = [];
+    const client = new MdbaseCollectionClient({
+      async operation<Result>(_operation: string, input: unknown) {
+        const query = input as Record<string, unknown>;
+        calls.push(query);
+        if (query.release_cursor) {
+          await new Promise((resolve) => setTimeout(resolve, 2_000));
+          throw new Error("cleanup unavailable");
+        }
+        return {
+          valid: true, diagnostics: [], result: {
+            results: [{ path: query.cursor ? "two.md" : "one.md", frontmatter: {}, types: [] }],
+            meta: { total_count: 2, has_more: !query.cursor,
+              ...(!query.cursor ? { cursor: "next" } : {}) }
+          }
+        } as Result;
+      }
+    });
+    const pending = client.queryAll({}, { pageSize: 256, timeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(pending).resolves.toMatchObject({
+      ok: true, value: { results: [{ path: "one.md" }, { path: "two.md" }] }
+    });
+    expect(calls).toEqual([
+      { limit: 256, offset: 0, pagination: "cursor" },
+      { cursor: "next" },
+      { release_cursor: "next" }
+    ]);
+    await vi.advanceTimersByTimeAsync(2_000);
+  });
+
+  it("does not return a partial query when the caller cancels before the final page", async () => {
+    const controller = new AbortController();
+    const client = new MdbaseCollectionClient({
+      async operation<Result>() {
+        return { valid: true, diagnostics: [], result: {
+          results: [{ path: "one.md", frontmatter: {}, types: [] }],
+          meta: { has_more: true }
+        } } as Result;
+      }
+    });
+    await expect(client.queryAll({}, {
+      signal: controller.signal, onProgress: () => controller.abort()
+    })).resolves.toMatchObject({ ok: false, problem: { code: "operation_cancelled" } });
+  });
+
   it("uses one total queryAll deadline while queryPages keeps an explicit per-page budget", async () => {
     vi.useFakeTimers();
     const requestOptions: Array<{ signal?: AbortSignal; timeoutMs?: number | null }> = [];

--- a/packages/client/src/operation-types.ts
+++ b/packages/client/src/operation-types.ts
@@ -207,7 +207,9 @@ export interface QueryResult<Record extends JsonObject = JsonObject> {
 }
 
 export interface QueryPagesOptions<Record extends JsonObject = JsonObject> {
+  /** Initial page size. Cursor authorities pin this size for the query lifetime. */
   firstPageSize?: number;
+  /** Also sets the initial size unless firstPageSize is explicit; authorities may cap it. */
   pageSize?: number;
   signal?: AbortSignal;
   /** Independent budget for each page requested by this caller-driven iterator. */
@@ -218,7 +220,9 @@ export interface QueryPagesOptions<Record extends JsonObject = JsonObject> {
 
 export interface QueryAllOptions<Record extends JsonObject = JsonObject>
   extends ConnectRequestOptions {
+  /** Initial page size. Cursor authorities pin this size for the query lifetime. */
   firstPageSize?: number;
+  /** Also sets the initial size unless firstPageSize is explicit; authorities may cap it. */
   pageSize?: number;
   onProgress?: (page: QueryPage<Record>) => void;
 }

--- a/packages/client/src/query-pagination.ts
+++ b/packages/client/src/query-pagination.ts
@@ -34,7 +34,7 @@ export async function* coordinatedQueryPages<Frontmatter extends JsonObject>(
       ...criteria
     } = input;
     let offset = nonNegativeInteger(requestedOffset, 0);
-    const firstPageSize = positiveInteger(options.firstPageSize ?? requestedLimit, 200);
+    const firstPageSize = positiveInteger(options.firstPageSize ?? options.pageSize ?? requestedLimit, 200);
     const pageSize = positiveInteger(options.pageSize ?? requestedLimit, 1_000);
     let cursor = requestedCursor;
     let cursorMode = requestedCursor !== undefined;
@@ -57,7 +57,8 @@ export async function* coordinatedQueryPages<Frontmatter extends JsonObject>(
           && requestedSnapshot === undefined;
         let queried = await query({
           ...criteria,
-          limit: pageNumber === 0 ? firstPageSize : pageSize,
+          // Continuations use the page size pinned when the cursor was opened.
+          ...(!cursorMode ? { limit: pageNumber === 0 ? firstPageSize : pageSize } : {}),
           ...(cursorMode
             ? (pageCursor ? { cursor: pageCursor } : { pagination: "cursor" as const })
             : {
@@ -136,7 +137,9 @@ export async function* coordinatedQueryPages<Frontmatter extends JsonObject>(
       }
     } finally {
       if (cursorMode && cursorToRelease) {
-        await releaseQueryCursor(cursorToRelease);
+        // Cleanup has its own bounded request. It must not delay delivery of
+        // completed pages or consume the caller's data deadline.
+        void releaseQueryCursor(cursorToRelease).catch(() => undefined);
       }
     }
 

--- a/packages/pickle/README.md
+++ b/packages/pickle/README.md
@@ -13,3 +13,13 @@ await pickle.respond(requests[0], {
 
 The adapter uses ordinary mdbase operations. Request state is derived from
 linked response records, and no record payload is stored outside the collection.
+
+For an inbox, use `pickle.list({ includeBody: false })`. It still waits for all
+response links before deriving pending, answered, and conflict states, but does
+not transfer every request's Markdown context. Fetch an opened request's context
+with `await pickle.readBody(request, { signal, timeoutMs: 10_000 })`. Response
+bodies are never needed for lifecycle calculation and are omitted from queries.
+
+Pickle requests 256 records per page from the first query. Cursor authorities
+pin that initial size; continuation requests reuse the cursor rather than asking
+for an ineffective larger limit.

--- a/packages/pickle/src/index.test.ts
+++ b/packages/pickle/src/index.test.ts
@@ -195,6 +195,7 @@ describe("Pickle contract adapter", () => {
             created_at: "2026-07-24T01:00:00Z",
             attachment_paths: ["attachments/req-one/report.txt"]
           },
+          file: { mtime: "2026-09-07T00:00:00Z" },
           body: "Review the release notes before deciding."
         }
       ]
@@ -226,6 +227,7 @@ describe("Pickle contract adapter", () => {
 
     const answered = await pickle.list({ includeBody: false });
     expect(answered[0].body).toBe("");
+    expect(answered[0].modifiedAt).toBeDefined();
     expect(await pickle.readBody(answered[0])).toBe("Review the release notes before deciding.");
     expect(answered[0]).toEqual(
       expect.objectContaining({

--- a/packages/pickle/src/index.test.ts
+++ b/packages/pickle/src/index.test.ts
@@ -224,7 +224,9 @@ describe("Pickle contract adapter", () => {
       { responder: "callum" }
     );
 
-    const answered = await pickle.list();
+    const answered = await pickle.list({ includeBody: false });
+    expect(answered[0].body).toBe("");
+    expect(await pickle.readBody(answered[0])).toBe("Review the release notes before deciding.");
     expect(answered[0]).toEqual(
       expect.objectContaining({
         state: "answered",
@@ -235,6 +237,14 @@ describe("Pickle contract adapter", () => {
         })
       })
     );
+    const originalQuery = sandbox.client.queryAll.bind(sandbox.client);
+    vi.spyOn(sandbox.client, "queryAll").mockImplementation((input, options) => {
+      if (input?.types?.includes(approvalType.name)) {
+        return Promise.resolve(connectFailure(connectProblem("timeout", "Response query timed out.")));
+      }
+      return originalQuery(input, options);
+    });
+    await expect(pickle.list({ includeBody: false })).rejects.toThrow("Response query timed out.");
     expect(sandbox.transport.snapshot()).toContainEqual(
       expect.objectContaining({
         path: expect.stringMatching(/^responses\/.+\.md$/),
@@ -281,6 +291,17 @@ describe("Pickle contract adapter", () => {
       signal: controller.signal,
       timeoutMs: 4_000
     });
+    const read = vi.spyOn(sandbox.client, "read");
+    const [summary] = await pickle.list({ includeBody: false });
+    expect(summary.body).toBe("");
+    expect(queryAll).toHaveBeenCalledWith(
+      expect.objectContaining({ includeBody: false }),
+      expect.objectContaining({ pageSize: 256 })
+    );
+    await pickle.readBody(summary, { signal: controller.signal, timeoutMs: 4_000 });
+    expect(read).toHaveBeenCalledWith({ path: summary.path }, {
+      signal: controller.signal, timeoutMs: 4_000
+    });
     await pickle.respond(request, { decision: "approve" }, {
       responder: "callum",
       signal: controller.signal,
@@ -293,6 +314,7 @@ describe("Pickle contract adapter", () => {
     });
     expect(queryAll).toHaveBeenCalledWith(expect.any(Object), {
       signal: controller.signal,
+      pageSize: 256,
       timeoutMs: 4_000
     });
     expect(create).toHaveBeenCalledWith(

--- a/packages/pickle/src/index.ts
+++ b/packages/pickle/src/index.ts
@@ -131,11 +131,6 @@ export interface PickleRequest {
   frontmatter: PickleFrontmatter;
 }
 
-export interface PickleListOptions extends ConnectRequestOptions {
-  /** Omit Markdown bodies for an inbox; load individual context with readBody. */
-  includeBody?: boolean;
-}
-
 export interface RespondOptions extends ConnectRequestOptions {
   responder?: string;
 }
@@ -245,7 +240,8 @@ export class PickleCollection {
     return { collection: this.description, contract: this.contract };
   }
 
-  async list({ includeBody = true, ...options }: PickleListOptions = {}): Promise<PickleRequest[]> {
+  /** Omit Markdown bodies for an inbox; load individual context with readBody. */
+  async list({ includeBody = true, ...options }: ConnectRequestOptions & { includeBody?: boolean } = {}): Promise<PickleRequest[]> {
     const { collection, contract } = await this.describe(options);
     const requestQuery = requireOutcome(
       await this.connect.queryAll(

--- a/packages/pickle/src/index.ts
+++ b/packages/pickle/src/index.ts
@@ -129,6 +129,11 @@ export interface PickleRequest {
   frontmatter: PickleFrontmatter;
 }
 
+export interface PickleListOptions extends ConnectRequestOptions {
+  /** Omit Markdown bodies for an inbox; load individual context with readBody. */
+  includeBody?: boolean;
+}
+
 export interface RespondOptions extends ConnectRequestOptions {
   responder?: string;
 }
@@ -238,16 +243,16 @@ export class PickleCollection {
     return { collection: this.description, contract: this.contract };
   }
 
-  async list(options: ConnectRequestOptions = {}): Promise<PickleRequest[]> {
+  async list({ includeBody = true, ...options }: PickleListOptions = {}): Promise<PickleRequest[]> {
     const { collection, contract } = await this.describe(options);
     const requestQuery = requireOutcome(
       await this.connect.queryAll(
         {
           types: contract.implementations.map(({ typeName }) => typeName),
-          includeBody: true,
+          includeBody,
           frontmatterMode: "effective"
         },
-        options
+        { ...options, pageSize: 256 }
       )
     );
     const requests = requestQuery.results.map(requireEffectiveFrontmatter);
@@ -270,10 +275,10 @@ export class PickleCollection {
             await this.connect.queryAll(
               {
                 types: responseTypes,
-                includeBody: true,
+                includeBody: false,
                 frontmatterMode: "effective"
               },
-              options
+              { ...options, pageSize: 256 }
             )
           )
         ).results.map(requireEffectiveFrontmatter)
@@ -285,6 +290,11 @@ export class PickleCollection {
       .sort((left, right) =>
         (right.createdAt ?? "").localeCompare(left.createdAt ?? "")
       );
+  }
+
+  async readBody(request: PickleRequest, options: ConnectRequestOptions = {}): Promise<string> {
+    const record = requireOutcome(await this.connect.read({ path: request.path }, options));
+    return record.body ?? "";
   }
 
   async respond(

--- a/packages/pickle/src/index.ts
+++ b/packages/pickle/src/index.ts
@@ -120,6 +120,8 @@ export interface PickleRequest {
   responseType: string;
   responseTypeDefinition?: CollectionTypeDescriptor;
   createdAt?: string;
+  /** Stable file modification time for invalidating an opened context. */
+  modifiedAt?: string;
   dueAt?: string;
   tags: string[];
   links: PickleLink[];
@@ -292,7 +294,7 @@ export class PickleCollection {
       );
   }
 
-  async readBody(request: PickleRequest, options: ConnectRequestOptions = {}): Promise<string> {
+  async readBody(request: Pick<PickleRequest, "path">, options: ConnectRequestOptions = {}): Promise<string> {
     const record = requireOutcome(await this.connect.read({ path: request.path }, options));
     return record.body ?? "";
   }
@@ -468,6 +470,7 @@ function normalizeRequest(
       role(implementation, "message", "message")
     ),
     body: record.body ?? "",
+    modifiedAt: record.file?.mtime,
     kind:
       stringField(record.effectiveFrontmatter, role(implementation, "kind", "kind")) ||
       "approval",


### PR DESCRIPTION
Pickle Android could exhaust its query deadline while waiting for cursor cleanup, even after every data page had arrived. Return completed query data promptly and release cursors independently with the existing bounded cleanup request. Make an explicit page size apply to cursor opening and omit ineffective continuation limits.

Add body-free Pickle list reads and on-demand context reads, preserving complete response-link lifecycle calculation. Expose file modification time so consumers can retain unchanged context through inbox refreshes.

Validation: full TypeScript tests and typecheck, Rust workspace tests and formatting, and local Connect end-to-end suite passed. Added regression coverage for slow/failed cleanup, cancellation, summary lifecycle failures, and context reads. The subsequent modification-time addition passed the focused adapter suite and package build.

Pickle consumes an equivalent beta.94 backport on `fix/pickle-loading-beta94`, avoiding an unrelated capability-contract migration. Live LAB validation is unavailable because preflight reports an identity mismatch.
