### PR TITLE
Refine editor loading and quiet visual treatment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,32 @@
 # Repository guidance
 
+## Avoid additive complexity
+
+Rapid AI-assisted development can amplify ordinary engineering failure modes:
+locally safe additions accumulate faster than old mechanisms are removed;
+uncertainty becomes optional state, defensive branches, fallbacks, and
+compatibility; conformance work produces parallel adapters instead of one
+canonical implementation; and inexpensive code generation weakens the natural
+pressure to simplify.
+
+Target these mechanisms regardless of who wrote the code. Do not assume that
+defensive code, compatibility, abstraction, or product breadth is inherently
+wrong; evaluate each against concrete invariants, consumers, persisted
+representations, tests, and ownership boundaries.
+
+Before handing off a change, ask:
+
+- What existing mechanism does this replace and delete?
+- What evidence proves each new state or fallback is reachable?
+- Is expected invalid input distinguished from an internal invariant failure?
+- Does compatibility name its consumer and removal condition?
+- Does each new abstraction represent a real boundary or repeated concept?
+- Does the change expand public, persisted, configured, or user-facing state?
+- Has the change produced net simplification?
+
+Prefer strong invariants over defensive hedging, replacement over accumulation,
+explicit failure over silent recovery, and simplification over expansion.
+
 - Read `PRODUCT.md` for product intent and `DESIGN.md` for interface direction
   before changing user-facing flows.
 

--- a/apps/editor/DESIGN.md
+++ b/apps/editor/DESIGN.md
@@ -85,12 +85,14 @@ disclosure, and raw source remains inspector-only. When a type declares
 and is not repeated among the remaining properties. Without a declared display
 field, the prominent input names the Markdown document and similarly named
 schema properties remain separate. The initial create operation includes the
-drafted body and properties. While an existing note is fetched, a stable
-document skeleton preserves the pane geometry and avoids flashing the empty
-state. The collection opens into the same three-pane geometry: the first page
-becomes usable immediately while the remaining index continues in the note
-list. A newly created note is adopted from the create response, so the editor
-never waits for a collection-wide refresh or a redundant read.
+drafted body and properties. While an existing note is fetched, the stable
+document frame stays in place with concise loading text; it does not impersonate
+the note with placeholder content or shimmer. Before collection metadata is
+available, a centered status avoids previewing unstable sidebars. The first page
+then becomes usable in the three-pane workspace while the remaining index
+continues in the note list. A newly created note is adopted from the create
+response, so the editor never waits for a collection-wide refresh or a redundant
+read.
 
 Type editing uses the same quiet document grammar. Application compatibility
 appears as a disclosure within the type, not as a separate dashboard. Each

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -523,13 +523,15 @@ describe("mdbase editor", () => {
     expect(screen.queryByLabelText("Loading note")).not.toBeInTheDocument();
   }, 15_000);
 
-  it("shows the collection-shaped opening state while metadata is loading", async () => {
+  it("shows an explicit opening state without previewing unstable sidebars", async () => {
     const gateway = new SlowDescriptionGateway();
     render(<App gateway={gateway} />);
 
     const opening = await screen.findByLabelText("Opening collection");
     expect(opening).toHaveAttribute("aria-busy", "true");
+    expect(opening).toHaveAttribute("data-loading-state", "opening");
     expect(screen.getByText("Reading its notes and types")).toBeInTheDocument();
+    expect(opening.querySelector(".opening-rail, .opening-list")).toBeNull();
     gateway.releaseDescription();
     expect(await screen.findByRole("heading", { name: "Writing" })).toBeInTheDocument();
   });

--- a/apps/editor/src/Brand.test.tsx
+++ b/apps/editor/src/Brand.test.tsx
@@ -14,11 +14,12 @@ describe("mdbase motion mark", () => {
     expect(mark?.querySelector("clipPath rect")).toHaveAttribute("width", "76");
   });
 
-  it("unfolds the existing editor wordmark while opening a collection", () => {
+  it("uses a stable editor wordmark while opening a collection", () => {
     const { container } = render(<OpeningScreen />);
 
     expect(screen.getByLabelText("Opening collection")).toHaveAttribute("aria-busy", "true");
-    expect(container.querySelector(".wordmark .mdbase-motion-unfold")).toBeInTheDocument();
-    expect(container.querySelector(".opening-pulse")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Opening collection");
+    expect(container.querySelector(".wordmark .mdbase-motion-mark")).toBeInTheDocument();
+    expect(container.querySelector(".wordmark [class*='mdbase-motion-unfold']")).not.toBeInTheDocument();
   });
 });

--- a/apps/editor/src/ConnectApp.test.tsx
+++ b/apps/editor/src/ConnectApp.test.tsx
@@ -34,8 +34,8 @@ describe("ConnectApp", () => {
     const { container } = render(<ConnectApp />);
 
     expect(screen.getByText("Opening mdbase connect")).toBeInTheDocument();
-    expect(container.querySelector(".connect-loading .mdbase-motion-bootstrap")).toBeInTheDocument();
-    expect(container.querySelector(".mdbase-mark-conveyor-track")).toBeInTheDocument();
+    expect(container.querySelector(".connect-loading .mdbase-motion-mark")).toBeInTheDocument();
+    expect(container.querySelector(".connect-loading .mdbase-motion-bootstrap")).not.toBeInTheDocument();
   });
 
   it("opens account management without requesting a collection grant", async () => {

--- a/apps/editor/src/ConnectApp.tsx
+++ b/apps/editor/src/ConnectApp.tsx
@@ -617,7 +617,7 @@ function RouteLink({ view, collectionId, navigate, children, className = "", ari
 }
 
 function ConnectLoading({ error }: { error: string }) {
-  return <div className="connect-loading" aria-busy={!error}><MdbaseMark motion={error ? undefined : "bootstrap"} /><strong>{error ? "mdbase connect is unavailable" : "Opening mdbase connect"}</strong><p>{error || "Loading your account and collections…"}</p></div>;
+  return <div className="connect-loading" aria-busy={!error}><MdbaseMark /><strong>{error ? "mdbase connect is unavailable" : "Opening mdbase connect"}</strong><p>{error || "Loading your account and collections…"}</p></div>;
 }
 
 function DesktopRecoveryHelp({ action }: { action: string }) {

--- a/apps/editor/src/FileViewer.tsx
+++ b/apps/editor/src/FileViewer.tsx
@@ -27,7 +27,7 @@ export function FileWorkspace({ file, asset, leadingActions, onBack, onRetry }: 
       {asset.status === "ready" ? <FileContent asset={asset} />
         : asset.status === "error" || asset.status === "too_large"
           ? <div className="file-workspace-message"><File aria-hidden="true" /><strong>Couldn’t preview {filename}</strong><span>{asset.error}</span>{asset.status === "error" && <button onClick={onRetry}>Try again</button>}</div>
-          : <div className="file-workspace-message" role="status" aria-busy="true"><span className="file-loading-mark" aria-hidden="true" /><strong>Opening {filename}</strong></div>}
+          : <div className="file-workspace-message" role="status" aria-busy="true"><strong>Opening {filename}</strong><span>Reading file content…</span></div>}
     </div>
   </main>;
 }

--- a/apps/editor/src/LoadingScreens.tsx
+++ b/apps/editor/src/LoadingScreens.tsx
@@ -2,18 +2,19 @@ import { Wordmark } from "./Brand";
 
 export function TypeWorkspaceLoading() {
   return <>
-    <section className="type-list-pane type-workspace-loading" aria-label="Loading types"><div /><span /><span /><span /></section>
-    <main className="type-inspector type-workspace-loading" aria-label="Loading type definition"><div /><strong /><span /><span /></main>
+    <section className="type-list-pane type-workspace-loading" aria-label="Loading types" aria-busy="true">
+      <strong>Types</strong><p role="status">Preparing type list…</p>
+    </section>
+    <main className="type-inspector type-workspace-loading" aria-label="Loading type definition" aria-busy="true">
+      <p role="status">Preparing type workspace…</p>
+    </main>
   </>;
 }
 export function OpeningScreen() {
-  return <main className="opening-shell" aria-label="Opening collection" aria-busy="true">
-    <aside className="opening-rail"><Wordmark motion="unfold" /><div className="opening-rail-lines"><span /><span /><span /></div></aside>
-    <section className="opening-list" aria-hidden="true"><div className="opening-list-heading"><span /><small /></div><div className="opening-search" />{Array.from({ length: 7 }, (_, index) => <div className="opening-row" key={index}><span /><small /></div>)}</section>
-    <section className="opening-document">
-      <div className="opening-document-bar" aria-hidden="true"><span /></div>
-      <div className="opening-message"><div><p>Opening collection</p><small>Reading its notes and types</small></div></div>
-      <div className="opening-document-lines" aria-hidden="true"><strong /><span /><span /><span /></div>
-    </section>
+  return <main className="opening-shell" data-loading-state="opening" aria-label="Opening collection" aria-busy="true">
+    <div className="opening-message" role="status">
+      <Wordmark />
+      <div><p>Opening collection</p><small>Reading its notes and types</small></div>
+    </div>
   </main>;
 }

--- a/apps/editor/src/MarkdownNoteEditor.tsx
+++ b/apps/editor/src/MarkdownNoteEditor.tsx
@@ -46,7 +46,7 @@ export function MarkdownNoteEditor({ editorKey, draft, preferences, documentId, 
   return <article className="writing-surface" style={{ "--editor-font-size": `${preferences.fontSize}px` } as CSSProperties}>
     <label className="sr-only" htmlFor="note-title">Note title</label>
     <input id="note-title" className="title-input" value={draft.title} onChange={(event) => onTitleChange(event.target.value)} placeholder="Untitled" spellCheck="true" readOnly={readOnly} aria-readonly={readOnly} />
-    <Suspense fallback={<div className="body-editor code-editor-loading" role="status" aria-label="Loading note editor" aria-busy="true"><span /></div>}>
+    <Suspense fallback={<div className="body-editor code-editor-loading" role="status" aria-label="Loading note editor" aria-busy="true">Preparing editor…</div>}>
       <CodeEditor key={editorKey} value={draft.body} onChange={onBodyChange} label="Note body" language="markdown" readOnly={readOnly}
         variant="writer" placeholder="Start writing" vimEnabled={preferences.vim} lineWrapping={preferences.lineWrapping}
         quietMarkdown={preferences.quietMarkdown} autoFocus={autoFocus} className="body-editor" documentId={documentId}

--- a/apps/editor/src/NoteList.tsx
+++ b/apps/editor/src/NoteList.tsx
@@ -140,14 +140,11 @@ export function NoteList({ entries, noteCount, fileCount, types, selectedPath, s
           onPreview(note.path, { left, right, top, bottom }, "sidebar");
         };
         return <button key={note.path} id={`note-entry-${virtualRow.index}`} tabIndex={-1} role="option" aria-selected={note.path === selectedPath} aria-busy={status?.busy || undefined} aria-disabled={status?.disabled || undefined} aria-describedby={previewPath === note.path ? notePreviewPopoverId() : undefined} className={`note-row${note.path === selectedPath ? " selected" : ""}${status ? ` ${status.tone}` : ""}`} onMouseEnter={(event) => requestPreview(event.currentTarget)} onMouseLeave={onDismissPreview} onFocus={(event) => requestPreview(event.currentTarget)} onBlur={onDismissPreview} onClick={() => { onDismissPreview(); if (!status?.disabled) onSelect(note.path); }} style={{ transform: `translateY(${virtualRow.start}px)`, height: virtualRow.size }}><span className="note-title-line">{typeIcon && <PhosphorIcon name={typeIcon} aria-hidden="true" />}<span className="note-title"><SearchMatchText text={title} ranges={searchQuery ? searchTextRanges(title, searchQuery) : []} /></span></span>{status ? <span className="note-transition">{status.label}</span> : searchContext ? <span className={`note-detail note-search-context ${searchContext.kind}`}><SearchMatchText text={searchContext.text} ranges={searchContext.ranges} /></span> : <span className="note-detail"><time>{noteTimestamp(note)}</time>{notePreview(note, types)}</span>}</button>;
-      })}</div> : structureLoading || filesLoading ? <NoteListSkeleton /> : <div className="list-empty"><p>{search ? "No notes or files found." : "This collection is empty."}</p>{!search && <button onClick={onCreate}>Create the first note</button>}</div>}
+      })}</div> : structureLoading || filesLoading ? <div className="list-loading" role="status">Reading notes and files…</div> : <div className="list-empty"><p>{search ? "No notes or files found." : "This collection is empty."}</p>{!search && <button onClick={onCreate}>Create the first note</button>}</div>}
     </div>
   </section>;
 }
 
-function NoteListSkeleton() {
-  return <div className="note-list-skeleton" aria-hidden="true">{Array.from({ length: 8 }, (_, index) => <div key={index}><span /><small /></div>)}</div>;
-}
 
 function browserCountLabel(noteCount: number, fileCount: number, resultCount: number, loading: boolean, structureLoading: boolean, filesLoading: boolean, contentIndexing: boolean, contentLoaded: number, total: number | undefined, contentTotal: number | undefined, searching: boolean, sort: NoteSort): string {
   if (searching && contentIndexing) return `${resultCount.toLocaleString()} found so far · searching ${contentLoaded.toLocaleString()} of ${contentTotal?.toLocaleString() ?? "…"}`;

--- a/apps/editor/src/NotePreview.tsx
+++ b/apps/editor/src/NotePreview.tsx
@@ -161,7 +161,7 @@ export function NotePreviewCard({ preview }: { preview?: NotePreviewState }) {
         <span>{preview.path}</span>
       </header>
       {preview.loading
-        ? <div className="note-preview-loading" aria-label="Loading preview" aria-busy="true"><i /><i /><i /></div>
+        ? <div className="note-preview-loading" aria-label="Loading preview" aria-busy="true">Loading preview…</div>
         : preview.unavailable
           ? <p className="note-preview-empty">Preview unavailable.</p>
           : excerpt

--- a/apps/editor/src/TypeBrowser.tsx
+++ b/apps/editor/src/TypeBrowser.tsx
@@ -294,7 +294,7 @@ export function TypeInspector({ type, availableTypes = [], contracts = [], docum
         </div>
       }
       {(error || visualError || parsed.error) && <p className="type-editor-error" role="alert">{error || visualError || parsed.error}</p>}
-      {loading ? <div className="type-source-loading" aria-label="Loading type definition"><span /><span /><span /></div>
+      {loading ? <div className="type-source-loading" role="status" aria-label="Loading type definition">Reading type definition…</div>
         : reviewing && impact ? <TypeChangeReview
           previousSource={document?.document}
           source={source}
@@ -974,9 +974,7 @@ function ContractCatalogBrowser({ catalog, contracts, types, loading, error, can
       </div>
       {catalog && <a href={catalog.sourceUrl} target="_blank" rel="noreferrer">Catalog source</a>}
     </div>
-    {loading && <div className="contract-catalog-loading" role="status" aria-label="Loading contract catalog">
-      <span /><span /><span />
-    </div>}
+    {loading && <div className="contract-catalog-loading" role="status" aria-label="Loading contract catalog">Loading available compatibility packs…</div>}
     {error && !loading && <div className="contract-catalog-error" role="alert">
       <div><strong>Catalog unavailable</strong><p>{error}</p></div>
       {onReload && <button onClick={onReload}>Try again</button>}

--- a/apps/editor/src/WorkspaceChrome.tsx
+++ b/apps/editor/src/WorkspaceChrome.tsx
@@ -53,12 +53,12 @@ export function BacklinksPanel({ notes, types, loading, onClose, onOpen }: {
 }
 
 export function NoteSkeleton({ leadingActions }: { leadingActions?: ReactNode }) {
-  return <div className="note-skeleton" aria-label="Loading note" aria-busy="true"><div className="skeleton-bar">{leadingActions}<span /></div><div className="skeleton-document"><span className="skeleton-title" /><span /><span /><span className="short" /></div></div>;
+  return <div className="note-skeleton" aria-label="Loading note" aria-busy="true"><div className="skeleton-bar">{leadingActions}<span role="status">Opening note…</span></div><div className="skeleton-document"><p>Reading note content…</p></div></div>;
 }
 
 export function PaneSkeleton({ label, leadingActions, variant = "document" }: { label: string; leadingActions?: ReactNode; variant?: "document" | "canvas" }) {
   if (variant === "canvas") {
-    return <main className="editor-pane file-workspace" aria-label={label} aria-busy="true"><div className="skeleton-bar">{leadingActions}<span /></div><div className="file-workspace-content"><span className="skeleton-canvas-pill" aria-hidden="true" /></div></main>;
+    return <main className="editor-pane file-workspace" aria-label={label} aria-busy="true"><div className="skeleton-bar">{leadingActions}<span role="status">{label}…</span></div><div className="file-workspace-content" /></main>;
   }
   return <main className="editor-pane" aria-label={label}><NoteSkeleton leadingActions={leadingActions} /></main>;
 }
@@ -135,7 +135,7 @@ export function OutlineMenu({ headings, onReveal }: { headings: NoteHeading[]; o
 }
 
 export function InspectorPanelLoading({ label }: { label: "Note properties" | "Backlinks" }) {
-  return <aside className="properties-panel properties-panel-loading" aria-label={label} aria-busy="true"><div /><span /><span /><span /></aside>;
+  return <aside className="properties-panel properties-panel-loading" aria-label={label} aria-busy="true"><strong>{label}</strong><p role="status">Loading…</p></aside>;
 }
 
 export function TypeAccessPrompt({ leadingActions, onAuthorize, onBack }: {

--- a/apps/editor/src/connect.css
+++ b/apps/editor/src/connect.css
@@ -1356,3 +1356,69 @@ button.danger:disabled {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Quiet-instrument treatment for account management. */
+.connect-nav > nav > .connect-nav-group > a,
+.connect-rail-account,
+.connect-inline-rename input,
+.connect-inline-form input,
+.connect-account-action,
+.connect-account-danger,
+.connect-feedback-topic label,
+.connect-feedback-field input,
+.connect-feedback-field textarea,
+.connect-feedback-origin select,
+.connect-feedback-upload,
+.connect-feedback-diagnostics,
+.connect-account-form input,
+.connect-account-reauthentication input,
+.connect-provider-loading {
+  border-radius: 2px;
+}
+
+.connect-nav > nav > .connect-nav-group > a.selected {
+  background: var(--selected);
+  color: var(--ink);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.connect-avatar {
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--muted);
+}
+
+.connect-primary-action {
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--accent) !important;
+}
+
+.connect-primary-action:hover {
+  background: var(--hover);
+  color: var(--accent-strong) !important;
+}
+
+.connect-account-message,
+.connect-pending-banner,
+.connect-deletion-effects,
+.connect-account-reauthentication {
+  border-radius: 2px;
+}
+
+.connect-account-message.success {
+  border-color: color-mix(in oklch, var(--success) 42%, var(--line));
+  background: transparent;
+  color: var(--success);
+}
+
+.connect-deleted-account > div {
+  padding-inline: 0;
+  border-right: 0;
+  border-left: 0;
+}
+
+.connect-empty {
+  justify-content: flex-start;
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -2,18 +2,18 @@
   color-scheme: light;
   color: var(--ink);
   background: var(--canvas);
-  font-family: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--sans);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --color-canvas: oklch(99.4% 0.003 245);
-  --color-surface: oklch(100% 0.002 245);
-  --color-surface-subtle: oklch(97.7% 0.006 245);
+  --color-canvas: oklch(99.5% 0.002 255);
+  --color-surface: oklch(99.5% 0.002 255);
+  --color-surface-subtle: oklch(97.8% 0.003 255);
   --color-text: oklch(21% 0.018 255);
-  --color-text-soft: oklch(51% 0.014 255);
-  --color-text-muted: oklch(52% 0.01 255);
-  --color-border: oklch(92.5% 0.006 255);
-  --color-border-strong: oklch(84% 0.009 255);
-  --color-selected: oklch(96.4% 0.016 238);
+  --color-text-soft: oklch(50% 0.014 255);
+  --color-text-muted: oklch(54% 0.01 255);
+  --color-border: oklch(92% 0.006 255);
+  --color-border-strong: oklch(82% 0.008 255);
+  --color-selected: oklch(96.8% 0.004 255);
   --color-accent: oklch(47% 0.1 238);
   --color-accent-strong: oklch(41% 0.1 238);
   --color-accent-soft: oklch(93.5% 0.035 238);
@@ -31,11 +31,14 @@
   --color-diff-remote-mark: oklch(91% 0.045 153);
   --color-editor-text: oklch(28% 0.014 255);
   --color-placeholder: oklch(78% 0.007 255);
-  --color-skeleton: oklch(95.5% 0.004 255);
-  --color-shadow: oklch(20% 0.02 255 / 0.1);
+  --color-skeleton: var(--color-border);
+  --color-shadow: oklch(20% 0.02 255 / 0.06);
   --color-scrim: oklch(21% 0.018 255 / 0.14);
-  --scrollbar-thumb: oklch(51% 0.014 255 / 0.24);
-  --scrollbar-thumb-hover: oklch(42% 0.016 255 / 0.42);
+  --scrollbar-thumb-rest: oklch(51% 0.014 255 / 0.07);
+  --scrollbar-thumb: oklch(51% 0.014 255 / 0.22);
+  --scrollbar-thumb-hover: oklch(42% 0.016 255 / 0.4);
+  --scrollbar-thumb-current: var(--scrollbar-thumb-rest);
+  --scrollbar-size: 2px;
   --syntax-comment: oklch(58% 0.012 255);
   --syntax-keyword: oklch(42% 0.09 294);
   --syntax-string: oklch(39% 0.075 153);
@@ -60,7 +63,8 @@
   --danger: var(--color-danger);
   --danger-soft: var(--color-danger-soft);
   --skeleton: var(--color-skeleton);
-  --mono: "Azeret Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --sans: "Atkinson Hyperlegible", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "Azeret Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
 /* Collection files share the note-list rhythm without turning the editor into a file manager. */
@@ -193,13 +197,13 @@
   color-scheme: dark;
   --color-canvas: oklch(17.5% 0.012 255);
   --color-surface: oklch(19.5% 0.012 255);
-  --color-surface-subtle: oklch(23.5% 0.014 255);
+  --color-surface-subtle: oklch(22.5% 0.012 255);
   --color-text: oklch(92% 0.008 255);
-  --color-text-soft: oklch(72% 0.012 255);
-  --color-text-muted: oklch(61% 0.011 255);
+  --color-text-soft: oklch(70% 0.012 255);
+  --color-text-muted: oklch(62% 0.011 255);
   --color-border: oklch(29% 0.012 255);
-  --color-border-strong: oklch(40% 0.014 255);
-  --color-selected: oklch(27% 0.035 238);
+  --color-border-strong: oklch(39% 0.012 255);
+  --color-selected: oklch(23.5% 0.012 255);
   --color-accent: oklch(73% 0.105 238);
   --color-accent-strong: oklch(65% 0.105 238);
   --color-accent-soft: oklch(31% 0.045 238);
@@ -220,6 +224,7 @@
   --color-skeleton: oklch(25% 0.012 255);
   --color-shadow: oklch(5% 0.01 255 / 0.22);
   --color-scrim: oklch(5% 0.01 255 / 0.46);
+  --scrollbar-thumb-rest: oklch(72% 0.012 255 / 0.06);
   --scrollbar-thumb: oklch(72% 0.012 255 / 0.2);
   --scrollbar-thumb-hover: oklch(78% 0.012 255 / 0.38);
   --syntax-comment: oklch(62% 0.012 255);
@@ -235,13 +240,13 @@
     color-scheme: dark;
     --color-canvas: oklch(17.5% 0.012 255);
     --color-surface: oklch(19.5% 0.012 255);
-    --color-surface-subtle: oklch(23.5% 0.014 255);
+    --color-surface-subtle: oklch(22.5% 0.012 255);
     --color-text: oklch(92% 0.008 255);
-    --color-text-soft: oklch(72% 0.012 255);
-    --color-text-muted: oklch(61% 0.011 255);
+    --color-text-soft: oklch(70% 0.012 255);
+    --color-text-muted: oklch(62% 0.011 255);
     --color-border: oklch(29% 0.012 255);
-    --color-border-strong: oklch(40% 0.014 255);
-    --color-selected: oklch(27% 0.035 238);
+    --color-border-strong: oklch(39% 0.012 255);
+    --color-selected: oklch(23.5% 0.012 255);
     --color-accent: oklch(73% 0.105 238);
     --color-accent-strong: oklch(65% 0.105 238);
     --color-accent-soft: oklch(31% 0.045 238);
@@ -262,6 +267,7 @@
     --color-skeleton: oklch(25% 0.012 255);
     --color-shadow: oklch(5% 0.01 255 / 0.22);
     --color-scrim: oklch(5% 0.01 255 / 0.46);
+    --scrollbar-thumb-rest: oklch(72% 0.012 255 / 0.06);
     --scrollbar-thumb: oklch(72% 0.012 255 / 0.2);
     --scrollbar-thumb-hover: oklch(78% 0.012 255 / 0.38);
     --syntax-comment: oklch(62% 0.012 255);
@@ -276,12 +282,18 @@
 * {
   box-sizing: border-box;
   scrollbar-width: thin;
-  scrollbar-color: var(--scrollbar-thumb) transparent;
+  scrollbar-color: var(--scrollbar-thumb-current) transparent;
+}
+
+.app-shell > *:hover,
+.app-shell > *:focus-within {
+  --scrollbar-thumb-current: var(--scrollbar-thumb);
+  --scrollbar-size: 6px;
 }
 
 *::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
 }
 
 *::-webkit-scrollbar-track,
@@ -290,10 +302,8 @@
 }
 
 *::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
   border-radius: 999px;
-  background: var(--scrollbar-thumb);
-  background-clip: padding-box;
+  background: var(--scrollbar-thumb-current);
 }
 
 *::-webkit-scrollbar-thumb:hover {
@@ -742,105 +752,17 @@ select:focus-visible {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 176px 304px minmax(380px, 1fr);
+  place-items: center;
   overflow: hidden;
   background: var(--canvas);
 }
 
-.opening-rail,
-.opening-list,
-.opening-document {
-  min-width: 0;
-  min-height: 0;
-  background: var(--white);
-}
-
-.opening-rail {
-  padding: 25px 16px;
-  border-right: 1px solid var(--line);
-}
-
-.opening-rail-lines {
-  display: grid;
-  gap: 18px;
-  margin-top: 53px;
-}
-
-.opening-rail-lines span,
-.opening-list-heading span,
-.opening-list-heading small,
-.opening-search,
-.opening-row span,
-.opening-row small,
-.opening-document-bar span,
-.opening-document-lines > * {
-  display: block;
-  border-radius: 2px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 1.3s ease-in-out infinite alternate;
-}
-
-.opening-rail-lines span {
-  width: 66%;
-  height: 7px;
-}
-
-.opening-rail-lines span:nth-child(2) { width: 52%; }
-.opening-rail-lines span:nth-child(3) { width: 59%; }
-
-.opening-list {
-  padding: 27px 18px 0;
-  border-right: 1px solid var(--line);
-}
-
-.opening-list-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 29px;
-}
-
-.opening-list-heading span { width: 88px; height: 12px; }
-.opening-list-heading small { width: 38px; height: 7px; }
-
-.opening-search {
-  width: 100%;
-  height: 32px;
-  margin: 18px 0 11px;
-  border-radius: 4px;
-}
-
-.opening-row {
-  display: grid;
-  gap: 10px;
-  height: 76px;
-  padding: 17px 3px;
-  border-bottom: 1px solid var(--line);
-}
-
-.opening-row span { width: 68%; height: 9px; }
-.opening-row small { width: 88%; height: 6px; }
-.opening-row:nth-child(2n) span { width: 51%; }
-.opening-row:nth-child(3n) small { width: 72%; }
-
-.opening-document {
-  position: relative;
-}
-
-.opening-document-bar {
-  height: 52px;
-  padding: 22px 24px 22px 88px;
-  border-bottom: 1px solid var(--line);
-}
-
-.opening-document-bar span { width: 78px; height: 8px; }
-
 .opening-message {
-  position: absolute;
-  top: 76px;
-  left: clamp(28px, 7vw, 112px);
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  color: var(--muted);
+  text-align: center;
 }
 
 .opening-message p,
@@ -850,7 +772,6 @@ select:focus-visible {
 }
 
 .opening-message p {
-  color: var(--muted);
   font-size: 13px;
 }
 
@@ -858,32 +779,6 @@ select:focus-visible {
   margin-top: 4px;
   color: var(--faint);
   font-size: 11px;
-}
-
-.opening-pulse {
-  width: 6px;
-  height: 6px;
-  margin-top: 5px;
-  border-radius: 50%;
-  background: var(--accent);
-  animation: opening-pulse 900ms ease-in-out infinite alternate;
-}
-
-.opening-document-lines {
-  display: grid;
-  gap: 22px;
-  width: min(760px, calc(100% - clamp(28px, 8vw, 110px) * 2));
-  margin: clamp(36px, 7vh, 78px) auto 0;
-}
-
-.opening-document-lines strong { width: 54%; height: 38px; margin-bottom: 10px; }
-.opening-document-lines span { width: 100%; height: 7px; }
-.opening-document-lines span:nth-child(3) { width: 91%; }
-.opening-document-lines span:nth-child(4) { width: 64%; }
-
-@keyframes opening-pulse {
-  from { opacity: 0.35; }
-  to { opacity: 1; }
 }
 
 .app-shell {
@@ -1390,20 +1285,6 @@ select:focus-visible {
   gap: 16px;
   padding: 24px 18px;
 }
-
-.type-workspace-loading > div,
-.type-workspace-loading > strong,
-.type-workspace-loading > span {
-  display: block;
-  border-radius: 3px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 900ms ease-in-out infinite alternate;
-}
-
-.type-workspace-loading > div { width: 42%; height: 18px; }
-.type-workspace-loading > strong { width: min(46%, 300px); height: 32px; margin-top: 40px; }
-.type-workspace-loading > span { width: 72%; height: 9px; }
-.type-workspace-loading > span:last-child { width: 55%; }
 
 .list-header {
   min-height: 70px;
@@ -2084,32 +1965,6 @@ kbd {
   border-top: 1px solid var(--line);
 }
 
-.note-list-skeleton {
-  display: grid;
-}
-
-.note-list-skeleton > div {
-  height: 76px;
-  display: grid;
-  align-content: center;
-  gap: 10px;
-  padding: 0 18px;
-  border-bottom: 1px solid var(--line);
-}
-
-.note-list-skeleton span,
-.note-list-skeleton small {
-  display: block;
-  border-radius: 2px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 1.3s ease-in-out infinite alternate;
-}
-
-.note-list-skeleton span { width: 58%; height: 9px; }
-.note-list-skeleton small { width: 82%; height: 6px; }
-.note-list-skeleton > div:nth-child(2n) span { width: 72%; }
-.note-list-skeleton > div:nth-child(3n) small { width: 65%; }
-
 .virtual-list {
   position: relative;
   width: 100%;
@@ -2349,23 +2204,6 @@ kbd {
   margin: 0;
   color: var(--muted);
 }
-
-.note-preview-loading {
-  display: grid;
-  gap: 9px;
-  margin-top: 15px;
-}
-
-.note-preview-loading i {
-  height: 7px;
-  border-radius: 2px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 900ms ease-in-out infinite alternate;
-}
-
-.note-preview-loading i:nth-child(1) { width: 92%; }
-.note-preview-loading i:nth-child(2) { width: 76%; }
-.note-preview-loading i:nth-child(3) { width: 48%; }
 
 .note-preview-excerpt,
 .note-preview-empty {
@@ -3192,22 +3030,6 @@ kbd {
   ) 0;
 }
 
-.code-editor-loading::before,
-.code-editor-loading::after,
-.code-editor-loading > span {
-  content: "";
-  display: block;
-  height: 10px;
-  margin-bottom: 18px;
-  border-radius: 3px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 900ms ease-in-out infinite alternate;
-}
-
-.code-editor-loading::before { width: 72%; }
-.code-editor-loading > span { width: 58%; }
-.code-editor-loading::after { width: 66%; margin-top: 42px; }
-
 .code-editor .cm-editor {
   height: 100%;
   background: transparent;
@@ -3606,25 +3428,6 @@ kbd {
 .properties-panel-loading {
   gap: 18px;
 }
-
-.properties-panel-loading > div,
-.properties-panel-loading > span {
-  display: block;
-  height: 9px;
-  border-radius: 3px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 900ms ease-in-out infinite alternate;
-}
-
-.properties-panel-loading > div {
-  width: 42%;
-  height: 18px;
-  margin-bottom: 10px;
-}
-
-.properties-panel-loading > span { width: 100%; }
-.properties-panel-loading > span:nth-child(3) { width: 76%; }
-.properties-panel-loading > span:last-child { width: 58%; }
 
 .panel-header {
   display: flex;
@@ -4975,22 +4778,10 @@ label.schema-value {
 
 .type-source-loading {
   flex: 1;
-  display: grid;
-  align-content: start;
-  gap: 14px;
   padding: 19px var(--type-source-gutter) 0;
+  color: var(--faint);
+  font-size: 12px;
 }
-
-.type-source-loading span {
-  width: min(72%, 480px);
-  height: 9px;
-  border-radius: 2px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 1.4s ease-in-out infinite alternate;
-}
-
-.type-source-loading span:nth-child(2) { width: min(48%, 340px); }
-.type-source-loading span:nth-child(3) { width: min(64%, 420px); }
 
 .type-view-switch {
   width: auto;
@@ -5951,17 +5742,6 @@ label.schema-value {
   padding: 14px 0 17px;
   border-top: 1px solid var(--line);
 }
-
-.contract-catalog-loading span {
-  height: 7px;
-  border-radius: 2px;
-  background: var(--skeleton);
-  animation: skeleton-pulse 900ms ease-in-out infinite alternate;
-}
-
-.contract-catalog-loading span:nth-child(1) { width: 34%; }
-.contract-catalog-loading span:nth-child(2) { width: 72%; }
-.contract-catalog-loading span:nth-child(3) { width: 48%; }
 
 .contract-catalog-error {
   min-height: 58px;
@@ -7962,10 +7742,6 @@ label.schema-value {
 }
 
 @media (max-width: 1120px) {
-  .opening-shell {
-    grid-template-columns: 156px 278px minmax(360px, 1fr);
-  }
-
   .app-shell,
   .app-shell.inspector-visible {
     --collection-display: min(var(--collection-track), 156px);
@@ -7995,47 +7771,6 @@ label.schema-value {
 @media (max-width: 760px) {
   body {
     overflow: hidden;
-  }
-
-  .opening-shell {
-    position: relative;
-    display: block;
-  }
-
-  .opening-rail {
-    position: absolute;
-    z-index: 1;
-    inset: 0 0 auto;
-    height: 54px;
-    display: flex;
-    align-items: center;
-    padding: max(16px, env(safe-area-inset-top)) 18px 10px;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .opening-rail-lines,
-  .opening-list {
-    display: none;
-  }
-
-  .opening-document {
-    position: absolute;
-    inset: 54px 0 0;
-  }
-
-  .opening-document-bar {
-    display: none;
-  }
-
-  .opening-message {
-    top: 30px;
-    left: 22px;
-  }
-
-  .opening-document-lines {
-    width: calc(100% - 44px);
-    margin-top: 92px;
   }
 
   .app-shell,
@@ -8690,5 +8425,224 @@ label.schema-value {
     transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+  }
+}
+
+/* Quiet-instrument treatment: neutral planes, ruled hierarchy, and explicit loading. */
+.collection-rail {
+  background: var(--canvas);
+}
+
+.collection-rail nav button,
+.collection-rail nav .editor-rail-link,
+.icon-button,
+.action-menu button,
+.context-menu button {
+  border-radius: 2px;
+}
+
+.collection-rail nav button.selected,
+.collection-rail nav .editor-rail-link.selected,
+.note-row.selected,
+.type-row.selected,
+.type-pack-entry.selected,
+.collection-switcher-list > button.current,
+.quick-open-results > button.selected,
+.connect-nav > nav > .connect-nav-group > a.selected {
+  background: var(--selected);
+  color: var(--ink);
+}
+
+.note-row.selected .note-title,
+.type-row.selected,
+.type-pack-entry.selected {
+  font-weight: 700;
+}
+
+.search-field,
+.select-control > select,
+.connect-inline-rename input,
+.connect-inline-form input,
+.connect-feedback-field input,
+.connect-feedback-field textarea,
+.connect-feedback-origin select,
+.connect-account-form input,
+.connect-account-reauthentication input {
+  border-radius: 2px;
+  background: transparent;
+}
+
+.combobox-popover,
+.quick-open,
+.shortcut-help,
+.confirm-dialog,
+.collection-switcher,
+.action-menu,
+.context-menu,
+.note-preview,
+.toast,
+.code-editor .cm-editor .cm-tooltip.cm-tooltip-autocomplete,
+.code-editor .cm-tooltip-lint,
+.icon-picker-popover {
+  border-radius: 2px;
+  box-shadow: none;
+}
+
+.dialog-scrim {
+  background: color-mix(in srgb, var(--ink) 14%, transparent);
+}
+
+.connect-avatar {
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--muted);
+}
+
+.connect-primary-action,
+.confirm-dialog > footer .confirm-primary,
+.rename-confirm .primary-confirm-action,
+.conflict-actions .primary-conflict-action,
+.type-review-actions .confirm-type-button {
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--accent) !important;
+}
+
+.connect-primary-action:hover,
+.confirm-dialog > footer .confirm-primary:hover,
+.rename-confirm .primary-confirm-action:hover,
+.conflict-actions .primary-conflict-action:hover,
+.type-review-actions .confirm-type-button:hover {
+  background: var(--hover);
+  color: var(--accent-strong) !important;
+}
+
+.connect-account-message.success {
+  border-color: color-mix(in oklch, var(--success) 42%, var(--line));
+  background: transparent;
+  color: var(--success);
+}
+
+.settings-secondary-action {
+  border: 1px solid var(--line-strong);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--ink);
+}
+
+.connect-pending-banner,
+.connect-account-message.error,
+.connect-deletion-effects,
+.connect-account-reauthentication,
+.field-conversion-warning,
+.type-definition-changes {
+  border-radius: 2px;
+}
+
+.type-workspace-loading p,
+.list-loading,
+.skeleton-document p,
+.properties-panel-loading p,
+.contract-catalog-loading,
+.code-editor-loading,
+.note-preview-loading {
+  margin: 0;
+  color: var(--faint);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.type-workspace-loading {
+  display: block;
+  padding: 25px 18px;
+}
+
+.type-workspace-loading > strong {
+  width: auto;
+  height: auto;
+  display: block;
+  margin: 0 0 8px;
+  background: transparent;
+  font-size: 15px;
+  animation: none;
+}
+
+.type-workspace-loading.type-inspector {
+  padding: 76px clamp(28px, 7vw, 82px);
+}
+
+.list-loading {
+  min-height: 152px;
+  display: flex;
+  align-items: flex-start;
+  padding: 20px 18px;
+}
+
+.skeleton-bar span {
+  width: auto;
+  height: auto;
+  margin-left: 8px;
+  background: transparent;
+  animation: none;
+}
+
+.skeleton-document {
+  min-height: 100%;
+  padding-top: clamp(36px, 7vh, 78px);
+}
+
+.properties-panel-loading {
+  gap: 8px;
+}
+
+.properties-panel-loading > strong {
+  margin-top: 2px;
+  font-size: 15px;
+}
+
+.contract-catalog-loading {
+  display: block;
+  padding: 18px 0;
+}
+
+.code-editor-loading {
+  padding-top: 6px;
+}
+
+.note-preview-loading {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+}
+
+.skeleton-document span,
+.skeleton-canvas-pill,
+.properties-panel-loading > div,
+.properties-panel-loading > span,
+.contract-catalog-loading span,
+.note-preview-loading i {
+  display: none;
+}
+
+.file-viewer-backdrop,
+.note-preview,
+.toast,
+.folder-loading i,
+.status-dot.reconnecting,
+.file-loading-mark {
+  animation: none;
+}
+
+.code-editor-writer .cm-file-embed.ready:hover,
+.code-editor-writer .cm-file-embed-active,
+.file-workspace-content.file-viewer-image img {
+  box-shadow: none;
+}
+
+@media (max-width: 560px) {
+  .confirm-dialog,
+  .collection-switcher {
+    border-radius: 2px 2px 0 0;
   }
 }

--- a/apps/editor/tests/editor.spec.ts
+++ b/apps/editor/tests/editor.spec.ts
@@ -250,13 +250,14 @@ async function expectSharedSelectControls(scope: Locator) {
   )).toBe(true);
 }
 
-test("keeps the application geometry visible while a collection opens", async ({ page }) => {
+test("shows an explicit status while a collection opens", async ({ page }) => {
   await page.goto("?demo=80&delay=450");
   const opening = page.getByRole("main", { name: "Opening collection" });
   await expect(opening).toBeVisible();
   await expect(opening).toHaveAttribute("aria-busy", "true");
+  await expect(opening).toHaveAttribute("data-loading-state", "opening");
   await expect(page.getByText("Reading its notes and types")).toBeVisible();
-  expect(await opening.locator(":scope > *").count()).toBe(3);
+  await expect(opening.locator(".opening-rail, .opening-list")).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "Writing" })).toBeVisible();
   await expect(opening).not.toBeAttached();
 });


### PR DESCRIPTION
## Summary

- preserve and adapt the quieter editor treatment from the divergent canonical checkout
- replace animated and skeleton-shaped loading placeholders with explicit status text
- simplify the pre-metadata opening state so it does not preview unstable sidebars
- add repository guidance for avoiding additive complexity during implementation

## Preservation scope

This ports only the unique editor and guidance work onto current `main`. The daemon fix and portal redesign remain isolated in PRs #404 and #392, release automation is already upstream, and generated lockfile drift was intentionally excluded.

## Validation

- `pnpm build:packages`
- `pnpm --filter mdbase-editor typecheck`
- `pnpm --filter mdbase-editor test` (53 files, 388 tests)
- `pnpm --filter mdbase-editor build`
- `pnpm test:accessibility`

The local runtime used Node 22.22.0 while the repository requests Node 24; all commands passed with the existing engine warning.
