### PR TITLE
Fix native hosted proof origin

### DIFF
--- a/services/server/src/app.test.ts
+++ b/services/server/src/app.test.ts
@@ -2114,7 +2114,7 @@ describe("mdbase connect server", () => {
     expect(state.rows.find(({ id }) => id === grants[1])?.revoked_at).toBeNull();
   });
 
-  it("provisions and reconciles prelude v1 contract-free hosted application access as unrestricted", async () => {
+  it("provisions native prelude v1 contract-free hosted access with an exact application origin", async () => {
     const READ_OPERATIONS = LEGACY_READ_OPERATIONS;
     const db = await createDatabase("memory");
     resources.push(() => db.end());
@@ -2212,7 +2212,7 @@ describe("mdbase connect server", () => {
     const authorization = await startWebAuthorization(app, cookie, {
       applicationId,
       applicationManifestDigest,
-      redirectUri: manifestServer.redirectUri,
+      redirectUri: manifestServer.nativeRedirectUri,
       verifier,
       state,
       operations: hostedOperations
@@ -2275,6 +2275,8 @@ describe("mdbase connect server", () => {
         allowedTypes: [],
         fullCollection: true,
         allowedOperations: hostedOperations.filter((operation) => operation !== "sync"),
+        allowedOrigin: new URL(manifestServer.manifest.homepage).origin,
+        proofPublicKey: expect.any(String),
         applicationDeclarationId: manifestServer.manifest.id,
         applicationDeclarationDigest: `sha256:${applicationManifestDigest}`
       })

--- a/services/server/src/features/authorizations/approval-service.test.ts
+++ b/services/server/src/features/authorizations/approval-service.test.ts
@@ -127,7 +127,7 @@ describe("approveHostedAuthorization prelude v1 retained replica recovery", () =
     expect(revokeReplica).toHaveBeenCalledWith(fixture.replicaId);
   });
 
-  it("restores no allowed origin for a prior custom-scheme authorization", async () => {
+  it("restores the stored exact origin for a prior custom-scheme authorization", async () => {
     const fixture = await retainedReplicaFixture({
       priorFlow: "authorization_code",
       priorRedirectUri: "dev.mdbase.restore-test://auth/mdbase/callback",
@@ -147,7 +147,11 @@ describe("approveHostedAuthorization prelude v1 retained replica recovery", () =
 
     expect(updateApplicationReplica.mock.calls[1]).toEqual([
       fixture.replicaId,
-      { ...fixture.priorPolicy, allowedOrigin: undefined }
+      {
+        ...fixture.priorPolicy,
+        allowedOrigin: "https://homepage.example",
+        fileCapability: undefined
+      }
     ]);
     expect(revokeReplica).not.toHaveBeenCalled();
   });

--- a/services/server/src/features/authorizations/approval-service.ts
+++ b/services/server/src/features/authorizations/approval-service.ts
@@ -726,11 +726,7 @@ export async function approveHostedAuthorization(
           pending.redirect_uri!,
           pending.application_homepage
         );
-    const allowedOrigin = pending.flow === "device_code"
-      ? pending.device_origin ?? "null"
-      : ["http:", "https:"].includes(new URL(pending.redirect_uri!).protocol)
-        ? new URL(pending.redirect_uri!).origin
-        : undefined;
+    const allowedOrigin = applicationOrigin;
     const applicationInstallationId =
       pending.application_authorization.binding.application_installation_id;
     const existing = await retainedReplicaPolicy.loadCandidates(connection, {

--- a/services/server/src/features/authorizations/redirects.test.ts
+++ b/services/server/src/features/authorizations/redirects.test.ts
@@ -1,10 +1,25 @@
 import { describe, expect, it } from "vitest";
 import {
   applicationOriginForDeviceRequest,
+  applicationOriginForRedirect,
   normalizedApplicationOrigin
 } from "./redirects.js";
 
 describe("application authorization origins", () => {
+  it("binds native callbacks to the manifest homepage origin", () => {
+    expect(applicationOriginForRedirect(
+      "dev.tasknotes.app://auth/mdbase/callback",
+      "https://app.tasknotes.dev/"
+    )).toBe("https://app.tasknotes.dev");
+  });
+
+  it("binds web callbacks to their exact redirect origin", () => {
+    expect(applicationOriginForRedirect(
+      "https://tasks.example:8443/auth/mdbase/callback",
+      "https://homepage.example/"
+    )).toBe("https://tasks.example:8443");
+  });
+
   it("keeps native device authorization on the opaque origin", () => {
     expect(applicationOriginForDeviceRequest(undefined)).toBe("null");
     expect(applicationOriginForDeviceRequest("null")).toBe("null");

--- a/services/server/src/hosted-replica-policy.ts
+++ b/services/server/src/hosted-replica-policy.ts
@@ -156,10 +156,7 @@ function completeRetainedReplicaPolicy(
       retained.application_authorization.binding.contracts
         .operation_transport_recovery ?? [],
     fileCapability: retained.file_capability ?? undefined,
-    allowedOrigin: priorAllowedOrigin(
-      retained.application_authorization.binding,
-      retained.application_origin
-    ),
+    allowedOrigin: retained.application_origin,
     proofPublicKey: retained.proof_public_key,
     applicationDeclarationId: declarationIdFromFamilyIdentity(
       retained.application_family_identity
@@ -167,15 +164,4 @@ function completeRetainedReplicaPolicy(
     applicationDeclarationDigest:
       `sha256:${retained.application_manifest_digest}`
   };
-}
-
-function priorAllowedOrigin(
-  binding: ApplicationAuthorizationProof["binding"],
-  storedApplicationOrigin: string
-): string | undefined {
-  if (binding.flow === "device_code") return storedApplicationOrigin;
-  const redirect = new URL(binding.redirect_uri!);
-  return ["http:", "https:"].includes(redirect.protocol)
-    ? redirect.origin
-    : undefined;
 }


### PR DESCRIPTION
## Summary
- bind hosted replica proof keys to the already-derived application origin
- use the manifest homepage origin for native custom-scheme callbacks
- restore the stored exact origin during retained-replica compensation
- add native, web, and compensation regression coverage

## Cause
Native authorization correctly derived `applicationOrigin` from the signed manifest homepage, but hosted replica provisioning separately derived `allowedOrigin` only from HTTP(S) redirect URIs. Custom-scheme callbacks therefore sent a proof key with no exact origin, which the hosted provider rejects.

## Validation
- server typecheck
- server suite: 474 passed, 16 skipped
- targeted native authorization and retained-policy tests: 37 passed
- `git diff --check`

Rust provider tests were not rerun because this worktree's external `mdbase-rs` path dependency currently disagrees with the checked-in lock revision. No Rust code changes are included.
