### PR TITLE
Patch newly disclosed transitive dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@hono/node-server': 2.0.11
+  '@xmldom/xmldom@<0.9.12': 0.9.12
+  sharp@<0.35.4: 0.35.4
   '@electron/rebuild': 4.2.0
   '@xmldom/xmldom@>=0.9.0 <0.9.12': 0.9.12
   sharp@>=0.35.0 <0.35.4: 0.35.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,8 @@ allowBuilds:
 
 overrides:
   "@hono/node-server": "2.0.11"
+  "@xmldom/xmldom@<0.9.12": "0.9.12"
+  "sharp@<0.35.4": "0.35.4"
   "@electron/rebuild": "4.2.0"
   "@xmldom/xmldom@>=0.9.0 <0.9.12": "0.9.12"
   "sharp@>=0.35.0 <0.35.4": "0.35.4"


### PR DESCRIPTION
## Summary
- force `@xmldom/xmldom` to 0.9.12 for the newly disclosed XML validation and resource-exhaustion advisories
- force `sharp` to 0.35.4 for the patched libheif release
- refresh the lockfile under the existing supply-chain policy

## Validation
- `pnpm audit:dependencies` passes (remaining high findings are the two existing documented exceptions)
- `sharp` loads its native binding
- lockfile supply-chain policy passes during install

The local workspace-pin check is blocked because the current sibling mdbase-rs checkout no longer contains mdbase-connect's pinned `5aa34fd` revision; CI provisions the pinned sibling independently.

This repairs the current default-branch audit baseline, which otherwise blocks unrelated Server CI runs including #407.
