### PR TITLE
Fix editor navigation races and bound background work

### DIFF
--- a/apps/editor/src/App.note-navigation.test.tsx
+++ b/apps/editor/src/App.note-navigation.test.tsx
@@ -1,0 +1,178 @@
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { App } from "./App";
+import { DemoCollectionGateway } from "./demo-gateway";
+import type { CreateNoteInput } from "./model";
+
+vi.mock("./CodeEditor", () => ({ CodeEditor: () => null }));
+vi.mock("./MarkdownNoteEditor", () => ({
+  MarkdownNoteEditor: ({ draft, onTitleChange, onBodyChange, onCreateLink }: {
+    draft: { title: string; body: string };
+    onTitleChange(value: string): void;
+    onBodyChange(value: string): void;
+    onCreateLink(target: string, label: string | undefined, format: "wikilink"): void;
+  }) => <>
+    <input aria-label="Note title" value={draft.title} onChange={(event) => onTitleChange(event.target.value)} />
+    <textarea aria-label="Note body" value={draft.body} onChange={(event) => onBodyChange(event.target.value)} />
+    <button onClick={() => onCreateLink("Linked.md", "Linked", "wikilink")}>Create linked note</button>
+  </>
+}));
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 76,
+    getVirtualItems: () => Array.from({ length: count }, (_, index) => ({ index, start: index * 76, size: 76 }))
+  })
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+async function harness() {
+  const gateway = new DemoCollectionGateway(3);
+  const { notes } = await gateway.list();
+  const first = notes[0]!;
+  const second = notes[1]!;
+  const third = notes[2]!;
+  const read = vi.spyOn(gateway, "read");
+  const list = vi.spyOn(gateway, "list");
+  const describeCollection = vi.spyOn(gateway, "describe");
+  const listFiles = vi.spyOn(gateway, "listFiles");
+  render(<App gateway={gateway} />);
+  await screen.findByDisplayValue("The shape of useful tools");
+  await waitFor(() => expect(screen.getAllByRole("option").length).toBeGreaterThanOrEqual(3));
+  const select = (name: RegExp) => fireEvent.click(screen.getByRole("option", { name }));
+  return { gateway, first, second, third, read, list, describeCollection, listFiles, select };
+}
+
+describe("note navigation ownership and recovery", () => {
+  it("retries the first note directly when no document has opened yet", async () => {
+    const gateway = new DemoCollectionGateway(1);
+    const read = vi.spyOn(gateway, "read").mockRejectedValueOnce(new Error("First read failed"));
+    const list = vi.spyOn(gateway, "list");
+    const describeCollection = vi.spyOn(gateway, "describe");
+    render(<App gateway={gateway} />);
+    expect(await screen.findByRole("alert")).toHaveTextContent("First read failed");
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await screen.findByDisplayValue("The shape of useful tools");
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(read.mock.calls[1]).toEqual(read.mock.calls[0]);
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(describeCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the active document mounted on a failed read and retries only the requested note", async () => {
+    const { gateway, first, second, read, list, describeCollection, listFiles, select } = await harness();
+    const originalRead = DemoCollectionGateway.prototype.read.bind(gateway);
+    const gate = deferred();
+    read.mockImplementationOnce(async (path) => { await gate.promise; return originalRead(path); });
+    const title = screen.getByRole("textbox", { name: "Note title" });
+    const body = screen.getByRole("textbox", { name: "Note body" });
+    const before = { list: list.mock.calls.length, describe: describeCollection.mock.calls.length, files: listFiles.mock.calls.length };
+    select(/Garden notes 2/);
+    expect(screen.getByRole("textbox", { name: "Note title" })).toBe(title);
+    expect(screen.getByRole("textbox", { name: "Note body" })).toBe(body);
+    expect(screen.getByText(`Opening “${second.path}”…`)).toHaveAttribute("role", "status");
+    await act(async () => gate.reject(new Error("Temporary read failure")));
+    const retry = await screen.findByRole("button", { name: "Retry note" });
+    expect(screen.getByRole("textbox", { name: "Note title" })).toBe(title);
+    expect(screen.getByRole("option", { name: /The shape of useful tools/ })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: /Garden notes 2/ })).toHaveAttribute("aria-selected", "false");
+    expect(localStorage.getItem("mdbase-editor:last-note")).toBe(first.path);
+    fireEvent.click(retry);
+    await screen.findByDisplayValue("Garden notes 2");
+    expect(read.mock.calls.map(([path]) => path)).toEqual([first.path, second.path, second.path]);
+    expect(list).toHaveBeenCalledTimes(before.list);
+    expect(describeCollection).toHaveBeenCalledTimes(before.describe);
+    expect(listFiles).toHaveBeenCalledTimes(before.files);
+    expect(screen.queryByRole("button", { name: "Retry note" })).not.toBeInTheDocument();
+  });
+
+  it("saves edits made to the retained document while the next note is loading", async () => {
+    const { gateway, first, read, select } = await harness();
+    const originalRead = DemoCollectionGateway.prototype.read.bind(gateway);
+    const gate = deferred();
+    read.mockImplementationOnce(async (path) => { await gate.promise; return originalRead(path); });
+    const update = vi.spyOn(gateway, "update");
+    select(/Garden notes 2/);
+    fireEvent.change(screen.getByRole("textbox", { name: "Note body" }), { target: { value: "Typed during navigation" } });
+    await act(async () => gate.resolve());
+    await screen.findByDisplayValue("Garden notes 2");
+    await waitFor(() => expect(update).toHaveBeenCalledWith(expect.objectContaining({ path: first.path, body: "Typed during navigation" })));
+    expect((await originalRead(first.path)).body).toContain("Typed during navigation");
+  });
+
+  it("does not surface a stale read failure after a newer note has opened", async () => {
+    const { gateway, read, select } = await harness();
+    const originalRead = DemoCollectionGateway.prototype.read.bind(gateway);
+    const gate = deferred();
+    read.mockImplementationOnce(async (path) => { await gate.promise; return originalRead(path); });
+    select(/Garden notes 2/);
+    select(/A quiet interface 3/);
+    await screen.findByDisplayValue("A quiet interface 3");
+    await act(async () => gate.reject(new Error("Obsolete failure")));
+    expect(screen.getByRole("textbox", { name: "Note title" })).toHaveValue("A quiet interface 3");
+    expect(screen.queryByText(/Obsolete failure/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry note" })).not.toBeInTheDocument();
+  });
+
+  it.each(["success", "failure"] as const)("ignores a pending read's %s after navigation to a file", async (outcome) => {
+    const { gateway, read, select } = await harness();
+    const originalRead = DemoCollectionGateway.prototype.read.bind(gateway);
+    const gate = deferred();
+    read.mockImplementationOnce(async (path) => { await gate.promise; return originalRead(path); });
+    select(/Garden notes 2/);
+    const file = screen.getAllByRole("option").find((row) => row.classList.contains("file-row"))!;
+    fireEvent.click(file);
+    await act(async () => outcome === "success" ? gate.resolve() : gate.reject(new Error("Obsolete failure")));
+    await waitFor(() => expect(file).toHaveAttribute("aria-selected", "true"));
+    expect(screen.queryByDisplayValue("Garden notes 2")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Obsolete failure/)).not.toBeInTheDocument();
+  });
+
+  it.each([true, false])("does not let slow linked creation replace newer navigation (cached=%s)", async (cached) => {
+    const { gateway, first, select } = await harness();
+    if (cached) {
+      select(/A quiet interface 3/);
+      await screen.findByDisplayValue("A quiet interface 3");
+      select(/The shape of useful tools/);
+      await screen.findByDisplayValue("The shape of useful tools");
+    }
+    const gate = deferred();
+    const originalCreate = gateway.create.bind(gateway);
+    vi.spyOn(gateway, "create").mockImplementation(async (input: CreateNoteInput) => { await gate.promise; return originalCreate(input); });
+    fireEvent.click(screen.getByRole("button", { name: "Create linked note" }));
+    select(/A quiet interface 3/);
+    await screen.findByDisplayValue("A quiet interface 3");
+    await act(async () => gate.resolve());
+    await screen.findByRole("option", { name: /Linked/ });
+    expect(screen.getByRole("textbox", { name: "Note title" })).toHaveValue("A quiet interface 3");
+    expect(within(screen.getByRole("group", { name: "Note history" })).getByRole("button", { name: "Back in note history" })).toHaveAttribute("title", expect.stringContaining(first.path));
+  });
+
+  it("does not perform fallback navigation when a stale linked creation fails", async () => {
+    const { gateway, read, select } = await harness();
+    const gate = deferred();
+    vi.spyOn(gateway, "create").mockImplementation(async () => { await gate.promise; throw new Error("Create failed"); });
+    fireEvent.click(screen.getByRole("button", { name: "Create linked note" }));
+    select(/A quiet interface 3/);
+    await screen.findByDisplayValue("A quiet interface 3");
+    const reads = read.mock.calls.length;
+    await act(async () => gate.resolve());
+    await screen.findByText(/Couldn’t create “Notes\/Linked.md”/);
+    expect(read).toHaveBeenCalledTimes(reads);
+    expect(screen.getByRole("textbox", { name: "Note title" })).toHaveValue("A quiet interface 3");
+  });
+
+  it("still adopts a created link when it remains the latest navigation", async () => {
+    const { gateway } = await harness();
+    const created = vi.spyOn(gateway, "create");
+    fireEvent.click(screen.getByRole("button", { name: "Create linked note" }));
+    await screen.findByDisplayValue("Linked");
+    expect(created).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("mdbase-editor:last-note")).toBe("Notes/Linked.md");
+  });
+});

--- a/apps/editor/src/App.test.tsx
+++ b/apps/editor/src/App.test.tsx
@@ -670,11 +670,14 @@ describe("mdbase editor", () => {
 
   it("navigates notes and reveals keyboard help without leaving the editor", async () => {
     const user = userEvent.setup();
-    render(<App gateway={new DemoCollectionGateway(4)} />);
+    const gateway = new DemoCollectionGateway(4);
+    const read = vi.spyOn(gateway, "read");
+    render(<App gateway={gateway} />);
 
     expect(await screen.findByRole("textbox", { name: "Note title" })).toHaveValue("The shape of useful tools");
     fireEvent.keyDown(window, { key: "j", altKey: true });
     await waitFor(() => expect(screen.getByRole("textbox", { name: "Note title" })).toHaveValue("Garden notes 2"));
+    expect(read).toHaveBeenCalledWith("Journal/garden-notes-2.md");
     fireEvent.keyDown(window, { key: "k", altKey: true });
     await waitFor(() => expect(screen.getByRole("textbox", { name: "Note title" })).toHaveValue("The shape of useful tools"));
 

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -12,6 +12,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   lazy,
   useMemo,
   useRef,
@@ -190,6 +191,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
   const [draft, setDraft] = useState<Draft>();
   const [noteLoading, setNoteLoading] = useState(false);
   const [pendingNotePath, setPendingNotePath] = useState<string>();
+  const [noteOpenFailure, setNoteOpenFailure] = useState<{ path: string; options: NoteNavigationOptions; message: string }>();
   const [creationMode, setCreationMode] = useState<"note" | "folder">();
   const [creationContext, setCreationContext] = useState<CreationContext>({});
   const [creationDirty, setCreationDirty] = useState(false);
@@ -442,6 +444,12 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
   }), [gateway, touchSession, updateNoteSummary]);
 
   const activateSession = useCallback((session: NoteSession) => {
+    const previous = noteSessions.current.active;
+    // The old editor remains usable during a read. Save any edits made after
+    // navigation started before adopting the newly loaded session.
+    if (previous && previous !== session && sessionDirty(previous)) {
+      void noteOperations.requestSave(previous).catch(() => undefined);
+    }
     noteSessions.current.activate(session);
     setSelectedPath(session.document.path);
     setDocument(session.document);
@@ -450,13 +458,14 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     setSaveState(session.activity === "saving" ? "saving" : session.saveState);
     setNoteLoading(false);
     setPendingNotePath(undefined);
+    setNoteOpenFailure(undefined);
     setCreationMode(undefined);
     setCreationContext({});
     setEditingPath(false);
     setNotice(session.error);
     localStorage.setItem("mdbase-editor:last-note", session.document.path);
     setRecentPaths((current) => rememberRecentPath(current, session.document.path));
-  }, []);
+  }, [noteOperations]);
 
   const adoptDocument = useCallback((next: NoteDocument) => {
     const session = noteSessions.current.create(next, typeDescriptorsRef.current);
@@ -524,6 +533,9 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
   const openNote = useCallback(async (path: string, options: NoteNavigationOptions = {}): Promise<boolean> => {
     const epoch = collectionEpoch.current;
     const generation = ++documentGeneration.current;
+    const navigation = navigationGeneration.current;
+    const current = () => epoch === collectionEpoch.current
+      && generation === documentGeneration.current && navigation === navigationGeneration.current;
     const cached = noteSessions.current.get(path);
     if (cached?.deleted) return false;
     setCreationMode(undefined);
@@ -531,6 +543,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     setPendingFilePath(undefined);
     setCreationContext({});
     setNotice(undefined);
+    setNoteOpenFailure(undefined);
     setPropertiesError(undefined);
     if (mobileLayout) {
       setPropertiesOpen(false);
@@ -546,22 +559,25 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
       else selectNoteHistoryIndex(options.historyIndex, path);
       return true;
     }
-    setSelectedPath(path);
-    setDocument(undefined);
-    setDraft(undefined);
+    // Keep the active session (and its editor) until the next read succeeds.
+    // pendingNotePath identifies the requested row without claiming it is open.
+    setPendingNotePath(path);
     setNoteLoading(true);
     try {
       const next = await gateway.read(path);
-      if (epoch !== collectionEpoch.current || generation !== documentGeneration.current) return false;
+      if (!current()) return false;
       adoptDocument(next);
       if (options.historyIndex === undefined) recordNoteNavigation(next.path);
       else selectNoteHistoryIndex(options.historyIndex, next.path);
       return true;
     } catch (error) {
-      if (epoch === collectionEpoch.current && generation === documentGeneration.current) setNotice(gatewayError(error));
+      if (current()) setNoteOpenFailure({ path, options, message: `Couldn’t open “${path}”. ${gatewayError(error)}` });
       return false;
     } finally {
-      if (epoch === collectionEpoch.current && generation === documentGeneration.current) setNoteLoading(false);
+      if (current()) {
+        setNoteLoading(false);
+        setPendingNotePath(undefined);
+      }
     }
   }, [
     activateSession,
@@ -574,6 +590,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
 
   const start = useCallback(async () => {
     const epoch = collectionEpoch.current, generation = ++startGeneration.current;
+    const navigation = navigationGeneration.current;
     const current = () => epoch === collectionEpoch.current && generation === startGeneration.current;
     const indexLoad = indexController.beginLoad();
     const fileLoad = fileController.reload().catch(() => []);
@@ -594,9 +611,11 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
       setPhase("ready");
       const remembered = localStorage.getItem("mdbase-editor:last-note");
       let opened = remembered ? await openNote(remembered) : false;
+      if (!current() || navigation !== navigationGeneration.current) return;
       if (!opened) {
         setNoteLoading(true);
         const initial = (await indexLoad.firstPage)[0]?.path;
+        if (!current() || navigation !== navigationGeneration.current) return;
         if (initial) opened = await openNote(initial);
       }
       if (!opened) setNoteLoading(false);
@@ -737,6 +756,8 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
 
   function finishNavigateToFile(file: CollectionFile) {
     navigationGeneration.current += 1;
+    setNoteLoading(false);
+    setNoteOpenFailure(undefined);
     saveCurrentInBackground();
     setCreationMode(undefined);
     setCreationContext({});
@@ -753,7 +774,8 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
   function finishNavigateToNote(path: string, options: NoteNavigationOptions = {}) {
     setCreationDirty(false);
     const generation = ++navigationGeneration.current;
-    if (path === noteSessions.current.active?.document.path && !noteLoading) {
+    setNoteOpenFailure(undefined);
+    if (path === noteSessions.current.active?.document.path && !noteLoading && !selectedCollectionFile) {
       setPendingNotePath(undefined);
       setMobilePane("editor");
       if (options.historyIndex !== undefined) selectNoteHistoryIndex(options.historyIndex, path);
@@ -795,7 +817,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     ? searchedResults.map((result) => result.note)
     : allNotes, [allNotes, searchedResults]);
   const searchContexts = useMemo(() => new Map(
-    searchedResults?.map((result) => [result.note.path, result.context]) ?? []
+    searchedResults?.map((result) => [result.note.path, result]) ?? []
   ), [searchedResults]);
   const visibleNotes = useMemo(() => {
     const filtered = !noteFilter
@@ -909,6 +931,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     setDraft(undefined);
     setSelectedPath(undefined);
     setPendingNotePath(undefined);
+    setNoteOpenFailure(undefined);
     setSelectedCollectionFile(undefined);
     setPendingFilePath(undefined);
     setOpenFileAsset(undefined);
@@ -993,6 +1016,8 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
 
   function beginCreation(mode: "note" | "folder", context: CreationContext = {}) {
     navigationGeneration.current += 1;
+    setNoteLoading(false);
+    setNoteOpenFailure(undefined);
     setPendingNotePath(undefined);
     setNotice(undefined);
     saveCurrentInBackground();
@@ -1099,6 +1124,9 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     }
     if (linkCreations.current.has(linked.path)) return;
     linkCreations.current.add(linked.path);
+    const navigation = ++navigationGeneration.current;
+    setNoteLoading(false);
+    setNoteOpenFailure(undefined);
     saveCurrentInBackground();
     setPendingNotePath(linked.path);
     setNotice(undefined);
@@ -1111,6 +1139,9 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     })).then((created) => {
       if (!mutationScope.current.isCurrent(token)) return;
       indexController.create(summaryFromDocument(created));
+      // Creation still belongs to the collection, but only the latest navigation
+      // may adopt its result. A slow create must not replace a later choice.
+      if (navigation !== navigationGeneration.current) return;
       documentGeneration.current += 1;
       setPropertiesError(undefined);
       setDeletePlan(undefined);
@@ -1119,12 +1150,16 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
       recordNoteNavigation(created.path);
     }).catch(async (error) => {
       if (!mutationScope.current.isCurrent(token)) return;
+      if (navigation !== navigationGeneration.current) {
+        setNotice(`Couldn’t create “${linked.path}”. ${gatewayError(error)}`);
+        return;
+      }
       const opened = await openNote(linked.path);
-      if (!opened) setNotice(gatewayError(error));
+      if (!opened && navigation === navigationGeneration.current) setNotice(gatewayError(error));
     }).finally(() => {
       if (!mutationScope.current.isCurrent(token)) return;
       linkCreations.current.delete(linked.path);
-      setPendingNotePath((current) => current === linked.path ? undefined : current);
+      if (navigation === navigationGeneration.current) setPendingNotePath((current) => current === linked.path ? undefined : current);
     });
   }
 
@@ -1616,6 +1651,8 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
 
   function finishSelectSurface(next: Surface) {
     navigationGeneration.current += 1;
+    setNoteLoading(false);
+    setNoteOpenFailure(undefined);
     setPendingNotePath(undefined);
     saveCurrentInBackground();
     setSurface(next);
@@ -1692,7 +1729,9 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     if (connection) requestForgetConnection(connection, description?.displayName);
   }
 
-  useEffect(() => {
+  // Native shortcuts must see the committed selection before the first key
+  // after navigation, rather than the previous render's passive effect.
+  useLayoutEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const modifier = event.metaKey || event.ctrlKey;
       const key = event.key.toLocaleLowerCase();
@@ -1749,11 +1788,12 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [creationMode, phase, quickOpen, selectedCollectionFile, selectedPath, shortcutsOpen, surface, visibleBrowserEntries]);
+  }, [creationDirty, creationMode, noteFilter, noteLoading, openNote, phase, quickOpen, selectedCollectionFile, selectedPath, shortcutsOpen, surface, visibleBrowserEntries]);
 
   const wordCount = useMemo(() => noteWordCount(draft?.body ?? ""), [draft?.body]);
   const dismissToast = useCallback((id: string) => {
     if (id === "notice") setNoticeState(undefined);
+    else if (id === "note-open") setNoteOpenFailure(undefined);
     else if (id === "recovery") setRecoveryAction(undefined);
   }, []);
   if (phase === "starting") return <OpeningScreen />;
@@ -1838,6 +1878,10 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
     onCopyPath: () => { if (document) copyFacet(document.path, "note path"); }
   });
   const activeToasts = buildToastItems({ notice, recoveryMessage: recoveryAction ? recoveryAction.kind === "delete" ? `Deleted “${noteTitle(recoveryAction.document, typeDescriptors)}”.` : `Renamed to “${recoveryAction.to}”.` : undefined, recoveryBusy, onUndo: () => void undoRecovery(), hasPendingRename: Boolean(activePendingRename), onResumeRename: () => { if (activePendingRename) void performRename(activePendingRename.plan, activePendingRename.updateRefs); } });
+  if (noteOpenFailure && document) activeToasts.push({
+    id: "note-open", message: noteOpenFailure.message, tone: "error", sticky: true,
+    action: { label: "Retry note", onAction: () => navigateToNote(noteOpenFailure.path, noteOpenFailure.options) }
+  });
   const typeAccessMissing = missingTypeCapabilities(connectionSummary);
   const editorLeadingActions = layout.listCollapsed ? <>
     {layout.collectionCollapsed && <PaneControl label="Show collections sidebar" action="show" onClick={() => setLayout((current) => ({ ...current, collectionCollapsed: false }))} />}
@@ -1951,7 +1995,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
         onCancel={cancelCreation}
         onDraftChange={setCreationDirty}
       /></Suspense> : <main className="editor-pane" aria-label="Note editor">
-        {noteLoading ? <NoteSkeleton leadingActions={editorLeadingActions} /> : document && draft ? <>
+        {noteLoading && !document ? <NoteSkeleton leadingActions={editorLeadingActions} /> : document && draft ? <>
           <header className="editor-bar">
             <button className="mobile-back icon-button" aria-label="Back to notes" onClick={() => returnToMobilePane("notes")}><ArrowLeft aria-hidden="true" /></button>
             {editorLeadingActions}
@@ -1977,6 +2021,7 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
                 <input id="note-path" className="path-input" value={pathDraft} onChange={(event) => setPathDraft(event.target.value)} onBlur={() => void requestRename()} disabled={mutationsFrozen} autoFocus />
               </form> : <button className="path-button" onClick={() => setEditingPath(true)} title="Rename Markdown path"><span>{document.path}</span><Pencil aria-hidden="true" /></button>}
             </div>
+            {noteLoading && <span role="status" className="note-opening-status" title={pendingNotePath}>Opening “{pendingNotePath}”…</span>}
             {!mobileLayout && <OutlineMenu headings={noteHeadings(draft.body)} onReveal={(line) => revealMarkdownLine(noteSessions.current.active?.editorSessionKey ?? document.path, line)} />}
             {!mobileLayout && <span className="word-count" aria-label={`${wordCount.toLocaleString()} words`}>{wordCount.toLocaleString()} {wordCount === 1 ? "word" : "words"}</span>}
             {preferences.vim && <span className="vim-label">vim</span>}
@@ -2029,9 +2074,9 @@ export function App({ gateway }: { gateway: CollectionGateway }) {
             onVisibleFileEmbeds={updateVisibleFileEmbeds} onVisibleNoteEmbeds={updateVisibleNoteEmbeds} />
         </> : <EmptyEditor
           leadingActions={editorLeadingActions}
-          notice={editorNotice}
+          notice={noteOpenFailure?.message ?? editorNotice}
           onCreate={beginCreate}
-          onRetry={() => void start()}
+          onRetry={() => noteOpenFailure ? navigateToNote(noteOpenFailure.path, noteOpenFailure.options) : void start()}
         />}
       </main>}
       {propertiesOpen && (document ? <Suspense fallback={<InspectorPanelLoading label="Note properties" />}>

--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -87,6 +87,7 @@ import {
 } from "./note-search";
 import { initialEditorSurface, loadPreferences, savePreferences, type EditorPreferences } from "./preferences";
 import { revealMarkdownLine } from "./code-editor-reveal";
+import { forgetRecentPath, loadRecentPaths, rememberRecentPath } from "./recent-notes";
 import { composeRecordSource, replaceDocumentFrontmatter } from "./record-source";
 import { buildQuickOpenCommands } from "./editor-commands";
 import { QuickOpen, ShortcutHelp } from "./QuickOpen";
@@ -2242,29 +2243,6 @@ function summaryFromDocument(document: NoteDocument): NoteSummary {
     ...summary,
     file: { ...document.file, path: document.path }
   };
-}
-
-const RECENT_NOTES_KEY = "mdbase-editor:recent-notes";
-
-function loadRecentPaths(): string[] {
-  try {
-    const value = JSON.parse(localStorage.getItem(RECENT_NOTES_KEY) ?? "[]");
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string").slice(0, 20) : [];
-  } catch {
-    return [];
-  }
-}
-
-function rememberRecentPath(current: string[], path: string): string[] {
-  const next = [path, ...current.filter((candidate) => candidate !== path)].slice(0, 20);
-  localStorage.setItem(RECENT_NOTES_KEY, JSON.stringify(next));
-  return next;
-}
-
-function forgetRecentPath(current: string[], path: string): string[] {
-  const next = current.filter((candidate) => candidate !== path);
-  localStorage.setItem(RECENT_NOTES_KEY, JSON.stringify(next));
-  return next;
 }
 
 function isEditableTarget(target: EventTarget | null): boolean {

--- a/apps/editor/src/CodeEditor.tsx
+++ b/apps/editor/src/CodeEditor.tsx
@@ -95,6 +95,13 @@ interface MarkdownEdit {
   head: number;
 }
 
+const EMPTY_STRINGS: string[] = [];
+const EMPTY_SUGGESTIONS: LinkSuggestion[] = [];
+const EMPTY_FILE_EMBEDS: ResolvedFileReference[] = [];
+const EMPTY_NOTE_EMBEDS: ResolvedNoteEmbed[] = [];
+const EMPTY_FILES: CollectionFile[] = [];
+const EMPTY_NOTES: NoteSummary[] = [];
+
 const rememberedEditors = new Map<string, RememberedEditor>();
 const rememberedEditorLimit = 40;
 const EMPTY_HISTORY_STATE = EditorState.create({ extensions: [history()] }).field(historyField);
@@ -117,18 +124,18 @@ export function CodeEditor({
   className = "",
   documentId,
   currentPath,
-  recentPaths = [],
-  linkSuggestions = [],
-  linkTypes = [],
+  recentPaths = EMPTY_STRINGS,
+  linkSuggestions = EMPTY_SUGGESTIONS,
+  linkTypes = EMPTY_STRINGS,
   onOpenLink,
   onCreateLink,
   onPreviewLink,
   onDismissLinkPreview,
-  embeddedFiles = [],
-  embeddedNotes = [],
+  embeddedFiles = EMPTY_FILE_EMBEDS,
+  embeddedNotes = EMPTY_NOTE_EMBEDS,
   onOpenFile,
-  files = [],
-  notes = [],
+  files = EMPTY_FILES,
+  notes = EMPTY_NOTES,
   onOpenFileLink,
   onVisibleFileEmbeds,
   onVisibleNoteEmbeds,
@@ -164,6 +171,12 @@ export function CodeEditor({
   const embeddedFilesRef = useRef(embeddedFiles);
   const embeddedNotesRef = useRef(embeddedNotes);
   const onOpenFileRef = useRef(onOpenFile);
+  // Widgets capture callbacks during decoration creation; retained DOM must
+  // forward to the latest prop rather than capture that render's callback.
+  const openEmbeddedNote = useRef((path: string) => onOpenLinkRef.current?.(path)).current;
+  const openEmbeddedFile = useRef((asset: Extract<FileAssetSnapshot, { status: "ready" }>) => onOpenFileRef.current?.(asset)).current;
+  const canOpenEmbeddedNote = Boolean(onOpenLink);
+  const canOpenEmbeddedFile = Boolean(onOpenFile);
   const filesRef = useRef(files);
   const notesRef = useRef(notes);
   const onOpenFileLinkRef = useRef(onOpenFileLink);
@@ -218,12 +231,12 @@ export function CodeEditor({
       writerPresentation.current.of(variant === "writer" && quietMarkdown ? quietMarkdownPresentation : []),
       fileEmbeds.current.of(variant === "writer" && language === "markdown" ? fileEmbedPresentation(
         () => embeddedFilesRef.current,
-        () => onOpenFileRef.current,
+        () => onOpenFileRef.current ? openEmbeddedFile : undefined,
         () => onVisibleFileEmbedsRef.current
       ) : []),
       noteEmbeds.current.of(variant === "writer" && language === "markdown" ? noteEmbedPresentation(
         () => embeddedNotesRef.current,
-        () => onOpenLinkRef.current,
+        () => onOpenLinkRef.current ? openEmbeddedNote : undefined,
         () => onVisibleNoteEmbedsRef.current
       ) : []),
       variant === "writer" ? writerInteractions(
@@ -255,6 +268,7 @@ export function CodeEditor({
     const state = remembered && rememberedValue(remembered) === value
       ? EditorState.fromJSON(remembered.state, config, { history: historyField })
       : EditorState.create({ doc: value, extensions });
+    const focusBeforeMount = parentRef.current.ownerDocument.activeElement;
     const view = new EditorView({ parent: parentRef.current, state });
     viewRef.current = view;
     if (documentId) registerActiveEditor(documentId, view);
@@ -267,8 +281,11 @@ export function CodeEditor({
       const editableOwner = HTMLElement && activeElement instanceof HTMLElement
         && (activeElement.matches("input, textarea, select") || activeElement.isContentEditable
           || activeElement.closest('[contenteditable]:not([contenteditable="false"])'));
-      // A lazy mount must not take typing away from another editable control.
-      if (autoFocus && (!editableOwner || view.dom.contains(activeElement))) view.focus();
+      // Preserve another control's focus, including focus moved after mounting
+      // but before this frame, and keep dialogs in charge of their own focus.
+      if (autoFocus && activeElement === focusBeforeMount
+          && (!editableOwner || view.dom.contains(activeElement))
+          && !activeElement?.closest("[role='dialog'], [role='alertdialog'], [role='combobox']")) view.focus();
     });
     return () => {
       if (documentId) rememberEditor(documentId, view, lineSeparator.current);
@@ -360,12 +377,12 @@ export function CodeEditor({
       effects: fileEmbeds.current.reconfigure(
         variant === "writer" && language === "markdown" ? fileEmbedPresentation(
           () => embeddedFilesRef.current,
-          () => onOpenFileRef.current,
+          () => onOpenFileRef.current ? openEmbeddedFile : undefined,
           () => onVisibleFileEmbedsRef.current
         ) : []
       )
     });
-  }, [embeddedFiles, language, onOpenFile, onVisibleFileEmbeds, variant]);
+  }, [embeddedFiles, language, canOpenEmbeddedFile, variant]);
 
   useEffect(() => {
     const view = viewRef.current;
@@ -374,12 +391,12 @@ export function CodeEditor({
       effects: noteEmbeds.current.reconfigure(
         variant === "writer" && language === "markdown" ? noteEmbedPresentation(
           () => embeddedNotesRef.current,
-          () => onOpenLinkRef.current,
+          () => onOpenLinkRef.current ? openEmbeddedNote : undefined,
           () => onVisibleNoteEmbedsRef.current
         ) : []
       )
     });
-  }, [embeddedNotes, language, onOpenLink, onVisibleNoteEmbeds, variant]);
+  }, [embeddedNotes, language, canOpenEmbeddedNote, variant]);
 
   useEffect(() => {
     const view = viewRef.current;

--- a/apps/editor/src/CodeEditor.ui.test.tsx
+++ b/apps/editor/src/CodeEditor.ui.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { Compartment } from "@codemirror/state";
 import { CodeEditor } from "./CodeEditor";
 import type { ResolvedFileReference } from "./use-file-assets";
 import type { ResolvedNoteEmbed } from "./note-embeds";
@@ -7,6 +8,24 @@ import type { ResolvedNoteEmbed } from "./note-embeds";
 vi.mock("./inline-pdf-viewer", () => ({
   mountInlinePdfViewer: vi.fn(() => ({ unmount: vi.fn() }))
 }));
+
+describe("editor autofocus ownership", () => {
+  it.each([true, false])("does not steal an outside text input's focus (focused before mount=%s)", async (beforeMount) => {
+    render(<input aria-label="Sidebar search" />);
+    const search = screen.getByRole("textbox", { name: "Sidebar search" });
+    if (beforeMount) search.focus();
+    render(<CodeEditor value="A note" label="Note body" language="markdown" variant="writer" autoFocus />);
+    if (!beforeMount) search.focus();
+    await act(async () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+    expect(search).toHaveFocus();
+  });
+
+  it("still focuses the editor when no other control owns focus", async () => {
+    render(<CodeEditor value="A note" label="Note body" language="markdown" variant="writer" autoFocus />);
+    await act(async () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+    expect(screen.getByRole("textbox", { name: "Note body" })).toHaveFocus();
+  });
+});
 
 describe("rendered Markdown links", () => {
   it("opens a rendered link without moving the caret into its source", async () => {
@@ -39,6 +58,37 @@ describe("rendered Markdown links", () => {
 });
 
 describe("note transclusions", () => {
+  it("does not reconfigure on unrelated renders or callback identities and keeps retained widgets fresh", async () => {
+    const reconfigure = vi.spyOn(Compartment.prototype, "reconfigure");
+    const first = vi.fn();
+    const latest = vi.fn();
+    const embeddedNotes = [noteReference];
+    const props = {
+      value: "Intro.\n\n![[Notes/plan#Decisions]]", label: "Note body",
+      language: "markdown" as const, variant: "writer" as const, embeddedNotes,
+      onOpenLink: first, onVisibleNoteEmbeds: vi.fn(), onVisibleFileEmbeds: vi.fn(), onOpenFile: vi.fn()
+    };
+    const editor = render(<CodeEditor {...props} />);
+    const button = await screen.findByRole("button", { name: "Open Project plan" });
+    reconfigure.mockClear();
+    editor.rerender(<CodeEditor {...props} className="unrelated" onOpenLink={latest}
+      onVisibleNoteEmbeds={vi.fn()} onVisibleFileEmbeds={vi.fn()} onOpenFile={vi.fn()} />);
+    expect(reconfigure).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Open Project plan" })).toBe(button);
+    fireEvent.click(button);
+    expect(first).not.toHaveBeenCalled();
+    expect(latest).toHaveBeenCalledWith("Notes/plan.md");
+    const updatedNotes = [{ ...noteReference, body: "Updated fragment", revision: "2" }];
+    editor.rerender(<CodeEditor {...props} onOpenLink={latest} embeddedNotes={updatedNotes} />);
+    expect(reconfigure).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("region", { name: "Transclusion of Project plan" })).toHaveTextContent("Updated fragment");
+    editor.rerender(<CodeEditor {...props} onOpenLink={undefined} embeddedNotes={updatedNotes} />);
+    expect(screen.queryByRole("button", { name: "Open Project plan" })).not.toBeInTheDocument();
+    editor.rerender(<CodeEditor {...props} onOpenLink={latest} embeddedNotes={updatedNotes} />);
+    expect(screen.getByRole("button", { name: "Open Project plan" })).toBeInTheDocument();
+    reconfigure.mockRestore();
+  });
+
   it("renders a resolved note fragment and opens its source note", async () => {
     const open = vi.fn();
     render(<CodeEditor
@@ -59,6 +109,41 @@ describe("note transclusions", () => {
 });
 
 describe("PDF links and embeds", () => {
+  it("retains file widgets across callback rerenders and updates changed assets", async () => {
+    const reconfigure = vi.spyOn(Compartment.prototype, "reconfigure");
+    const file = { ...pdfReference.file, path: "Documents/image.png", mediaType: "image/png", mediaClass: "image" as const };
+    const reference: ResolvedFileReference = {
+      ...pdfReference, file, asset: { status: "ready", file, url: "blob:first" }
+    };
+    const embeddedFiles = [reference];
+    const first = vi.fn(), latest = vi.fn();
+    const props = {
+      value: "Intro.\n\n![[Documents/image.png]]", label: "Note body",
+      language: "markdown" as const, variant: "writer" as const, embeddedFiles
+    };
+    const editor = render(<CodeEditor {...props} onOpenFile={first} />);
+    const button = await screen.findByRole("button", { name: "Open image.png" });
+    reconfigure.mockClear();
+    editor.rerender(<CodeEditor {...props} onOpenFile={latest} onVisibleFileEmbeds={vi.fn()} />);
+    expect(reconfigure).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Open image.png" })).toBe(button);
+    fireEvent.click(button);
+    expect(first).not.toHaveBeenCalled();
+    expect(latest).toHaveBeenCalledWith(reference.asset);
+    const asset = { status: "ready" as const, file, url: "blob:updated" };
+    editor.rerender(<CodeEditor {...props} onOpenFile={latest} embeddedFiles={[{ ...reference, asset }]} />);
+    expect(reconfigure).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("img", { name: "image.png" })).toHaveAttribute("src", "blob:updated");
+    fireEvent.click(screen.getByRole("button", { name: "Open image.png" }));
+    expect(latest).toHaveBeenLastCalledWith(asset);
+    const updatedFiles = [{ ...reference, asset }];
+    editor.rerender(<CodeEditor {...props} onOpenFile={undefined} embeddedFiles={updatedFiles} />);
+    expect(screen.queryByRole("button", { name: "Open image.png" })).not.toBeInTheDocument();
+    editor.rerender(<CodeEditor {...props} onOpenFile={latest} embeddedFiles={updatedFiles} />);
+    expect(screen.getByRole("button", { name: "Open image.png" })).toBeInTheDocument();
+    reconfigure.mockRestore();
+  });
+
   it("focuses an embedded PDF in place without opening a modal", async () => {
     render(<CodeEditor
       value={"Intro.\n\n![[Documents/paper.pdf]]"}

--- a/apps/editor/src/NoteList.test.tsx
+++ b/apps/editor/src/NoteList.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { NoteList } from "./NoteList";
+import type { NoteSummary } from "./model";
+import { buildNoteSearchIndex, searchNoteResults } from "./note-search";
+
+// Supply a deterministic viewport, independent of jsdom layout measurements.
+const viewport = vi.hoisted(() => ({ start: 0 }));
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 76,
+    getVirtualItems: () => Array.from({ length: 20 }, (_, offset) => ({
+      index: viewport.start + offset, start: (viewport.start + offset) * 76, size: 76
+    }))
+  })
+}));
+
+describe("NoteList search presentation", () => {
+  it("accesses contexts only for virtual rows while retaining the full count", () => {
+    viewport.start = 0;
+    const notes: NoteSummary[] = Array.from({ length: 10_000 }, (_, i) => ({
+      path: `Notes/${String(i).padStart(4, "0")}.md`, frontmatter: {},
+      effectiveFrontmatter: {}, types: [], body: "needle body",
+      file: { path: `Notes/${String(i).padStart(4, "0")}.md`, name: `${i}.md`, folder: "Notes", size: 11, mtime: "" }
+    }));
+    const index = buildNoteSearchIndex(notes);
+    const accessed: string[] = [];
+    for (const entry of index) Object.defineProperty(entry, "bodyText", {
+      get: () => { accessed.push(entry.note.path); return "needle body"; }
+    });
+    const results = searchNoteResults(index, "needle");
+    const searchContexts = new Map(results.map((result) => [result.note.path, result]));
+    const noop = () => {};
+    const props = {
+      entries: notes.map((note) => ({ kind: "note" as const, path: note.path, note })),
+      noteCount: notes.length, fileCount: 0, types: [], statuses: new Map(),
+      search: "needle", searchQuery: "needle", searchContexts, sort: "path-asc" as const,
+      collectionName: "Test", loading: false, structureLoading: false, filesLoading: false,
+      contentIndexing: false, contentLoaded: notes.length,
+      onSearch: noop, onSort: noop, onClearScope: noop, onQuickOpen: noop,
+      onRetryContent: noop, onRetryFiles: noop, onSelect: noop, onSelectFile: noop,
+      onPreview: noop, onDismissPreview: noop, onCreate: noop, onCollections: noop
+    };
+    const view = render(<NoteList {...props} />);
+    expect(screen.getByText(`${(10_000).toLocaleString()} found · relevance`)).toBeInTheDocument();
+    // The first virtual row is the folder header.
+    expect(screen.getAllByRole("option")).toHaveLength(19);
+    expect(accessed).toEqual(notes.slice(0, 19).map((note) => note.path));
+    viewport.start = 9001;
+    view.rerender(<NoteList {...props} />);
+    expect(screen.getAllByRole("option")).toHaveLength(20);
+    expect(accessed.slice(19)).toEqual(notes.slice(9000, 9020).map((note) => note.path));
+    view.rerender(<NoteList {...props} />);
+    expect(accessed).toHaveLength(39);
+  });
+});

--- a/apps/editor/src/NoteList.tsx
+++ b/apps/editor/src/NoteList.tsx
@@ -8,7 +8,7 @@ import { noteSortSummary, moveListIndex, type NoteSort, type ListNavigationKey }
 import { NoteListViewOptions } from "./NoteListViewOptions";
 import { notePreviewPopoverId, type NotePreviewAnchor, type NotePreviewSource } from "./NotePreview";
 import { isPhosphorIconName, PhosphorIcon, collectionTypeIcon } from "./PhosphorIcon";
-import { searchTextRanges, type NoteSearchContext } from "./note-search";
+import { searchTextRanges, type NoteSearchResult } from "./note-search";
 import { SearchMatchText } from "./SearchMatchText";
 import { browserListItems, collectionFileFormat, collectionFileTitle, formatFileSize, type CollectionBrowserEntry } from "./collection-browser";
 
@@ -35,7 +35,7 @@ export function NoteList({ entries, noteCount, fileCount, types, selectedPath, s
   statuses: Map<string, NoteRowStatus>;
   search: string;
   searchQuery: string;
-  searchContexts: Map<string, NoteSearchContext>;
+  searchContexts: Map<string, NoteSearchResult>;
   sort: NoteSort;
   scopeLabel?: string;
   collectionName: string;
@@ -132,7 +132,7 @@ export function NoteList({ entries, noteCount, fileCount, types, selectedPath, s
         }
         const note = entry.note;
         const status: NoteRowStatus | undefined = pendingPath === note.path ? { label: "Opening", tone: "busy", busy: true } : statuses.get(note.path);
-        const searchContext = searchQuery.trim() ? searchContexts.get(note.path) : undefined;
+        const searchContext = searchQuery.trim() ? searchContexts.get(note.path)?.context : undefined;
         const title = noteTitle(note, types);
         const typeIcon = note.types.map((type) => typeIcons.get(type)).find(isPhosphorIconName);
         const requestPreview = (target: HTMLButtonElement) => {

--- a/apps/editor/src/code-editor-file-embeds.ts
+++ b/apps/editor/src/code-editor-file-embeds.ts
@@ -16,7 +16,8 @@ class FileEmbedWidget extends WidgetType {
   eq(other: FileEmbedWidget) {
     const current = this.reference.asset;
     const next = other.reference.asset;
-    return current.file.fileId === next.file.fileId
+    return Boolean(this.open) === Boolean(other.open)
+      && current.file.fileId === next.file.fileId
       && current.file.revision === next.file.revision
       && current.status === next.status
       && (current.status !== "ready" || next.status !== "ready" || current.url === next.url)

--- a/apps/editor/src/code-editor-note-embeds.ts
+++ b/apps/editor/src/code-editor-note-embeds.ts
@@ -9,7 +9,8 @@ class NoteEmbedWidget extends WidgetType {
   ) { super(); }
 
   eq(other: NoteEmbedWidget) {
-    return this.reference.status === other.reference.status
+    return Boolean(this.open) === Boolean(other.open)
+      && this.reference.status === other.reference.status
       && this.reference.path === other.reference.path
       && this.reference.revision === other.reference.revision
       && this.reference.body === other.reference.body

--- a/apps/editor/src/file-asset-store.test.ts
+++ b/apps/editor/src/file-asset-store.test.ts
@@ -41,6 +41,199 @@ describe("FileAssetStore", () => {
     await store.load(file("two.png", "r1", 6, "2"));
     expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["error", "too_large"] as const)("bounds released %s entries without ready URLs", async (status) => {
+    const readFile = vi.fn(async () => { throw new Error("offline"); });
+    const store = new FileAssetStore({ readFile }, { maxEntries: 3, maxPreviewBytes: 8 });
+    const files = Array.from({ length: 100 }, (_, i) => file(`${i}.png`, "r1", status === "too_large" ? 9 : 1, String(i)));
+    for (const current of files) {
+      const release = store.acquire(current);
+      expect((await store.load(current)).status).toBe(status);
+      release();
+      expect(files.filter((value) => store.get(value).status !== "idle").length).toBeLessThanOrEqual(3);
+    }
+    expect(files.slice(-3).map((value) => store.get(value).status)).toEqual([status, status, status]);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    expect(readFile).toHaveBeenCalledTimes(status === "error" ? 100 : 0);
+  });
+
+  it.each(["error", "too_large"] as const)("bounds load-only %s entries", async (status) => {
+    const store = new FileAssetStore({ readFile: vi.fn().mockRejectedValue(new Error("offline")) }, {
+      maxEntries: 2, maxPreviewBytes: 8
+    });
+    const files = Array.from({ length: 20 }, (_, i) => file(`${i}.png`, "r1", status === "too_large" ? 9 : 1, String(i)));
+    for (const current of files) await store.load(current);
+    expect(files.filter((value) => store.get(value).status !== "idle")).toEqual(files.slice(-2));
+  });
+
+  it("keeps failed snapshots passive but retries on reacquisition for visible embeds", async () => {
+    const readFile = vi.fn().mockRejectedValueOnce(new Error("offline")).mockResolvedValue(new Blob(["ok"]));
+    const store = new FileAssetStore({ readFile });
+    const current = file("one.png", "r1", 2);
+    await store.load(current);
+    for (let i = 0; i < 10; i++) expect(store.get(current).status).toBe("error");
+    expect(readFile).toHaveBeenCalledTimes(1);
+    const release = store.acquire(current);
+    expect((await store.load(current)).status).toBe("ready");
+    release();
+    expect(readFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts abandoned in-flight entries at the entry limit and ignores late settlement", async () => {
+    const pending: { signal?: AbortSignal; resolve: (blob: Blob) => void }[] = [];
+    const readFile = vi.fn((_file: CollectionFile, options?: { signal?: AbortSignal }) => new Promise<Blob>((resolve) => {
+      pending.push({ signal: options?.signal, resolve });
+    }));
+    const store = new FileAssetStore({ readFile }, { maxEntries: 2 });
+    const files = Array.from({ length: 10 }, (_, i) => file(`${i}.png`, "r1", 1, String(i)));
+    const loads = files.map((current, i) => {
+      // Cover both abandoned acquire() and the load-only path.
+      const release = i % 2 === 0 ? store.acquire(current) : undefined;
+      const load = store.load(current);
+      release?.();
+      return load;
+    });
+    expect(pending.map(({ signal }) => signal?.aborted)).toEqual([...Array(8).fill(true), false, false]);
+    expect(files.filter((value) => store.get(value).status === "loading")).toEqual(files.slice(-2));
+    pending.forEach(({ resolve }) => resolve(new Blob(["x"])));
+    await Promise.all(loads);
+    expect(files.slice(0, -2).every((value) => store.get(value).status === "idle")).toBe(true);
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(2);
+    store.reset();
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps all referenced statuses pinned and restores bounds on idempotent release", async () => {
+    const readFile = vi.fn(async (value: CollectionFile) => {
+      if (value.path === "error.png") throw new Error("offline");
+      return new Blob(["ok"]);
+    });
+    const store = new FileAssetStore({ readFile }, { maxEntries: 1, maxCacheBytes: 1, maxPreviewBytes: 8 });
+    const files = [file("ready.png", "r1", 2, "1"), file("error.png", "r1", 1, "2"), file("large.png", "r1", 9, "3")];
+    const releases = files.map((value) => store.acquire(value));
+    await Promise.all(files.map((value) => store.load(value)));
+    expect(files.map((value) => store.get(value).status)).toEqual(["ready", "error", "too_large"]);
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    releases[1]();
+    releases[1]();
+    expect(store.get(files[1]).status).toBe("idle");
+    expect(store.get(files[0]).status).toBe("ready");
+    releases[0]();
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(store.get(files[2]).status).toBe("too_large");
+    releases[2]();
+    store.reset();
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["reset", "invalidate"] as const)("fences late reads after %s and leaves a replacement request alone", async (action) => {
+    const pending: { resolve: (blob: Blob) => void; signal?: AbortSignal }[] = [];
+    const store = new FileAssetStore({ readFile: vi.fn((_file, options) => new Promise<Blob>((resolve) => {
+      pending.push({ resolve, signal: options?.signal });
+    })) });
+    const current = file("one.png", "r1", 1);
+    const old = store.load(current);
+    if (action === "reset") store.reset();
+    else store.invalidate(current.fileId);
+    const replacement = store.load(current);
+    const version = store.getVersion();
+    pending[0].resolve(new Blob(["old"]));
+    await old;
+    expect(pending[0].signal?.aborted).toBe(true);
+    expect(store.getVersion()).toBe(version);
+    expect(store.get(current).status).toBe("loading");
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    pending[1].resolve(new Blob(["new"]));
+    await replacement;
+    expect(store.get(current).status).toBe("ready");
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it("revokes every owned URL exactly once across retry, revision, eviction and reset", async () => {
+    let nextUrl = 0;
+    vi.mocked(URL.createObjectURL).mockImplementation(() => `blob:owned-${++nextUrl}`);
+    const store = new FileAssetStore({ readFile: vi.fn().mockResolvedValue(new Blob(["ok"])) }, { maxEntries: 1 });
+    const current = file("one.png", "r1", 2);
+    await store.load(current);
+    await store.retry(current);
+    await store.load({ ...current, revision: "r2" });
+    await store.load(file("two.png", "r1", 2, "2"));
+    store.reset();
+    store.reset();
+    store.invalidate(current.fileId);
+    expect(vi.mocked(URL.revokeObjectURL).mock.calls).toEqual([
+      ["blob:owned-1"], ["blob:owned-2"], ["blob:owned-3"], ["blob:owned-4"]
+    ]);
+  });
+
+  it("pins a shared pending read until the last consumer releases it", async () => {
+    let resolve!: (blob: Blob) => void;
+    let signal: AbortSignal | undefined;
+    const readFile = vi.fn((_file, options) => {
+      signal = options?.signal;
+      return new Promise<Blob>((yes) => { resolve = yes; });
+    });
+    const store = new FileAssetStore({ readFile }, { maxEntries: 0 });
+    const current = file("one.png", "r1", 1);
+    const first = store.acquire(current);
+    const second = store.acquire(current);
+    const loading = store.retry(current);
+    expect(readFile).toHaveBeenCalledTimes(1);
+    first();
+    first();
+    expect(signal?.aborted).toBe(false);
+    expect(store.get(current).status).toBe("loading");
+    second();
+    expect(signal?.aborted).toBe(true);
+    expect(store.get(current).status).toBe("idle");
+    resolve(new Blob(["late"]));
+    await loading;
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("enforces a zero-entry budget for immediate oversized loads and retries", async () => {
+    const readFile = vi.fn().mockResolvedValue(new Blob());
+    const store = new FileAssetStore({ readFile }, { maxEntries: 0, maxPreviewBytes: 1 });
+    const current = file("large.png", "r1", 2);
+    expect((await store.load(current)).status).toBe("idle");
+    expect((await store.retry(current)).status).toBe("idle");
+    const release = store.acquire(current);
+    expect((await store.retry(current)).status).toBe("too_large");
+    release();
+    expect(store.get(current).status).toBe("idle");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("ignores a rejected evicted request without publishing stale errors", async () => {
+    let reject!: (error: Error) => void;
+    const readFile = vi.fn().mockImplementationOnce(() => new Promise<Blob>((_yes, no) => { reject = no; }))
+      .mockResolvedValue(new Blob(["ok"]));
+    const store = new FileAssetStore({ readFile }, { maxEntries: 1 });
+    const current = file("one.png", "r1", 1);
+    const old = store.load(current);
+    await store.load(file("two.png", "r1", 1, "2"));
+    const version = store.getVersion();
+    reject(new Error("late error"));
+    await old;
+    expect(store.getVersion()).toBe(version);
+    expect(store.get(current).status).toBe("idle");
+  });
+
+  it("uses access order even when the clock does not advance", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1);
+    try {
+      const store = new FileAssetStore({ readFile: vi.fn().mockResolvedValue(new Blob()) }, { maxEntries: 2 });
+      const files = [1, 2, 3].map((id) => file(`${id}.png`, "r1", 1, String(id)));
+      await store.load(files[0]);
+      await store.load(files[1]);
+      await store.load(files[0]);
+      await store.load(files[2]);
+      expect(files.map((value) => store.get(value).status)).toEqual(["ready", "idle", "ready"]);
+    } finally {
+      vi.mocked(Date.now).mockRestore();
+    }
+  });
 });
 
 function file(path: string, revision: string, size: number, id = "1"): CollectionFile {

--- a/apps/editor/src/file-asset-store.ts
+++ b/apps/editor/src/file-asset-store.ts
@@ -34,6 +34,7 @@ export class FileAssetStore {
   private readonly entries = new Map<string, AssetEntry>();
   private readonly listeners = new Set<() => void>();
   private version = 0;
+  private usage = 0;
   private readonly maxPreviewBytes: number;
   private readonly maxCacheBytes: number;
   private readonly maxEntries: number;
@@ -66,20 +67,21 @@ export class FileAssetStore {
   acquire(file: CollectionFile): () => void {
     const entry = this.entry(file);
     entry.references += 1;
-    entry.lastUsed = Date.now();
+    entry.lastUsed = ++this.usage;
     void this.loadEntry(entry);
     let active = true;
     return () => {
       if (!active) return;
       active = false;
       entry.references = Math.max(0, entry.references - 1);
-      entry.lastUsed = Date.now();
+      entry.lastUsed = ++this.usage;
       this.evict();
     };
   }
 
   async load(file: CollectionFile): Promise<FileAssetSnapshot> {
     const entry = this.entry(file);
+    entry.lastUsed = ++this.usage;
     await this.loadEntry(entry);
     return this.get(file);
   }
@@ -90,7 +92,6 @@ export class FileAssetStore {
     this.disposeEntry(entry);
     entry.status = "idle";
     entry.error = undefined;
-    this.changed();
     return this.load(file);
   }
 
@@ -123,7 +124,7 @@ export class FileAssetStore {
       file,
       status: "idle",
       references: 0,
-      lastUsed: Date.now()
+      lastUsed: ++this.usage
     };
     this.entries.set(key, entry);
     return entry;
@@ -135,6 +136,7 @@ export class FileAssetStore {
     if (entry.file.size > this.maxPreviewBytes) {
       entry.status = "too_large";
       entry.error = `Preview is limited to ${formatBytes(this.maxPreviewBytes)}. Download this ${formatBytes(entry.file.size)} file to open it.`;
+      this.evict();
       this.changed();
       return;
     }
@@ -143,43 +145,51 @@ export class FileAssetStore {
     entry.request = controller;
     entry.status = "loading";
     entry.error = undefined;
-    this.changed();
     const promise = this.source.readFile(entry.file, { signal: controller.signal })
       .then((blob) => {
-        if (controller.signal.aborted || entry.request !== controller) return;
+        if (!this.ownsRequest(entry, controller)) return;
         entry.url = URL.createObjectURL(blob);
         entry.status = "ready";
-        entry.lastUsed = Date.now();
+        entry.lastUsed = ++this.usage;
       })
       .catch((error: unknown) => {
-        if (controller.signal.aborted || entry.request !== controller) return;
+        if (!this.ownsRequest(entry, controller)) return;
         entry.status = "error";
         entry.error = error instanceof Error ? error.message : "The file could not be opened.";
       })
       .finally(() => {
-        if (entry.request === controller) entry.request = undefined;
-        if (entry.promise === promise) entry.promise = undefined;
+        if (!this.ownsRequest(entry, controller)) return;
+        entry.request = undefined;
+        entry.promise = undefined;
         this.evict();
         this.changed();
       });
     entry.promise = promise;
+    this.evict();
+    this.changed();
     return promise;
   }
 
   private evict(): void {
-    const ready = [...this.entries.entries()].filter(([, entry]) => entry.status === "ready");
-    let bytes = ready.reduce((total, [, entry]) => total + entry.file.size, 0);
-    let count = ready.length;
-    const candidates = ready
+    const cached = [...this.entries.entries()];
+    let bytes = cached.reduce((total, [, entry]) => total + (entry.url ? entry.file.size : 0), 0);
+    let count = cached.length;
+    if (bytes <= this.maxCacheBytes && count <= this.maxEntries) return;
+    const candidates = cached
       .filter(([, entry]) => entry.references === 0)
       .sort((left, right) => left[1].lastUsed - right[1].lastUsed);
     for (const [key, entry] of candidates) {
       if (bytes <= this.maxCacheBytes && count <= this.maxEntries) break;
-      bytes -= entry.file.size;
+      if (entry.url) bytes -= entry.file.size;
       count -= 1;
       this.disposeEntry(entry);
       this.entries.delete(key);
     }
+  }
+
+  private ownsRequest(entry: AssetEntry, controller: AbortController): boolean {
+    return !controller.signal.aborted && entry.request === controller
+      && this.entries.get(fileAssetKey(entry.file)) === entry;
   }
 
   private disposeEntry(entry: AssetEntry): void {

--- a/apps/editor/src/file-inventory-controller.test.ts
+++ b/apps/editor/src/file-inventory-controller.test.ts
@@ -51,6 +51,105 @@ describe("FileInventoryController", () => {
     controller.remove(original.fileId);
     expect(controller.getSnapshot().files).toEqual([]);
   });
+
+  it("sorts 10,000 files once across 100 cumulative progress snapshots", async () => {
+    const files = Array.from({ length: 10_000 }, (_, i) => file(`image${10_000 - i}.png`, String(i)));
+    const originalSort = Array.prototype.sort;
+    let sorts = 0;
+    let comparisons = 0;
+    const sort = vi.spyOn(Array.prototype, "sort").mockImplementation(function<T>(this: T[], compare?: (a: T, b: T) => number): T[] {
+      const isInventory = this.length > 0 && typeof this[0] === "object" && this[0] !== null && "fileId" in this[0];
+      if (isInventory) sorts += 1;
+      return originalSort.call(this, compare && ((a: T, b: T) => {
+        if (isInventory) comparisons += 1;
+        return compare(a, b);
+      })) as T[];
+    });
+    try {
+      let progressCount = 0;
+      const controller = new FileInventoryController({
+        listFiles: vi.fn(async ({ onProgress } = {}) => {
+          for (let count = 100; count <= files.length; count += 100) {
+            const batch = files.slice(0, count);
+            onProgress?.({ files: batch, complete: count === files.length });
+            const snapshot = controller.getSnapshot();
+            expect(snapshot.files).toEqual(batch);
+            expect(snapshot.files).not.toBe(batch);
+            expect(snapshot.error).toBeUndefined();
+            expect(snapshot.loading).toBe(count < files.length);
+            progressCount += 1;
+          }
+          return files;
+        })
+      });
+      const result = await controller.reload();
+      expect(progressCount).toBe(100);
+      expect(sorts).toBe(1);
+      expect(comparisons).toBeLessThan(200_000);
+      expect(result.map(({ path }) => path)).toEqual(Array.from({ length: 10_000 }, (_, i) => `image${i + 1}.png`));
+      expect(controller.getSnapshot().files).toBe(result);
+      expect(files[0].path).toBe("image10000.png");
+    } finally {
+      sort.mockRestore();
+    }
+  });
+
+  it("matches numeric/base locale order and retains source order for equal paths", async () => {
+    const files = ["z10.png", "Z2.png", "á1.png", "A1.png", "a1.png", "folder/11.png", "folder/2.png"]
+      .map((path, i) => file(path, String(i)));
+    const expected = [...files].sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true, sensitivity: "base" }));
+    const controller = new FileInventoryController({ listFiles: vi.fn().mockResolvedValue(files) });
+    expect(await controller.reload()).toEqual(expected);
+    expect(controller.getSnapshot().files.filter(({ path }) => /1\.png$/.test(path)).slice(0, 3)).toEqual(files.slice(2, 5));
+  });
+
+  it("preserves usable progress on failure, propagates the error, and clears it on retry", async () => {
+    const partial = [file("z.png", "1"), file("a.png", "2")];
+    const failure = new Error("offline");
+    const source = {
+      listFiles: vi.fn<CollectionGateway["listFiles"]>()
+        .mockImplementationOnce(async ({ onProgress } = {}) => {
+          onProgress?.({ files: partial, complete: false });
+          throw failure;
+        })
+        .mockResolvedValueOnce(partial)
+    };
+    const controller = new FileInventoryController(source);
+    await expect(controller.reload()).rejects.toBe(failure);
+    expect(controller.getSnapshot()).toEqual({ files: partial, loading: false, complete: false, error: "offline" });
+    const retry = controller.reload();
+    expect(controller.getSnapshot()).toMatchObject({ loading: true, complete: false, error: undefined });
+    expect(await retry).toEqual([partial[1], partial[0]]);
+    expect(controller.getSnapshot()).toMatchObject({ loading: false, complete: true });
+  });
+
+  it.each(["resolve", "reject"] as const)("ignores stale progress and %s after reset", async (settlement) => {
+    let options!: Parameters<CollectionGateway["listFiles"]>[0];
+    let resolve!: (files: CollectionFile[]) => void;
+    let reject!: (error: Error) => void;
+    const stale = [file("stale.png", "1")];
+    const latest = [file("latest.png", "2")];
+    const source = {
+      listFiles: vi.fn<CollectionGateway["listFiles"]>()
+        .mockImplementationOnce((value) => {
+          options = value;
+          return new Promise((yes, no) => { resolve = yes; reject = no; });
+        })
+        .mockResolvedValueOnce(latest)
+    };
+    const controller = new FileInventoryController(source);
+    const first = controller.reload();
+    controller.reset();
+    expect(options?.signal?.aborted).toBe(true);
+    options?.onProgress?.({ files: stale, complete: true });
+    expect(controller.getSnapshot()).toEqual({ files: [], loading: false, complete: false });
+    await controller.reload();
+    options?.onProgress?.({ files: stale, complete: false });
+    if (settlement === "resolve") resolve(stale);
+    else reject(new Error("stale failure"));
+    expect(await first).toEqual([]);
+    expect(controller.getSnapshot()).toMatchObject({ files: latest, complete: true, loading: false });
+  });
 });
 
 function file(path: string, id: string): CollectionFile {

--- a/apps/editor/src/file-inventory-controller.ts
+++ b/apps/editor/src/file-inventory-controller.ts
@@ -48,7 +48,9 @@ export class FileInventoryController {
     const acceptProgress = (progress: FileListProgress) => {
       if (!this.isCurrent(controller, generation)) return;
       this.publish({
-        files: stableFileOrder(progress.files),
+        // Partial inventories are usable in source order. Sort only the final
+        // result, rather than re-sorting every cumulative pagination snapshot.
+        files: [...progress.files],
         loading: !progress.complete,
         complete: progress.complete,
         error: undefined
@@ -108,11 +110,10 @@ export class FileInventoryController {
   }
 }
 
+const filePathCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+
 function stableFileOrder(files: readonly CollectionFile[]): CollectionFile[] {
-  return [...files].sort((left, right) => left.path.localeCompare(right.path, undefined, {
-    numeric: true,
-    sensitivity: "base"
-  }));
+  return [...files].sort((left, right) => filePathCollator.compare(left.path, right.path));
 }
 
 function defaultErrorMessage(error: unknown): string {

--- a/apps/editor/src/note-embeds.test.ts
+++ b/apps/editor/src/note-embeds.test.ts
@@ -13,8 +13,8 @@ const target = { path: "Shared/target.md", title: "Target" };
 const document = (body: string) => ({ path: target.path, revision: body, body, frontmatter: {}, effectiveFrontmatter: {}, types: [], document: body, file: { name: "target.md", folder: "Shared", size: body.length, mtime: "", tags: [], links: [], embeds: [] } });
 const summary = (body?: string) => ({ ...document(body ?? ""), ...(body === undefined ? { body: undefined } : {}) });
 function embedHarness(read: (path: string) => Promise<ReturnType<typeof document>>, body?: string) {
-  const props = { gateway: { read }, owner: { collectionId: "a" as string | undefined, epoch: 1 }, notes: [summary(body)] };
-  const hook = renderHook(() => useEmbeddedNoteReferences(props.gateway, props.owner, "![[Target]]", props.notes as never, [target], [], "Shared/source.md"));
+  const props = { gateway: { read }, owner: { collectionId: "a" as string | undefined, epoch: 1 }, notes: [summary(body)], suggestions: [target], files: [] };
+  const hook = renderHook(() => useEmbeddedNoteReferences(props.gateway, props.owner, "![[Target]]", props.notes as never, props.suggestions, props.files, "Shared/source.md"));
   return { props, ...hook };
 }
 
@@ -63,6 +63,31 @@ describe("Markdown transclusion fragments", () => {
 });
 
 describe("embedded note owner cache", () => {
+  it.each(["success", "error"])("memoizes unchanged inputs and publishes async %s and epoch resets", async (outcome) => {
+    const pending = deferred<ReturnType<typeof document>>();
+    const read = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValueOnce(document("new epoch"));
+    const hook = embedHarness(read);
+    const empty = hook.result.current;
+    hook.rerender();
+    expect(hook.result.current).toBe(empty);
+    await waitFor(() => expect(hook.result.current[0]?.status).toBe("loading"));
+    const loading = hook.result.current;
+    hook.rerender();
+    expect(hook.result.current).toBe(loading);
+    await act(async () => outcome === "success" ? pending.resolve(document("cached")) : pending.reject(new Error("read failed")));
+    await waitFor(() => expect(hook.result.current[0]?.status).toBe(outcome === "success" ? "ready" : "error"));
+    expect(hook.result.current).not.toBe(loading);
+    const completed = hook.result.current;
+    hook.props.owner = { collectionId: "a", epoch: 1 };
+    hook.rerender();
+    expect(hook.result.current).toBe(completed);
+    hook.props.owner = { collectionId: "a", epoch: 2 };
+    hook.rerender();
+    expect(hook.result.current).not.toBe(completed);
+    await ready(hook.result, "new epoch");
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
   it("does not reuse a completed same-path document after A to B", async () => {
     const read = vi.fn(async () => document("A body"));
     const hook = embedHarness(read);

--- a/apps/editor/src/note-embeds.ts
+++ b/apps/editor/src/note-embeds.ts
@@ -16,6 +16,8 @@ export type ResolvedNoteEmbed = MarkdownReference & {
   error?: string;
 };
 
+const EMPTY_REFERENCES: MarkdownReference[] = [];
+
 type EmbedCacheOwner = { collectionId: string | undefined; epoch: number };
 type EmbedCacheStore = {
   gateway: Pick<CollectionGateway, "read">;
@@ -36,7 +38,7 @@ export function useEmbeddedNoteReferences(
   sourcePath?: string,
   visibleKeys?: ReadonlySet<string>
 ): ResolvedNoteEmbed[] {
-  const [, rerender] = useState(0);
+  const [cacheVersion, rerender] = useState(0);
   const store = useMemo<EmbedCacheStore>(() => ({
     gateway, collectionId: owner.collectionId, epoch: owner.epoch,
     documents: new Map(), errors: new Map(), pending: new Map()
@@ -55,8 +57,8 @@ export function useEmbeddedNoteReferences(
   const cache = store.documents;
   const errors = store.errors;
 
-  const [parsed, setParsed] = useState<{ source: string; references: MarkdownReference[] }>(() => ({ source: "", references: [] }));
-  const references = parsed.source === source ? parsed.references : [];
+  const [parsed, setParsed] = useState<{ source: string; references: MarkdownReference[] }>(() => ({ source: "", references: EMPTY_REFERENCES }));
+  const references = parsed.source === source ? parsed.references : EMPTY_REFERENCES;
   useEffect(() => {
     let active = true;
     void import("./markdown-references").then(({ markdownReferences }) => {
@@ -70,7 +72,8 @@ export function useEmbeddedNoteReferences(
     return () => { active = false; };
   }, [source]);
 
-  const resolved = references.flatMap((reference): ResolvedNoteEmbed[] => {
+  const notesByPath = useMemo(() => new Map(notes.map((note) => [note.path, note])), [notes]);
+  const resolved = useMemo(() => references.flatMap((reference): ResolvedNoteEmbed[] => {
     const key = `${reference.from}:${reference.to}`;
     const matches = reference.target
       ? resolveLinkSuggestionMatches(reference.target, suggestions, sourcePath, reference.format)
@@ -93,7 +96,7 @@ export function useEmbeddedNoteReferences(
     if (path === sourcePath) {
       return [{ ...reference, key, status: "cycle", path, title: suggestion.title }];
     }
-    const note = notes.find((candidate) => candidate.path === path);
+    const note = notesByPath.get(path);
     const cached = cache.get(path);
     const body = typeof note?.body === "string" ? note.body : cached?.body;
     const error = errors.get(path);
@@ -118,7 +121,7 @@ export function useEmbeddedNoteReferences(
       body: fragment,
       revision: cached?.revision
     }];
-  });
+  }), [references, suggestions, sourcePath, files, notesByPath, store, cache, errors, cacheVersion]);
 
   const requests = resolved.filter((reference) => (
     reference.status === "loading"

--- a/apps/editor/src/note-search.test.ts
+++ b/apps/editor/src/note-search.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CollectionTypeDescriptor } from "@mdbase-dev/connect";
 import {
   buildNoteSearchIndex,
@@ -86,6 +86,88 @@ describe("note search", () => {
     const [metadataResult] = searchNoteResults(index, "roadmap");
     expect(metadataResult.context.kind).toBe("metadata");
     expect(metadataResult.context.text).toContain("#roadmap");
+  });
+
+  it("keeps all 10,000 tied results in input order without constructing contexts", () => {
+    const many = Array.from({ length: 10_000 }, (_, i) =>
+      summary(`Notes/${String(9999 - i).padStart(4, "0")}.md`, {}, [], "needle body"));
+    const entries = buildNoteSearchIndex(many);
+    const reads = vi.fn(() => "needle body");
+    for (const entry of entries) Object.defineProperty(entry, "bodyText", { get: reads });
+    const results = searchNoteResults(entries, "needle");
+    expect(results.map((result) => result.note)).toEqual(many);
+    expect(reads).not.toHaveBeenCalled();
+    expect(searchNotes(entries, "needle")).toEqual(many);
+    expect(reads).not.toHaveBeenCalled();
+    const context = results[9000].context;
+    expect(context.kind).toBe("body");
+    expect(results[9000].context).toBe(context);
+    expect(reads).toHaveBeenCalledTimes(1);
+    expect(searchNoteResults(entries, "needle", 12).map((result) => result.note)).toEqual(many.slice(0, 12));
+  });
+
+  it("defers field rescoring and caches whitespace and metadata contexts too", () => {
+    const [entry] = buildNoteSearchIndex([summary("Notes/one.md", { tag: "needle" }, [], "")]);
+    const metadata = vi.fn(() => "tag: needle");
+    const body = vi.fn(() => "");
+    Object.defineProperty(entry, "metadataText", { get: metadata });
+    Object.defineProperty(entry, "body", { get: body });
+    const [result] = searchNoteResults([entry], "needle");
+    expect(metadata).not.toHaveBeenCalled();
+    expect(body).not.toHaveBeenCalled();
+    expect(result.context.kind).toBe("metadata");
+    expect(result.context).toBe(result.context);
+    expect(metadata).toHaveBeenCalledTimes(1);
+    expect(body).toHaveBeenCalledTimes(1);
+    const path = vi.fn(() => "Notes/one.md");
+    Object.defineProperty(entry.note, "path", { get: path });
+    const [empty] = searchNoteResults([entry], "   ");
+    searchNotes([entry], "   ");
+    expect(path).not.toHaveBeenCalled();
+    expect(empty.context).toBe(empty.context);
+    expect(path).toHaveBeenCalledTimes(1);
+  });
+
+  it("still lets body matches outrank expensive fuzzy matches and combines fields per token", () => {
+    const slow = summary("a------------------------------b.md", {}, [], "ab");
+    const title = summary("ab.md", {}, [], "unrelated");
+    const metadata = summary("other.md", { value: "ab" }, [], "");
+    const mixed = summary("alpha.md", {}, [], "omega");
+    const entries = buildNoteSearchIndex([slow, metadata, title, mixed]);
+    expect(searchNotes(entries, "ab")).toEqual([title, metadata, slow]);
+    expect(searchNoteResults(entries, "ab").at(-1)?.context.kind).toBe("body");
+    expect(searchNotes(entries, "alpha omega")).toEqual([mixed]);
+  });
+
+  it("compiles matching expressions once per query, including lazy contexts", () => {
+    const entries = buildNoteSearchIndex(Array.from({ length: 100 }, (_, i) =>
+      summary(`Notes/${i}.md`, {}, [], "needle body")));
+    const OriginalRegExp = globalThis.RegExp;
+    const compile = vi.fn(function (pattern: string, flags?: string) {
+      return new OriginalRegExp(pattern, flags);
+    });
+    vi.stubGlobal("RegExp", compile);
+    try {
+      const results = searchNoteResults(entries, "needle body");
+      expect(compile).toHaveBeenCalledTimes(2);
+      for (const result of results) expect(result.context.kind).toBe("body");
+      expect(compile).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("retains literal punctuation, accent normalization, and whitespace behavior", () => {
+    const special = summary("Notes/special.md", {}, [], "Café [a+b] \\ end");
+    const entries = buildNoteSearchIndex([special]);
+    expect(searchNotes(entries, "CAFÉ [a+b]")).toEqual([special]);
+    expect(searchNoteResults(entries, "CAFÉ [a+b]")[0].context.ranges).toEqual([
+      { from: 0, to: 4 }, { from: 5, to: 10 }
+    ]);
+    expect(searchNotes(index, "  \t\n")).toEqual(notes);
+    expect(searchNoteResults(index, "  \t\n")[0].context).toEqual({
+      kind: "path", text: notes[0].path, ranges: []
+    });
   });
 
   it("finds every non-overlapping literal search token for quiet highlighting", () => {

--- a/apps/editor/src/note-search.ts
+++ b/apps/editor/src/note-search.ts
@@ -85,44 +85,66 @@ export function searchNoteResults(
   query: string,
   limit = Number.POSITIVE_INFINITY
 ): NoteSearchResult[] {
-  const tokens = normalize(query).split(/\s+/).filter(Boolean);
+  const tokens = normalize(query).split(/\s+/).filter(Boolean).map((text) => ({
+    text,
+    wordStart: new RegExp(`(?:^|[\\s/_.-])${escapeRegExp(text)}`)
+  }));
+  const contextTokens = highlightTokens(query);
   if (!tokens.length) {
-    return index.slice(0, limit).map((entry) => ({
-      note: entry.note,
-      context: searchContext(entry.note.path, query, "path")
-    }));
+    return index.slice(0, limit).map((entry) => {
+      let context: NoteSearchContext | undefined;
+      return {
+        note: entry.note,
+        get context() {
+          return context ??= searchContext(entry.note.path, contextTokens, "path");
+        }
+      };
+    });
   }
   return index
     .map((entry, order) => ({ entry, order, score: noteScore(entry, tokens) }))
     .filter((candidate) => Number.isFinite(candidate.score))
     .sort((left, right) => left.score - right.score || left.order - right.order)
     .slice(0, limit)
-    .map((candidate) => ({
-      note: candidate.entry.note,
-      context: bestSearchContext(candidate.entry, query, tokens)
-    }));
+    .map((candidate) => {
+      let context: NoteSearchContext | undefined;
+      return {
+        note: candidate.entry.note,
+        get context() {
+          return context ??= bestSearchContext(candidate.entry, contextTokens, tokens);
+        }
+      };
+    });
 }
 
-function noteScore(entry: NoteSearchEntry, tokens: string[]): number {
+interface SearchToken {
+  text: string;
+  wordStart: RegExp;
+}
+
+function noteScore(entry: NoteSearchEntry, tokens: SearchToken[]): number {
   let score = 0;
   for (const token of tokens) {
-    const tokenScore = Math.min(
+    let tokenScore = Math.min(
       fuzzyScore(entry.title, token),
       fuzzyScore(entry.filename, token) + 0.35,
-      fuzzyScore(entry.path, token) + 0.75,
-      substringScore(entry.metadata, token) + 2,
-      substringScore(entry.body, token) + 4
+      fuzzyScore(entry.path, token) + 0.75
     );
+    // Substring positions are nonnegative: these fields cannot improve a
+    // score already at or below their minimum weight.
+    if (tokenScore > 2) tokenScore = Math.min(tokenScore, substringScore(entry.metadata, token) + 2);
+    if (tokenScore > 4) tokenScore = Math.min(tokenScore, substringScore(entry.body, token) + 4);
     if (!Number.isFinite(tokenScore)) return Number.POSITIVE_INFINITY;
     score += tokenScore;
   }
   return score + Math.min(entry.path.length / 1_000, 0.25);
 }
 
-function fuzzyScore(value: string, query: string): number {
+function fuzzyScore(value: string, token: SearchToken): number {
+  const query = token.text;
   if (value === query) return 0;
   if (value.startsWith(query)) return 0.4;
-  const wordIndex = value.search(new RegExp(`(?:^|[\\s/_.-])${escapeRegExp(query)}`));
+  const wordIndex = value.search(token.wordStart);
   if (wordIndex >= 0) return 0.8 + wordIndex / 1_000;
   const substring = value.indexOf(query);
   if (substring >= 0) return 1.4 + substring / 1_000;
@@ -140,8 +162,8 @@ function fuzzyScore(value: string, query: string): number {
   return 2.2 + (last - first - query.length + 1) * 0.08 + first * 0.005;
 }
 
-function substringScore(value: string, query: string): number {
-  const index = value.indexOf(query);
+function substringScore(value: string, token: SearchToken): number {
+  const index = value.indexOf(token.text);
   return index < 0 ? Number.POSITIVE_INFINITY : index / 10_000;
 }
 
@@ -159,10 +181,17 @@ function collectSearchValues(value: unknown, values: string[]) {
   }
 }
 
-export function searchTextRanges(text: string, query: string): SearchTextRange[] {
-  const haystack = text.toLocaleLowerCase();
-  const tokens = [...new Set(query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean))]
+function highlightTokens(query: string): string[] {
+  return [...new Set(query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean))]
     .sort((left, right) => right.length - left.length);
+}
+
+export function searchTextRanges(text: string, query: string): SearchTextRange[] {
+  return textRanges(text, highlightTokens(query));
+}
+
+function textRanges(text: string, tokens: string[]): SearchTextRange[] {
+  const haystack = text.toLocaleLowerCase();
   const ranges: SearchTextRange[] = [];
   for (const token of tokens) {
     let from = haystack.indexOf(token);
@@ -175,7 +204,7 @@ export function searchTextRanges(text: string, query: string): SearchTextRange[]
   return ranges.sort((left, right) => left.from - right.from);
 }
 
-function bestSearchContext(entry: NoteSearchEntry, query: string, tokens: string[]): NoteSearchContext {
+function bestSearchContext(entry: NoteSearchEntry, query: string[], tokens: SearchToken[]): NoteSearchContext {
   const fields = [
     { kind: "title" as const, score: combinedScore(entry.title, tokens, fuzzyScore) },
     { kind: "filename" as const, score: combinedScore(entry.filename, tokens, fuzzyScore) + 0.35 },
@@ -191,8 +220,8 @@ function bestSearchContext(entry: NoteSearchEntry, query: string, tokens: string
 
 function combinedScore(
   value: string,
-  tokens: string[],
-  score: (value: string, query: string) => number
+  tokens: SearchToken[],
+  score: (value: string, query: SearchToken) => number
 ): number {
   let total = 0;
   for (const token of tokens) {
@@ -205,20 +234,19 @@ function combinedScore(
 
 function searchContext(
   value: string,
-  query: string,
+  query: string[],
   kind: NoteSearchContext["kind"],
   excerpted = false
 ): NoteSearchContext {
   const text = excerpted ? searchExcerpt(value, query) : value;
-  return { kind, text, ranges: searchTextRanges(text, query) };
+  return { kind, text, ranges: textRanges(text, query) };
 }
 
-function searchExcerpt(value: string, query: string, maximumLength = 104): string {
+function searchExcerpt(value: string, query: string[], maximumLength = 104): string {
   const text = value.replace(/\s+/g, " ").trim();
   if (text.length <= maximumLength) return text;
   const folded = text.toLocaleLowerCase();
-  const matches = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean)
-    .map((token) => folded.indexOf(token))
+  const matches = query.map((token) => folded.indexOf(token))
     .filter((index) => index >= 0);
   const anchor = matches.length ? Math.min(...matches) : 0;
   let from = Math.max(0, anchor - Math.floor(maximumLength * 0.34));

--- a/apps/editor/src/recent-notes.test.ts
+++ b/apps/editor/src/recent-notes.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { forgetRecentPath, loadRecentPaths, rememberRecentPath } from "./recent-notes";
+
+const KEY = "mdbase-editor:recent-notes";
+
+beforeEach(() => localStorage.clear());
+
+describe("recent note storage", () => {
+  it("loads only string paths and bounds persisted history", () => {
+    const paths = Array.from({ length: 25 }, (_, index) => `note-${index}.md`);
+    localStorage.setItem(KEY, JSON.stringify([null, 42, {}, ...paths]));
+    expect(loadRecentPaths()).toEqual(paths.slice(0, 20));
+  });
+
+  it("ignores absent, malformed, or non-array history", () => {
+    expect(loadRecentPaths()).toEqual([]);
+    for (const value of ["{", "null", '{"path":"note.md"}']) {
+      localStorage.setItem(KEY, value);
+      expect(loadRecentPaths()).toEqual([]);
+    }
+  });
+
+  it("moves an existing note first and persists at most twenty paths", () => {
+    const paths = Array.from({ length: 20 }, (_, index) => `note-${index}.md`);
+    const reordered = rememberRecentPath(paths, "note-8.md");
+    expect(reordered).toEqual(["note-8.md", ...paths.filter((path) => path !== "note-8.md")]);
+    expect(loadRecentPaths()).toEqual(reordered);
+    expect(paths[0]).toBe("note-0.md");
+    const added = rememberRecentPath(reordered, "new.md");
+    expect(added).toEqual(["new.md", ...reordered.slice(0, 19)]);
+    expect(loadRecentPaths()).toEqual(added);
+  });
+
+  it("forgets a path without changing the remaining order", () => {
+    const paths = ["first.md", "removed.md", "last.md"];
+    expect(forgetRecentPath(paths, "removed.md")).toEqual(["first.md", "last.md"]);
+    expect(loadRecentPaths()).toEqual(["first.md", "last.md"]);
+    expect(paths).toEqual(["first.md", "removed.md", "last.md"]);
+  });
+});

--- a/apps/editor/src/recent-notes.ts
+++ b/apps/editor/src/recent-notes.ts
@@ -1,0 +1,22 @@
+const RECENT_NOTES_KEY = "mdbase-editor:recent-notes";
+
+export function loadRecentPaths(): string[] {
+  try {
+    const value = JSON.parse(localStorage.getItem(RECENT_NOTES_KEY) ?? "[]");
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string").slice(0, 20) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function rememberRecentPath(current: string[], path: string): string[] {
+  const next = [path, ...current.filter((candidate) => candidate !== path)].slice(0, 20);
+  localStorage.setItem(RECENT_NOTES_KEY, JSON.stringify(next));
+  return next;
+}
+
+export function forgetRecentPath(current: string[], path: string): string[] {
+  const next = current.filter((candidate) => candidate !== path);
+  localStorage.setItem(RECENT_NOTES_KEY, JSON.stringify(next));
+  return next;
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -2477,6 +2477,15 @@ kbd {
   border-bottom: 1px solid var(--line);
 }
 
+.note-opening-status {
+  max-width: 20ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .note-history {
   display: inline-flex;
   align-items: center;

--- a/apps/editor/src/use-collection-watch.test.tsx
+++ b/apps/editor/src/use-collection-watch.test.tsx
@@ -1,0 +1,177 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CollectionChange } from "@mdbase-dev/connect";
+import type { CollectionGateway } from "./model";
+import { useCollectionWatch } from "./use-collection-watch";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function setup(notes: string[] = []) {
+  let handler!: Parameters<CollectionGateway["watch"]>[0];
+  let status!: NonNullable<Parameters<CollectionGateway["watch"]>[2]>;
+  let signal!: AbortSignal;
+  const watching = deferred();
+  const reads: { path: string; gate: ReturnType<typeof deferred> }[] = [];
+  let active = 0;
+  let maxActive = 0;
+  const watch = vi.fn<CollectionGateway["watch"]>((change, abort, onStatus) => {
+    handler = change; signal = abort; status = onStatus!;
+    return watching.promise;
+  });
+  const reload = vi.fn(async () => undefined);
+  const input = {
+    phase: "ready", connectionRetry: 0,
+    gateway: { watch } as unknown as CollectionGateway,
+    index: { getSnapshot: () => ({ notes: notes.map((path) => ({ path })) }) } as Parameters<typeof useCollectionWatch>[0]["index"],
+    files: { reload, remove: vi.fn() } as unknown as Parameters<typeof useCollectionWatch>[0]["files"],
+    assets: { invalidate: vi.fn() } as unknown as Parameters<typeof useCollectionWatch>[0]["assets"],
+    loadIndex: vi.fn<() => Promise<void>>(async () => undefined),
+    refreshChangedNote: vi.fn(async (path: string) => {
+      const gate = deferred();
+      reads.push({ path, gate });
+      maxActive = Math.max(maxActive, ++active);
+      try { await gate.promise; } finally { active--; }
+    }),
+    refreshDescription: vi.fn(async () => undefined),
+    refreshAfterConnectionGap: vi.fn(async () => undefined),
+    setConnectionState: vi.fn(), setConnectionIssue: vi.fn(), setNotice: vi.fn()
+  };
+  const hook = renderHook(() => useCollectionWatch(input));
+  return {
+    ...hook, input, reads, watching, reload,
+    get signal() { return signal; }, get maxActive() { return maxActive; },
+    emit: (path: string, type = "mdbase.record.modified") => handler({ type, payload: { path }, cursor: 1, occurredAt: "2026-01-01T00:00:00Z" } as CollectionChange),
+    unknown: () => handler(), status: (value: Parameters<typeof status>[0]) => status(value)
+  };
+}
+const tick = () => act(async () => { await vi.advanceTimersByTimeAsync(180); });
+const finish = (state: ReturnType<typeof setup>, index: number, error?: string) => act(async () => {
+  if (error) state.reads[index].gate.reject(new Error(error));
+  else state.reads[index].gate.resolve();
+});
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => { cleanup(); vi.useRealTimers(); });
+
+describe("useCollectionWatch bounded drain", () => {
+  it("eventually refreshes 200 paths and a second burst through the same serial worker", async () => {
+    const state = setup();
+    for (let i = 0; i < 200; i++) state.emit(`${i}.md`);
+    await tick();
+    expect(state.reads.map((read) => read.path)).toEqual(["0.md"]);
+    for (let i = 200; i < 240; i++) state.emit(`${i}.md`);
+    await tick();
+    expect(state.reads).toHaveLength(1);
+    for (let i = 0; i < 240; i++) await finish(state, i);
+    expect(state.reads.map((read) => read.path)).toEqual(Array.from({ length: 240 }, (_, i) => `${i}.md`));
+    expect(state.maxActive).toBe(1);
+  });
+
+  it("coalesces pending duplicates but rereads a path changed during its read", async () => {
+    const state = setup();
+    state.emit("a.md"); state.emit("b.md");
+    await tick();
+    for (let i = 0; i < 10; i++) { state.emit("a.md"); state.emit("b.md"); }
+    await tick();
+    await finish(state, 0);
+    await finish(state, 1);
+    await finish(state, 2);
+    expect(state.reads.map((read) => read.path)).toEqual(["a.md", "b.md", "a.md"]);
+    expect(state.maxActive).toBe(1);
+  });
+
+  it("reports ordinary errors without fallback or stopping the remaining reads", async () => {
+    const state = setup();
+    state.emit("a.md"); state.emit("b.md");
+    await tick();
+    await finish(state, 0, "read failed");
+    expect(state.input.setNotice).toHaveBeenCalledWith("read failed");
+    expect(state.input.loadIndex).not.toHaveBeenCalled();
+    expect(state.reads[1].path).toBe("b.md");
+    await finish(state, 1);
+  });
+
+  it("shares the bound with deletion confirmations and awaits their index fallback", async () => {
+    const state = setup(["a.md", "b.md"]);
+    const fallback = deferred();
+    state.input.loadIndex.mockImplementation(() => fallback.promise);
+    state.emit("a.md", "mdbase.record.deleted"); state.emit("a.md");
+    state.emit("b.md", "mdbase.record.deleted"); state.emit("c.md");
+    await tick();
+    await finish(state, 0, "missing");
+    expect(state.input.loadIndex).toHaveBeenCalledTimes(1);
+    state.emit("d.md"); await tick();
+    expect(state.reads).toHaveLength(1);
+    await act(async () => { fallback.reject(new Error("index failed")); });
+    expect(state.input.setConnectionIssue).toHaveBeenCalledWith("index failed");
+    for (let i = 1; i < 4; i++) await finish(state, i);
+    expect(state.reads.map((read) => read.path)).toEqual(["a.md", "b.md", "c.md", "d.md"]);
+    expect(state.input.loadIndex).toHaveBeenCalledTimes(1);
+    expect(state.input.setNotice).not.toHaveBeenCalled();
+    expect(state.maxActive).toBe(1);
+  });
+
+  it.each(["unmount", "switch", "reset"])("%s cancels queued and debounced work and ignores late read failures", async (stop) => {
+    const state = setup(["a.md"]);
+    state.emit("a.md", "mdbase.record.deleted"); state.emit("b.md");
+    await tick();
+    state.emit("c.md");
+    const oldSignal = state.signal;
+    if (stop === "unmount") state.unmount();
+    else if (stop === "switch") { state.input.phase = "loading"; state.rerender(); }
+    else state.status({ state: "reset_required" } as Parameters<typeof state.status>[0]);
+    expect(oldSignal.aborted).toBe(true);
+    state.emit("late.md");
+    await finish(state, 0, "late failure");
+    await tick();
+    expect(state.reads).toHaveLength(1);
+    expect(state.input.loadIndex).not.toHaveBeenCalled();
+    expect(state.input.setNotice).not.toHaveBeenCalled();
+    expect(state.input.setConnectionIssue).not.toHaveBeenCalled();
+    if (stop === "reset") {
+      state.status({ state: "reset_required" } as Parameters<typeof state.status>[0]);
+      await act(async () => { state.watching.reject(new Error("watch ended")); });
+      expect(state.input.refreshAfterConnectionGap).toHaveBeenCalledTimes(1);
+      expect(state.input.setConnectionState).not.toHaveBeenCalled();
+    }
+  });
+
+  it("suppresses late ordinary notices and deletion fallback errors on cleanup", async () => {
+    const ordinary = setup(); ordinary.emit("a.md"); await tick(); ordinary.unmount();
+    await finish(ordinary, 0, "late ordinary failure");
+    expect(ordinary.input.setNotice).not.toHaveBeenCalled();
+    const state = setup(["a.md"]);
+    const fallback = deferred(); state.input.loadIndex.mockImplementation(() => fallback.promise);
+    state.emit("a.md", "mdbase.record.deleted"); state.emit("b.md"); await tick();
+    await finish(state, 0, "missing"); state.unmount();
+    await act(async () => { fallback.reject(new Error("late index failure")); });
+    expect(state.input.setConnectionIssue).not.toHaveBeenCalled();
+    expect(state.reads).toHaveLength(1);
+  });
+
+  it("retains debounce, structural/index refresh, and types/files refresh semantics", async () => {
+    const state = setup(["exists.md"]);
+    state.emit("exists.md", "mdbase.record.deleted");
+    state.emit("new.md", "mdbase.record.created");
+    state.emit("type.md", "mdbase.type.changed");
+    state.emit("file.png", "mdbase.file.put");
+    await act(async () => { await vi.advanceTimersByTimeAsync(179); });
+    expect(state.input.loadIndex).not.toHaveBeenCalled();
+    state.emit("modified.md");
+    await act(async () => { await vi.advanceTimersByTimeAsync(179); });
+    expect(state.reads).toHaveLength(0);
+    await tick();
+    expect(state.input.loadIndex).toHaveBeenCalledTimes(1);
+    expect(state.input.refreshDescription).toHaveBeenCalledTimes(1);
+    expect(state.reload).toHaveBeenCalledTimes(1);
+    expect(state.reads.map((read) => read.path)).toEqual(["modified.md"]);
+    await finish(state, 0);
+    state.unknown(); await tick();
+    expect(state.input.loadIndex).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/editor/src/use-collection-watch.ts
+++ b/apps/editor/src/use-collection-watch.ts
@@ -28,13 +28,48 @@ export function useCollectionWatch(input: {
     if (input.phase !== "ready") return;
     const controller = new AbortController();
     let refreshTimer: number | undefined;
-    let resetHandled = false;
     const changedPaths = new Set<string>();
     const structuralChanges: CollectionChange[] = [];
     let filesChanged = false;
     let typesChanged = false;
     let indexChanged = false;
+    // One worker for the effect lifetime, not one limiter per debounce batch.
+    // Remove a path before reading so changes during that read enqueue a follow-up.
+    const pendingReads = new Map<string, boolean>();
+    let draining = false;
+    const drainReads = async () => {
+      if (draining || controller.signal.aborted) return;
+      draining = true;
+      try {
+        while (!controller.signal.aborted && pendingReads.size) {
+          const [path, confirmDeletion] = pendingReads.entries().next().value!;
+          pendingReads.delete(path);
+          try {
+            await input.refreshChangedNote(path);
+          } catch (error) {
+            if (controller.signal.aborted) return;
+            if (confirmDeletion) {
+              try {
+                await input.loadIndex();
+              } catch (error) {
+                if (!controller.signal.aborted) input.setConnectionIssue(gatewayError(error));
+              }
+            } else input.setNotice(gatewayError(error));
+          }
+        }
+      } finally {
+        draining = false;
+      }
+    };
+    const stop = () => {
+      controller.abort();
+      window.clearTimeout(refreshTimer);
+      changedPaths.clear();
+      structuralChanges.length = 0;
+      pendingReads.clear();
+    };
     const handleChange = (change?: CollectionChange) => {
+      if (controller.signal.aborted) return;
       if (change && isFileChange(change)) {
         filesChanged = true;
         reconcileFileChange(change, input.files, input.assets);
@@ -47,6 +82,7 @@ export function useCollectionWatch(input: {
 
       window.clearTimeout(refreshTimer);
       refreshTimer = window.setTimeout(() => {
+        if (controller.signal.aborted) return;
         const paths = [...changedPaths];
         changedPaths.clear();
         const shouldRefreshTypes = typesChanged;
@@ -61,14 +97,9 @@ export function useCollectionWatch(input: {
         if (shouldRefreshIndex) void input.loadIndex().catch((error) => {
           if (!controller.signal.aborted) input.setConnectionIssue(gatewayError(error));
         });
-        else for (const path of structural.deletedPathsToConfirm) {
-          void input.refreshChangedNote(path).catch(() => input.loadIndex().catch((error) => {
-            if (!controller.signal.aborted) input.setConnectionIssue(gatewayError(error));
-          }));
-        }
-        for (const path of paths) void input.refreshChangedNote(path).catch((error) => {
-          if (!controller.signal.aborted) input.setNotice(gatewayError(error));
-        });
+        else for (const path of structural.deletedPathsToConfirm) pendingReads.set(path, true);
+        for (const path of paths) pendingReads.set(path, pendingReads.get(path) ?? false);
+        void drainReads();
         if (shouldRefreshTypes) void input.refreshDescription();
         if (shouldRefreshFiles) void input.files.reload().catch(() => undefined);
       }, 180);
@@ -82,18 +113,15 @@ export function useCollectionWatch(input: {
         input.setConnectionState("connected");
         input.setConnectionIssue(undefined);
       } else if (status.state === "reset_required") {
-        resetHandled = true;
+        stop();
         void input.refreshAfterConnectionGap();
       }
     }).catch((error) => {
-      if (!controller.signal.aborted && !resetHandled) {
+      if (!controller.signal.aborted) {
         input.setConnectionState("reconnecting");
         input.setConnectionIssue(gatewayError(error));
       }
     });
-    return () => {
-      controller.abort();
-      window.clearTimeout(refreshTimer);
-    };
+    return stop;
   }, [input.assets, input.connectionRetry, input.files, input.gateway, input.index, input.loadIndex, input.phase, input.refreshAfterConnectionGap, input.refreshChangedNote, input.refreshDescription, input.setConnectionIssue, input.setConnectionState, input.setNotice]);
 }

--- a/apps/editor/src/use-file-assets.test.ts
+++ b/apps/editor/src/use-file-assets.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FileAssetStore } from "./file-asset-store";
+import type { CollectionFile } from "./model";
+import { useEmbeddedFileAssets } from "./use-file-assets";
+
+const file: CollectionFile = {
+  fileId: "image", path: "image.png", revision: "1", contentDigest: "sha256:image",
+  size: 10, mediaType: "image/png", mediaClass: "image", modifiedAt: ""
+};
+const files = [file];
+const hidden = new Set<string>();
+
+describe("embedded file asset identity", () => {
+  it("publishes async acquired assets and invalidates on store replacement", async () => {
+    const createURL = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:ready");
+    const revokeURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    let resolve!: (blob: Blob) => void;
+    const readFile = vi.fn(() => new Promise<Blob>((done) => { resolve = done; }));
+    const store = new FileAssetStore({ readFile });
+    const hook = renderHook(({ store }) => useEmbeddedFileAssets(store, "![[image.png]]", files), { initialProps: { store } });
+    await waitFor(() => expect(hook.result.current[0]?.asset.status).toBe("loading"));
+    const loading = hook.result.current;
+    hook.rerender({ store });
+    expect(hook.result.current).toBe(loading);
+    expect(readFile).toHaveBeenCalledTimes(1);
+    await act(async () => resolve(new Blob(["image"])));
+    expect(hook.result.current).not.toBe(loading);
+    expect(hook.result.current[0].asset).toMatchObject({ status: "ready", url: "blob:ready" });
+    const ready = hook.result.current;
+    hook.rerender({ store });
+    expect(hook.result.current).toBe(ready);
+    const replacement = new FileAssetStore({ readFile: vi.fn(async () => { throw new Error("new collection"); }) });
+    hook.rerender({ store: replacement });
+    await waitFor(() => expect(hook.result.current[0]?.asset).toMatchObject({ status: "error", error: "new collection" }));
+    expect(hook.result.current).not.toBe(ready);
+    hook.unmount();
+    store.reset();
+    replacement.reset();
+    createURL.mockRestore();
+    revokeURL.mockRestore();
+  });
+
+  it("retains arrays on unchanged renders but publishes asset versions and store resets", async () => {
+    const readFile = vi.fn(async () => { throw new Error("asset failed"); });
+    const store = new FileAssetStore({ readFile });
+    const hook = renderHook(() => useEmbeddedFileAssets(store, "![[image.png]]", files, "source.md", hidden));
+    const empty = hook.result.current;
+    hook.rerender();
+    expect(hook.result.current).toBe(empty);
+    await waitFor(() => expect(hook.result.current).toHaveLength(1));
+    const idle = hook.result.current;
+    hook.rerender();
+    expect(hook.result.current).toBe(idle);
+    expect(readFile).not.toHaveBeenCalled();
+    await act(async () => { await store.load(file); });
+    expect(hook.result.current).not.toBe(idle);
+    expect(hook.result.current[0].asset).toMatchObject({ status: "error", error: "asset failed" });
+    const failed = hook.result.current;
+    hook.rerender();
+    expect(hook.result.current).toBe(failed);
+    act(() => store.reset());
+    expect(hook.result.current).not.toBe(failed);
+    expect(hook.result.current[0].asset.status).toBe("idle");
+  });
+});

--- a/apps/editor/src/use-file-assets.ts
+++ b/apps/editor/src/use-file-assets.ts
@@ -9,6 +9,9 @@ export interface ResolvedFileReference extends Omit<FileReference, "file"> {
   asset: FileAssetSnapshot;
 }
 
+const EMPTY_REFERENCES: Array<FileReference & { file: CollectionFile }> = [];
+const EMPTY_FILES: readonly CollectionFile[] = [];
+
 export function useFileAssetStore(gateway: CollectionGateway): FileAssetStore {
   const store = useMemo(() => new FileAssetStore(gateway), [gateway]);
   useEffect(() => () => store.reset(), [store]);
@@ -31,16 +34,16 @@ export function useEmbeddedFileAssets(
   sourcePath?: string,
   visibleKeys?: ReadonlySet<string>
 ): ResolvedFileReference[] {
-  useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion);
+  const version = useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion);
   const [parsed, setParsed] = useState<{
     source: string;
     files: readonly CollectionFile[];
     sourcePath?: string;
     references: Array<FileReference & { file: CollectionFile }>;
-  }>(() => ({ source: "", files: [], references: [] }));
+  }>(() => ({ source: "", files: EMPTY_FILES, references: EMPTY_REFERENCES }));
   const references = parsed.source === source && parsed.files === files && parsed.sourcePath === sourcePath
     ? parsed.references
-    : [];
+    : EMPTY_REFERENCES;
   useEffect(() => {
     let active = true;
     void import("./file-references").then(({ fileReferences }) => {
@@ -65,5 +68,5 @@ export function useEmbeddedFileAssets(
     // key captures file identity, revision, and viewport membership.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, store]);
-  return references.map((reference) => ({ ...reference, asset: store.get(reference.file) }));
+  return useMemo(() => references.map((reference) => ({ ...reference, asset: store.get(reference.file) })), [references, store, version]);
 }

--- a/config/architecture-budgets.json
+++ b/config/architecture-budgets.json
@@ -6,7 +6,7 @@
   },
   "productionFileBudgetsByPackage": {
     "apps/desktop": 39,
-    "apps/editor": 109,
+    "apps/editor": 110,
     "apps/portal": 16,
     "crates/connect-agent": 34,
     "crates/connect-cli": 7,
@@ -43,11 +43,11 @@
     "semanticProjectionFormatVersion": 6
   },
   "reviewBudgets": {
-    "productionFiles": 675,
-    "relativeImports": 1432,
+    "productionFiles": 676,
+    "relativeImports": 1433,
     "workspacePackages": 24,
     "rustPublicDeclarations": 3163,
-    "typeScriptExportDeclarations": 2396,
+    "typeScriptExportDeclarations": 2399,
     "mdbaseCollectionReferences": 16,
     "typedCollectionReferences": 1
   }


### PR DESCRIPTION
## Summary

- Preserve the active document/draft during a failed note read and retry only the requested note; fence delayed linked-note creation against newer navigation.
- Make search contexts lazy and cached without truncating results, serialize watch refreshes, bound all asset-cache states, sort a completed file inventory once, and stabilize embed inputs/callbacks.
- Keep native keyboard handlers current and extend the upstream autofocus guard to respect intervening focus moves and dialogs.
- Add deterministic rendered/component regression coverage for failures, races, caching, search, and watch bursts.
- Extract the unchanged recent-note persistence helpers into `recent-notes.ts`, retaining App's 2,273-line cap. Record the precise internal inventory delta: one production file/import and three module exports; no new package API or increased file-size allowance.

## Integration scope

Ported from the locally audited editor fix onto current main (`03d2020c`). The saved visual/lockfile baseline snapshots and PRs #405/#392 are **not** included. The pre-existing two-phase metadata/body hydration design remains unchanged. No protocol, grant, SDK concurrency-limit, or Rust dependency changes.

## Validation on this PR head

- `pnpm install --frozen-lockfile --offline`
- `pnpm typecheck`
- `pnpm test` (editor initially **443 tests / 58 files**, then **447 / 59** after the helper extraction; whole workspace and CI passed, with existing optional server tests skipped)
- `pnpm --filter mdbase-editor test:e2e` (**52 Chromium tests passed**)
- `pnpm --filter mdbase-editor build`
- `pnpm --filter mdbase-editor check:bundle` (**150.9 KiB initial JS / 38.3 KiB CSS**, gzip)
- `cargo fmt --all --check` and `cargo test --workspace --locked --offline` on upstream's Rust dependency pin: **628 passed, 79 ignored**
- Isolated local `pnpm e2e` passed
- 10,000-note local browser fixture: 1,168 ms first usable, 1,392 ms full index, 39 ms search ready, 16 rendered rows. These are fixture measurements, not production guarantees.

Prepared and verified in an isolated worktree; the original dirty checkout is preserved. Merge through the repository's normal CI/merge queue without bypasses.
