### PR TITLE
Fix portal consent clarity, theme persistence, and recovery

### DIFF
--- a/apps/portal/public/theme-bootstrap.js
+++ b/apps/portal/public/theme-bootstrap.js
@@ -1,7 +1,5 @@
 try {
-  const theme = /^\/authorize\/[0-9a-f-]+$/i.test(location.pathname)
-    ? "system"
-    : localStorage.getItem("mdbase:theme");
+  const theme = localStorage.getItem("mdbase:theme");
   if (theme === "light" || theme === "dark") document.documentElement.dataset.theme = theme;
   const dark = theme === "dark" || (theme !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
   document.querySelector('meta[name="theme-color"]')?.setAttribute("content", dark ? "#1c1e24" : "#fcfcfd");

--- a/apps/portal/src/auth-view.tsx
+++ b/apps/portal/src/auth-view.tsx
@@ -27,6 +27,7 @@ export function Login() {
         }
         try {
           setConfig(await api<AuthConfig>("/v1/auth/config"));
+          setError("");
         } catch (configError) {
           setError(message(configError));
         }

--- a/apps/portal/src/authority-workflows.tsx
+++ b/apps/portal/src/authority-workflows.tsx
@@ -11,15 +11,26 @@ export function Pairing({ pairingId }: { pairingId: string }) {
   const [pairing, setPairing] = useState<{ connector_name: string; approved_at: string | null } | null>(null);
   const [deepLink, setDeepLink] = useState("");
   const [error, setError] = useState("");
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
+    let active = true;
+    setPairing(null);
+    setDeepLink("");
+    setError("");
     api<{ pairing: { connector_name: string; approved_at: string | null } }>(`/v1/pairing-requests/${pairingId}`)
-      .then((value) => setPairing(value.pairing))
+      .then((value) => {
+        if (!active) return;
+        setPairing(value.pairing);
+        setError("");
+      })
       .catch((reason) => {
+        if (!active) return;
         if (reason instanceof ApiError && reason.status === 401) location.href = `/login?return_to=${encodeURIComponent(location.href)}`;
         else setError(message(reason));
       });
-  }, [pairingId]);
+    return () => { active = false; };
+  }, [pairingId, attempt]);
 
   async function approve() {
     try {
@@ -28,7 +39,7 @@ export function Pairing({ pairingId }: { pairingId: string }) {
     } catch (approveError) { setError(message(approveError)); }
   }
 
-  if (!pairing) return <Loading error={error} />;
+  if (!pairing) return <Loading error={error} onRetry={() => { if (error) { setError(""); setAttempt((value) => value + 1); } }} />;
   return (
     <main className="center-page">
       <PageBrand label="Computer pairing" />
@@ -56,9 +67,16 @@ export function MirrorPairing({ pairingId }: { pairingId: string }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
+  const [attempt, setAttempt] = useState(0);
+
   useEffect(() => {
+    let active = true;
+    setRequest(null);
+    setError("");
     api<NonNullable<typeof request>>(`/v1/mirror-pairing-requests/${pairingId}`)
       .then((value) => {
+        if (!active) return;
+        setError("");
         setRequest(value);
         setApproved(Boolean(value.pairing.approved_at));
         const preferred = value.collections.some(
@@ -69,13 +87,15 @@ export function MirrorPairing({ pairingId }: { pairingId: string }) {
         setCollectionId(value.pairing.collection_id ?? preferred);
       })
       .catch((reason) => {
+        if (!active) return;
         if (reason instanceof ApiError && reason.status === 401) {
           location.href = `/login?return_to=${encodeURIComponent(location.href)}`;
         } else {
           setError(message(reason));
         }
       });
-  }, [pairingId]);
+    return () => { active = false; };
+  }, [pairingId, attempt]);
 
   async function approve() {
     if (!collectionId) return;
@@ -94,7 +114,7 @@ export function MirrorPairing({ pairingId }: { pairingId: string }) {
     }
   }
 
-  if (!request) return <Loading error={error} />;
+  if (!request) return <Loading error={error} onRetry={() => { if (error) { setError(""); setAttempt((value) => value + 1); } }} />;
   const selected = request.collections.find((collection) => collection.id === collectionId);
   return (
     <main className="center-page">

--- a/apps/portal/src/authorization-permissions.tsx
+++ b/apps/portal/src/authorization-permissions.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import type { ApplicationFileAction, PendingAuthorization } from "./api";
 import type { AuthorizationCapabilityGroup } from "./authorization-capabilities";
 
@@ -70,6 +71,7 @@ export function PermissionChoices({ groups, selected, disabled, onToggle }: {
   disabled: boolean;
   onToggle(group: AuthorizationCapabilityGroup): void;
 }) {
+  const descriptionId = useId();
   const exact = groups.some((group) => group.semantics === "exact");
   const optional = groups.filter((group) => !group.required);
   if (optional.length === 0) return null;
@@ -80,9 +82,9 @@ export function PermissionChoices({ groups, selected, disabled, onToggle }: {
         <b>Review</b>
       </summary>
       <div className="permission-groups">{optional.map((group) => (
-        <fieldset className="permission-group" key={group.id}>
+        <fieldset className="permission-group" key={group.id} aria-describedby={`${descriptionId}-${group.id}`}>
           <legend>{group.label}</legend>
-          <p>{group.description}</p>
+          <p id={`${descriptionId}-${group.id}`}>{group.description}</p>
           <div><label>
             <input
               type="checkbox"
@@ -113,17 +115,17 @@ export function FilePermissionSummary({ files, selected, disabled, onToggle }: {
   disabled: boolean;
   onToggle(action: ApplicationFileAction): void;
 }) {
-  if ("actions" in files) return <details className="permission-review file-permission-review">
-    <summary><span><strong>Review exact file permissions</strong><small>{files.actions.length} requested actions, approved together.</small></span><b>Details</b></summary>
-    <div className="permission-groups"><fieldset className="permission-group">
-      <legend>Files</legend>
-      <p>{files.scope.kind === "collection" ? "Every visible folder in this collection." : `Only ${files.scope.folders.join(", ")}.`} Hidden folders are always excluded. These actions are approved together.</p>
-      <ul className="permission-action-list">{files.actions.map((action) => <li key={action}>{FILE_ACTION_LABELS[action]}</li>)}</ul>
-    </fieldset></div>
-  </details>;
   const scope = files.scope.kind === "collection"
     ? "Every visible folder in this collection. Hidden folders are always excluded."
     : `Only ${files.scope.folders.join(", ")}. Hidden folders are always excluded.`;
+  if ("actions" in files) return <details className="permission-review file-permission-review">
+    <summary><span><strong>Review exact file permissions</strong><small>{files.actions.length} requested {files.actions.length === 1 ? "action" : "actions"}, approved together. {scope}</small></span><b>Details</b></summary>
+    <div className="permission-groups"><fieldset className="permission-group">
+      <legend>Files</legend>
+      <p>{scope} These actions are approved together.</p>
+      <ul className="permission-action-list">{files.actions.map((action) => <li key={action}>{FILE_ACTION_LABELS[action]}</li>)}</ul>
+    </fieldset></div>
+  </details>;
   return (
     <details className="permission-review file-permission-review">
       <summary>

--- a/apps/portal/src/authorization-view.tsx
+++ b/apps/portal/src/authorization-view.tsx
@@ -54,14 +54,13 @@ import {
   relativeTime,
   scopeDescription
 } from "./portal-model";
-import { Loading, PageBrand, useSystemTheme } from "./portal-ui";
+import { Loading, PageBrand } from "./portal-ui";
 export function DeviceAuthorization() {
   const initialCode = formatDeviceCode(new URLSearchParams(location.search).get("user_code") ?? "");
   const [code, setCode] = useState(initialCode);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const automaticallyClaimed = useRef(false);
-  useSystemTheme();
 
   async function openRequest(value: string) {
     const userCode = formatDeviceCode(value);
@@ -95,7 +94,7 @@ export function DeviceAuthorization() {
 
   return (
     <main className="center-page">
-      <PageBrand label="Downloaded application" themePicker={false} />
+      <PageBrand label="Downloaded application" />
       <form className="decision-panel device-panel" onSubmit={(event) => {
         event.preventDefault();
         void openRequest(code);
@@ -140,7 +139,6 @@ export function Authorization({ requestId }: { requestId: string }) {
   const [error, setError] = useState("");
   const [decisionError, setDecisionError] = useState("");
   const returning = useRef(false);
-  useSystemTheme();
 
   useEffect(() => {
     let active = true;
@@ -215,7 +213,6 @@ export function Authorization({ requestId }: { requestId: string }) {
     <main className="center-page">
       <PageBrand
         label="Application request"
-        themePicker={false}
         markMotion={setupMotionActive ? (preparingStructure ? "rebalance" : "conveyor") : undefined}
       />
       <section className="decision-panel authorization-panel">
@@ -261,7 +258,7 @@ export function RequestIdentity({ request, large = false }: { request: PendingAu
           ? `Downloaded HTML file${request.project_url ? ` · ${host(request.project_url)}` : ""}`
           : host(request.homepage)} · expires {relativeTime(request.expires_at)}</small>
         {request.distribution !== "portable" && (
-          <small className="request-guidance">Only continue if you recognize this exact site. An approved application can use the selected data until you revoke it.</small>
+          <small className="request-guidance">Only continue if you recognize this exact site.</small>
         )}
         <small className="request-scope">Requests access to the entire selected collection.</small>
         {request.requirements.contracts.length > 0 && (
@@ -964,7 +961,7 @@ function SupportedApprovalForm({
         <div className="approval-receipt">
           <strong>{request.application_name} · {selected?.display_name}</strong>
           {higherImpactLabels.length > 0 && <span>{higherImpactLabels.join(" · ")}</span>}
-          <small>Access continues until you revoke it in mdbase connect.</small>
+          {request.distribution !== "portable" && <small>Access continues until you revoke it in mdbase connect.</small>}
         </div>
         <div className="approval-actions">
           <button className="button secondary deny-button" type="button" disabled={submitting !== null} onClick={() => void decide("denied")}>{submitting === "denied" ? "Denying…" : "Deny"}</button>

--- a/apps/portal/src/portal-ui.tsx
+++ b/apps/portal/src/portal-ui.tsx
@@ -170,16 +170,7 @@ export function ThemeMenu({ placement = "down" }: { placement?: "up" | "down" })
     </div>}
   </div>;
 }
-export function useSystemTheme() {
-  useEffect(() => {
-    applyThemePreference("system");
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    const update = () => applyThemePreference("system");
-    media.addEventListener("change", update);
-    return () => media.removeEventListener("change", update);
-  }, []);
-}
-export function PageBrand({ label, themePicker = true, markMotion }: { label: string; themePicker?: boolean; markMotion?: MdbaseMarkMotion }) { return <div className="page-brand-row"><div className="page-brand"><Brand markMotion={markMotion} /><span>{label}</span></div>{themePicker && <ThemeMenu />}</div>; }
+export function PageBrand({ label, markMotion }: { label: string; markMotion?: MdbaseMarkMotion }) { return <div className="page-brand-row"><div className="page-brand"><Brand markMotion={markMotion} /><span>{label}</span></div><ThemeMenu /></div>; }
 export function Brand({ productLabel = false, markMotion }: { productLabel?: boolean; markMotion?: MdbaseMarkMotion }) { return <div className="product-brand"><MdbaseMark motion={markMotion} /><strong>mdbase</strong>{productLabel && <span className="product-brand-label">connect</span>}</div>; }
 
 const conveyorXs = [-6, 22, 50, 78, 106] as const;
@@ -219,7 +210,7 @@ function MdbaseMark({ motion }: { motion?: MdbaseMarkMotion }) {
 }
 export function SectionHeading({ title, note, count }: { title: string; note: string; count?: number }) { return <div className="section-heading"><div><h2>{title}</h2><p>{note}</p></div>{count !== undefined && <span>{count}</span>}</div>; }
 export function Empty({ title, text }: { title: string; text: string }) { return <div className="empty"><span className="empty-folder" /><strong>{title}</strong><p>{text}</p></div>; }
-export function Loading({ error = "" }: { error?: string }) { return <main className="loading" aria-busy={!error}><Brand productLabel markMotion={error ? undefined : "bootstrap"} /><p>{error || "Opening mdbase connect…"}</p></main>; }
+export function Loading({ error = "", onRetry }: { error?: string; onRetry?(): void }) { return <main className="loading" aria-busy={!error}><PageBrand label="connect" markMotion={error ? undefined : "bootstrap"} /><p role={error ? "alert" : "status"}>{error || "Opening mdbase connect…"}</p>{error && onRetry && <button className="button primary" onClick={onRetry}>Try again</button>}</main>; }
 
 function ThemeGlyph({ preference }: { preference: ThemePreference }) {
   if (preference === "light") return <svg className="theme-glyph" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="3" /><path d="M10 2.4v1.2M10 16.4v1.2M2.4 10h1.2M16.4 10h1.2M4.6 4.6l.9.9M14.5 14.5l.9.9M15.4 4.6l-.9.9M5.5 14.5l-.9.9" /></svg>;

--- a/apps/portal/theme-bootstrap.test.mjs
+++ b/apps/portal/theme-bootstrap.test.mjs
@@ -5,23 +5,21 @@ import vm from "node:vm";
 
 const source = await readFile(new URL("./public/theme-bootstrap.js", import.meta.url), "utf8");
 
-test("authorization requests always start with the system theme", () => {
-  const context = themeContext("/authorize/11111111-1111-4111-8111-111111111111", "dark", false);
-
-  vm.runInNewContext(source, context);
-
-  assert.equal(context.document.documentElement.dataset.theme, undefined);
-  assert.equal(context.themeColor, "#fcfcfd");
-});
-
-test("other portal pages keep the saved theme preference", () => {
-  const context = themeContext("/", "dark", false);
-
-  vm.runInNewContext(source, context);
-
-  assert.equal(context.document.documentElement.dataset.theme, "dark");
-  assert.equal(context.themeColor, "#1c1e24");
-});
+for (const pathname of ["/", "/login", "/signup", "/device", "/authorize/11111111-1111-4111-8111-111111111111"]) {
+  for (const [savedTheme, systemDark, expected, color] of [
+    ["dark", false, "dark", "#1c1e24"],
+    ["light", true, "light", "#fcfcfd"],
+    ["system", true, undefined, "#1c1e24"],
+    ["system", false, undefined, "#fcfcfd"]
+  ]) {
+    test(`${pathname}: ${savedTheme} with OS ${systemDark ? "dark" : "light"} before first paint`, () => {
+      const context = themeContext(pathname, savedTheme, systemDark);
+      vm.runInNewContext(source, context);
+      assert.equal(context.document.documentElement.dataset.theme, expected);
+      assert.equal(context.themeColor, color);
+    });
+  }
+}
 
 function themeContext(pathname, savedTheme, systemDark) {
   const context = {
@@ -32,9 +30,7 @@ function themeContext(pathname, savedTheme, systemDark) {
     document: {
       documentElement: { dataset: {} },
       querySelector: () => ({
-        setAttribute: (_name, value) => {
-          context.themeColor = value;
-        }
+        setAttribute: (_name, value) => { context.themeColor = value; }
       })
     }
   };

--- a/scripts/browser-accessibility.test.mjs
+++ b/scripts/browser-accessibility.test.mjs
@@ -16,12 +16,15 @@ const browser = await chromium.launch({ headless: true });
 
 try {
   await auditPortalLogin();
-  await auditEditorConnect();
+  await auditPortalRecovery();
+  if (!process.argv.includes("--portal-only")) await auditEditorConnect();
   await auditPortalColdStartAuthorization();
   await auditPortalColdStartAuthorization({ atomic: true });
   await auditPortalDeviceAuthorization();
-  await auditDesktopResumedAuthorization();
-  await auditDesktopRoutes();
+  if (!process.argv.includes("--portal-only")) {
+    await auditDesktopResumedAuthorization();
+    await auditDesktopRoutes();
+  }
   console.log(
     "Browser accessibility passed: landmarks, names, headings, keyboard reachability, and reduced motion."
   );
@@ -35,8 +38,19 @@ try {
   );
 }
 
+async function localPage(options) {
+  const page = await browser.newPage(options);
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    return servers.some(({ origin }) => url.origin === origin)
+      ? route.continue()
+      : route.abort("blockedbyclient");
+  });
+  return page;
+}
+
 async function auditPortalLogin() {
-  const page = await browser.newPage();
+  const page = await localPage();
   const errors = watchPageErrors(page);
   await page.route("**/v1/**", async (route) => {
     const pathname = new URL(route.request().url()).pathname;
@@ -61,6 +75,17 @@ async function auditPortalLogin() {
   });
   await page.goto(`${servers[0].origin}/login`);
   await page.getByRole("heading", { level: 1 }).waitFor();
+  await page.getByLabel("Email", { exact: true }).focus();
+  await page.keyboard.press("Tab");
+  assert.deepEqual(await page.getByLabel("Password", { exact: true }).evaluate((element) => {
+    const style = getComputedStyle(element);
+    const probe = document.createElement("span");
+    probe.style.color = "var(--accent)";
+    element.after(probe);
+    const accent = getComputedStyle(probe).color;
+    probe.remove();
+    return [element === document.activeElement, style.outlineWidth, style.outlineStyle, style.outlineColor === accent];
+  }), [true, "2px", "solid", true], "password keyboard focus has an accent ring");
   await auditPage(page, "portal login", { keyboard: true });
   assert.deepEqual(
     errors.filter((error) => !error.includes("status of 401")),
@@ -69,8 +94,60 @@ async function auditPortalLogin() {
   await page.close();
 }
 
+async function auditPortalRecovery() {
+  for (const [saved, os] of [["dark", "light"], ["light", "dark"]]) {
+    const page = await localPage({ colorScheme: os });
+    await page.addInitScript((theme) => localStorage.setItem("mdbase:theme", theme), saved);
+    let configFails = false;
+    await page.route("**/v1/**", async (route) => {
+      const config = new URL(route.request().url()).pathname === "/v1/auth/config";
+      await route.fulfill(config && !configFails
+        ? { json: { provider: "session", providers: [], password_login: true, registration: "closed" } }
+        : { status: 500, json: { error: config ? "config_failed" : "identify_failed" } });
+    });
+    await page.goto(`${servers[0].origin}/login`);
+    await page.getByRole("heading", { name: "Sign in to mdbase connect" }).waitFor();
+    assert.equal(await page.getByRole("alert").count(), 0, "successful config clears obsolete identification error");
+    assert.equal(await page.locator("html").getAttribute("data-theme"), saved);
+    await page.getByRole("button", { name: `Color theme: ${saved === "dark" ? "Dark" : "Light"}` }).click();
+    await page.getByRole("menuitemradio", { name: "System", exact: true }).click();
+    assert.equal(await page.locator("html").getAttribute("data-theme"), null);
+    configFails = true;
+    await page.reload();
+    await page.getByRole("alert").waitFor();
+    assert.match(await page.getByRole("alert").innerText(), /Request failed with HTTP 500\./, "configuration failure remains visible");
+    await page.close();
+  }
+  for (const [path, endpoint, data, heading] of [
+    ["pair", "pairing-requests", { pairing: { connector_name: "Retry computer", approved_at: null } }, "Retry computer"],
+    ["mirror", "mirror-pairing-requests", { pairing: { mirror_name: "Retry mirror", mode: "read_only", approved_at: null, consumed_at: null, collection_id: null }, collections: [{ id: "collection", display_name: "Notes" }] }, "Retry mirror"]
+  ]) {
+    const page = await localPage();
+    let calls = 0;
+    let releaseRetry;
+    const retryResponse = new Promise((resolveRetry) => { releaseRetry = resolveRetry; });
+    await page.route(`**/v1/${endpoint}/*`, async (route) => {
+      calls += 1;
+      if (calls > 1) await retryResponse;
+      await route.fulfill(calls === 1 ? { status: 500, json: { error: "temporary_failure" } } : { json: data });
+    });
+    await page.goto(`${servers[0].origin}/${path}/11111111-1111-4111-8111-111111111111`);
+    await page.getByRole("alert").waitFor();
+    const retried = page.waitForRequest(`**/v1/${endpoint}/*`);
+    await page.getByRole("button", { name: "Try again" }).click();
+    await retried;
+    await page.locator('main[aria-busy="true"]').waitFor();
+    assert.equal(await page.getByRole("button", { name: "Try again" }).count(), 0, `${path}: cannot retry during a pending request`);
+    releaseRetry();
+    await page.getByRole("heading", { name: heading }).waitFor();
+    assert.equal(calls, 2, `${path}: one guarded retry`);
+    assert.equal(await page.getByRole("alert").count(), 0);
+    await page.close();
+  }
+}
+
 async function auditEditorConnect() {
-  const page = await browser.newPage();
+  const page = await localPage();
   const errors = watchPageErrors(page);
   const now = new Date().toISOString();
   await page.route("**/v1/**", async (route) => {
@@ -254,7 +331,7 @@ async function auditEditorConnect() {
 }
 
 async function auditPortalDeviceAuthorization() {
-  const page = await browser.newPage();
+  const page = await localPage();
   const errors = watchPageErrors(page);
   await page.goto(`${servers[0].origin}/device`);
   await page.getByRole("heading", { level: 1 }).waitFor();
@@ -264,12 +341,16 @@ async function auditPortalDeviceAuthorization() {
 }
 
 async function auditPortalColdStartAuthorization({ atomic = false } = {}) {
-  const page = await browser.newPage();
+  const page = await localPage();
   const errors = watchPageErrors(page);
   const requestId = "22222222-2222-4222-8222-222222222222";
   const authorization = atomic
     ? portalAtomicAuthorizationFixture(requestId)
     : portalAuthorizationFixture(requestId);
+  authorization.requirements.files = atomic
+    ? { required: ["read"], optional: ["delete"], scope: { kind: "folders", folders: ["attachments"] } }
+    : { actions: ["read", "delete"], scope: { kind: "collection" } };
+  authorization.notifications.criteria = [{ id: "changed", presentation: { title: "Records changed" }, event: { id: "records.changed", version: 1 } }];
   await page.route("**/v1/**", async (route) => {
     const pathname = new URL(route.request().url()).pathname;
     if (pathname === `/v1/authorization-requests/${requestId}`) {
@@ -345,15 +426,25 @@ async function auditPortalColdStartAuthorization({ atomic = false } = {}) {
     ? ["Read this collection", "Create records", "Edit records", "Delete records"]
     : ["Read records", "Create records", "Delete records"];
   for (const label of labels) await summary.getByText(label, { exact: true }).waitFor();
-  assert.deepEqual(await summary.locator("strong").allTextContents(), labels,
+  const summaryLabels = [...labels, "Manage and delete files"];
+  assert.deepEqual(await summary.locator("strong").allTextContents(), summaryLabels,
     "portal authorization: summary names exactly the requested permissions");
-  await summary.getByText("Higher impact", { exact: true }).waitFor();
+  assert.equal(await summary.getByText("Higher impact", { exact: true }).count(), 2);
+  assert.match(await page.locator(".file-permission-review summary").innerText(), atomic
+    ? /2 approved actions.*Only attachments.*Hidden folders are always excluded/
+    : /2 requested actions.*Every visible folder.*Hidden folders are always excluded/);
+  assert.match(await page.locator(".notification-access summary").innerText(), /1 optional rule.*no record content/);
+  assert.equal(await page.getByText(/until you revoke/).count(), 1, "approval discloses persistent access once");
   await page.getByText(atomic ? "Optional capabilities" : "Review exact permissions", { exact: true }).click();
+  assert.equal(await page.locator(".permission-group[aria-describedby]").evaluateAll((groups) =>
+    groups.length > 0 && groups.every((group) => document.getElementById(group.getAttribute("aria-describedby"))?.textContent.trim())
+  ), true, "permission fieldsets have accessible descriptions");
   if (atomic) {
-    assert.deepEqual(await page.getByRole("group").locator("legend").allTextContents(),
+    const permissionChoices = page.locator(".permission-review:not(.file-permission-review)");
+    assert.deepEqual(await permissionChoices.getByRole("group").locator("legend").allTextContents(),
       ["Create records", "Edit records", "Delete records"],
       "portal authorization: required read capability has no optional toggle");
-    assert.equal(await page.getByRole("checkbox").count(), 3,
+    assert.equal(await permissionChoices.getByRole("checkbox").count(), 3,
       "portal authorization: one checkbox per optional atomic capability");
     await page.getByRole("group", { name: "Edit records", exact: true }).getByRole("checkbox").uncheck();
     assert.equal(await summary.getByText("Edit records", { exact: true }).count(), 0,
@@ -374,7 +465,7 @@ async function auditPortalColdStartAuthorization({ atomic = false } = {}) {
   await page.getByText("Personal notes", { exact: true }).first().waitFor();
   await summary.getByText("Delete records", { exact: true }).waitFor();
   assert.deepEqual(await summary.locator("strong").allTextContents(),
-    labels.filter((label) => label !== (atomic ? "Edit records" : "Create records")),
+    summaryLabels.filter((label) => label !== (atomic ? "Edit records" : "Create records")),
     "portal authorization: selected and denied permissions survive refresh");
   await page.getByText(atomic ? "Optional capabilities" : "Review exact permissions", { exact: true }).click();
   assert.equal(await page.getByRole("checkbox", {
@@ -386,12 +477,40 @@ async function auditPortalColdStartAuthorization({ atomic = false } = {}) {
   assert.equal(await denied.isChecked(), false, "portal authorization: denied control stays unchecked after refresh");
   assert.equal(await page.getByRole("button", { name: "Allow Workout journal" }).count(), 1, "portal authorization: review state survives refresh");
   await auditPage(page, `portal ${atomic ? "atomic" : "legacy exact"} application access review`, { keyboard: true });
+  await page.locator(".file-permission-review summary").click();
+  const fileControls = page.locator(".file-permission-review");
+  if (atomic) {
+    assert.equal(await fileControls.getByRole("checkbox", { name: "Read file contents (required)", exact: true }).isDisabled(), true);
+    await fileControls.getByRole("checkbox", { name: "Delete files (optional)", exact: true }).uncheck();
+    await page.reload();
+    await page.locator(".file-permission-review summary").click();
+    assert.equal(await fileControls.getByRole("checkbox", { name: "Delete files (optional)", exact: true }).isChecked(), false, "optional file denial survives refresh");
+    assert.equal(await fileControls.getByRole("checkbox", { name: "Read file contents (required)", exact: true }).isChecked(), true);
+  } else {
+    assert.equal(await fileControls.getByRole("checkbox").count(), 0, "legacy file actions are fixed, not optional capabilities");
+    assert.deepEqual(await fileControls.getByRole("listitem").allTextContents(), ["Read file contents", "Delete files"]);
+  }
+  await page.setViewportSize({ width: 390, height: 844 });
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true, "approval controls do not overflow a narrow viewport");
+  await auditPage(page, "portal narrow file permissions", { keyboard: true });
+  for (const [saved, os] of [["dark", "light"], ["light", "dark"]]) {
+    await page.evaluate((theme) => localStorage.setItem("mdbase:theme", theme), saved);
+    await page.emulateMedia({ colorScheme: os });
+    await page.reload();
+    await page.getByRole("button", { name: "Allow Workout journal" }).waitFor();
+    assert.equal(await page.locator("html").getAttribute("data-theme"), saved, "authorization honors explicit theme despite OS preference");
+    assert.equal(await page.getByRole("button", { name: /Color theme/ }).count(), 1);
+  }
+  authorization.distribution = "portable";
+  await page.reload();
+  await page.getByText("Downloaded file, unverified origin", { exact: true }).waitFor();
+  assert.equal(await page.getByText(/until you revoke/).count(), 0, "portable approval does not promise durability");
   assert.deepEqual(errors, []);
   await page.close();
 }
 
 async function auditDesktopResumedAuthorization() {
-  const page = await browser.newPage();
+  const page = await localPage();
   const errors = watchPageErrors(page);
   const requestId = "33333333-3333-4333-8333-333333333333";
   await page.addInitScript((authorizationId) => {
@@ -450,7 +569,7 @@ async function auditDesktopResumedAuthorization() {
 }
 
 async function auditDesktopRoutes() {
-  const page = await browser.newPage();
+  const page = await localPage();
   const errors = watchPageErrors(page);
   await page.addInitScript((pendingAuthorization) => {
     localStorage.setItem("mdbase:collection-completion", JSON.stringify({


### PR DESCRIPTION
## Summary

- Honor saved Light/Dark before paint and throughout transactional approval/device screens; keep the System/Light/Dark picker available.
- Associate permission fieldsets with their descriptions and show exact legacy file scope alongside the collapsed action count.
- Show the durable-access disclosure once, next to approval, without promising persistence for downloaded portable applications.
- Allow a guarded retry after failed pairing/mirror-pairing discovery and clear obsolete identification errors after successful auth-config discovery.
- Extend browser coverage for consent semantics, file-action retention, saved themes, keyboard focus, narrow layouts, portable disclosure, and failed-request recovery. Browser fixtures block non-local traffic.

## Integration scope

Ported onto current main (`03d2020c`), preserving the newer **v1 exact-action / v2 atomic-capability** authorization model, required groups, optional file controls, entire-collection disclosure, and existing higher-impact summaries. No permission broadening or protocol changes.

The saved UI/lockfile snapshots and visual-design PR #392 are **not** included. The shared input focus ring and notification counts already present on main are retained and regression-tested rather than replaced with the old baseline. Editor fixes are separate in #410.

## Validation on this PR head

- `pnpm install --frozen-lockfile --offline`
- `pnpm check:architecture`
- `pnpm typecheck`
- `pnpm test` (whole workspace; existing optional server tests skipped)
- Browser-storage integration tests
- Full `scripts/browser-accessibility.test.mjs` against built portal/editor/mocked desktop: **passed**, including both legacy and atomic permission flows, required/optional files, retries, themes, and narrow viewport checks

Prepared in an isolated worktree. No live service/LAB mutations or deployment commands. Merge through the normal CI/merge queue, without bypasses.
