### PR TITLE
Fix Editor deployment file-intent verification for semantic v2

### DIFF
--- a/apps/editor/scripts/verify-deployment-manifest.mjs
+++ b/apps/editor/scripts/verify-deployment-manifest.mjs
@@ -39,9 +39,14 @@ export async function verifyManifest(
 }
 
 export function assertEditorManifest(manifest, expectedHomepage, expectedConnectOrigin) {
-  const required = manifest?.requirements?.capabilities?.required;
-  const actions = manifest?.requirements?.files?.actions;
-  const scope = manifest?.requirements?.files?.scope;
+  const capabilities = manifest?.requirements?.capabilities;
+  const version = capabilities?.contract_version === undefined ? 1 : capabilities.contract_version;
+  const required = capabilities?.required;
+  const files = manifest?.requirements?.files;
+  // Check Editor-specific file intent in the original declared semantics.
+  // Optional v2 actions and legacy field names cannot satisfy required access.
+  const actions = version === 2 ? files?.required : files?.actions;
+  const scope = files?.scope;
   const problems = [];
 
   if (manifest?.homepage !== expectedHomepage) problems.push(`homepage must be ${expectedHomepage}`);
@@ -56,8 +61,14 @@ export function assertEditorManifest(manifest, expectedHomepage, expectedConnect
     }
   }
   if (manifest?.requirements?.access !== "full_collection") problems.push("access must be full_collection");
-  if (!Array.isArray(required) || !required.includes("files.list")) problems.push("files.list capability is required");
-  if (!Array.isArray(required) || !required.includes("files.read")) problems.push("files.read capability is required");
+  if (version === 1) {
+    if (!Array.isArray(required) || !required.includes("files.list")) problems.push("files.list capability is required");
+    if (!Array.isArray(required) || !required.includes("files.read")) problems.push("files.read capability is required");
+  } else if (version === 2) {
+    if (files && Object.hasOwn(files, "actions")) problems.push("v2 file requirements must not contain legacy actions");
+  } else {
+    problems.push("unsupported capability contract version");
+  }
   if (!Array.isArray(actions) || !actions.includes("list")) problems.push("file list action is required");
   if (!Array.isArray(actions) || !actions.includes("read")) problems.push("file read action is required");
   if (scope?.kind !== "collection") problems.push("file scope must cover the collection");

--- a/apps/editor/scripts/verify-deployment-manifest.test.mjs
+++ b/apps/editor/scripts/verify-deployment-manifest.test.mjs
@@ -1,46 +1,121 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { assertEditorManifest } from "./verify-deployment-manifest.mjs";
 
 const homepage = "https://editor.mdbase.dev/";
 
-test("accepts collection-wide binary file access", () => {
-  assert.doesNotThrow(() => assertEditorManifest(manifest(), homepage));
-});
-
-test("accepts the exact configured Connect callback", () => {
-  const value = manifest();
-  value.redirect_uris.push("https://editor.mdbase.dev/?server=https%3A%2F%2Fconnect-staging.mdbase.dev");
-  assert.doesNotThrow(() => assertEditorManifest(value, homepage, "https://connect-staging.mdbase.dev"));
-});
-
-test("rejects a deployment without the configured Connect callback", () => {
-  assert.throws(
-    () => assertEditorManifest(manifest(), homepage, "https://connect-staging.mdbase.dev"),
-    /redirect URIs must include/
-  );
-});
-
-for (const [name, mutate, expected] of [
-  ["file capabilities", (value) => { value.requirements.capabilities.required = []; }, /files\.list capability/],
-  ["file actions", (value) => { delete value.requirements.files; }, /file list action/],
-  ["collection scope", (value) => { value.requirements.files.scope = { kind: "selected_folders", folders: ["Media"] }; }, /scope must cover the collection/]
-]) {
-  test(`rejects a deployment without ${name}`, () => {
-    const value = manifest();
-    mutate(value);
-    assert.throws(() => assertEditorManifest(value, homepage), expected);
+for (const version of [1, 2]) {
+  test(`accepts v${version} collection-wide binary file access`, () => {
+    assert.doesNotThrow(() => assertEditorManifest(manifest(version), homepage));
   });
+
+  test(`accepts the exact configured v${version} Connect callback`, () => {
+    const value = manifest(version);
+    value.redirect_uris.push("https://editor.mdbase.dev/?server=https%3A%2F%2Fconnect-staging.mdbase.dev");
+    assert.doesNotThrow(() => assertEditorManifest(value, homepage, "https://connect-staging.mdbase.dev"));
+  });
+
+  test(`rejects v${version} without the configured Connect callback`, () => {
+    assert.throws(
+      () => assertEditorManifest(manifest(version), homepage, "https://connect-staging.mdbase.dev"),
+      /redirect URIs must include/
+    );
+  });
+
+  for (const [name, mutate, expected] of [
+    ["file actions", (value) => { delete value.requirements.files; }, /file list action/],
+    ["collection scope", (value) => { value.requirements.files.scope = { kind: "selected_folders", folders: ["Media"] }; }, /scope must cover the collection/],
+    ["full collection access", (value) => { value.requirements.access = "scoped"; }, /access must be full_collection/],
+    ["homepage", (value) => { value.homepage = "https://other.invalid/"; }, /homepage must be/],
+    ["first redirect", (value) => { value.redirect_uris = []; }, /first redirect URI/]
+  ]) {
+    test(`rejects v${version} without ${name}`, () => {
+      const value = manifest(version);
+      mutate(value);
+      assert.throws(() => assertEditorManifest(value, homepage), expected);
+    });
+  }
 }
 
-function manifest() {
+test("retains the legacy omitted-version file-intent check", () => {
+  const value = manifest(1);
+  delete value.requirements.capabilities.contract_version;
+  assert.doesNotThrow(() => assertEditorManifest(value, homepage));
+});
+
+test("retains both required v1 file capabilities", () => {
+  for (const action of ["list", "read"]) {
+    const value = manifest(1);
+    value.requirements.capabilities.required = value.requirements.capabilities.required.filter(
+      (capability) => capability !== `files.${action}`
+    );
+    assert.throws(() => assertEditorManifest(value, homepage), new RegExp(`files\\.${action} capability`));
+  }
+});
+
+test("v2 optional or legacy actions cannot replace required binary file access", () => {
+  for (const action of ["list", "read"]) {
+    const value = manifest(2);
+    value.requirements.files.required = value.requirements.files.required.filter((item) => item !== action);
+    value.requirements.files.optional.push(action);
+    assert.throws(() => assertEditorManifest(value, homepage), new RegExp(`file ${action} action`));
+  }
+  const legacy = manifest(2);
+  delete legacy.requirements.files.required;
+  legacy.requirements.files.actions = ["list", "read"];
+  assert.throws(() => assertEditorManifest(legacy, homepage), /file list action/);
+});
+
+test("rejects mixed v2 and legacy file-action representations", () => {
+  const value = manifest(2);
+  value.requirements.files.actions = ["list", "read"];
+  assert.throws(() => assertEditorManifest(value, homepage), /v2 file requirements must not contain legacy actions/);
+});
+
+test("fails closed on unknown or malformed explicit capability versions", () => {
+  for (const version of [0, 3, null, "2"]) {
+    const value = manifest(1);
+    value.requirements.capabilities.contract_version = version;
+    assert.throws(() => assertEditorManifest(value, homepage), /unsupported capability contract version/);
+  }
+});
+
+test("accepts the actual production manifest generator output", (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "mdbase-editor-manifest-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  mkdirSync(join(directory, "scripts"));
+  const writer = join(directory, "scripts", "write-manifest.mjs");
+  copyFileSync(new URL("./write-manifest.mjs", import.meta.url), writer);
+  execFileSync(process.execPath, [writer], {
+    env: {
+      ...process.env,
+      MDBASE_EDITOR_ORIGIN: homepage,
+      MDBASE_EDITOR_BASE_PATH: "/",
+      MDBASE_CONNECT_URL: ""
+    }
+  });
+  const value = JSON.parse(readFileSync(join(directory, "public", ".well-known", "mdbase-app.json"), "utf8"));
+  assert.equal(value.requirements.capabilities.contract_version, 2);
+  assert.doesNotThrow(() => assertEditorManifest(value, homepage));
+});
+
+function manifest(version) {
   return {
     homepage,
     redirect_uris: [homepage],
     requirements: {
       access: "full_collection",
-      capabilities: { required: ["files.list", "files.read"] },
-      files: { actions: ["list", "read"], scope: { kind: "collection" } }
+      capabilities: {
+        contract_version: version,
+        required: version === 1 ? ["files.list", "files.read"] : ["collection.read"]
+      },
+      files: version === 1
+        ? { actions: ["list", "read"], scope: { kind: "collection" } }
+        : { required: ["list", "read"], optional: ["add"], scope: { kind: "collection" } }
     }
   };
 }


### PR DESCRIPTION
## Summary

Fix the Editor-specific deployment file-access check to read the declaration's original semantic version:

- v1 retains both legacy `files.list`/`files.read` capabilities and `files.actions` checks;
- v2 requires `list` and `read` in `files.required`; optional or legacy actions cannot substitute;
- mixed v2/legacy actions and unknown explicit versions fail closed;
- collection scope, full-collection access, homepage and callback checks remain required.

The regression suite now runs the actual production manifest generator rather than relying only on hard-coded v1 fixtures.

## Release context and limits

Production Editor run **34590922930/attempt2** passed its tests and built the exact `v0.1.0-beta.96` source, but stopped at **Verify editor manifest**. **Deploy editor was skipped**. The generated semantic-v2 declaration is correct; the old verifier still requires the v1 representation.

This is a verifier-only source fix. It does **not** change the generated declaration, application permissions, runtime source, release version, immutable tag, existing workflow/source guards, or production deployment. The existing beta96 tag remains bound to `56ed32ffde055d2ab2b22ff95722df8ef06bdb1d` and therefore still contains the old verifier. Merging this PR alone would not repair a rerun of that immutable-tag workflow. No tag movement, newer-source substitution, direct deployment or verification bypass is proposed here.

## Validation

- The new 22-case verifier suite reproduced six failures against the old verifier, including the real generator's output; all 22 pass after the fix.
- All **55** Editor script, deploy-editor-dev and client-publication targeted tests pass after normal frozen dependency installation and package build.
- `node scripts/release-components.mjs --check` passes.
- `git diff --check` passes.
- An earlier broader invocation in the fresh checkout stopped on missing uninstalled workspace dependencies/Wrangler; that observation is retained separately, not relabeled as passing.

No request-path code changed. This draft preserves the narrow fix for review without claiming that the immutable beta96 Editor publication is complete.
