### PR TITLE
Advance upgrade predecessor to beta96 while retaining exact beta95 coverage

### DIFF
--- a/.github/previous-release.env
+++ b/.github/previous-release.env
@@ -1,6 +1,6 @@
 # Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.95
-MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=408c67bc10f128e0833f0da62cb3efb9d94657d7
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:95a89fd6f13de72bd9e45fbfa5f00df5f7b599d8fb9a4da22d1f22c5d0391970
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:1ef08bfa18431357a29e2565bc9a490a182e73f9e2b532594ac968a3c3563048
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.96
+MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=56ed32ffde055d2ab2b22ff95722df8ef06bdb1d
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:84bb6bf960046d303a7333a3d52ffeeab96feb06a8b3d311a75ccd1f3af09b59
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:dbd58b57dc280d2ee1de5cac53e92e813be02f108de4c1327ee53ee2d363625d

--- a/.github/retained-v2-predecessor.env
+++ b/.github/retained-v2-predecessor.env
@@ -1,0 +1,6 @@
+# Immutable beta95 regression fixture for semantic-v2 rollback/reupgrade.
+# Not the current immediate predecessor or production rollback authorization.
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.95
+MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=408c67bc10f128e0833f0da62cb3efb9d94657d7
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:95a89fd6f13de72bd9e45fbfa5f00df5f7b599d8fb9a4da22d1f22c5d0391970
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:1ef08bfa18431357a29e2565bc9a490a182e73f9e2b532594ac968a3c3563048

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -295,14 +295,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Verify and cache the checked-in immediate predecessor
+      - name: Verify and cache the immutable beta95 regression fixture
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          source .github/previous-release.env
+          source .github/retained-v2-predecessor.env
           source test/upgrade/lib.sh
-          upgrade_verify_previous_release "$PWD"
+          upgrade_verify_retained_v2_release "$PWD"
           docker pull "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE" >/dev/null
           docker pull postgres:17-alpine >/dev/null
       - name: Preserve pending v2 state through beta95 rollback and reupgrade
@@ -358,14 +358,14 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @mdbase-dev/connect-protocol build
-      - name: Verify and cache the checked-in immediate predecessor
+      - name: Verify and cache the immutable beta95 regression fixture
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          source .github/previous-release.env
+          source .github/retained-v2-predecessor.env
           source test/upgrade/lib.sh
-          upgrade_verify_previous_release "$PWD"
+          upgrade_verify_retained_v2_release "$PWD"
           docker pull "$MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE" >/dev/null
           docker pull postgres:18-alpine >/dev/null
       - name: Qualify candidate-issued v2 through beta95 rollback and reupgrade

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -50,6 +50,24 @@ Schema versions are monotonic. Readers fail closed on unknown versions and
 unknown, missing, duplicated, mutable, wrong-platform, or wrong-repository
 components.
 
+## Upgrade predecessor and historical regressions
+
+`.github/previous-release.env` identifies the immediate published predecessor.
+Update its annotated tag, full commit and immutable server/provider digests as
+part of release preparation; ordinary upgrade qualification still requires it to
+be the unique newest non-draft GitHub release. Beta97 preparation advances this
+pin to beta96 (`56ed32ffde055d2ab2b22ff95722df8ef06bdb1d`), using the signed image
+bundle from publication34316504048 / qualification34315442229, both attempt1.
+
+The exact-beta95 semantic-v2 provider and pending-server regression lanes remain
+required. Their separate `.github/retained-v2-predecessor.env` cannot advance with
+the ordinary pin: the verifiers require the original beta95 tag, commit and both
+image digests, a published non-draft release and its matching annotated origin
+tag. Beta94's historical prelude lane is unchanged. No job, scenario, deadline,
+image/source check or signed-publication gate is removed. These historical
+regressions do not establish beta97's immediate-predecessor rollback relationship
+or change private production recovery authority; those need their own evidence.
+
 ## Local LAB experiments
 
 `pnpm deploy:lab --confirm LAB` builds the current checkout, pushes immutable

--- a/scripts/lib/retained-v2-upgrade.test.mjs
+++ b/scripts/lib/retained-v2-upgrade.test.mjs
@@ -54,8 +54,8 @@ test('retained-v2 rejects a mutable beta94 tag before starting resources', async
 test('Server CI requires retained-v2 evidence separately from the historical v1 lane', async () => {
   const workflow = await readFile(new URL('../../.github/workflows/server-ci.yml', import.meta.url), 'utf8');
   assert.match(workflow, /run: test\/upgrade\/provider-from-previous --retained-v2/);
-  assert.match(workflow, /source \.github\/previous-release\.env/);
-  assert.match(workflow, /upgrade_verify_previous_release "\$PWD"/);
+  assert.match(workflow, /source \.github\/retained-v2-predecessor\.env/);
+  assert.match(workflow, /upgrade_verify_retained_v2_release "\$PWD"/);
   assert.doesNotMatch(workflow, /vars\.RETAINED_V2_BETA95_PROVIDER_IMAGE/);
   assert.match(workflow, /provider-from-previous --legacy-prelude/);
   assert.match(workflow, /- retained-v2-provider-upgrade/);

--- a/scripts/lib/upgrade-release-identity.test.mjs
+++ b/scripts/lib/upgrade-release-identity.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execute = promisify(execFile);
+const root = resolve(import.meta.dirname, "../..");
+const beta95 = "408c67bc10f128e0833f0da62cb3efb9d94657d7";
+const beta96 = "56ed32ffde055d2ab2b22ff95722df8ef06bdb1d";
+const release95 = { id: 95, tag_name: "v0.1.0-beta.95", draft: false, published_at: "2026-09-08T00:00:00Z" };
+const release96 = { ...release95, id: 96, tag_name: "v0.1.0-beta.96" };
+const annotated = (tag, commit) => `${"a".repeat(40)}\trefs/tags/${tag}\n${commit}\trefs/tags/${tag}^{}\n`;
+
+async function verify(context, { historical = false, metadata, refs, override = "", network = "ok", image = false, inspection } = {}) {
+  const work = await mkdtemp(join(tmpdir(), "upgrade-release-identity-"));
+  context.after(() => rm(work, { recursive: true, force: true }));
+  const bin = join(work, "bin");
+  await mkdir(bin);
+  const scripts = {
+    curl: `#!/usr/bin/env bash
+set -euo pipefail
+url=\"\${@: -1}\"
+printf 'curl %s\\n' \"$url\" >> \"$CALLS\"
+[[ $url == \"$EXPECTED_URL\" && $NETWORK == ok ]] || exit 22
+printf '%s' \"$METADATA\"
+`,
+    git: `#!/usr/bin/env bash
+set -euo pipefail
+printf 'git\\n' >> \"$CALLS\"
+[[ $* == \"-C $ROOT ls-remote --exit-code --tags origin refs/tags/$TAG refs/tags/$TAG^{}\" ]] || exit 23
+printf '%s' \"$REFS\"
+`,
+    docker: `#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker\\n' >> \"$CALLS\"
+[[ $1 == image && $2 == inspect ]] || exit 24
+printf '%s' \"$INSPECTION\"
+`
+  };
+  for (const [name, content] of Object.entries(scripts)) await writeFile(join(bin, name), content, { mode: 0o700 });
+  const tag = historical ? release95.tag_name : release96.tag_name;
+  const commit = historical ? beta95 : beta96;
+  const calls = join(work, "calls");
+  const pin = historical ? "retained-v2-predecessor.env" : "previous-release.env";
+  const verifier = historical ? "upgrade_verify_retained_v2_release" : "upgrade_verify_previous_release";
+  let code = 0;
+  let stderr = "";
+  try {
+    await execute("/usr/bin/bash", ["-euo", "pipefail", "-c", `
+source "$ROOT/.github/${pin}"
+source "$ROOT/test/upgrade/lib.sh"
+${override}
+${image ? 'upgrade_verify_previous_image "$MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE"' : `${verifier} "$ROOT"`}
+`], {
+      timeout: 5000,
+      env: {
+        PATH: `${bin}:/usr/bin:/bin`, HOME: work, LANG: "C", ROOT: root, CALLS: calls,
+        TAG: tag, NETWORK: network,
+        EXPECTED_URL: historical
+          ? "https://api.github.com/repos/mdbase-dev/mdbase-connect/releases/tags/v0.1.0-beta.95"
+          : "https://api.github.com/repos/mdbase-dev/mdbase-connect/releases?per_page=100",
+        METADATA: typeof metadata === "string" ? metadata : JSON.stringify(metadata ?? (historical ? release95 : [release96, release95])),
+        REFS: refs ?? annotated(tag, commit),
+        INSPECTION: JSON.stringify(inspection ?? [{ Config: { Labels: {
+          "org.opencontainers.image.source": "https://github.com/mdbase-dev/mdbase-connect",
+          "org.opencontainers.image.revision": commit
+        } } }])
+      }
+    });
+  } catch (error) {
+    if (error.killed || typeof error.code !== "number") throw error;
+    code = error.code;
+    stderr = error.stderr;
+  }
+  return { code, stderr, calls: await readFile(calls, "utf8").catch(() => "") };
+}
+
+test("ordinary predecessor verifies newest beta96 and its annotated origin tag", async (context) => {
+  const result = await verify(context);
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.calls, /releases\?per_page=100\ngit\n$/);
+});
+
+test("ordinary qualification cannot substitute the historical beta95 pin for newest beta96", async (context) => {
+  const result = await verify(context, { override: 'source "$ROOT/.github/retained-v2-predecessor.env"' });
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /not the unique newest non-draft/);
+  assert.doesNotMatch(result.calls, /^git$/m);
+});
+
+for (const [name, metadata] of [
+  ["older pin", [release95, release96]],
+  ["duplicate release", [release96, release96]],
+  ["draft only", [{ ...release96, draft: true }]],
+  ["missing release", []],
+  ["object instead of inventory", release96],
+  ["malformed JSON", "not-json"]
+]) test(`ordinary predecessor rejects ${name}`, async (context) => {
+  const result = await verify(context, { metadata });
+  assert.notEqual(result.code, 0);
+  assert.doesNotMatch(result.calls, /^git$/m);
+});
+
+for (const historical of [false, true]) {
+  const tag = historical ? release95.tag_name : release96.tag_name;
+  const commit = historical ? beta95 : beta96;
+  for (const [name, refs] of [
+    ["wrong peeled commit", annotated(tag, "b".repeat(40))],
+    ["lightweight tag", `${commit}\trefs/tags/${tag}\n`],
+    ["duplicate peeled ref", annotated(tag, commit) + `${commit}\trefs/tags/${tag}^{}\n`],
+    ["foreign ref", annotated(tag, commit) + `${commit}\trefs/heads/main\n`],
+    ["malformed ref hash", `bad\trefs/tags/${tag}\n`]
+  ]) test(`${historical ? "historical" : "ordinary"} rejects ${name}`, async (context) => {
+    const result = await verify(context, { historical, refs });
+    assert.notEqual(result.code, 0);
+    assert.match(result.calls, /^git$/m);
+  });
+  test(`${historical ? "historical" : "ordinary"} fails closed on release GET failure`, async (context) => {
+    const result = await verify(context, { historical, network: "failed" });
+    assert.notEqual(result.code, 0);
+    assert.doesNotMatch(result.calls, /^git$/m);
+  });
+}
+
+test("historical regression verifies published beta95 by exact tag, independently of newest release", async (context) => {
+  const result = await verify(context, { historical: true });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.calls, /releases\/tags\/v0\.1\.0-beta\.95\ngit\n$/);
+});
+
+for (const metadata of [
+  { ...release95, draft: true }, { ...release95, tag_name: release96.tag_name },
+  { ...release95, published_at: null }, { ...release95, published_at: "" },
+  { ...release95, id: "95" }, [release95], {}, "not-json"
+]) test(`historical rejects unqualified release metadata ${JSON.stringify(metadata)}`, async (context) => {
+  const result = await verify(context, { historical: true, metadata });
+  assert.notEqual(result.code, 0);
+  assert.doesNotMatch(result.calls, /^git$/m);
+});
+
+for (const variable of ["RELEASE", "RELEASE_COMMIT", "SERVER_IMAGE", "PROVIDER_IMAGE"]) {
+  test(`historical rejects altered ${variable} before network`, async (context) => {
+    const result = await verify(context, { historical: true, override: `MDBASE_CONNECT_PREVIOUS_${variable}=changed` });
+    assert.equal(result.code, 2);
+    assert.equal(result.calls, "");
+  });
+}
+for (const variable of ["RELEASE", "RELEASE_COMMIT"]) {
+  test(`ordinary rejects malformed ${variable} before network`, async (context) => {
+    const result = await verify(context, { override: `MDBASE_CONNECT_PREVIOUS_${variable}=bad/path` });
+    assert.equal(result.code, 2);
+    assert.equal(result.calls, "");
+  });
+}
+
+test("pulled image must still identify the exact predecessor source and revision", async (context) => {
+  assert.equal((await verify(context, { image: true })).code, 0);
+  for (const inspection of [[], [{ Config: { Labels: {} } }], [{ Config: { Labels: {
+    "org.opencontainers.image.source": "https://github.com/mdbase-dev/mdbase-connect",
+    "org.opencontainers.image.revision": beta95
+  } } }]]) assert.notEqual((await verify(context, { image: true, inspection })).code, 0);
+});

--- a/scripts/lib/upgrade-test-contract.test.mjs
+++ b/scripts/lib/upgrade-test-contract.test.mjs
@@ -27,10 +27,10 @@ test("upgrade pins the exact immediate predecessor", async () => {
   );
   assert.equal(fixture, `# Exact server image from the release immediately preceding this candidate.
 # Update this file as part of each release-preparation change.
-MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.95
-MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=408c67bc10f128e0833f0da62cb3efb9d94657d7
-MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:95a89fd6f13de72bd9e45fbfa5f00df5f7b599d8fb9a4da22d1f22c5d0391970
-MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:1ef08bfa18431357a29e2565bc9a490a182e73f9e2b532594ac968a3c3563048
+MDBASE_CONNECT_PREVIOUS_RELEASE=v0.1.0-beta.96
+MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT=56ed32ffde055d2ab2b22ff95722df8ef06bdb1d
+MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-server@sha256:84bb6bf960046d303a7333a3d52ffeeab96feb06a8b3d311a75ccd1f3af09b59
+MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE=ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:dbd58b57dc280d2ee1de5cac53e92e813be02f108de4c1327ee53ee2d363625d
 `);
 });
 
@@ -50,13 +50,15 @@ test("both upgrade programs execute release and pulled-image verification", asyn
     ["test/upgrade/retained-v2.sh", "MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE"]
   ]) {
     const program = await readFile(resolve(repoRoot, script), "utf8");
-    const releaseCheck = program.indexOf('upgrade_verify_previous_release "$repo_root"');
+    const verifier = script.endsWith('retained-v2.sh')
+      ? 'upgrade_verify_retained_v2_release' : 'upgrade_verify_previous_release';
+    const releaseCheck = program.indexOf(`${verifier} "$repo_root"`);
     const imageCheck = program.indexOf(`upgrade_verify_previous_image "$${imageVariable}"`);
     assert.ok(releaseCheck >= 0 && releaseCheck < imageCheck, `${script} must verify the release before use`);
     if (script.endsWith('retained-v2.sh')) {
       const cachedImage = program.indexOf(`docker image inspect "$${imageVariable}"`);
       assert.ok(cachedImage >= 0 && cachedImage < imageCheck, 'provider must verify its cached immutable image');
-      assert.match(program, /source "\$repo_root\/\.github\/previous-release\.env"/);
+      assert.match(program, /source "\$repo_root\/\.github\/retained-v2-predecessor\.env"/);
     } else {
       const pull = program.indexOf(`docker pull "$${imageVariable}"`);
       assert.ok(pull >= 0 && imageCheck > pull, `${script} must inspect the image after pulling it`);

--- a/test/upgrade/RETAINED-V2.md
+++ b/test/upgrade/RETAINED-V2.md
@@ -14,7 +14,7 @@ Use Node 24 and build the protocol package first:
 ```sh
 export PATH=/home/calluma/.local/share/fnm/node-versions/v24.19.0/installation/bin:$PATH
 pnpm --filter @mdbase-dev/connect-protocol build
-# The exact beta95 digest is read from .github/previous-release.env.
+# The exact beta95 digest is read from .github/retained-v2-predecessor.env.
 # It must already be in the local Docker cache. Overrides must match that pin.
 env -u DATABASE_URL -u MDBASE_CONNECT_R2_ENDPOINT \
   test/upgrade/provider-from-previous --retained-v2
@@ -24,9 +24,16 @@ The immutable source binding is `v0.1.0-beta.95` at
 `408c67bc10f128e0833f0da62cb3efb9d94657d7`, whose fresh policy is `[1]`.
 The harness checks the local tag commit, that source's policy, the candidate's
 `v2-enablement` `[1,2]` policy, and the cached predecessor image's OCI source and
-revision labels. Server CI verifies that the checked-in predecessor is the
-unique newest non-draft release with its exact annotated origin tag, then caches
-the pinned digest. A mutable repository variable cannot select the fixture.
+revision labels. Server CI and the harness verify the fixed published, non-draft
+beta95 release by tag and its exact annotated origin commit, then CI caches the
+pinned digest. All four historical pin fields must match the immutable beta95
+release/commit/image pair. A mutable repository variable cannot select the fixture.
+
+This historical regression is intentionally independent of
+`.github/previous-release.env`, which advances to the actual newest published
+release (currently beta96) and retains its mandatory newest-release check.
+Preserving beta95 coverage does not establish a later candidate's immediate-
+predecessor provider rollback or authorize production recovery.
 Image labels are not signature verification: the release contract's independent
 signature/attestation verification remains required for release qualification.
 No signature or deployment qualification is claimed by this local scenario.

--- a/test/upgrade/SERVER-RETAINED-V2.md
+++ b/test/upgrade/SERVER-RETAINED-V2.md
@@ -4,7 +4,7 @@ Run the registered scenario through the existing server upgrade entry point:
 
 ```sh
 export PATH=/home/calluma/.local/share/fnm/node-versions/v24.19.0/installation/bin:$PATH
-# Preload postgres:17-alpine and the exact server digest from .github/previous-release.env.
+# Preload postgres:17-alpine and the exact server digest from .github/retained-v2-predecessor.env.
 # This scenario neither pulls predecessor images nor accesses registry credentials.
 env -u DATABASE_URL -u UPGRADE_SERVER_URL test/upgrade/server-from-previous --retained-v2-pending
 ```
@@ -21,7 +21,12 @@ env -u DATABASE_URL -u UPGRADE_SERVER_URL \
 ```
 
 Inputs require beta.95, commit `408c67bc10f128e0833f0da62cb3efb9d94657d7`,
-and the digest-only server image in the parent's pin file. The helper verifies
+and the digest-only server image in `.github/retained-v2-predecessor.env`.
+The full release/commit/image pair is fixed, its published non-draft release is
+verified by tag, and the annotated origin tag must peel to that exact commit.
+The default lane separately uses `.github/previous-release.env` and requires the
+newest published release (currently beta96); historical beta95 is not substituted
+for that immediate predecessor. The helper verifies
 OCI source/revision labels, source policy phases, and the actual images'
 generated fresh semantic ceilings `[1]` and `[1,2]`. Containers run by resolved
 image ID throughout. This is local binary evidence, not signature/attestation,

--- a/test/upgrade/lib.sh
+++ b/test/upgrade/lib.sh
@@ -20,7 +20,7 @@ upgrade_verify_previous_release() {
   local repo_root=$1
   local release=${MDBASE_CONNECT_PREVIOUS_RELEASE:-}
   local commit=${MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT:-}
-  local releases_json refs ref_hash ref_name peeled_commit=
+  local releases_json
   local -a curl_headers=()
 
   if [[ ! $release =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
@@ -54,6 +54,48 @@ upgrade_verify_previous_release() {
     return 1
   fi
 
+  upgrade_verify_annotated_release_tag "$repo_root"
+}
+
+# This historical lane is fixed to the original beta95 bytes, not a caller's
+# arbitrary older release. Newest-release verification above remains mandatory
+# for the ordinary immediate-predecessor lane.
+upgrade_verify_retained_v2_release() {
+  local repo_root=$1 metadata
+  local -a curl_headers=()
+  if [[ ${MDBASE_CONNECT_PREVIOUS_RELEASE:-} != v0.1.0-beta.95 ||
+        ${MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT:-} != 408c67bc10f128e0833f0da62cb3efb9d94657d7 ||
+        ${MDBASE_CONNECT_PREVIOUS_SERVER_IMAGE:-} != ghcr.io/mdbase-dev/mdbase-connect-server@sha256:95a89fd6f13de72bd9e45fbfa5f00df5f7b599d8fb9a4da22d1f22c5d0391970 ||
+        ${MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE:-} != ghcr.io/mdbase-dev/mdbase-connect-hosted-provider@sha256:1ef08bfa18431357a29e2565bc9a490a182e73f9e2b532594ac968a3c3563048 ]]; then
+    printf 'Historical retained-v2 regression requires the exact beta95 release, commit and image pair.\n' >&2
+    return 2
+  fi
+  if [[ -n ${GITHUB_TOKEN:-} ]]; then
+    curl_headers=(--header "authorization: Bearer $GITHUB_TOKEN")
+  fi
+  if ! metadata=$(curl --fail-with-body --silent --show-error \
+    --connect-timeout 5 --max-time 20 --retry 2 --retry-all-errors \
+    --header 'accept: application/vnd.github+json' \
+    "${curl_headers[@]}" \
+    'https://api.github.com/repos/mdbase-dev/mdbase-connect/releases/tags/v0.1.0-beta.95'); then
+    printf 'Could not query the fixed beta95 release metadata.\n' >&2
+    return 1
+  fi
+  if ! jq -e 'type == "object" and .tag_name == "v0.1.0-beta.95" and
+    .draft == false and (.id | type) == "number" and
+    (.published_at | type) == "string" and (.published_at | length) > 0' \
+    <<<"$metadata" >/dev/null; then
+    printf 'The fixed beta95 release is missing, draft or malformed.\n' >&2
+    return 1
+  fi
+  upgrade_verify_annotated_release_tag "$repo_root"
+}
+
+upgrade_verify_annotated_release_tag() {
+  local repo_root=$1
+  local release=${MDBASE_CONNECT_PREVIOUS_RELEASE:-}
+  local commit=${MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT:-}
+  local refs ref_hash ref_name peeled_commit=
   if ! refs=$(timeout 30s git -C "$repo_root" ls-remote --exit-code --tags origin \
     "refs/tags/$release" "refs/tags/$release^{}"); then
     printf 'Could not resolve annotated release tag %s from origin.\n' "$release" >&2

--- a/test/upgrade/retained-v2.sh
+++ b/test/upgrade/retained-v2.sh
@@ -3,7 +3,7 @@
 
 retained_v2_inputs() {
   local supplied_image=${MDBASE_CONNECT_PREVIOUS_PROVIDER_IMAGE:-}
-  source "$repo_root/.github/previous-release.env"
+  source "$repo_root/.github/retained-v2-predecessor.env"
   [[ $MDBASE_CONNECT_PREVIOUS_RELEASE == v0.1.0-beta.95 &&
      $MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT == 408c67bc10f128e0833f0da62cb3efb9d94657d7 ]] || {
     printf 'Retained-v2 enablement qualification requires the exact beta95 predecessor.\n' >&2; return 2;
@@ -16,7 +16,7 @@ retained_v2_inputs() {
     printf 'Retained-v2 requires an immutable beta.95 provider digest.\n' >&2; return 2;
   }
   [[ $(git -C "$repo_root" rev-parse "$MDBASE_CONNECT_PREVIOUS_RELEASE^{commit}") == "$MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT" ]]
-  upgrade_verify_previous_release "$repo_root"
+  upgrade_verify_retained_v2_release "$repo_root"
   git -C "$repo_root" show "$MDBASE_CONNECT_PREVIOUS_RELEASE_COMMIT:config/application-issuance-policy.json" |
     jq -e '.phase == "compatibility-prelude" and .fresh_semantic_versions == [1]' >/dev/null
   jq -e '.phase == "v2-enablement" and .fresh_semantic_versions == [1,2]' \

--- a/test/upgrade/server-from-previous
+++ b/test/upgrade/server-from-previous
@@ -4,13 +4,10 @@ set -euo pipefail
 repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
 # shellcheck source=test/upgrade/lib.sh
 source "$repo_root/test/upgrade/lib.sh"
-# The release pin is resolved from the repository root above.
-# shellcheck disable=SC1091
-source "$repo_root/.github/previous-release.env"
-
 case ${1:-} in
   --retained-v2-pending)
     [[ $# == 1 ]] || exit 2
+    source "$repo_root/.github/retained-v2-predecessor.env"
     source "$repo_root/test/upgrade/server-retained-v2.sh"
     server_retained_v2_run
     exit $?
@@ -18,6 +15,10 @@ case ${1:-} in
   '') ;;
   *) printf 'Usage: server-from-previous [--retained-v2-pending]\n' >&2; exit 2 ;;
 esac
+
+# The immediate predecessor is independent of the immutable beta95 regression.
+# shellcheck disable=SC1091
+source "$repo_root/.github/previous-release.env"
 
 CANDIDATE_IMAGE=${CANDIDATE_IMAGE:-mdbase-connect-server:upgrade-candidate}
 UPGRADE_SERVER_PORT=${UPGRADE_SERVER_PORT:-8787}

--- a/test/upgrade/server-retained-v2.sh
+++ b/test/upgrade/server-retained-v2.sh
@@ -13,7 +13,7 @@ server_retained_v2_inputs() {
     jq -e '.policy_version == 1 and .phase == "compatibility-prelude" and .fresh_semantic_versions == [1]' >/dev/null
   jq -e '.policy_version == 1 and .phase == "v2-enablement" and .fresh_semantic_versions == [1,2]' \
     "$repo_root/config/application-issuance-policy.json" >/dev/null
-  upgrade_verify_previous_release "$repo_root"
+  upgrade_verify_retained_v2_release "$repo_root"
 }
 
 server_retained_v2_run() (


### PR DESCRIPTION
## Why

The first beta97 integration merge group (`e36e1cfd1a7ff1366b1dfc9f78d1e68128f1dc39`, Server CI34598759602) failed its three upgrade lanes before scenario execution: beta95 is no longer the newest published release after beta96 publication. Retrying that source cannot fix the prerequisite.

## Change

- Advance the ordinary immediate-predecessor pin to exact beta96 `56ed32ffde055d2ab2b22ff95722df8ef06bdb1d`, using the server/provider digests from its signed publication34316504048 / qualification34315442229, attempt1.
- Keep ordinary newest-release verification unchanged in substance. It still rejects stale, duplicate, draft, malformed and wrong-tag/commit evidence.
- Give both required exact-beta95 regression lanes a separate immutable pin. Require the original release, commit and both image digests, published non-draft beta95 metadata by its fixed tag, and its exact annotated origin tag. Retain all actual beta95 scenario and image checks.
- Keep beta94 historical coverage. No job, dependency, condition, scenario step, deadline or signed-publication gate is removed or relaxed. Only the two beta95 preload steps change their pin/verifier.

This is not beta97 release qualification, a provider rollback-policy exception, or production recovery authorization. No version tag, deployment or publication is created by this PR. Beta97 still needs its own immediate-predecessor rollback evidence and normal release gates.

## Verification

- All164 script tests pass, including56 targeted upgrade/identity cases. New tests execute the actual shell verifiers with isolated transport fixtures and no inherited credentials, covering positive identities, historical-vs-newest separation, malformed/draft/duplicate metadata, wrong/lightweight/duplicate annotated refs, altered pins, GET failures and OCI labels.
- Actual GET-only execution separately verifies newest beta96 and fixed historical beta95 against GitHub and annotated origin tags. No image pull or cloud mutation.
- Release components, architecture and whitespace checks pass. Structured workflow comparison confirms unchanged job inventory, dependencies, conditions, deadlines and scenario steps.
- Standalone ShellCheck reports existing sourced-script/subshell warnings; exact baseline/current finding inventories match. This is not represented as a clean ShellCheck run.
- Initial local syntax/dependency/fixture-assertion failures are retained separately; passing hermetic checks are not actual-binary or complete release qualification. Full exact-head/merge-group CI remains required.
