### PR TITLE
Prepare v0.1.0-beta.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "chrono",
  "mdbase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/mdbase-dev/mdbase-connect"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mdbase/connect-desktop",
   "productName": "mdbase connect",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "description": "Connect applications to authorized mdbase collections.",
   "author": "mdbase",
   "private": true,

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-portal",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/docker/Cargo.lock.hosted-provider
+++ b/deploy/docker/Cargo.lock.hosted-provider
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "connect-hosted-storage-benchmark"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-cli"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "chrono-tz",
  "clap",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-core"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-daemon"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "async-trait",
  "axum",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-hosted-provider"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-mirror"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "async-trait",
  "axum",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-protocol"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "mdbase-connect-runtime"
-version = "0.1.0-beta.96"
+version = "0.1.0-beta.97"
 dependencies = [
  "chrono",
  "mdbase",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
 
   hosted-object-store-init:
     profiles: ["hosted"]
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       hosted-object-store:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
 
   hosted-object-store:
     profiles: ["hosted"]
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command: ["server", "/data"]
     environment:
       MINIO_ROOT_USER: ${MDBASE_CONNECT_R2_ACCESS_KEY_ID:-local-r2-access}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbase-connect",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": true,
   "packageManager": "pnpm@11.15.1",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-dev",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/management/package.json
+++ b/packages/management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-management",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/pickle/package.json
+++ b/packages/pickle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/pickle",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-protocol",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-sync",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-testing",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-ui",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase-dev/connect-webhooks",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": false,
   "type": "module",
   "license": "MIT",

--- a/scripts/hosted-files-e2e.mjs
+++ b/scripts/hosted-files-e2e.mjs
@@ -385,7 +385,7 @@ async function startPostgres() {
   throw new Error("PostgreSQL did not start");
 }
 async function startObjects() {
-  await execute("docker", ["run", "--rm", "-d", "--name", objects, "-e", `MINIO_ROOT_USER=${objectAccess}`, "-e", `MINIO_ROOT_PASSWORD=${objectSecret}`, "-p", "127.0.0.1::9000", "minio/minio:RELEASE.2025-09-07T16-13-09Z", "server", "/data", "--address", ":9000"]);
+  await execute("docker", ["run", "--rm", "-d", "--name", objects, "-e", `MINIO_ROOT_USER=${objectAccess}`, "-e", `MINIO_ROOT_PASSWORD=${objectSecret}`, "-p", "127.0.0.1::9000", "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e", "server", "/data", "--address", ":9000"]);
   const port = (await execute("docker", ["port", objects, "9000/tcp"])).stdout.match(/:(\d+)/)[1];
   for (let i = 0; i < 120; i += 1) { if (await fetch(`http://127.0.0.1:${port}/minio/health/ready`).then(r => r.ok, () => false)) break; await delay(250); }
   await mc("mb", "--ignore-existing", `local/${bucket}`);

--- a/scripts/hosted-files-e2e.mjs
+++ b/scripts/hosted-files-e2e.mjs
@@ -391,7 +391,7 @@ async function startObjects() {
   await mc("mb", "--ignore-existing", `local/${bucket}`);
   return `http://127.0.0.1:${port}`;
 }
-async function mc(...args) { return (await execute("docker", ["run", "--rm", "--network", `container:${objects}`, "--entrypoint", "/bin/sh", "minio/mc:RELEASE.2025-08-13T08-35-41Z", "-c", `mc alias set local http://127.0.0.1:9000 ${objectAccess} ${objectSecret} >/dev/null && mc ${args.join(" ")}`])).stdout; }
+async function mc(...args) { return (await execute("docker", ["run", "--rm", "--network", `container:${objects}`, "--entrypoint", "/bin/sh", "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727", "-c", `mc alias set local http://127.0.0.1:9000 ${objectAccess} ${objectSecret} >/dev/null && mc ${args.join(" ")}`])).stdout; }
 async function startProvider(databaseUrl, endpoint) {
   const child = spawn(providerBinary, [], { cwd: root, env: { ...process.env, DATABASE_URL: databaseUrl, MDBASE_CONNECT_HOSTED_PROVIDER_INTERNAL_TOKEN: internalToken, MDBASE_CONNECT_HOSTED_PROVIDER_MASTER_KEY: masterKey, MDBASE_CONNECT_R2_ENDPOINT: endpoint, MDBASE_CONNECT_R2_BUCKET: bucket, MDBASE_CONNECT_R2_ACCESS_KEY_ID: objectAccess, MDBASE_CONNECT_R2_SECRET_ACCESS_KEY: objectSecret, MDBASE_CONNECT_ALLOW_INSECURE_R2: "true", HOST: "127.0.0.1", PORT: "0", RUST_LOG: "warn" }, stdio: ["ignore", "pipe", "pipe"] });
   let logs = ""; child.stderr.on("data", chunk => { logs += chunk; });

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -4358,7 +4358,7 @@ async function startObjectStore() {
     "--env", "MINIO_ROOT_USER=mdbase-test-access",
     "--env", "MINIO_ROOT_PASSWORD=mdbase-test-secret-key",
     "--publish", "127.0.0.1::9000",
-    "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+    "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e",
     "server", "/data", "--address", ":9000"
   ]);
   objectStoreStarted = true;

--- a/scripts/hosted-provider-e2e.mjs
+++ b/scripts/hosted-provider-e2e.mjs
@@ -4374,7 +4374,7 @@ async function startObjectStore() {
   await execute("docker", [
     "run", "--rm", "--network", `container:${objectStoreContainer}`,
     "--entrypoint", "/bin/sh",
-    "minio/mc:RELEASE.2025-08-13T08-35-41Z",
+    "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727",
     "-c",
     "mc alias set local http://127.0.0.1:9000 mdbase-test-access mdbase-test-secret-key && mc mb --ignore-existing local/mdbase-connect-files"
   ]);

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-mcp",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ export function createMcpServer(
   gateway: ConnectGateway,
   oauth: OAuthService
 ): McpServer {
-  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.96" });
+  const server = new McpServer({ name: "mdbase", version: "0.1.0-beta.97" });
 
   server.registerTool("list_connections", {
     title: "List mdbase collections",

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdbase/connect-server",
-  "version": "0.1.0-beta.96",
+  "version": "0.1.0-beta.97",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the beta97 version identity after the five requested fixes have all merged normally:

- #412 — semantic-v2 Editor deployment-manifest verifier
- #404 — installed desktop daemon targeting
- #405 — quiet Editor loading treatment
- #392 — minimal portal authorization/authentication views
- #403 — Google/GitHub public signup

Base: c675d1db176314b5d52e47b5b8d3e17b709eedde. Each selected PR completed full merge-group qualification.

The version edits change only the 14 synchronized npm manifests, Cargo workspace version and the eight owned package versions in each Cargo lock, and the MCP advertised version. Third-party dependencies, engine pin, capability/issuance semantics, migrations, workflows and tests are unchanged. The ordinary predecessor remains exact published beta96; historical beta95 coverage remains separate and mandatory.

## Identical test-image registry repair

The first full merge-group run34644607286 failed in files/provider fixture startup: Docker Hub denied anonymous pulls for `minio/minio:RELEASE.2025-09-07T16-13-09Z`. Independent inspection reproduced the denial. MinIO's official Quay registry serves the identical multi-platform manifest, SHA256 `14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`, matching the previously used Docker Hub image's recorded digest. The two system scripts and shared Compose fixture now use that official registry with tag plus exact digest. No mirror infrastructure, changed binary, credential workaround, scenario omission or deadline relaxation. The second full group34647908340 reached the companion `minio/mc` command and exposed the same Docker Hub denial there; the local cache had hidden that pull. Its official Quay manifest is likewise identical: SHA256 `a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727`. All six references across the three files are now audited and digest-pinned, with both remote manifests independently resolved. Registered files/provider suites pass locally at6351f2ade18c45773aff275a028dd3a06ac7763b. A fresh complete merge group remains mandatory; both original failures are retained.

## Validation

- Release version/tag consistency and release-version lock regression tests
- Frozen pnpm install and workspace package builds
- Release component contract and architecture checks
- Locked Cargo metadata, Cargo formatting, and whitespace checks
- Normal exact-head checks and full merge-queue qualification remain required

## Release boundaries

This PR does not create a tag or authorize deployment/client publication. Beta97 requires its own exact main CI and signed bundle, reviewed supported beta96 rollback relationship (current private41→41 policy does not yet admit it), genuine provider signup acceptance, staging qualification/rollback/soak, protected production promotion, live verification and monitoring. Do not reuse beta96's consumed publication attempts or alter its immutable tag. Client publication remains npm → desktop → production Editor only after exact beta97 production verification.
